### PR TITLE
chore(input): implement get/set

### DIFF
--- a/src/examples/input-demo.ts
+++ b/src/examples/input-demo.ts
@@ -52,10 +52,10 @@ Type: Enter text in focused field`
     keyLegendDisplay.content = keyLegendText
   }
 
-  const nameValue = nameInput?.getValue() || ""
-  const emailValue = emailInput?.getValue() || ""
-  const passwordValue = passwordInput?.getValue() || ""
-  const commentValue = commentInput?.getValue() || ""
+  const nameValue = nameInput?.value || ""
+  const emailValue = emailInput?.value || ""
+  const passwordValue = passwordInput?.value || ""
+  const commentValue = commentInput?.value || ""
 
   const nameStatus = nameInput?.focused ? "FOCUSED" : "BLURRED"
   const nameColor = nameInput?.focused ? "#00FF00" : "#FF0000"
@@ -124,10 +124,10 @@ function navigateToInput(index: number): void {
 }
 
 function resetInputs(): void {
-  nameInput?.setValue("")
-  emailInput?.setValue("")
-  passwordInput?.setValue("")
-  commentInput?.setValue("")
+  nameInput!.value = ""
+  emailInput!.value = ""
+  passwordInput!.value = ""
+  commentInput!.value = ""
 
   lastActionText = "All inputs reset to empty values"
   lastActionColor = "#FF00FF"
@@ -332,7 +332,7 @@ export function run(rendererInstance: CliRenderer): void {
       // Only respond to Ctrl+C for clear
       const activeInput = getActiveInput()
       if (activeInput) {
-        activeInput.setValue("")
+        activeInput.value = ""
         lastActionText = `${getInputName(activeInput)} input cleared`
         lastActionColor = "#FFAA00"
         updateDisplays()

--- a/src/examples/input-select-layout-demo.ts
+++ b/src/examples/input-select-layout-demo.ts
@@ -309,7 +309,7 @@ function updateDisplay(): void {
 
   const selectedColor = leftSelect.getSelectedOption()
   const selectedSize = rightSelect.getSelectedOption()
-  const inputValue = textInput.getValue()
+  const inputValue = textInput.value
 
   let displayText = "Enter your text:"
   if (inputValue) {


### PR DESCRIPTION
## Description

### New setters:
- `backgroundColor` - Sets the background color with automatic color parsing
- `textColor` - Sets the text color with automatic color parsing
- `focusedBackgroundColor` - Sets the focused background color
- `focusedTextColor` - Sets the focused text color
- `placeholderColor` - Sets the placeholder text color
- `cursorColor` - Sets the cursor color
- `maxLength` - Sets the max length
- `placeholder` - Sets the placeholder text

### Converted to get/set:
- `value` - getValue()/setValue() → get/set value
- `cursorPosition` - getCursorPosition()/setCursorPosition() → get/set cursorPosition

### Removed unused **getters** (_for now_):
- `placeholder` - getPlaceholder()
- `maxLength` - getMaxLength()

### Implementation Details:
- All private fields were renamed with underscore prefix (e.g., `_backgroundColor`)
- All setters call `this.needsUpdate()` to trigger re-rendering when properties change
- Color setters use `parseColor()` to handle different color input formats
- All references throughout the class were updated to use the new private field names
