### PR TITLE
fix(core): recalculate height

### DIFF
--- a/packages/core/src/renderables/Text.ts
+++ b/packages/core/src/renderables/Text.ts
@@ -129,7 +129,7 @@ export class TextRenderable extends Renderable {
     this._lineInfo.lineWidths = lineInfo.lineWidths
 
     const numLines = this._lineInfo.lineStarts.length
-    if (this._positionType === "absolute" && this._height === "auto") {
+    if (this._height === "auto") {
       this._heightValue = numLines
       this.layoutNode.yogaNode.markDirty()
     }


### PR DESCRIPTION
# Description

- there's a user reported bug that found when multiline text was updated after initial render only the first line is displayed! investigations point me to the height not recalculating 

# Reproduction

```tsx
import { type TextRenderable } from "@opentui/core"
import { render } from "@opentui/react"
import { useEffect, useState } from "react"

export const App = () => {
  const [output, setOutput] = useState("")

  useEffect(() => {
    setTimeout(() => {
      setOutput(`First line
Second line
Third line
`)
    }, 500)
  }, [])

  return <text>{output}</text>
}

void render(<App />)

```