### PR TITLE
fix: convert MapIterator to array for frameRequests.forEach

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1037,7 +1037,7 @@ export class CliRenderer extends EventEmitter {
     this.renderStats.fps = this.currentFps
     const overallStart = performance.now()
 
-    const frameRequests = this.animationRequest.values()
+    const frameRequests = Array.from(this.animationRequest.values())
     this.animationRequest.clear()
     const animationRequestStart = performance.now()
     frameRequests.forEach((callback) => callback(deltaTime))


### PR DESCRIPTION
The animationRequest.values() method returns a MapIterator which doesn't have a forEach method, causing "frameRequests.forEach is not a function" runtime error when requestAnimationFrame callbacks are processed.  Wrap with Array.from() to convert the iterator to an array before calling forEach in the render loop.  Fixes animation frame callback processing in Node.js environments.