### PR TITLE
fix: console constructor undefined on rerun

### DIFF
--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -90,8 +90,6 @@ export interface RenderableOptions extends Partial<LayoutOptions> {
   onKeyDown?: (key: ParsedKey) => void
 }
 
-let renderableNumber = 1
-
 function validateOptions(id: string, options: RenderableOptions): void {
   if (typeof options.width === "number") {
     if (options.width < 0) {
@@ -170,6 +168,7 @@ export function isSizeType(value: any): value is number | `${number}%` | undefin
 }
 
 export abstract class Renderable extends EventEmitter {
+  private static renderableNumber = 1
   static renderablesByNumber: Map<number, Renderable> = new Map()
 
   public readonly id: string
@@ -216,7 +215,7 @@ export abstract class Renderable extends EventEmitter {
   constructor(id: string, options: RenderableOptions) {
     super()
     this.id = id
-    this.num = renderableNumber++
+    this.num = Renderable.renderableNumber++
     Renderable.renderablesByNumber.set(this.num, this)
 
     validateOptions(id, options)

--- a/packages/core/src/buffer.ts
+++ b/packages/core/src/buffer.ts
@@ -4,8 +4,6 @@ import { resolveRenderLib, type RenderLib } from "./zig"
 import { type Pointer } from "bun:ffi"
 import { type BorderStyle, type BorderSides, type BorderCharacters, BorderCharArrays, borderCharsToArray } from "./lib"
 
-let fbIdCounter = 0
-
 function isRGBAWithAlpha(color: RGBA): boolean {
   return color.a < 1.0
 }
@@ -71,6 +69,7 @@ function blendColors(overlay: RGBA, text: RGBA): RGBA {
 }
 
 export class OptimizedBuffer {
+  private static fbIdCounter = 0
   public id: string
   public lib: RenderLib
   private bufferPtr: Pointer
@@ -102,7 +101,7 @@ export class OptimizedBuffer {
     height: number,
     options: { respectAlpha?: boolean },
   ) {
-    this.id = `fb_${fbIdCounter++}`
+    this.id = `fb_${OptimizedBuffer.fbIdCounter++}`
     this.lib = lib
     this.respectAlpha = options.respectAlpha || false
     this.width = width

--- a/packages/core/src/console.ts
+++ b/packages/core/src/console.ts
@@ -7,6 +7,7 @@ import util from "node:util"
 import fs from "node:fs"
 import path from "node:path"
 import { Capture, CapturedWritableStream } from "./lib/output.capture"
+import { singleton } from "./singleton"
 
 interface CallerInfo {
   functionName: string
@@ -46,22 +47,27 @@ enum LogLevel {
   DEBUG = "DEBUG",
 }
 
-export const capture = new Capture()
-const mockStdout = new CapturedWritableStream("stdout", capture)
-const mockStderr = new CapturedWritableStream("stderr", capture)
+export const { capture } = singleton('ConsoleCapture', () => {
+  const capture = new Capture()
+  const mockStdout = new CapturedWritableStream("stdout", capture)
+  const mockStderr = new CapturedWritableStream("stderr", capture)
+  
+  if (process.env.SKIP_CONSOLE_CACHE !== "true") {
+    global.console = new Console({
+      stdout: mockStdout,
+      stderr: mockStderr,
+      colorMode: true,
+      inspectOptions: {
+        compact: false,
+        breakLength: 80,
+        depth: 2,
+      },
+    })
+  }
 
-if (process.env.SKIP_CONSOLE_CACHE !== "true") {
-  global.console = new Console({
-    stdout: mockStdout,
-    stderr: mockStderr,
-    colorMode: true,
-    inspectOptions: {
-      compact: false,
-      breakLength: 80,
-      depth: 2,
-    },
-  })
-}
+  return { capture };
+})
+
 
 class TerminalConsoleCache extends EventEmitter {
   private originalConsole: {
@@ -169,9 +175,12 @@ class TerminalConsoleCache extends EventEmitter {
   }
 }
 
-const terminalConsoleCache = new TerminalConsoleCache()
-process.on("exit", () => {
-  terminalConsoleCache.destroy()
+const terminalConsoleCache = singleton('TerminalConsoleCache', () => {
+  const terminalConsoleCache = new TerminalConsoleCache()
+  process.on("exit", () => {
+      terminalConsoleCache.destroy()
+  })
+  return terminalConsoleCache
 })
 
 export enum ConsolePosition {

--- a/packages/core/src/lib/KeyHandler.ts
+++ b/packages/core/src/lib/KeyHandler.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "events"
 import { parseKeypress } from "./parse.keypress"
+import { singleton } from "../singleton"
 
 export class KeyHandler extends EventEmitter {
   constructor() {
@@ -26,7 +27,7 @@ let keyHandler: KeyHandler | null = null
 
 export function getKeyHandler(): KeyHandler {
   if (!keyHandler) {
-    keyHandler = new KeyHandler()
+    keyHandler = singleton('KeyHandler', () => new KeyHandler())
   }
   return keyHandler
 }

--- a/packages/core/src/lib/TrackedNode.ts
+++ b/packages/core/src/lib/TrackedNode.ts
@@ -8,9 +8,8 @@ interface NodeMetadata {
   [key: string]: any
 }
 
-let idCounter = 0
-
 class TrackedNode<T extends NodeMetadata = NodeMetadata> extends EventEmitter {
+  private static idCounter = 0
   id: number
   yogaNode: YogaNode
   metadata: T
@@ -25,7 +24,7 @@ class TrackedNode<T extends NodeMetadata = NodeMetadata> extends EventEmitter {
 
   constructor(yogaNode: YogaNode, metadata: T = {} as T) {
     super()
-    this.id = idCounter++
+    this.id = TrackedNode.idCounter++
     this.yogaNode = yogaNode
     this.metadata = metadata
     this.parent = null

--- a/packages/core/src/singleton.ts
+++ b/packages/core/src/singleton.ts
@@ -1,0 +1,14 @@
+const singletonCacheSymbol = Symbol.for('@opentui/core/singleton')
+
+/**
+ * Ensures a value is initialized once per process,
+ * persists across Bun hot reloads, and is type-safe.
+ */
+export function singleton<T>(key: string, factory: () => T): T {
+  // @ts-expect-error this symbol is only used in this file and is not part of the public API
+  const bag = globalThis[singletonCacheSymbol] ??= {}
+  if (!(key in bag)) {
+    bag[key] = factory()
+  }
+  return bag[key] as T
+}

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -1100,7 +1100,10 @@ let opentuiLibPath: string | undefined
 let opentuiLib: RenderLib | undefined
 
 export function setRenderLibPath(libPath: string) {
-  opentuiLibPath = libPath
+  if (opentuiLibPath !== libPath) {
+    opentuiLibPath = libPath
+    opentuiLib = undefined
+  }
 }
 
 export function resolveRenderLib(): RenderLib {


### PR DESCRIPTION
Fixes `new console.Console` causing crash as can be seen in #41. This can be reproduced in various ways, but I mainly experience it when running with Bun hot reload (`bun run --hot ....`).

This PR doesn't aim to fully support hot reload though. Notably, the old TUI isn't destroyed on hot reload, so there will be glitches and memory leaks. But at least this prevents a crash. User can rerun the bun command or use `--watch` if they want to clear the old instance.