### PR TITLE
Move babel packages from dev dependencies to dependencies

### DIFF
--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -33,14 +33,14 @@
   },
   "devDependencies": {
     "@types/babel__core": "7.20.5",
-    "babel-plugin-module-resolver": "5.0.2",
-    "@babel/core": "7.28.0",
-    "@babel/preset-typescript": "7.27.1",
-    "babel-preset-solid": "1.9.9",
     "@types/bun": "latest"
   },
   "dependencies": {
-    "@opentui/core": "workspace:*"
+    "@opentui/core": "workspace:*",
+    "babel-plugin-module-resolver": "5.0.2",
+    "@babel/core": "7.28.0",
+    "@babel/preset-typescript": "7.27.1",
+    "babel-preset-solid": "1.9.9"
   },
   "peerDependencies": {
     "solid-js": "1.9.9",


### PR DESCRIPTION
Adresses #79 

Moves babel packages from dev dependencies to dependencies so that they install automatically. 
Should be moved out to create-opentui-app once that is setup.