### PR TITLE
Migrate to zig 0.15.1

### DIFF
--- a/packages/core/scripts/build.ts
+++ b/packages/core/scripts/build.ts
@@ -78,11 +78,13 @@ if (missingRequired.length > 0) {
   process.exit(1)
 }
 
+const zigExe = process.env.ZIG ?? "zig"
+
 if (buildNative) {
   console.log(`Building native ${isDev ? "dev" : "prod"} binaries...`)
 
   const zigBuild: SpawnSyncReturns<Buffer> = spawnSync(
-    "zig",
+    zigExe,
     ["build", `-Doptimize=${isDev ? "Debug" : "ReleaseFast"}`],
     {
       cwd: join(rootDir, "src", "zig"),

--- a/packages/core/src/zig/ansi.zig
+++ b/packages/core/src/zig/ansi.zig
@@ -19,15 +19,15 @@ pub const ANSI = struct {
 
     // Direct writing to any writer - the most efficient option
     pub fn moveToOutput(writer: anytype, x: u32, y: u32) AnsiError!void {
-        std.fmt.format(writer, "\x1b[{d};{d}H", .{ y, x }) catch return AnsiError.WriteFailed;
+        writer.print("\x1b[{d};{d}H", .{ y, x }) catch return AnsiError.WriteFailed;
     }
 
     pub fn fgColorOutput(writer: anytype, r: u8, g: u8, b: u8) AnsiError!void {
-        std.fmt.format(writer, "\x1b[38;2;{d};{d};{d}m", .{ r, g, b }) catch return AnsiError.WriteFailed;
+        writer.print("\x1b[38;2;{d};{d};{d}m", .{ r, g, b }) catch return AnsiError.WriteFailed;
     }
 
     pub fn bgColorOutput(writer: anytype, r: u8, g: u8, b: u8) AnsiError!void {
-        std.fmt.format(writer, "\x1b[48;2;{d};{d};{d}m", .{ r, g, b }) catch return AnsiError.WriteFailed;
+        writer.print("\x1b[48;2;{d};{d};{d}m", .{ r, g, b }) catch return AnsiError.WriteFailed;
     }
 
     // Text attribute constants
@@ -49,7 +49,7 @@ pub const ANSI = struct {
     pub const cursorUnderlineBlink = "\x1b[3 q";
 
     pub fn cursorColorOutputWriter(writer: anytype, r: u8, g: u8, b: u8) AnsiError!void {
-        std.fmt.format(writer, "\x1b]12;#{x:0>2}{x:0>2}{x:0>2}\x07", .{ r, g, b }) catch return AnsiError.WriteFailed;
+        writer.print("\x1b]12;#{x:0>2}{x:0>2}{x:0>2}\x07", .{ r, g, b }) catch return AnsiError.WriteFailed;
     }
 
     pub const resetCursorColor = "\x1b]12;default\x07";
@@ -73,7 +73,7 @@ pub const ANSI = struct {
         // This approach is more compatible across different terminals
         var i: u32 = height;
         while (i > 0) : (i -= 1) {
-            std.fmt.format(writer, "\x1b[{d};1H\x1b[2K", .{i}) catch return AnsiError.WriteFailed;
+            writer.print("\x1b[{d};1H\x1b[2K", .{i}) catch return AnsiError.WriteFailed;
         }
     }
 };

--- a/packages/core/src/zig/buffer.zig
+++ b/packages/core/src/zig/buffer.zig
@@ -367,7 +367,7 @@ pub const OptimizedBuffer = struct {
         while (utf8_it.nextCodepoint()) |codepoint| : (i += 1) {
             const charX = x + i;
             if (charX >= self.width) break;
-            
+
             // Use provided background or get existing background
             var bgColor: RGBA = undefined;
             if (bg) |b| {

--- a/packages/core/src/zig/build.zig
+++ b/packages/core/src/zig/build.zig
@@ -8,9 +8,7 @@ const SupportedZigVersion = struct {
 };
 
 const SUPPORTED_ZIG_VERSIONS = [_]SupportedZigVersion{
-    .{ .major = 0, .minor = 14, .patch = 0 },
-    .{ .major = 0, .minor = 14, .patch = 1 },
-    // .{ .major = 0, .minor = 15, .patch = 0 },
+    .{ .major = 0, .minor = 15, .patch = 1 },
 };
 
 const SupportedTarget = struct {


### PR DESCRIPTION
Also includes a small change to the build script which allows setting the Zig compiler with the ZIG environment variable, as this makes it much easier than needing to change your PATH back and forth when testing different versions of zig.

Migrates:  
std.fmt.format -> std.Io.Writer.print  
std.ArrayList -> std.ArrayListUnmanaged (while std.array_list.Managed does exist and should be the same as the old ArrayList, the managed options will be removed in the future, so I thought might as well bite the bullet and use the Unmanaged versions as is recommended)  
CliRenderer.addStatSample to a method instead of a function so that it can use self.allocator for the unmanaged arraylist it now uses  
Removes the use of bufferedWriter and now just stores the buffer and constructs the stdout writer as needed.  

One consideration is the use of the std.io.GenericWriter in the CliRenderer.writer return type, this is technically deprecated, but as far as I can tell, the other options requires a much larger refactoring, so I have marked it as a TODO, however you may want to just hold out on moving to Zig 0.15 and migrate it properly at the same time as upgrading the toolchain version instead.

With these changes I also seem to get faster speeds from the src/benchmark/renderer-benchmark.ts, though unsure why that is or whether it is a fluke.  
Before:
<img width="418" height="316" alt="image" src="https://github.com/user-attachments/assets/b42962e4-6738-4b57-b347-e3ec43b2f2a4" />
After:
<img width="418" height="316" alt="image" src="https://github.com/user-attachments/assets/887e0a31-d5f6-467d-b627-fa41682f27c2" />
