### PR TITLE
React: Fix JSX Namespace Compatibility

### DIFF
--- a/packages/react/jsx-namespace.d.ts
+++ b/packages/react/jsx-namespace.d.ts
@@ -1,20 +1,23 @@
+import type * as React from "react"
 import type { BoxProps, GroupProps, InputProps, SelectProps, TabSelectProps, TextProps } from "./src/types/components"
 import type { ExtendedIntrinsicElements, OpenTUIComponents } from "./src/types/extend"
 
 export namespace JSX {
-  interface Element extends React.ReactElement<any, any> {}
+  type Element = React.ReactNode
 
-  interface ElementClass {
-    render: any
+  interface ElementClass extends React.ComponentClass<any> {
+    render(): React.ReactNode
   }
+
   interface ElementAttributesProperty {
     props: {}
   }
+
   interface ElementChildrenAttribute {
     children: {}
   }
 
-  interface IntrinsicElements extends ExtendedIntrinsicElements<OpenTUIComponents> {
+  interface IntrinsicElements extends React.JSX.IntrinsicElements, ExtendedIntrinsicElements<OpenTUIComponents> {
     box: BoxProps
     group: GroupProps
     input: InputProps

--- a/packages/react/scripts/build.ts
+++ b/packages/react/scripts/build.ts
@@ -137,14 +137,7 @@ const tsconfigBuild: TsconfigBuild = {
     },
   },
   include: ["src/**/*", "jsx-runtime.d.ts", "jsx-dev-runtime.d.ts", "jsx-namespace.d.ts"],
-  exclude: [
-    "**/*.test.ts",
-    "**/*.spec.ts", 
-    "examples/**/*", 
-    "scripts/**/*",
-    "node_modules/**/*",
-    "../core/**/*",
-  ],
+  exclude: ["**/*.test.ts", "**/*.spec.ts", "examples/**/*", "scripts/**/*", "node_modules/**/*", "../core/**/*"],
 }
 
 writeFileSync(tsconfigBuildPath, JSON.stringify(tsconfigBuild, null, 2))
@@ -200,7 +193,7 @@ const exports = {
     require: "./jsx-runtime.js",
   },
   "./jsx-dev-runtime": {
-    types: "./jsx-dev-runtime.d.ts", 
+    types: "./jsx-dev-runtime.d.ts",
     import: "./jsx-dev-runtime.js",
     require: "./jsx-dev-runtime.js",
   },


### PR DESCRIPTION
# Description

- Updated JSX.Element type from React.ReactElement<any, any> to React.ReactNode for broader compatibility
- Enhanced IntrinsicElements to extend React's built-in JSX elements while adding OpenTUI components
- Fixed ElementClass interface to properly extend React's ComponentClass