### PR TITLE
fix: fallback to default values when properties undefined

### DIFF
--- a/packages/core/src/examples/ascii-font-selection-demo.ts
+++ b/packages/core/src/examples/ascii-font-selection-demo.ts
@@ -28,6 +28,7 @@ export function run(renderer: CliRenderer): void {
     borderColor: "#50565d",
     title: "ASCII Font Selection Demo",
     titleAlignment: "center",
+    border: true,
   })
   renderer.root.add(mainContainer)
 
@@ -106,6 +107,7 @@ export function run(renderer: CliRenderer): void {
     borderColor: "#50565d",
     title: "Selection Status",
     titleAlignment: "left",
+    border: true,
   })
   renderer.root.add(statusBox)
 

--- a/packages/core/src/examples/console-demo.ts
+++ b/packages/core/src/examples/console-demo.ts
@@ -57,6 +57,7 @@ class ConsoleButton extends BoxRenderable {
       borderStyle: "rounded",
       title: label,
       titleAlignment: "center",
+      border: true,
     })
 
     this.logType = logType

--- a/packages/core/src/examples/hast-syntax-highlighting-demo.ts
+++ b/packages/core/src/examples/hast-syntax-highlighting-demo.ts
@@ -36,6 +36,7 @@ export function run(rendererInstance: CliRenderer): void {
     backgroundColor: "#0D1117",
     title: "HAST to Styled Text Demo",
     titleAlignment: "center",
+    border: true,
   })
   parentContainer.add(titleBox)
 
@@ -52,6 +53,7 @@ export function run(rendererInstance: CliRenderer): void {
     title: "TypeScript Code",
     titleAlignment: "left",
     paddingLeft: 1,
+    border: true,
   })
   parentContainer.add(codeBox)
 

--- a/packages/core/src/examples/index.ts
+++ b/packages/core/src/examples/index.ts
@@ -318,6 +318,7 @@ class ExampleSelector {
       titleAlignment: "center",
       backgroundColor: "transparent",
       shouldFill: false,
+      border: true,
     })
 
     this.selectElement = new SelectRenderable("example-selector", {

--- a/packages/core/src/examples/input-select-layout-demo.ts
+++ b/packages/core/src/examples/input-select-layout-demo.ts
@@ -61,6 +61,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     borderColor: "#2563eb",
     flexGrow: 0,
     flexShrink: 0,
+    border: true,
   })
 
   header = new TextRenderable("header", {
@@ -84,6 +85,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     backgroundColor: "#1e293b",
     borderStyle: "single",
     borderColor: "#475569",
+    border: true,
   })
 
   selectContainer = new GroupRenderable("select-container", {
@@ -110,6 +112,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     flexGrow: 1,
     flexShrink: 1,
     backgroundColor: "transparent",
+    border: true,
   })
 
   leftSelect = new SelectRenderable("color-select", {
@@ -148,6 +151,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     flexGrow: 1,
     flexShrink: 1,
     backgroundColor: "transparent",
+    border: true,
   })
 
   rightSelect = new SelectRenderable("size-select", {
@@ -182,6 +186,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     backgroundColor: "#0f172a",
     borderStyle: "single",
     borderColor: "#334155",
+    border: true,
   })
 
   inputContainer = new GroupRenderable("input-container", {
@@ -215,6 +220,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     flexShrink: 0,
     marginTop: 1,
     backgroundColor: "transparent",
+    border: true,
   })
 
   textInput = new InputRenderable("text-input", {
@@ -244,6 +250,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     borderColor: "#1d4ed8",
     flexGrow: 0,
     flexShrink: 0,
+    border: true,
   })
 
   footer = new TextRenderable("footer", {

--- a/packages/core/src/examples/live-state-demo.ts
+++ b/packages/core/src/examples/live-state-demo.ts
@@ -157,6 +157,7 @@ function addDemoRenderable(renderer: CliRenderer): void {
     borderStyle: "double",
     title: "Demo Renderable",
     titleAlignment: "center",
+    border: true,
   })
 
   renderer.root.add(demoRenderable)

--- a/packages/core/src/examples/live-state-demo.ts
+++ b/packages/core/src/examples/live-state-demo.ts
@@ -40,7 +40,7 @@ class LiveButton extends BoxRenderable {
   private label: string
 
   constructor(id: string, options: BoxOptions & { label: string }) {
-    super(id, { zIndex: 100, ...options })
+    super(id, { zIndex: 100, border: true, ...options })
 
     this.label = options.label
     const base = this.backgroundColor

--- a/packages/core/src/examples/mouse-interaction-demo.ts
+++ b/packages/core/src/examples/mouse-interaction-demo.ts
@@ -61,6 +61,7 @@ class DraggableBox extends BoxRenderable {
       borderStyle: "rounded",
       title: label,
       titleAlignment: "center",
+      border: true,
     })
     this.baseWidth = width
     this.baseHeight = height

--- a/packages/core/src/examples/nested-zindex-demo.ts
+++ b/packages/core/src/examples/nested-zindex-demo.ts
@@ -64,6 +64,7 @@ export function run(renderer: CliRenderer): void {
     borderColor: "#FF44FF",
     title: "Parent A (z=100)",
     titleAlignment: "center",
+    border: true,
   })
   parentGroupA.add(boxA1)
 
@@ -88,6 +89,7 @@ export function run(renderer: CliRenderer): void {
     zIndex: 5,
     borderStyle: "single",
     borderColor: "#FF88FF",
+    border: true,
   })
   parentGroupA.add(boxA2)
 
@@ -114,6 +116,7 @@ export function run(renderer: CliRenderer): void {
     borderColor: "#44FF44",
     title: "Parent B (z=50)",
     titleAlignment: "center",
+    border: true,
   })
   parentGroupB.add(boxB1)
 
@@ -138,6 +141,7 @@ export function run(renderer: CliRenderer): void {
     zIndex: 15,
     borderStyle: "single",
     borderColor: "#88FF88",
+    border: true,
   })
   parentGroupB.add(boxB2)
 
@@ -164,6 +168,7 @@ export function run(renderer: CliRenderer): void {
     borderColor: "#FFFF44",
     title: "Parent C (z=20)",
     titleAlignment: "center",
+    border: true,
   })
   parentGroupC.add(boxC1)
 
@@ -188,6 +193,7 @@ export function run(renderer: CliRenderer): void {
     zIndex: 25,
     borderStyle: "single",
     borderColor: "#FFFF88",
+    border: true,
   })
   parentGroupC.add(boxC2)
 

--- a/packages/core/src/examples/opentui-demo.ts
+++ b/packages/core/src/examples/opentui-demo.ts
@@ -226,6 +226,7 @@ export function run(renderer: CliRenderer): void {
         zIndex: 0,
         borderStyle: "single",
         borderColor: "#FFFFFF",
+        border: true,
       })
       tabGroup.add(box1)
 
@@ -250,6 +251,7 @@ export function run(renderer: CliRenderer): void {
         zIndex: 1,
         borderStyle: "double",
         borderColor: "#FFFF00",
+        border: true,
       })
       tabGroup.add(box2)
 
@@ -367,6 +369,7 @@ export function run(renderer: CliRenderer): void {
         zIndex: 0,
         borderStyle: "single",
         borderColor: "#FFFFFF",
+        border: true,
       })
       tabGroup.add(singleBox)
       const singleLabel = new TextRenderable("single-label", {
@@ -390,6 +393,7 @@ export function run(renderer: CliRenderer): void {
         zIndex: 0,
         borderStyle: "double",
         borderColor: "#FFFFFF",
+        border: true,
       })
       tabGroup.add(doubleBox)
       const doubleLabel = new TextRenderable("double-label", {
@@ -413,6 +417,7 @@ export function run(renderer: CliRenderer): void {
         zIndex: 0,
         borderStyle: "rounded",
         borderColor: "#FFFFFF",
+        border: true,
       })
       tabGroup.add(roundedBox)
       const roundedLabel = new TextRenderable("rounded-label", {
@@ -471,6 +476,7 @@ export function run(renderer: CliRenderer): void {
         zIndex: 0,
         borderStyle: "single",
         borderColor: "#FFFFFF",
+        border: true,
       })
       tabGroup.add(partialAnimated)
       const partialAnimatedLabel = new TextRenderable("partial-animated-label", {
@@ -557,6 +563,7 @@ export function run(renderer: CliRenderer): void {
         borderStyle: "single",
         borderColor: "#FFFFFF",
         customBorderChars: asciiBorders,
+        border: true,
       })
       tabGroup.add(asciiBox)
       const asciiLabel = new TextRenderable("ascii-label", {
@@ -580,6 +587,7 @@ export function run(renderer: CliRenderer): void {
         zIndex: 0,
         borderStyle: "single",
         borderColor: "#FFFFFF",
+        border: true,
       })
       blockBox.customBorderChars = blockBorders
       tabGroup.add(blockBox)
@@ -605,6 +613,7 @@ export function run(renderer: CliRenderer): void {
         borderStyle: "single",
         borderColor: "#FFFFFF",
         customBorderChars: starBorders,
+        border: true,
       })
       tabGroup.add(starBox)
       const starLabel = new TextRenderable("star-label", {
@@ -686,6 +695,7 @@ export function run(renderer: CliRenderer): void {
         zIndex: 0,
         borderStyle: "rounded",
         borderColor: "#FF00FF",
+        border: true,
       })
       tabGroup.add(animatedBox)
 
@@ -699,6 +709,7 @@ export function run(renderer: CliRenderer): void {
         zIndex: 0,
         borderStyle: "double",
         borderColor: "#FFFFFF",
+        border: true,
       })
       tabGroup.add(colorBox)
 
@@ -779,6 +790,7 @@ export function run(renderer: CliRenderer): void {
         borderColor: "#FFFFFF",
         title: "Left Aligned",
         titleAlignment: "left",
+        border: true,
       })
       tabGroup.add(titledLeft)
 
@@ -794,6 +806,7 @@ export function run(renderer: CliRenderer): void {
         borderColor: "#FFFFFF",
         title: "Centered Title",
         titleAlignment: "center",
+        border: true,
       })
       tabGroup.add(titledCenter)
 
@@ -809,6 +822,7 @@ export function run(renderer: CliRenderer): void {
         borderColor: "#FFFFFF",
         title: "Right Aligned",
         titleAlignment: "right",
+        border: true,
       })
       tabGroup.add(titledRight)
     },
@@ -846,6 +860,7 @@ export function run(renderer: CliRenderer): void {
         zIndex: 0,
         borderStyle: "double",
         borderColor: "#FFFFFF",
+        border: true,
       })
       tabGroup.add(interactiveBorder)
 

--- a/packages/core/src/examples/relative-positioning-demo.ts
+++ b/packages/core/src/examples/relative-positioning-demo.ts
@@ -53,6 +53,7 @@ export function run(renderer: CliRenderer): void {
     flexDirection: "row",
     alignItems: "stretch",
     justifyContent: "space-between",
+    border: true,
   })
   parentContainerA.add(parentBoxA)
 
@@ -68,6 +69,7 @@ export function run(renderer: CliRenderer): void {
     flexGrow: 1,
     flexShrink: 1,
     minWidth: 8,
+    border: true,
   })
   parentBoxA.add(childA1)
 
@@ -83,6 +85,7 @@ export function run(renderer: CliRenderer): void {
     flexGrow: 1,
     flexShrink: 1,
     minWidth: 8,
+    border: true,
   })
   parentBoxA.add(childA2)
 
@@ -98,6 +101,7 @@ export function run(renderer: CliRenderer): void {
     flexGrow: 1,
     flexShrink: 1,
     minWidth: 8,
+    border: true,
   })
   parentBoxA.add(childA3)
 
@@ -124,6 +128,7 @@ export function run(renderer: CliRenderer): void {
     padding: 1,
     flexDirection: "column",
     justifyContent: "space-between",
+    border: true,
   })
   parentContainerB.add(parentBoxB)
 
@@ -171,6 +176,7 @@ export function run(renderer: CliRenderer): void {
     titleAlignment: "center",
     padding: 1,
     flexDirection: "column",
+    border: true,
   })
   staticContainer.add(staticBox)
 

--- a/packages/core/src/examples/shader-cube-demo.ts
+++ b/packages/core/src/examples/shader-cube-demo.ts
@@ -132,6 +132,7 @@ export async function run(renderer: CliRenderer): Promise<void> {
     borderColor: "#FFFFFF",
     title: "Shader Cube Demo",
     titleAlignment: "center",
+    border: true,
   })
   parentContainer.add(backgroundBox)
 

--- a/packages/core/src/examples/simple-layout-example.ts
+++ b/packages/core/src/examples/simple-layout-example.ts
@@ -222,6 +222,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     backgroundColor: "#3b82f6",
     borderStyle: "single",
     alignItems: "center",
+    border: true,
   })
 
   headerText = new TextRenderable("header-text", {
@@ -253,6 +254,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
+    border: true,
   })
 
   sidebarText = new TextRenderable("sidebar-text", {
@@ -275,6 +277,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
+    border: true,
   })
 
   mainContentText = new TextRenderable("main-content-text", {
@@ -297,6 +300,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
+    border: true,
   })
 
   rightSidebarText = new TextRenderable("right-sidebar-text", {
@@ -319,6 +323,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
+    border: true,
   })
 
   footerText = new TextRenderable("footer-text", {
@@ -343,6 +348,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
+    border: true,
   })
 
   moveableText = new TextRenderable("moveable-text", {
@@ -367,6 +373,7 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
+    border: true,
   })
 
   absolutePositionedText = new TextRenderable("absolute-positioned-text", {

--- a/packages/core/src/examples/split-mode-demo.ts
+++ b/packages/core/src/examples/split-mode-demo.ts
@@ -69,6 +69,7 @@ class SplitModeAnimations {
       borderColor: "#4a4a6a",
       title: "◆ SYSTEM MONITOR ◆",
       titleAlignment: "center",
+      border: true,
     })
     this.container.add(statusPanel)
 
@@ -99,7 +100,6 @@ class SplitModeAnimations {
         height: 1,
         backgroundColor: "#333333",
         zIndex: 1,
-        border: false,
       })
       this.container.add(bgBar)
 
@@ -111,7 +111,6 @@ class SplitModeAnimations {
         height: 1,
         backgroundColor: system.color,
         zIndex: 2,
-        border: false,
       })
       this.container.add(progressBar)
       this.systemLoadingBars.push(progressBar)
@@ -129,6 +128,7 @@ class SplitModeAnimations {
       borderColor: "#8a4a8a",
       title: "◇ REAL-TIME STATS ◇",
       titleAlignment: "center",
+      border: true,
     })
     this.container.add(statsPanel)
 
@@ -158,7 +158,6 @@ class SplitModeAnimations {
         height: 1,
         backgroundColor: color,
         zIndex: 3,
-        border: false,
       })
       this.container.add(orb)
       this.movingOrbs.push(orb)
@@ -175,7 +174,6 @@ class SplitModeAnimations {
         height: 1,
         backgroundColor: color,
         zIndex: 3,
-        border: false,
       })
       this.container.add(pulse)
       this.pulsingElements.push(pulse)

--- a/packages/core/src/examples/styled-text-demo.ts
+++ b/packages/core/src/examples/styled-text-demo.ts
@@ -89,6 +89,7 @@ ${bgYellow(fg("black")(" NOTICE "))} System update available`
     borderStyle: "single",
     title: "COMPLEX REAL-TIME DASHBOARD",
     titleAlignment: "center",
+    border: true,
   })
   parentContainer.add(dashboardBox)
 

--- a/packages/core/src/examples/text-selection-demo.ts
+++ b/packages/core/src/examples/text-selection-demo.ts
@@ -42,6 +42,7 @@ export function run(renderer: CliRenderer): void {
     borderColor: "#50565d",
     title: "Text Selection Demo",
     titleAlignment: "center",
+    border: true,
   })
   renderer.root.add(mainContainer)
 
@@ -62,6 +63,7 @@ export function run(renderer: CliRenderer): void {
     title: "Document Section 1",
     flexDirection: "column",
     padding: 1,
+    border: true,
   })
   leftGroup.add(box1)
 
@@ -98,6 +100,7 @@ export function run(renderer: CliRenderer): void {
     zIndex: 25,
     borderColor: "#a371f7",
     borderStyle: "double",
+    border: true,
   })
   leftGroup.add(nestedBox)
 
@@ -132,6 +135,7 @@ export function run(renderer: CliRenderer): void {
     borderStyle: "rounded",
     flexDirection: "column",
     padding: 1,
+    border: true,
   })
   rightGroup.add(box2)
 
@@ -178,6 +182,7 @@ export function run(renderer: CliRenderer): void {
     borderColor: "#2ea043",
     title: "README",
     borderStyle: "single",
+    border: true,
   })
   renderer.root.add(floatingBox)
 
@@ -215,6 +220,7 @@ ${green("✓")} Styled text support`,
     title: "Selection Status",
     titleAlignment: "left",
     padding: 1,
+    border: true,
   })
   renderer.root.add(statusBox)
 

--- a/packages/core/src/examples/timeline-example.ts
+++ b/packages/core/src/examples/timeline-example.ts
@@ -286,7 +286,6 @@ class TimelineExample {
         height: 1,
         backgroundColor: "#FFE66D",
         zIndex: 2,
-        border: false,
       })
       this.parentContainer.add(newMainProgressBox)
     }
@@ -303,7 +302,6 @@ class TimelineExample {
         height: 1,
         backgroundColor: "#FF6B6B",
         zIndex: 2,
-        border: false,
       })
       this.parentContainer.add(newSub1ProgressBox)
     }
@@ -320,7 +318,6 @@ class TimelineExample {
         height: 1,
         backgroundColor: "#4ECDC4",
         zIndex: 2,
-        border: false,
       })
       this.parentContainer.add(newSub2ProgressBox)
     }

--- a/packages/core/src/examples/transparency-demo.ts
+++ b/packages/core/src/examples/transparency-demo.ts
@@ -30,7 +30,6 @@ class DraggableTransparentBox extends BoxRenderable {
       height,
       zIndex,
       backgroundColor: bg,
-      border: false,
       titleAlignment: "center",
       position: "absolute",
       left: x,

--- a/packages/core/src/examples/transparency-demo.ts
+++ b/packages/core/src/examples/transparency-demo.ts
@@ -34,6 +34,7 @@ class DraggableTransparentBox extends BoxRenderable {
       position: "absolute",
       left: x,
       top: y,
+      border: true,
     })
     this.alphaPercentage = Math.round(bg.a * 100)
   }

--- a/packages/core/src/renderables/Box.ts
+++ b/packages/core/src/renderables/Box.ts
@@ -39,7 +39,7 @@ export class BoxRenderable extends Renderable {
   protected _defaultOptions = {
     backgroundColor: "transparent",
     borderStyle: "single",
-    border: true,
+    border: false,
     borderColor: "#FFFFFF",
     shouldFill: true,
     titleAlignment: "left",

--- a/packages/core/src/renderables/Box.ts
+++ b/packages/core/src/renderables/Box.ts
@@ -79,13 +79,10 @@ export class BoxRenderable extends Renderable {
   }
 
   public set backgroundColor(value: RGBA | string | undefined) {
-    let _value = value ?? this._defaultOptions.backgroundColor
-    if (_value) {
-      const newColor = parseColor(_value)
-      if (this._backgroundColor !== newColor) {
-        this._backgroundColor = newColor
-        this.needsUpdate()
-      }
+    const newColor = parseColor(value ?? this._defaultOptions.backgroundColor)
+    if (this._backgroundColor !== newColor) {
+      this._backgroundColor = newColor
+      this.needsUpdate()
     }
   }
 
@@ -120,8 +117,7 @@ export class BoxRenderable extends Renderable {
   }
 
   public set borderColor(value: RGBA | string) {
-    let _value = value ?? this._defaultOptions.borderColor
-    const newColor = parseColor(_value)
+    const newColor = parseColor(value ?? this._defaultOptions.borderColor)
     if (this._borderColor !== newColor) {
       this._borderColor = newColor
       this.needsUpdate()
@@ -133,8 +129,7 @@ export class BoxRenderable extends Renderable {
   }
 
   public set focusedBorderColor(value: RGBA | string) {
-    let _value = value ?? this._defaultOptions.focusedBorderColor
-    const newColor = parseColor(_value)
+    const newColor = parseColor(value ?? this._defaultOptions.focusedBorderColor)
     if (this._focusedBorderColor !== newColor) {
       this._focusedBorderColor = newColor
       if (this._focused) {

--- a/packages/core/src/renderables/Box.ts
+++ b/packages/core/src/renderables/Box.ts
@@ -1,15 +1,15 @@
+import { Edge } from "yoga-layout"
 import { type RenderableOptions, Renderable } from "../Renderable"
 import type { OptimizedBuffer } from "../buffer"
-import { RGBA, parseColor, type ColorInput } from "../lib/RGBA"
 import {
-  type BorderStyle,
-  type BorderSides,
   type BorderCharacters,
+  type BorderSides,
   type BorderSidesConfig,
-  getBorderSides,
+  type BorderStyle,
   borderCharsToArray,
+  getBorderSides,
 } from "../lib"
-import { Edge } from "yoga-layout"
+import { type ColorInput, RGBA, parseColor } from "../lib/RGBA"
 
 export interface BoxOptions extends RenderableOptions {
   backgroundColor?: string | RGBA
@@ -36,20 +36,30 @@ export class BoxRenderable extends Renderable {
   protected _title?: string
   protected _titleAlignment: "left" | "center" | "right"
 
+  protected _defaultOptions = {
+    backgroundColor: "transparent",
+    borderStyle: "single",
+    border: true,
+    borderColor: "#FFFFFF",
+    shouldFill: true,
+    titleAlignment: "left",
+    focusedBorderColor: "#00AAFF",
+  } satisfies Partial<BoxOptions>
+
   constructor(id: string, options: BoxOptions) {
     super(id, options)
 
-    this._backgroundColor = parseColor(options.backgroundColor || "transparent")
-    this._border = options.border ?? true
-    this._borderStyle = options.borderStyle || "single"
-    this._borderColor = parseColor(options.borderColor || "#FFFFFF")
-    this._focusedBorderColor = parseColor(options.focusedBorderColor || "#00AAFF")
+    this._backgroundColor = parseColor(options.backgroundColor || this._defaultOptions.backgroundColor)
+    this._border = options.border ?? this._defaultOptions.border
+    this._borderStyle = options.borderStyle || this._defaultOptions.borderStyle
+    this._borderColor = parseColor(options.borderColor || this._defaultOptions.borderColor)
+    this._focusedBorderColor = parseColor(options.focusedBorderColor || this._defaultOptions.focusedBorderColor)
     this._customBorderCharsObj = options.customBorderChars
     this._customBorderChars = this._customBorderCharsObj ? borderCharsToArray(this._customBorderCharsObj) : undefined
     this.borderSides = getBorderSides(this._border)
-    this.shouldFill = options.shouldFill ?? true
+    this.shouldFill = options.shouldFill ?? this._defaultOptions.shouldFill
     this._title = options.title
-    this._titleAlignment = options.titleAlignment || "left"
+    this._titleAlignment = options.titleAlignment || this._defaultOptions.titleAlignment
 
     this.applyYogaBorders()
   }
@@ -69,8 +79,9 @@ export class BoxRenderable extends Renderable {
   }
 
   public set backgroundColor(value: RGBA | string | undefined) {
-    if (value) {
-      const newColor = parseColor(value)
+    let _value = value ?? this._defaultOptions.backgroundColor
+    if (_value) {
+      const newColor = parseColor(_value)
       if (this._backgroundColor !== newColor) {
         this._backgroundColor = newColor
         this.needsUpdate()
@@ -96,8 +107,9 @@ export class BoxRenderable extends Renderable {
   }
 
   public set borderStyle(value: BorderStyle) {
-    if (this._borderStyle !== value) {
-      this._borderStyle = value
+    let _value = value ?? this._defaultOptions.borderStyle
+    if (this._borderStyle !== _value) {
+      this._borderStyle = _value
       this._customBorderChars = undefined
       this.needsUpdate()
     }
@@ -108,7 +120,8 @@ export class BoxRenderable extends Renderable {
   }
 
   public set borderColor(value: RGBA | string) {
-    const newColor = parseColor(value)
+    let _value = value ?? this._defaultOptions.borderColor
+    const newColor = parseColor(_value)
     if (this._borderColor !== newColor) {
       this._borderColor = newColor
       this.needsUpdate()
@@ -120,7 +133,8 @@ export class BoxRenderable extends Renderable {
   }
 
   public set focusedBorderColor(value: RGBA | string) {
-    const newColor = parseColor(value)
+    let _value = value ?? this._defaultOptions.focusedBorderColor
+    const newColor = parseColor(_value)
     if (this._focusedBorderColor !== newColor) {
       this._focusedBorderColor = newColor
       if (this._focused) {

--- a/packages/core/src/renderables/Input.ts
+++ b/packages/core/src/renderables/Input.ts
@@ -281,68 +281,50 @@ export class InputRenderable extends Renderable {
   }
 
   public set backgroundColor(value: ColorInput) {
-    let _value = value ?? this._defaultOptions.backgroundColor
-    if (_value) {
-      const newColor = parseColor(_value)
-      if (this._backgroundColor !== newColor) {
-        this._backgroundColor = newColor
-        this.needsUpdate()
-      }
+    const newColor = parseColor(value ?? this._defaultOptions.backgroundColor)
+    if (this._backgroundColor !== newColor) {
+      this._backgroundColor = newColor
+      this.needsUpdate()
     }
   }
 
   public set textColor(value: ColorInput) {
-    let _value = value ?? this._defaultOptions.textColor
-    if (_value) {
-      const newColor = parseColor(_value)
-      if (this._textColor !== newColor) {
-        this._textColor = newColor
-        this.needsUpdate()
-      }
+    const newColor = parseColor(value ?? this._defaultOptions.textColor)
+    if (this._textColor !== newColor) {
+      this._textColor = newColor
+      this.needsUpdate()
     }
   }
 
   public set focusedBackgroundColor(value: ColorInput) {
-    let _value = value ?? this._defaultOptions.focusedBackgroundColor
-    if (_value) {
-      const newColor = parseColor(_value)
-      if (this._focusedBackgroundColor !== newColor) {
-        this._focusedBackgroundColor = newColor
-        this.needsUpdate()
-      }
+    const newColor = parseColor(value ?? this._defaultOptions.focusedBackgroundColor)
+    if (this._focusedBackgroundColor !== newColor) {
+      this._focusedBackgroundColor = newColor
+      this.needsUpdate()
     }
   }
 
   public set focusedTextColor(value: ColorInput) {
-    let _value = value ?? this._defaultOptions.focusedTextColor
-    if (_value) {
-      const newColor = parseColor(_value)
-      if (this._focusedTextColor !== newColor) {
-        this._focusedTextColor = newColor
-        this.needsUpdate()
-      }
+    const newColor = parseColor(value ?? this._defaultOptions.focusedTextColor)
+    if (this._focusedTextColor !== newColor) {
+      this._focusedTextColor = newColor
+      this.needsUpdate()
     }
   }
 
   public set placeholderColor(value: ColorInput) {
-    let _value = value ?? this._defaultOptions.placeholderColor
-    if (_value) {
-      const newColor = parseColor(_value)
-      if (this._placeholderColor !== newColor) {
-        this._placeholderColor = newColor
-        this.needsUpdate()
-      }
+    const newColor = parseColor(value ?? this._defaultOptions.placeholderColor)
+    if (this._placeholderColor !== newColor) {
+      this._placeholderColor = newColor
+      this.needsUpdate()
     }
   }
 
   public set cursorColor(value: ColorInput) {
-    let _value = value ?? this._defaultOptions.cursorColor
-    if (_value) {
-      const newColor = parseColor(_value)
-      if (this._cursorColor !== newColor) {
-        this._cursorColor = newColor
-        this.needsUpdate()
-      }
+    const newColor = parseColor(value ?? this._defaultOptions.cursorColor)
+    if (this._cursorColor !== newColor) {
+      this._cursorColor = newColor
+      this.needsUpdate()
     }
   }
 

--- a/packages/core/src/renderables/Input.ts
+++ b/packages/core/src/renderables/Input.ts
@@ -1,8 +1,8 @@
 import { CliRenderer } from ".."
-import { Renderable, type RenderableOptions } from "../Renderable"
 import { OptimizedBuffer } from "../buffer"
 import type { ParsedKey } from "../lib/parse.keypress"
 import { RGBA, parseColor, type ColorInput } from "../lib/RGBA"
+import { Renderable, type RenderableOptions } from "../Renderable"
 
 export interface InputRenderableOptions extends RenderableOptions {
   backgroundColor?: ColorInput
@@ -38,21 +38,37 @@ export class InputRenderable extends Renderable {
   private _maxLength: number
   private _lastCommittedValue: string = ""
 
+  protected _defaultOptions = {
+    backgroundColor: "transparent",
+    textColor: "#FFFFFF",
+    focusedBackgroundColor: "#1a1a1a",
+    focusedTextColor: "#FFFFFF",
+    placeholder: "",
+    placeholderColor: "#666666",
+    cursorColor: "#FFFFFF",
+    maxLength: 1000,
+    value: "",
+  } satisfies Partial<InputRenderableOptions>
+
   constructor(id: string, options: InputRenderableOptions) {
     super(id, { ...options, buffered: true })
 
-    this._backgroundColor = parseColor(options.backgroundColor || "transparent")
-    this._textColor = parseColor(options.textColor || "#FFFFFF")
-    this._focusedBackgroundColor = parseColor(options.focusedBackgroundColor || options.backgroundColor || "#1a1a1a")
-    this._focusedTextColor = parseColor(options.focusedTextColor || options.textColor || "#FFFFFF")
-    this._placeholder = options.placeholder || ""
-    this._value = options.value || ""
+    this._backgroundColor = parseColor(options.backgroundColor || this._defaultOptions.backgroundColor)
+    this._textColor = parseColor(options.textColor || this._defaultOptions.textColor)
+    this._focusedBackgroundColor = parseColor(
+      options.focusedBackgroundColor || options.backgroundColor || this._defaultOptions.focusedBackgroundColor,
+    )
+    this._focusedTextColor = parseColor(
+      options.focusedTextColor || options.textColor || this._defaultOptions.focusedTextColor,
+    )
+    this._placeholder = options.placeholder || this._defaultOptions.placeholder
+    this._value = options.value || this._defaultOptions.value
     this._lastCommittedValue = this._value
     this._cursorPosition = this._value.length
-    this._maxLength = options.maxLength || 1000
+    this._maxLength = options.maxLength || this._defaultOptions.maxLength
 
-    this._placeholderColor = parseColor(options.placeholderColor || "#666666")
-    this._cursorColor = parseColor(options.cursorColor || "#FFFFFF")
+    this._placeholderColor = parseColor(options.placeholderColor || this._defaultOptions.placeholderColor)
+    this._cursorColor = parseColor(options.cursorColor || this._defaultOptions.cursorColor)
   }
 
   private updateCursorPosition(): void {
@@ -264,34 +280,70 @@ export class InputRenderable extends Renderable {
     }
   }
 
-  public set backgroundColor(color: ColorInput) {
-    this._backgroundColor = parseColor(color)
-    this.needsUpdate()
+  public set backgroundColor(value: ColorInput) {
+    let _value = value ?? this._defaultOptions.backgroundColor
+    if (_value) {
+      const newColor = parseColor(_value)
+      if (this._backgroundColor !== newColor) {
+        this._backgroundColor = newColor
+        this.needsUpdate()
+      }
+    }
   }
 
-  public set textColor(color: ColorInput) {
-    this._textColor = parseColor(color)
-    this.needsUpdate()
+  public set textColor(value: ColorInput) {
+    let _value = value ?? this._defaultOptions.textColor
+    if (_value) {
+      const newColor = parseColor(_value)
+      if (this._textColor !== newColor) {
+        this._textColor = newColor
+        this.needsUpdate()
+      }
+    }
   }
 
-  public set focusedBackgroundColor(color: ColorInput) {
-    this._focusedBackgroundColor = parseColor(color)
-    this.needsUpdate()
+  public set focusedBackgroundColor(value: ColorInput) {
+    let _value = value ?? this._defaultOptions.focusedBackgroundColor
+    if (_value) {
+      const newColor = parseColor(_value)
+      if (this._focusedBackgroundColor !== newColor) {
+        this._focusedBackgroundColor = newColor
+        this.needsUpdate()
+      }
+    }
   }
 
-  public set focusedTextColor(color: ColorInput) {
-    this._focusedTextColor = parseColor(color)
-    this.needsUpdate()
+  public set focusedTextColor(value: ColorInput) {
+    let _value = value ?? this._defaultOptions.focusedTextColor
+    if (_value) {
+      const newColor = parseColor(_value)
+      if (this._focusedTextColor !== newColor) {
+        this._focusedTextColor = newColor
+        this.needsUpdate()
+      }
+    }
   }
 
-  public set placeholderColor(color: ColorInput) {
-    this._placeholderColor = parseColor(color)
-    this.needsUpdate()
+  public set placeholderColor(value: ColorInput) {
+    let _value = value ?? this._defaultOptions.placeholderColor
+    if (_value) {
+      const newColor = parseColor(_value)
+      if (this._placeholderColor !== newColor) {
+        this._placeholderColor = newColor
+        this.needsUpdate()
+      }
+    }
   }
 
-  public set cursorColor(color: ColorInput) {
-    this._cursorColor = parseColor(color)
-    this.needsUpdate()
+  public set cursorColor(value: ColorInput) {
+    let _value = value ?? this._defaultOptions.cursorColor
+    if (_value) {
+      const newColor = parseColor(_value)
+      if (this._cursorColor !== newColor) {
+        this._cursorColor = newColor
+        this.needsUpdate()
+      }
+    }
   }
 
   public updateFromLayout(): void {

--- a/packages/react/examples/ascii.tsx
+++ b/packages/react/examples/ascii.tsx
@@ -17,6 +17,7 @@ export const App = () => {
         style={{
           height: 8,
           marginBottom: 1,
+          border: true,
         }}
       >
         <select

--- a/packages/react/examples/basic.tsx
+++ b/packages/react/examples/basic.tsx
@@ -47,7 +47,7 @@ export const App = () => {
       />
       <text content={t`${bold(italic(fg("cyan")(`Styled Text!`)))}`} />
 
-      <box title="Username" style={{ width: 40, height: 3, marginTop: 1 }}>
+      <box title="Username" style={{ border: true, width: 40, height: 3, marginTop: 1 }}>
         <input
           placeholder="Enter your username..."
           onInput={handleUsernameChange}
@@ -57,7 +57,7 @@ export const App = () => {
         />
       </box>
 
-      <box title="Password" style={{ width: 40, height: 3, marginTop: 1, marginBottom: 1 }}>
+      <box title="Password" style={{ border: true, width: 40, height: 3, marginTop: 1, marginBottom: 1 }}>
         <input
           placeholder="Enter your password..."
           onInput={handlePasswordChange}

--- a/packages/react/examples/borders.tsx
+++ b/packages/react/examples/borders.tsx
@@ -4,16 +4,16 @@ export const App = () => {
   return (
     <>
       <group flexDirection="row">
-        <box borderStyle="single">
+        <box border borderStyle="single">
           <text content="Single" />
         </box>
-        <box borderStyle="double">
+        <box border borderStyle="double">
           <text content="Double" />
         </box>
-        <box borderStyle="rounded">
+        <box border borderStyle="rounded">
           <text content="Rounded" />
         </box>
-        <box borderStyle="heavy">
+        <box border borderStyle="heavy">
           <text content="Heavy" />
         </box>
       </group>

--- a/packages/react/examples/box.tsx
+++ b/packages/react/examples/box.tsx
@@ -5,29 +5,29 @@ export const App = () => {
     <>
       <group flexDirection="column">
         <text attributes={1} content="Box Examples" />
-        <box>
+        <box border>
           <text content="1. Standard Box" />
         </box>
-        <box title="Title">
+        <box border title="Title">
           <text content="2. Box with Title" />
         </box>
-        <box backgroundColor="blue">
+        <box border backgroundColor="blue">
           <text content="3. Box with Background Color" />
         </box>
-        <box padding={1}>
+        <box border padding={1}>
           <text content="4. Box with Padding" />
         </box>
-        <box margin={1}>
+        <box border margin={1}>
           <text content="5. Box with Margin" />
         </box>
-        <box alignItems="center">
+        <box border alignItems="center">
           <text content="6. Centered Text" />
         </box>
-        <box justifyContent="center" height={5}>
+        <box border justifyContent="center" height={5}>
           <text content="7. Justified Center" />
         </box>
-        <box title="Nested Boxes" backgroundColor="red">
-          <box backgroundColor="blue">
+        <box border title="Nested Boxes" backgroundColor="red">
+          <box border backgroundColor="blue">
             <text content="8. Nested Box" />
           </box>
         </box>

--- a/packages/react/examples/extend-example.tsx
+++ b/packages/react/examples/extend-example.tsx
@@ -52,6 +52,7 @@ export function ExtendExample() {
     <consoleButton
       label="Another Button"
       style={{
+        border: true,
         backgroundColor: "green",
       }}
     />

--- a/packages/solid/examples/components/ExampleSelector.tsx
+++ b/packages/solid/examples/components/ExampleSelector.tsx
@@ -110,7 +110,7 @@ const ExampleSelector = () => {
         <TabSelectDemo />
       </Match>
       <Match when={selected() === -1}>
-        <box style={{ height: terminalDimensions().height, backgroundColor: "#001122", padding: 1 }}>
+        <box style={{ height: terminalDimensions().height, backgroundColor: "#001122", padding: 1, border: true }}>
           <group alignItems="center">
             <ascii_font
               style={{
@@ -128,6 +128,7 @@ const ExampleSelector = () => {
           <box
             title="Examples"
             style={{
+              border: true,
               flexGrow: 1,
               marginTop: 1,
               borderStyle: "single",

--- a/packages/solid/examples/components/ExampleSelector.tsx
+++ b/packages/solid/examples/components/ExampleSelector.tsx
@@ -110,7 +110,7 @@ const ExampleSelector = () => {
         <TabSelectDemo />
       </Match>
       <Match when={selected() === -1}>
-        <box style={{ height: terminalDimensions().height, backgroundColor: "#001122", padding: 1, border: true }}>
+        <box style={{ height: terminalDimensions().height, backgroundColor: "#001122", padding: 1 }}>
           <group alignItems="center">
             <ascii_font
               style={{

--- a/packages/solid/examples/components/ExampleSelector.tsx
+++ b/packages/solid/examples/components/ExampleSelector.tsx
@@ -110,7 +110,7 @@ const ExampleSelector = () => {
         <TabSelectDemo />
       </Match>
       <Match when={selected() === -1}>
-        <box style={{ height: terminalDimensions().height, backgroundColor: "#001122", border: false, padding: 1 }}>
+        <box style={{ height: terminalDimensions().height, backgroundColor: "#001122", padding: 1 }}>
           <group alignItems="center">
             <ascii_font
               style={{

--- a/packages/solid/examples/components/animation-demo.tsx
+++ b/packages/solid/examples/components/animation-demo.tsx
@@ -76,7 +76,6 @@ export const SplitModeDemo = () => {
                   height: 1,
                   backgroundColor: "#333333",
                   zIndex: 1,
-                  border: false,
                   flexGrow: 1,
                 }}
               >
@@ -86,7 +85,6 @@ export const SplitModeDemo = () => {
                     height: 1,
                     backgroundColor: system.color,
                     zIndex: 2,
-                    border: false,
                   }}
                 />
               </box>
@@ -139,7 +137,6 @@ export const SplitModeDemo = () => {
               height: 1,
               backgroundColor: color,
               zIndex: 3,
-              border: false,
             }}
           />
         )}
@@ -156,7 +153,6 @@ export const SplitModeDemo = () => {
               height: 1,
               backgroundColor: color,
               zIndex: 3,
-              border: false,
             }}
           />
         )}

--- a/packages/solid/examples/components/animation-demo.tsx
+++ b/packages/solid/examples/components/animation-demo.tsx
@@ -77,6 +77,7 @@ export const SplitModeDemo = () => {
                   backgroundColor: "#333333",
                   zIndex: 1,
                   flexGrow: 1,
+                  border: true,
                 }}
               >
                 <box
@@ -85,6 +86,7 @@ export const SplitModeDemo = () => {
                     height: 1,
                     backgroundColor: system.color,
                     zIndex: 2,
+                    border: true,
                   }}
                 />
               </box>
@@ -137,6 +139,7 @@ export const SplitModeDemo = () => {
               height: 1,
               backgroundColor: color,
               zIndex: 3,
+              border: true,
             }}
           />
         )}
@@ -153,6 +156,7 @@ export const SplitModeDemo = () => {
               height: 1,
               backgroundColor: color,
               zIndex: 3,
+              border: true,
             }}
           />
         )}

--- a/packages/solid/examples/components/animation-demo.tsx
+++ b/packages/solid/examples/components/animation-demo.tsx
@@ -77,7 +77,6 @@ export const SplitModeDemo = () => {
                   backgroundColor: "#333333",
                   zIndex: 1,
                   flexGrow: 1,
-                  border: true,
                 }}
               >
                 <box
@@ -86,7 +85,6 @@ export const SplitModeDemo = () => {
                     height: 1,
                     backgroundColor: system.color,
                     zIndex: 2,
-                    border: true,
                   }}
                 />
               </box>
@@ -139,7 +137,6 @@ export const SplitModeDemo = () => {
               height: 1,
               backgroundColor: color,
               zIndex: 3,
-              border: true,
             }}
           />
         )}
@@ -156,7 +153,6 @@ export const SplitModeDemo = () => {
               height: 1,
               backgroundColor: color,
               zIndex: 3,
-              border: true,
             }}
           />
         )}

--- a/packages/solid/examples/components/input-demo.tsx
+++ b/packages/solid/examples/components/input-demo.tsx
@@ -10,7 +10,7 @@ const InputScene = () => {
   const [nameValue, setNameValue] = createSignal("")
 
   return (
-    <box height={4}>
+    <box height={4} border>
       <text>Name: {nameValue()}</text>
       <input focused onInput={(value) => setNameValue(value)} />
     </box>

--- a/packages/solid/examples/components/mouse-demo.tsx
+++ b/packages/solid/examples/components/mouse-demo.tsx
@@ -22,7 +22,6 @@ class DraggableTransparentBox extends BoxRenderable {
       height,
       zIndex,
       backgroundColor: bg,
-      border: false,
       titleAlignment: "center",
       position: "absolute",
       left: x,

--- a/packages/solid/examples/components/mouse-demo.tsx
+++ b/packages/solid/examples/components/mouse-demo.tsx
@@ -26,6 +26,7 @@ class DraggableTransparentBox extends BoxRenderable {
       position: "absolute",
       left: x,
       top: y,
+      border: true,
     })
     this.alphaPercentage = Math.round(bg.a * 100)
   }

--- a/packages/solid/examples/components/text-selection-demo.tsx
+++ b/packages/solid/examples/components/text-selection-demo.tsx
@@ -83,6 +83,7 @@ export default function TextSelectionDemo() {
           zIndex: 1,
           borderColor: "#50565d",
           titleAlignment: "center",
+          border: true,
         }}
         title="Text Selection Demo"
       >
@@ -103,6 +104,7 @@ export default function TextSelectionDemo() {
               borderColor: "#58a6ff",
               flexDirection: "column",
               padding: 1,
+              border: true,
             }}
             title="Document Section 1"
           >
@@ -120,6 +122,7 @@ export default function TextSelectionDemo() {
               zIndex: 25,
               borderColor: "#a371f7",
               borderStyle: "double",
+              border: true,
             }}
           >
             <text style={{ width: 27, height: 1, zIndex: 26, selectionBg: "#4a5568", selectionFg: "#ffffff" }}>
@@ -147,6 +150,7 @@ export default function TextSelectionDemo() {
               borderStyle: "rounded",
               flexDirection: "column",
               padding: 1,
+              border: true,
             }}
             title="Code Example"
           >
@@ -179,6 +183,7 @@ export default function TextSelectionDemo() {
           zIndex: 30,
           borderColor: "#2ea043",
           borderStyle: "single",
+          border: true,
         }}
         title="README"
       >
@@ -204,6 +209,7 @@ export default function TextSelectionDemo() {
           borderColor: "#50565d",
           titleAlignment: "left",
           padding: 1,
+          border: true,
         }}
         title="Selection Status"
       >

--- a/packages/solid/examples/components/text-style-demo.tsx
+++ b/packages/solid/examples/components/text-style-demo.tsx
@@ -25,7 +25,7 @@ export default function TextStyleScene() {
         And {bold("chunk arrays")} work {fg("#ff8c00")("as welll")}!! {italic(underline(`${counter()}`))}
       </text>
       You do not need to have a text node {counter()} as a parent when dealing with text {counter()}
-      <box>
+      <box border>
         {counter()} Mix in some {bold("more text")} {counter()}
       </box>
     </group>


### PR DESCRIPTION
## Description

- this largely covers color properties as others either respect undefined when passed or undefined is absurd 
- sets `border` to false by default on `box` renderable