### PR TITLE
add instruction to readme to run build before running example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This creates platform-specific libraries in `src/zig/lib/` that are automaticall
 
 ## Examples
 
+Requires running a build script first. (`build`, `build:dev`, `build:prod`)
+
 ```bash
 bun run src/examples/index.ts
 ```


### PR DESCRIPTION
otherwise 

```
❯ bun run src/examples/index.ts
38 |   const targetLibPath = join(libDir, target, `${libraryName}.${suffix}`)
39 |   if (existsSync(targetLibPath)) {
40 |     return targetLibPath
41 |   }
42 | 
43 |   throw new Error(`Could not find opentui library for platform: ${target}`)
             ^
error: Could not find opentui library for platform: aarch64-macos
...
```