### PR TITLE
refactor(renderer): Separate render loop from single frame    rendering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -745,7 +745,9 @@ export class CliRenderer extends Renderable {
     const frameRequests = this.animationRequest.values()
     this.animationRequest.clear()
     const animationRequestStart = performance.now()
-    frameRequests.forEach((callback) => callback(deltaTime))
+    for (const callback of frameRequests) {
+      callback(deltaTime)
+    }
     const animationRequestEnd = performance.now()
     const animationRequestTime = animationRequestEnd - animationRequestStart
 


### PR DESCRIPTION
This pull request refactors the CliRenderer to improve code clarity and
  maintainability.

  The core rendering logic has been extracted from the loop() method into a
  new private method called _renderFrame().

  This change allows renderOnce() to directly call the rendering logic without
  invoking the entire loop, which is more efficient and semantically correct.
  The loop() method now focuses on its primary responsibility: managing the
  rendering loop and scheduling frames.

  This refactoring improves the overall structure of the CliRenderer and makes
  the code easier to understand and maintain. No functional changes are
  introduced.