### PR TITLE
docs(react): add ascii-font example

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -39,6 +39,7 @@ OpenTUI React provides several built-in components that map to OpenTUI core rend
 - **`<input>`** - Text input field
 - **`<select>`** - Selection dropdown
 - **`<tab-select>`** - Tab-based selection
+- **`<ascii-font>`** - Display ASCII art text with different font styles
 
 ### Styling
 
@@ -270,6 +271,67 @@ function SelectExample() {
         }}
       />
     </box>
+  )
+}
+```
+
+### ASCII Font Component
+
+Display ASCII art text with different font styles.
+
+```tsx
+import { measureText } from "@opentui/core"
+import { useState } from "react"
+
+function ASCIIFontExample() {
+  const text = "ASCII"
+  const [font, setFont] = useState<"block" | "shade" | "slick" | "tiny">("tiny")
+
+  const { width, height } = measureText({
+    text,
+    font,
+  })
+
+  return (
+    <group style={{ paddingLeft: 1, paddingRight: 1 }}>
+      <box
+        style={{
+          height: 8,
+          marginBottom: 1,
+        }}
+      >
+        <select
+          focused
+          onChange={(_, option) => setFont(option?.value)}
+          showScrollIndicator
+          options={[
+            {
+              name: "Tiny",
+              description: "Tiny font",
+              value: "tiny",
+            },
+            {
+              name: "Block",
+              description: "Block font",
+              value: "block",
+            },
+            {
+              name: "Slick",
+              description: "Slick font",
+              value: "slick",
+            },
+            {
+              name: "Shade",
+              description: "Shade font",
+              value: "shade",
+            },
+          ]}
+          style={{ flexGrow: 1 }}
+        />
+      </box>
+
+      <ascii-font style={{ width, height }} text={text} font={font} />
+    </group>
   )
 }
 ```


### PR DESCRIPTION
## Description

- added `ascii-font` to react readme