### PR TITLE
Almost full unicode

### DIFF
--- a/packages/core/src/benchmark/renderer-benchmark.ts
+++ b/packages/core/src/benchmark/renderer-benchmark.ts
@@ -88,7 +88,8 @@ const renderer = await createCliRenderer({
 const WIDTH = renderer.terminalWidth
 const HEIGHT = renderer.terminalHeight
 
-const fbRenderable = new FrameBufferRenderable("main", {
+const fbRenderable = new FrameBufferRenderable(renderer, {
+  id: "main",
   width: WIDTH,
   height: HEIGHT,
   zIndex: 10,
@@ -158,19 +159,22 @@ engine.setActiveCamera(cameraNode)
 
 const TEST_CUBE_COUNT = 300
 
-const uiContainer = new GroupRenderable("ui-container", {
+const uiContainer = new GroupRenderable(renderer, {
+  id: "ui-container",
   zIndex: 15,
   visible: true,
 })
 renderer.root.add(uiContainer)
 
-const benchmarkStatus = new TextRenderable("benchmark", {
+const benchmarkStatus = new TextRenderable(renderer, {
+  id: "benchmark",
   content: "Initializing benchmark...",
   zIndex: 20,
 })
 uiContainer.add(benchmarkStatus)
 
-const cubeCountStatus = new TextRenderable("cube-count", {
+const cubeCountStatus = new TextRenderable(renderer, {
+  id: "cube-count",
   content: `Test cubes outside view: ${TEST_CUBE_COUNT}`,
   position: "absolute",
   left: 0,
@@ -180,7 +184,8 @@ const cubeCountStatus = new TextRenderable("cube-count", {
 uiContainer.add(cubeCountStatus)
 
 if (options.debug) {
-  const debugStatus = new TextRenderable("debug", {
+  const debugStatus = new TextRenderable(renderer, {
+    id: "debug",
     content: `Culling: ${options.culling !== false ? "ON" : "OFF"}`,
     position: "absolute",
     left: 0,
@@ -536,7 +541,8 @@ function getScenarioName(scenario: BenchmarkScenario): string {
 }
 
 function displayBenchmarkResults(): void {
-  const resultsBox = new BoxRenderable("results-box", {
+  const resultsBox = new BoxRenderable(renderer, {
+    id: "results-box",
     position: "absolute",
     left: Math.floor(WIDTH / 6),
     top: Math.floor(HEIGHT / 6),
@@ -547,7 +553,8 @@ function displayBenchmarkResults(): void {
   })
   uiContainer.add(resultsBox)
 
-  const resultsTitle = new TextRenderable("results-title", {
+  const resultsTitle = new TextRenderable(renderer, {
+    id: "results-title",
     position: "absolute",
     left: Math.floor(WIDTH / 6) + 2,
     top: Math.floor(HEIGHT / 6) + 1,
@@ -558,7 +565,8 @@ function displayBenchmarkResults(): void {
   let y = Math.floor(HEIGHT / 6) + 3
   for (let i = 0; i < results.length; i++) {
     const result = results[i]
-    const resultHeader = new TextRenderable(`result-header-${i}`, {
+    const resultHeader = new TextRenderable(renderer, {
+      id: `result-header-${i}`,
       position: "absolute",
       left: Math.floor(WIDTH / 6) + 2,
       top: y++,
@@ -573,7 +581,8 @@ function displayBenchmarkResults(): void {
       `  • Standard Deviation: ${result.stdDev.toFixed(2)}ms`,
     ]
     for (let j = 0; j < statLines.length; j++) {
-      const statText = new TextRenderable(`result-stat-${i}-${j}`, {
+      const statText = new TextRenderable(renderer, {
+        id: `result-stat-${i}-${j}`,
         position: "absolute",
         left: Math.floor(WIDTH / 6) + 2,
         top: y + j,
@@ -612,7 +621,8 @@ function displayBenchmarkResults(): void {
         `    (min: ${(minAB / 1024 / 1024).toFixed(2)}MB, max: ${(maxAB / 1024 / 1024).toFixed(2)}MB, median: ${(medianAB / 1024 / 1024).toFixed(2)}MB)`,
       ]
       for (let j = 0; j < memStatLines.length; j++) {
-        const memStatText = new TextRenderable(`result-mem-stat-${i}-${j}`, {
+        const memStatText = new TextRenderable(renderer, {
+          id: `result-mem-stat-${i}-${j}`,
           position: "absolute",
           left: Math.floor(WIDTH / 6) + 2,
           top: y + j,
@@ -626,7 +636,8 @@ function displayBenchmarkResults(): void {
     y++
   }
   if (results.length > 1) {
-    const comparisonTitle = new TextRenderable("results-comparison", {
+    const comparisonTitle = new TextRenderable(renderer, {
+      id: "results-comparison",
       position: "absolute",
       left: Math.floor(WIDTH / 6) + 2,
       top: y++,
@@ -641,7 +652,8 @@ function displayBenchmarkResults(): void {
       const ratio = currentPerf / basePerf
       const percent = ((ratio - 1) * 100).toFixed(1)
       const compareText = `  • ${results[i].name}: ${ratio > 1 ? "+" : ""}${percent}% frame time vs. baseline`
-      const compareTextObj = new TextRenderable(`result-compare-${i}`, {
+      const compareTextObj = new TextRenderable(renderer, {
+        id: `result-compare-${i}`,
         position: "absolute",
         left: Math.floor(WIDTH / 6) + 2,
         top: y++,
@@ -652,7 +664,8 @@ function displayBenchmarkResults(): void {
     }
   }
 
-  const resultsFooter = new TextRenderable("results-footer", {
+  const resultsFooter = new TextRenderable(renderer, {
+    id: "results-footer",
     position: "absolute",
     left: Math.floor(WIDTH / 6) + 2,
     top: Math.floor((HEIGHT * 5) / 6) - 2,

--- a/packages/core/src/buffer.ts
+++ b/packages/core/src/buffer.ts
@@ -3,6 +3,7 @@ import { RGBA } from "./lib"
 import { resolveRenderLib, type RenderLib } from "./zig"
 import { type Pointer } from "bun:ffi"
 import { type BorderStyle, type BorderSides, type BorderCharacters, BorderCharArrays, borderCharsToArray } from "./lib"
+import { type WidthMethod } from "./types"
 
 function isRGBAWithAlpha(color: RGBA): boolean {
   return color.a < 1.0
@@ -110,10 +111,15 @@ export class OptimizedBuffer {
     this.buffer = buffer
   }
 
-  static create(width: number, height: number, options: { respectAlpha?: boolean } = {}): OptimizedBuffer {
+  static create(
+    width: number,
+    height: number,
+    widthMethod: WidthMethod,
+    options: { respectAlpha?: boolean } = {},
+  ): OptimizedBuffer {
     const lib = resolveRenderLib()
     const respectAlpha = options.respectAlpha || false
-    return lib.createOptimizedBuffer(width, height, respectAlpha)
+    return lib.createOptimizedBuffer(width, height, widthMethod, respectAlpha)
   }
 
   public get buffers(): {

--- a/packages/core/src/console.ts
+++ b/packages/core/src/console.ts
@@ -561,7 +561,7 @@ export class TerminalConsole extends EventEmitter {
       terminalConsoleCache.setCachingEnabled(false)
 
       if (!this.frameBuffer) {
-        this.frameBuffer = OptimizedBuffer.create(this.consoleWidth, this.consoleHeight, {
+        this.frameBuffer = OptimizedBuffer.create(this.consoleWidth, this.consoleHeight, this.renderer.widthMethod, {
           respectAlpha: this.backgroundColor.a < 1,
         })
       }

--- a/packages/core/src/examples/ascii-font-selection-demo.ts
+++ b/packages/core/src/examples/ascii-font-selection-demo.ts
@@ -17,7 +17,8 @@ let allFontRenderables: ASCIIFontRenderable[] = []
 export function run(renderer: CliRenderer): void {
   renderer.setBackgroundColor("#0d1117")
 
-  mainContainer = new BoxRenderable("mainContainer", {
+  mainContainer = new BoxRenderable(renderer, {
+    id: "mainContainer",
     position: "absolute",
     left: 1,
     top: 1,
@@ -32,7 +33,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(mainContainer)
 
-  fontGroup = new GroupRenderable("fontGroup", {
+  fontGroup = new GroupRenderable(renderer, {
+    id: "fontGroup",
     position: "absolute",
     left: 2,
     top: 2,
@@ -40,7 +42,8 @@ export function run(renderer: CliRenderer): void {
   })
   mainContainer.add(fontGroup)
 
-  const tinyFont = new ASCIIFontRenderable("tinyFont", {
+  const tinyFont = new ASCIIFontRenderable(renderer, {
+    id: "tinyFont",
     text: "TINY FONT DEMO",
     font: "tiny",
     fg: RGBA.fromInts(255, 255, 0, 255),
@@ -52,7 +55,8 @@ export function run(renderer: CliRenderer): void {
   fontGroup.add(tinyFont)
   allFontRenderables.push(tinyFont)
 
-  const blockFont = new ASCIIFontRenderable("blockFont", {
+  const blockFont = new ASCIIFontRenderable(renderer, {
+    id: "blockFont",
     text: "opentui",
     font: "block",
     fg: [RGBA.fromInts(255, 100, 100, 255), RGBA.fromInts(100, 255, 100, 255)],
@@ -64,7 +68,8 @@ export function run(renderer: CliRenderer): void {
   fontGroup.add(blockFont)
   allFontRenderables.push(blockFont)
 
-  const shadeFont = new ASCIIFontRenderable("shadeFont", {
+  const shadeFont = new ASCIIFontRenderable(renderer, {
+    id: "shadeFont",
     text: "SHADE",
     font: "shade",
     fg: [RGBA.fromInts(255, 200, 100, 255), RGBA.fromInts(100, 150, 200, 255)],
@@ -76,7 +81,8 @@ export function run(renderer: CliRenderer): void {
   fontGroup.add(shadeFont)
   allFontRenderables.push(shadeFont)
 
-  const slickFont = new ASCIIFontRenderable("slickFont", {
+  const slickFont = new ASCIIFontRenderable(renderer, {
+    id: "slickFont",
     text: "SLICK",
     font: "slick",
     fg: [RGBA.fromInts(100, 255, 100, 255), RGBA.fromInts(255, 100, 255, 255)],
@@ -88,7 +94,8 @@ export function run(renderer: CliRenderer): void {
   fontGroup.add(slickFont)
   allFontRenderables.push(slickFont)
 
-  const instructions = new TextRenderable("ascii-font-instructions", {
+  const instructions = new TextRenderable(renderer, {
+    id: "ascii-font-instructions",
     content: "Click and drag to select text across any ASCII font elements. Press 'C' to clear selection.",
     left: 2,
     top: 26,
@@ -97,7 +104,8 @@ export function run(renderer: CliRenderer): void {
   })
   mainContainer.add(instructions)
 
-  statusBox = new BoxRenderable("statusBox", {
+  statusBox = new BoxRenderable(renderer, {
+    id: "statusBox",
     position: "absolute",
     left: 1,
     top: 32,
@@ -111,13 +119,15 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(statusBox)
 
-  statusText = new TextRenderable("statusText", {
+  statusText = new TextRenderable(renderer, {
+    id: "statusText",
     content: "No selection - try selecting across different ASCII fonts",
     fg: "#f0f6fc",
   })
   statusBox.add(statusText)
 
-  selectionStartText = new TextRenderable("selectionStartText", {
+  selectionStartText = new TextRenderable(renderer, {
+    id: "selectionStartText",
     content: "",
     left: 3,
     zIndex: 2,
@@ -125,7 +135,8 @@ export function run(renderer: CliRenderer): void {
   })
   statusBox.add(selectionStartText)
 
-  selectionMiddleText = new TextRenderable("selectionMiddleText", {
+  selectionMiddleText = new TextRenderable(renderer, {
+    id: "selectionMiddleText",
     content: "",
     left: 3,
     zIndex: 2,
@@ -133,7 +144,8 @@ export function run(renderer: CliRenderer): void {
   })
   statusBox.add(selectionMiddleText)
 
-  selectionEndText = new TextRenderable("selectionEndText", {
+  selectionEndText = new TextRenderable(renderer, {
+    id: "selectionEndText",
     content: "",
     left: 3,
     zIndex: 2,
@@ -141,7 +153,8 @@ export function run(renderer: CliRenderer): void {
   })
   statusBox.add(selectionEndText)
 
-  debugText = new TextRenderable("debugText", {
+  debugText = new TextRenderable(renderer, {
+    id: "debugText",
     content: "",
     left: 3,
     zIndex: 2,

--- a/packages/core/src/examples/console-demo.ts
+++ b/packages/core/src/examples/console-demo.ts
@@ -9,6 +9,7 @@ import {
   BoxRenderable,
   type MouseEvent,
   OptimizedBuffer,
+  type RenderContext,
 } from "../index"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
 
@@ -34,6 +35,7 @@ class ConsoleButton extends BoxRenderable {
   private lastClickTime = 0
 
   constructor(
+    ctx: RenderContext,
     id: string,
     x: number,
     y: number,
@@ -45,7 +47,8 @@ class ConsoleButton extends BoxRenderable {
   ) {
     const borderColor = RGBA.fromValues(color.r * 1.3, color.g * 1.3, color.b * 1.3, 1.0)
 
-    super(id, {
+    super(ctx, {
+      id,
       position: "absolute",
       left: x,
       top: y,
@@ -183,7 +186,8 @@ export function run(renderer: CliRenderer): void {
   const backgroundColor = RGBA.fromInts(18, 22, 35, 255)
   renderer.setBackgroundColor(backgroundColor)
 
-  titleText = new TextRenderable("console_demo_title", {
+  titleText = new TextRenderable(renderer, {
+    id: "console_demo_title",
     content: "Console Logging Demo",
     position: "absolute",
     left: 2,
@@ -194,7 +198,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(titleText)
 
-  instructionsText = new TextRenderable("console_demo_instructions", {
+  instructionsText = new TextRenderable(renderer, {
+    id: "console_demo_instructions",
     content:
       "Click buttons to trigger different console log levels • Press ` to toggle console • Escape: return to menu",
     position: "absolute",
@@ -205,7 +210,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(instructionsText)
 
-  statusText = new TextRenderable("console_demo_status", {
+  statusText = new TextRenderable(renderer, {
+    id: "console_demo_status",
     content: "Click any button to start logging...",
     position: "absolute",
     left: 2,
@@ -228,18 +234,49 @@ export function run(renderer: CliRenderer): void {
   const spacing = 18
 
   consoleButtons = [
-    new ConsoleButton("log-btn", 2, startY, buttonWidth, buttonHeight, logColor, "LOG", "log"),
-    new ConsoleButton("info-btn", 2 + spacing, startY, buttonWidth, buttonHeight, infoColor, "INFO", "info"),
-    new ConsoleButton("warn-btn", 2 + spacing * 2, startY, buttonWidth, buttonHeight, warnColor, "WARN", "warn"),
-    new ConsoleButton("error-btn", 2 + spacing * 3, startY, buttonWidth, buttonHeight, errorColor, "ERROR", "error"),
-    new ConsoleButton("debug-btn", 2 + spacing * 4, startY, buttonWidth, buttonHeight, debugColor, "DEBUG", "debug"),
+    new ConsoleButton(renderer, "log-btn", 2, startY, buttonWidth, buttonHeight, logColor, "LOG", "log"),
+    new ConsoleButton(renderer, "info-btn", 2 + spacing, startY, buttonWidth, buttonHeight, infoColor, "INFO", "info"),
+    new ConsoleButton(
+      renderer,
+      "warn-btn",
+      2 + spacing * 2,
+      startY,
+      buttonWidth,
+      buttonHeight,
+      warnColor,
+      "WARN",
+      "warn",
+    ),
+    new ConsoleButton(
+      renderer,
+      "error-btn",
+      2 + spacing * 3,
+      startY,
+      buttonWidth,
+      buttonHeight,
+      errorColor,
+      "ERROR",
+      "error",
+    ),
+    new ConsoleButton(
+      renderer,
+      "debug-btn",
+      2 + spacing * 4,
+      startY,
+      buttonWidth,
+      buttonHeight,
+      debugColor,
+      "DEBUG",
+      "debug",
+    ),
   ]
 
   for (const button of consoleButtons) {
     renderer.root.add(button)
   }
 
-  const decorText1 = new TextRenderable("decor1", {
+  const decorText1 = new TextRenderable(renderer, {
+    id: "decor1",
     content: "✦ ✧ ✦ ✧ ✦ ✧ ✦ ✧ ✦ ✧ ✦ ✧ ✦ ✧ ✦ ✧ ✦",
     position: "absolute",
     left: 2,
@@ -249,7 +286,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(decorText1)
 
-  const decorText2 = new TextRenderable("decor2", {
+  const decorText2 = new TextRenderable(renderer, {
+    id: "decor2",
     content: "Console will appear at the bottom. Use Ctrl+P/Ctrl+O to change position, +/- to resize.",
     position: "absolute",
     left: 2,

--- a/packages/core/src/examples/fonts.ts
+++ b/packages/core/src/examples/fonts.ts
@@ -39,13 +39,15 @@ export function run(rendererInstance: CliRenderer): void {
   renderer = rendererInstance
   renderer.setBackgroundColor("#000028")
 
-  parentContainer = new GroupRenderable("fonts-container", {
+  parentContainer = new GroupRenderable(renderer, {
+    id: "fonts-container",
     zIndex: 15,
     visible: true,
   })
   renderer.root.add(parentContainer)
 
-  buffer = new FrameBufferRenderable("ascii-demo", {
+  buffer = new FrameBufferRenderable(renderer, {
+    id: "ascii-demo",
     width: renderer.terminalWidth,
     height: contentHeight,
     position: "absolute",
@@ -192,7 +194,8 @@ export function run(rendererInstance: CliRenderer): void {
     font: "slick",
   })
 
-  const scrollInstructions = new TextRenderable("scroll-instructions", {
+  const scrollInstructions = new TextRenderable(renderer, {
+    id: "scroll-instructions",
     content: "USE J/K OR ARROW KEYS TO SCROLL",
     position: "absolute",
     left: renderer.terminalWidth - 32,

--- a/packages/core/src/examples/fractal-shader-demo.ts
+++ b/packages/core/src/examples/fractal-shader-demo.ts
@@ -41,7 +41,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   const WIDTH = renderer.terminalWidth
   const HEIGHT = renderer.terminalHeight
 
-  parentContainer = new GroupRenderable("fractal-container", {
+  parentContainer = new GroupRenderable(renderer, {
+    id: "fractal-container",
     zIndex: 10,
     visible: true,
   })
@@ -130,14 +131,16 @@ export async function run(renderer: CliRenderer): Promise<void> {
 
   engine.setActiveCamera(cameraNode)
 
-  const titleText = new TextRenderable("fractal_title", {
+  const titleText = new TextRenderable(renderer, {
+    id: "fractal_title",
     content: "Shader by @XorDev",
     fg: "#FFFFFF",
     zIndex: 25,
   })
   parentContainer.add(titleText)
 
-  const controlsText = new TextRenderable("fractal_controls", {
+  const controlsText = new TextRenderable(renderer, {
+    id: "fractal_controls",
     content: "Space: Pause/Resume | R: Reset | P: Screenshot | +/-: Speed | Escape: Back to menu",
     position: "absolute",
     top: HEIGHT - 2,
@@ -146,7 +149,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(controlsText)
 
-  const statusText = new TextRenderable("fractal_status", {
+  const statusText = new TextRenderable(renderer, {
+    id: "fractal_status",
     content: "Speed: 1.0x",
     position: "absolute",
     top: 1,

--- a/packages/core/src/examples/framebuffer-demo.ts
+++ b/packages/core/src/examples/framebuffer-demo.ts
@@ -37,13 +37,15 @@ export function run(renderer: CliRenderer): void {
   const backgroundColor = RGBA.fromInts(10, 10, 30)
   renderer.setBackgroundColor(backgroundColor)
 
-  parentContainer = new GroupRenderable("framebuffer-container", {
+  parentContainer = new GroupRenderable(renderer, {
+    id: "framebuffer-container",
     zIndex: 10,
     visible: true,
   })
   renderer.root.add(parentContainer)
 
-  const titleText = new TextRenderable("framebuffer_title", {
+  const titleText = new TextRenderable(renderer, {
+    id: "framebuffer_title",
     content: "FrameBuffer Demo",
     position: "absolute",
     left: 2,
@@ -54,7 +56,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentContainer.add(titleText)
 
-  const subtitleText = new TextRenderable("framebuffer_subtitle", {
+  const subtitleText = new TextRenderable(renderer, {
+    id: "framebuffer_subtitle",
     content: "Showcasing framebuffers with transparency and partial drawing",
     position: "absolute",
     left: 2,
@@ -64,7 +67,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentContainer.add(subtitleText)
 
-  const instructionsText = new TextRenderable("framebuffer_instructions", {
+  const instructionsText = new TextRenderable(renderer, {
+    id: "framebuffer_instructions",
     content: "Press Escape to return to menu",
     position: "absolute",
     left: 2,
@@ -74,7 +78,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentContainer.add(instructionsText)
 
-  const patternBufferRenderable = new FrameBufferRenderable("pattern", {
+  const patternBufferRenderable = new FrameBufferRenderable(renderer, {
+    id: "pattern",
     width: renderer.terminalWidth,
     height: renderer.terminalHeight,
     position: "absolute",
@@ -92,7 +97,8 @@ export function run(renderer: CliRenderer): void {
     }
   }
 
-  const boxObj = new FrameBufferRenderable("moving-box", {
+  const boxObj = new FrameBufferRenderable(renderer, {
+    id: "moving-box",
     width: 20,
     height: 10,
     position: "absolute",
@@ -122,7 +128,8 @@ export function run(renderer: CliRenderer): void {
 
   boxBuffer.drawText("Moving Box", 5, 2, RGBA.fromInts(255, 255, 255), RGBA.fromInts(100, 40, 120), TextAttributes.BOLD)
 
-  const overlayBufferRenderable = new FrameBufferRenderable("overlay", {
+  const overlayBufferRenderable = new FrameBufferRenderable(renderer, {
+    id: "overlay",
     width: 40,
     height: 15,
     position: "absolute",
@@ -166,7 +173,8 @@ export function run(renderer: CliRenderer): void {
   )
   overlayBuffer.drawText("show through!", 5, 7, RGBA.fromInts(255, 255, 255), RGBA.fromInts(0, 120, 180, 200))
 
-  const ballObj = new FrameBufferRenderable("ball", {
+  const ballObj = new FrameBufferRenderable(renderer, {
+    id: "ball",
     width: 3,
     height: 3,
     position: "absolute",
@@ -187,7 +195,8 @@ export function run(renderer: CliRenderer): void {
   ballBuffer.drawText(" ", 1, 2, RGBA.fromInts(255, 255, 255), RGBA.fromInts(200, 50, 50))
   ballBuffer.drawText(" ", 2, 2, RGBA.fromInts(255, 255, 255), RGBA.fromInts(200, 50, 50))
 
-  const resizableObj = new FrameBufferRenderable("resizable-box", {
+  const resizableObj = new FrameBufferRenderable(renderer, {
+    id: "resizable-box",
     width: 10,
     height: 5,
     position: "absolute",
@@ -236,7 +245,8 @@ export function run(renderer: CliRenderer): void {
   drawResizableContent()
 
   // Create a large source framebuffer for partial drawing demonstration
-  const sourceObj = new FrameBufferRenderable("large-source", {
+  const sourceObj = new FrameBufferRenderable(renderer, {
+    id: "large-source",
     width: 40,
     height: 20,
     position: "absolute",
@@ -259,7 +269,8 @@ export function run(renderer: CliRenderer): void {
   }
 
   // Create smaller framebuffers to demonstrate partial drawing
-  const cropBuffer1Renderable = new FrameBufferRenderable("crop-demo-1", {
+  const cropBuffer1Renderable = new FrameBufferRenderable(renderer, {
+    id: "crop-demo-1",
     width: 12,
     height: 8,
     position: "absolute",
@@ -270,7 +281,8 @@ export function run(renderer: CliRenderer): void {
   renderer.root.add(cropBuffer1Renderable)
   const { frameBuffer: cropBuffer1 } = cropBuffer1Renderable
 
-  const cropBuffer2Renderable = new FrameBufferRenderable("crop-demo-2", {
+  const cropBuffer2Renderable = new FrameBufferRenderable(renderer, {
+    id: "crop-demo-2",
     width: 15,
     height: 6,
     position: "absolute",
@@ -281,7 +293,8 @@ export function run(renderer: CliRenderer): void {
   renderer.root.add(cropBuffer2Renderable)
   const { frameBuffer: cropBuffer2 } = cropBuffer2Renderable
 
-  const cropBuffer3Renderable = new FrameBufferRenderable("crop-demo-3", {
+  const cropBuffer3Renderable = new FrameBufferRenderable(renderer, {
+    id: "crop-demo-3",
     width: 10,
     height: 10,
     position: "absolute",
@@ -293,7 +306,8 @@ export function run(renderer: CliRenderer): void {
   const { frameBuffer: cropBuffer3 } = cropBuffer3Renderable
 
   // Label for the crop demo
-  const cropDemoLabel = new TextRenderable("crop_demo_label", {
+  const cropDemoLabel = new TextRenderable(renderer, {
+    id: "crop_demo_label",
     content: "Partial FrameBuffer Drawing Demo:",
     position: "absolute",
     left: 5,
@@ -477,7 +491,8 @@ export function run(renderer: CliRenderer): void {
     }
   })
 
-  const debugInstructionsText = new TextRenderable("framebuffer_debug_instructions", {
+  const debugInstructionsText = new TextRenderable(renderer, {
+    id: "framebuffer_debug_instructions",
     content: "Press 1-4 to change corner | Escape: Back to menu",
     position: "absolute",
     left: 2,

--- a/packages/core/src/examples/full-unicode-demo.ts
+++ b/packages/core/src/examples/full-unicode-demo.ts
@@ -1,0 +1,181 @@
+import {
+  createCliRenderer,
+  RGBA,
+  FrameBufferRenderable,
+  GroupRenderable,
+  TextRenderable,
+  t,
+  blue,
+  bold,
+  underline,
+  fg,
+  type MouseEvent,
+  type CliRenderer,
+  type RenderContext,
+} from "../index"
+
+const GRAPHEME_LINES: string[] = [
+  "👩🏽‍💻  👨‍👩‍👧‍👦  🏳️‍🌈  🇺🇸  🇩🇪  🇯🇵  🇮🇳",
+  "a̐éö̲  Z͑͗͛̒͘a̴͈͚̐̓l̷͓̱͉g̶̙̗̓͘o̵͍͈  क्‍ष",
+  "مرحبا  こんにちは  สวัสดี  Здравствуйте",
+  "𝔘𝔫𝔦𝔠𝔬𝔡𝔢  𝒻𝓊𝓁𝓁 𝓌𝒾𝒹𝓉𝒽：ＡＢＣ  ½ ⅞ ⅓",
+]
+
+class DraggableGraphemeBox extends FrameBufferRenderable {
+  private isDragging = false
+  private dragOffsetX = 0
+  private dragOffsetY = 0
+
+  constructor(
+    ctx: RenderContext,
+    id: string,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    bg: RGBA,
+    respectAlpha = true,
+  ) {
+    super(ctx, { id, width, height, position: "absolute", left: x, top: y, respectAlpha })
+
+    // Fill the internal framebuffer with graphemes
+    this.frameBuffer.clear(RGBA.fromInts(0, 0, 0, Math.round(bg.a * 255)))
+
+    const fg = RGBA.fromInts(255, 255, 255, 255)
+    let row = 0
+    for (const line of GRAPHEME_LINES) {
+      if (row >= height) break
+      this.frameBuffer.drawText(line, 1, row, fg, bg)
+      row += 1
+    }
+  }
+
+  protected onMouseEvent(event: MouseEvent): void {
+    switch (event.type) {
+      case "down":
+        this.isDragging = true
+        this.dragOffsetX = event.x - this.x
+        this.dragOffsetY = event.y - this.y
+        event.preventDefault()
+        break
+      case "drag":
+        if (this.isDragging) {
+          this.x = event.x - this.dragOffsetX
+          this.y = event.y - this.dragOffsetY
+          event.preventDefault()
+        }
+        break
+      case "drag-end":
+        if (this.isDragging) {
+          this.isDragging = false
+          event.preventDefault()
+        }
+        break
+    }
+  }
+}
+
+class GraphemeBackground extends FrameBufferRenderable {
+  constructor(ctx: RenderContext, id: string, width: number, height: number) {
+    super(ctx, { id, width, height, position: "absolute", left: 0, top: 0, respectAlpha: false })
+
+    // Fill entire background with repeating grapheme lines
+    const fg = RGBA.fromInts(220, 220, 220, 255)
+    const bg = RGBA.fromInts(0, 17, 34, 255)
+    this.frameBuffer.clear(RGBA.fromInts(0, 17, 34, 255))
+    for (let y = 0; y < height; y++) {
+      const line = GRAPHEME_LINES[y % GRAPHEME_LINES.length]
+      this.frameBuffer.drawText(line, 2, y, fg, bg)
+    }
+  }
+}
+
+class DraggableStyledText extends TextRenderable {
+  private isDragging = false
+  private dragOffsetX = 0
+  private dragOffsetY = 0
+
+  constructor(ctx: RenderContext, id: string, x: number, y: number) {
+    super(ctx, {
+      id,
+      position: "absolute",
+      left: x,
+      top: y,
+      zIndex: 2,
+      selectable: false,
+    })
+
+    // Styled text content with graphemes
+    const content = t`${bold(blue("Graphemes:"))} 👩🏽‍💻  👨‍👩‍👧‍👦  🏳️‍🌈  🇺🇸  🇩🇪  🇯🇵  🇮🇳
+${underline("Complex:")} a̐éö̲  Z͑͗͛̒͘a̴͈͚̐̓l̷͓̱͉g̶̙̗̓͘o̵͍͈  क्‍ष`
+
+    this.content = content
+    this.fg = RGBA.fromInts(255, 255, 255, 255)
+    this.bg = RGBA.fromInts(0, 0, 0, 0)
+  }
+
+  protected onMouseEvent(event: MouseEvent): void {
+    switch (event.type) {
+      case "down":
+        this.isDragging = true
+        this.dragOffsetX = event.x - this.x
+        this.dragOffsetY = event.y - this.y
+        event.preventDefault()
+        break
+      case "drag":
+        if (this.isDragging) {
+          this.x = event.x - this.dragOffsetX
+          this.y = event.y - this.dragOffsetY
+          event.preventDefault()
+        }
+        break
+      case "drag-end":
+        if (this.isDragging) {
+          this.isDragging = false
+          event.preventDefault()
+        }
+        break
+    }
+  }
+}
+
+export function run(renderer: CliRenderer): void {
+  renderer.start()
+  renderer.setBackgroundColor(RGBA.fromInts(0, 17, 34, 255))
+
+  const rootGroup = new GroupRenderable(renderer, { id: "full-unicode-root", zIndex: 1 })
+  renderer.root.add(rootGroup)
+
+  const bg = new GraphemeBackground(renderer, "grapheme-bg", renderer.terminalWidth, renderer.terminalHeight)
+  rootGroup.add(bg)
+
+  const box1 = new DraggableGraphemeBox(renderer, "grapheme-box-1", 6, 4, 30, 6, RGBA.fromInts(32, 96, 192, 160), true)
+  const box2 = new DraggableGraphemeBox(
+    renderer,
+    "grapheme-box-2",
+    24,
+    10,
+    28,
+    6,
+    RGBA.fromInts(192, 96, 128, 180),
+    true,
+  )
+  const box3 = new DraggableGraphemeBox(renderer, "grapheme-box-3", 42, 7, 26, 6, RGBA.fromInts(64, 176, 96, 128), true)
+
+  rootGroup.add(box1)
+  rootGroup.add(box2)
+  rootGroup.add(box3)
+
+  // Draggable styled text using TextRenderable (grapheme-aware via TextBuffer)
+  const styledText = new DraggableStyledText(renderer, "draggable-styled-text", 8, 12)
+  rootGroup.add(styledText)
+}
+
+export function destroy(renderer: CliRenderer): void {
+  renderer.root.remove("full-unicode-root")
+}
+
+if (import.meta.main) {
+  const renderer = await createCliRenderer({ exitOnCtrlC: true })
+  run(renderer)
+}

--- a/packages/core/src/examples/hast-syntax-highlighting-demo.ts
+++ b/packages/core/src/examples/hast-syntax-highlighting-demo.ts
@@ -22,14 +22,16 @@ export function run(rendererInstance: CliRenderer): void {
   renderer.start()
   renderer.setBackgroundColor("#0D1117")
 
-  parentContainer = new GroupRenderable("parent-container", {
+  parentContainer = new GroupRenderable(renderer, {
+    id: "parent-container",
     zIndex: 10,
     visible: true,
     padding: 1,
   })
   renderer.root.add(parentContainer)
 
-  const titleBox = new BoxRenderable("title-box", {
+  const titleBox = new BoxRenderable(renderer, {
+    id: "title-box",
     height: 3,
     borderStyle: "double",
     borderColor: "#4ECDC4",
@@ -40,13 +42,15 @@ export function run(rendererInstance: CliRenderer): void {
   })
   parentContainer.add(titleBox)
 
-  const instructionsText = new TextRenderable("instructions", {
+  const instructionsText = new TextRenderable(renderer, {
+    id: "instructions",
     content: "ESC to return | R to re-transform | Demonstrating HAST tree conversion to syntax-highlighted text",
     fg: "#888888",
   })
   titleBox.add(instructionsText)
 
-  const codeBox = new BoxRenderable("code-box", {
+  const codeBox = new BoxRenderable(renderer, {
+    id: "code-box",
     borderStyle: "single",
     borderColor: "#6BCF7F",
     backgroundColor: "#0D1117",
@@ -75,7 +79,8 @@ export function run(rendererInstance: CliRenderer): void {
   const transformEnd = performance.now()
   const transformTime = (transformEnd - transformStart).toFixed(2)
 
-  const codeDisplay = new TextRenderable("code-display", {
+  const codeDisplay = new TextRenderable(renderer, {
+    id: "code-display",
     content: styledText,
     bg: "#0D1117",
     selectable: true,
@@ -84,7 +89,8 @@ export function run(rendererInstance: CliRenderer): void {
   })
   codeBox.add(codeDisplay)
 
-  const timingText = new TextRenderable("timing-display", {
+  const timingText = new TextRenderable(renderer, {
+    id: "timing-display",
     content: `HAST transformation time: ${transformTime}ms (Cache: ${syntaxStyle.getCacheSize()} entries) (Press 'R' to re-transform)`,
     fg: "#A8E6CF",
   })

--- a/packages/core/src/examples/index.ts
+++ b/packages/core/src/examples/index.ts
@@ -12,6 +12,7 @@ import {
   type SelectOption,
   type ParsedKey,
 } from "../index"
+import { resolveRenderLib } from "../zig"
 import { renderFontToFrameBuffer, measureText } from "../lib/ascii.font"
 import * as boxExample from "./fonts"
 import * as fractalShaderExample from "./fractal-shader-demo"
@@ -42,6 +43,7 @@ import * as splitModeExample from "./split-mode-demo"
 import * as consoleExample from "./console-demo"
 import * as hastSyntaxHighlightingExample from "./hast-syntax-highlighting-demo"
 import * as liveStateExample from "./live-state-demo"
+import * as fullUnicodeExample from "./full-unicode-demo"
 import { getKeyHandler } from "../lib/KeyHandler"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
 
@@ -58,6 +60,12 @@ const examples: Example[] = [
     description: "Interactive mouse trails and clickable cells demonstration",
     run: mouseInteractionExample.run,
     destroy: mouseInteractionExample.destroy,
+  },
+  {
+    name: "Full Unicode Demo",
+    description: "Draggable boxes and background filled with complex graphemes",
+    run: fullUnicodeExample.run,
+    destroy: fullUnicodeExample.destroy,
   },
   {
     name: "Text Selection Demo",
@@ -258,7 +266,8 @@ class ExampleSelector {
     const { width: titleWidth, height: titleHeight } = measureText({ text: titleText, font: titleFont })
     const centerX = Math.floor(width / 2) - Math.floor(titleWidth / 2)
 
-    this.title = new FrameBufferRenderable("title", {
+    this.title = new FrameBufferRenderable(renderer, {
+      id: "title",
       width: titleWidth,
       height: titleHeight,
       position: "absolute",
@@ -284,7 +293,8 @@ class ExampleSelector {
 
     this.createTitle(width, height)
 
-    this.instructions = new TextRenderable("instructions", {
+    this.instructions = new TextRenderable(renderer, {
+      id: "instructions",
       position: "absolute",
       left: 2,
       top: 4,
@@ -305,7 +315,8 @@ class ExampleSelector {
       value: example,
     }))
 
-    this.selectBox = new BoxRenderable("example-selector-box", {
+    this.selectBox = new BoxRenderable(renderer, {
+      id: "example-selector-box",
       position: "absolute",
       left: 1,
       top: 6,
@@ -321,7 +332,8 @@ class ExampleSelector {
       border: true,
     })
 
-    this.selectElement = new SelectRenderable("example-selector", {
+    this.selectElement = new SelectRenderable(renderer, {
+      id: "example-selector",
       width: width - 4,
       height: height - 10,
       options: selectOptions,
@@ -394,7 +406,8 @@ class ExampleSelector {
       selected.run(this.renderer)
     } else {
       if (!this.notImplementedText) {
-        this.notImplementedText = new TextRenderable("not-implemented", {
+        this.notImplementedText = new TextRenderable(renderer, {
+          id: "not-implemented",
           position: "absolute",
           left: 10,
           top: 10,
@@ -465,8 +478,13 @@ class ExampleSelector {
 const renderer = await createCliRenderer({
   exitOnCtrlC: false,
   targetFps: 60,
-  // useAlternateScreen: false
+  useAlternateScreen: false,
 })
+
+// Get and log terminal capabilities
+const lib = resolveRenderLib()
+const capabilities = lib.getTerminalCapabilities(renderer.rendererPtr)
+console.log("Terminal capabilities:", capabilities)
 
 renderer.setBackgroundColor("#001122")
 new ExampleSelector(renderer)

--- a/packages/core/src/examples/input-demo.ts
+++ b/packages/core/src/examples/input-demo.ts
@@ -143,14 +143,16 @@ export function run(rendererInstance: CliRenderer): void {
   renderer = rendererInstance
   renderer.setBackgroundColor("#001122")
 
-  const parentContainer = new GroupRenderable("parent-container", {
+  const parentContainer = new GroupRenderable(renderer, {
+    id: "parent-container",
     zIndex: 10,
     visible: true,
   })
   renderer.root.add(parentContainer)
 
   // Create input elements
-  nameInput = new InputRenderable("name-input", {
+  nameInput = new InputRenderable(renderer, {
+    id: "name-input",
     position: "absolute",
     left: 5,
     top: 2,
@@ -166,7 +168,8 @@ export function run(rendererInstance: CliRenderer): void {
     maxLength: 50,
   })
 
-  emailInput = new InputRenderable("email-input", {
+  emailInput = new InputRenderable(renderer, {
+    id: "email-input",
     position: "absolute",
     left: 5,
     top: 6,
@@ -182,7 +185,8 @@ export function run(rendererInstance: CliRenderer): void {
     maxLength: 100,
   })
 
-  passwordInput = new InputRenderable("password-input", {
+  passwordInput = new InputRenderable(renderer, {
+    id: "password-input",
     position: "absolute",
     left: 5,
     top: 10,
@@ -198,7 +202,8 @@ export function run(rendererInstance: CliRenderer): void {
     maxLength: 50,
   })
 
-  commentInput = new InputRenderable("comment-input", {
+  commentInput = new InputRenderable(renderer, {
+    id: "comment-input",
     position: "absolute",
     left: 5,
     top: 14,
@@ -221,7 +226,8 @@ export function run(rendererInstance: CliRenderer): void {
   renderer.root.add(passwordInput)
   renderer.root.add(commentInput)
 
-  keyLegendDisplay = new TextRenderable("key-legend", {
+  keyLegendDisplay = new TextRenderable(renderer, {
+    id: "key-legend",
     content: t``,
     width: 50,
     height: 12,
@@ -233,7 +239,8 @@ export function run(rendererInstance: CliRenderer): void {
   })
   parentContainer.add(keyLegendDisplay)
 
-  statusDisplay = new TextRenderable("status-display", {
+  statusDisplay = new TextRenderable(renderer, {
+    id: "status-display",
     content: t``,
     width: 80,
     height: 18,

--- a/packages/core/src/examples/input-select-layout-demo.ts
+++ b/packages/core/src/examples/input-select-layout-demo.ts
@@ -52,7 +52,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
   renderer = rendererInstance
   renderer.setBackgroundColor("#001122")
 
-  headerBox = new BoxRenderable("header-box", {
+  headerBox = new BoxRenderable(renderer, {
+    id: "header-box",
     zIndex: 0,
     width: "auto",
     height: 3,
@@ -64,7 +65,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  header = new TextRenderable("header", {
+  header = new TextRenderable(renderer, {
+    id: "header",
     content: "INPUT & SELECT LAYOUT DEMO",
     fg: "#ffffff",
     bg: "transparent",
@@ -75,7 +77,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
 
   headerBox.add(header)
 
-  selectContainerBox = new BoxRenderable("select-container-box", {
+  selectContainerBox = new BoxRenderable(renderer, {
+    id: "select-container-box",
     zIndex: 0,
     width: "auto",
     height: "auto",
@@ -88,7 +91,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  selectContainer = new GroupRenderable("select-container", {
+  selectContainer = new GroupRenderable(renderer, {
+    id: "select-container",
     zIndex: 1,
     width: "auto",
     height: "auto",
@@ -99,7 +103,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
 
   selectContainerBox.add(selectContainer)
 
-  leftSelectBox = new BoxRenderable("color-select-box", {
+  leftSelectBox = new BoxRenderable(renderer, {
+    id: "color-select-box",
     zIndex: 0,
     width: "auto",
     height: "auto",
@@ -115,7 +120,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  leftSelect = new SelectRenderable("color-select", {
+  leftSelect = new SelectRenderable(renderer, {
+    id: "color-select",
     zIndex: 1,
     width: "auto",
     height: "auto",
@@ -138,7 +144,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
 
   leftSelectBox.add(leftSelect)
 
-  rightSelectBox = new BoxRenderable("size-select-box", {
+  rightSelectBox = new BoxRenderable(renderer, {
+    id: "size-select-box",
     zIndex: 0,
     width: "auto",
     height: "auto",
@@ -154,7 +161,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  rightSelect = new SelectRenderable("size-select", {
+  rightSelect = new SelectRenderable(renderer, {
+    id: "size-select",
     zIndex: 1,
     width: "auto",
     height: "auto",
@@ -177,7 +185,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
 
   rightSelectBox.add(rightSelect)
 
-  inputContainerBox = new BoxRenderable("input-container-box", {
+  inputContainerBox = new BoxRenderable(renderer, {
+    id: "input-container-box",
     zIndex: 0,
     width: "auto",
     height: 7,
@@ -189,7 +198,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  inputContainer = new GroupRenderable("input-container", {
+  inputContainer = new GroupRenderable(renderer, {
+    id: "input-container",
     zIndex: 1,
     width: "auto",
     height: "auto",
@@ -200,7 +210,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
 
   inputContainerBox.add(inputContainer)
 
-  inputLabel = new TextRenderable("input-label", {
+  inputLabel = new TextRenderable(renderer, {
+    id: "input-label",
     content: "Enter your text:",
     fg: "#f1f5f9",
     bg: "#0f172a",
@@ -209,7 +220,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     flexShrink: 0,
   })
 
-  textInputBox = new BoxRenderable("text-input-box", {
+  textInputBox = new BoxRenderable(renderer, {
+    id: "text-input-box",
     zIndex: 0,
     width: "auto",
     height: 3,
@@ -223,7 +235,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  textInput = new InputRenderable("text-input", {
+  textInput = new InputRenderable(renderer, {
+    id: "text-input",
     zIndex: 1,
     width: "auto",
     height: 1,
@@ -241,7 +254,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
 
   textInputBox.add(textInput)
 
-  footerBox = new BoxRenderable("footer-box", {
+  footerBox = new BoxRenderable(renderer, {
+    id: "footer-box",
     zIndex: 0,
     width: "auto",
     height: 3,
@@ -253,7 +267,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  footer = new TextRenderable("footer", {
+  footer = new TextRenderable(renderer, {
+    id: "footer",
     content: "TAB: focus next | SHIFT+TAB: focus prev | ARROWS/JK: navigate | ESC: quit",
     fg: "#dbeafe",
     bg: "transparent",

--- a/packages/core/src/examples/lights-phong-demo.ts
+++ b/packages/core/src/examples/lights-phong-demo.ts
@@ -51,13 +51,15 @@ export async function run(renderer: CliRenderer): Promise<void> {
   const WIDTH = renderer.terminalWidth
   const HEIGHT = renderer.terminalHeight
 
-  const parentContainer = new GroupRenderable("phong-container", {
+  const parentContainer = new GroupRenderable(renderer, {
+    id: "phong-container",
     zIndex: 15,
     visible: true,
   })
   renderer.root.add(parentContainer)
 
-  const framebufferRenderable = new FrameBufferRenderable("phong-main", {
+  const framebufferRenderable = new FrameBufferRenderable(renderer, {
+    id: "phong-main",
     width: WIDTH,
     height: HEIGHT,
     zIndex: 10,
@@ -152,7 +154,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   engine.setActiveCamera(camera)
   sceneRoot.add(camera)
 
-  const titleText = new TextRenderable("phong-title", {
+  const titleText = new TextRenderable(renderer, {
+    id: "phong-title",
     content: "WebGPU Phong Lights Demo",
     position: "absolute",
     fg: "#FFFFFF",
@@ -160,7 +163,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(titleText)
 
-  const statusText = new TextRenderable("phong-status", {
+  const statusText = new TextRenderable(renderer, {
+    id: "phong-status",
     content: "Ready.",
     position: "absolute",
     top: 1,
@@ -169,7 +173,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(statusText)
 
-  const controlsText = new TextRenderable("phong-controls", {
+  const controlsText = new TextRenderable(renderer, {
+    id: "phong-controls",
     content: "WASD: Move | QE: Rotate | ZX: Zoom | R: Reset | U: Super Sample",
     position: "absolute",
     top: HEIGHT - 2,

--- a/packages/core/src/examples/live-state-demo.ts
+++ b/packages/core/src/examples/live-state-demo.ts
@@ -15,6 +15,7 @@ import {
   green,
   blue,
   fg,
+  type RenderContext,
 } from "../index"
 import type { BoxOptions } from "../renderables/Box"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
@@ -39,8 +40,8 @@ class LiveButton extends BoxRenderable {
   private pressBg: RGBA
   private label: string
 
-  constructor(id: string, options: BoxOptions & { label: string }) {
-    super(id, { zIndex: 100, border: true, ...options })
+  constructor(ctx: RenderContext, options: BoxOptions & { label: string }) {
+    super(ctx, { zIndex: 100, border: true, ...options })
 
     this.label = options.label
     const base = this.backgroundColor
@@ -146,7 +147,8 @@ function addDemoRenderable(renderer: CliRenderer): void {
     return
   }
 
-  demoRenderable = new BoxRenderable("demo-renderable", {
+  demoRenderable = new BoxRenderable(renderer, {
+    id: "demo-renderable",
     position: "absolute",
     left: 60,
     top: 15,
@@ -180,7 +182,8 @@ export function run(renderer: CliRenderer): void {
   const backgroundColor = RGBA.fromInts(25, 30, 45, 255)
   renderer.setBackgroundColor(backgroundColor)
 
-  titleText = new TextRenderable("live_demo_title", {
+  titleText = new TextRenderable(renderer, {
+    id: "live_demo_title",
     content: "Live State Management Demo",
     position: "absolute",
     left: 2,
@@ -191,7 +194,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(titleText)
 
-  instructionsText = new TextRenderable("live_demo_instructions", {
+  instructionsText = new TextRenderable(renderer, {
+    id: "live_demo_instructions",
     content: "Test the live state management system • Escape: return to menu",
     position: "absolute",
     left: 2,
@@ -201,7 +205,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(instructionsText)
 
-  statusText = new TextRenderable("live_demo_status", {
+  statusText = new TextRenderable(renderer, {
+    id: "live_demo_status",
     content: "Ready - Click buttons to test live state management",
     position: "absolute",
     left: 2,
@@ -212,7 +217,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(statusText)
 
-  rendererStateText = new TextRenderable("renderer_state", {
+  rendererStateText = new TextRenderable(renderer, {
+    id: "renderer_state",
     content: "",
     position: "absolute",
     left: 2,
@@ -222,7 +228,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(rendererStateText)
 
-  renderableStateText = new TextRenderable("renderable_state", {
+  renderableStateText = new TextRenderable(renderer, {
+    id: "renderable_state",
     content: "",
     position: "absolute",
     left: 2,
@@ -245,7 +252,8 @@ export function run(renderer: CliRenderer): void {
 
   // Renderer control buttons
   liveButtons = [
-    new LiveButton("request-live-btn", {
+    new LiveButton(renderer, {
+      id: "request-live-btn",
       position: "absolute",
       left: 2,
       top: startY,
@@ -261,7 +269,8 @@ export function run(renderer: CliRenderer): void {
         updateRenderableState()
       },
     }),
-    new LiveButton("drop-live-btn", {
+    new LiveButton(renderer, {
+      id: "drop-live-btn",
       position: "absolute",
       left: 2 + spacing,
       top: startY,
@@ -279,7 +288,8 @@ export function run(renderer: CliRenderer): void {
     }),
 
     // Renderable management buttons
-    new LiveButton("add-renderable-btn", {
+    new LiveButton(renderer, {
+      id: "add-renderable-btn",
       position: "absolute",
       left: 2,
       top: startY + 5,
@@ -294,7 +304,8 @@ export function run(renderer: CliRenderer): void {
         updateRenderableState()
       },
     }),
-    new LiveButton("remove-renderable-btn", {
+    new LiveButton(renderer, {
+      id: "remove-renderable-btn",
       position: "absolute",
       left: 2 + spacing,
       top: startY + 5,
@@ -311,7 +322,8 @@ export function run(renderer: CliRenderer): void {
     }),
 
     // Live state buttons
-    new LiveButton("set-live-true-btn", {
+    new LiveButton(renderer, {
+      id: "set-live-true-btn",
       position: "absolute",
       left: 2,
       top: startY + 10,
@@ -332,7 +344,8 @@ export function run(renderer: CliRenderer): void {
         updateRenderableState()
       },
     }),
-    new LiveButton("set-live-false-btn", {
+    new LiveButton(renderer, {
+      id: "set-live-false-btn",
       position: "absolute",
       left: 2 + spacing,
       top: startY + 10,
@@ -355,7 +368,8 @@ export function run(renderer: CliRenderer): void {
     }),
 
     // Visibility state buttons
-    new LiveButton("set-visible-true-btn", {
+    new LiveButton(renderer, {
+      id: "set-visible-true-btn",
       position: "absolute",
       left: 2,
       top: startY + 15,
@@ -376,7 +390,8 @@ export function run(renderer: CliRenderer): void {
         updateRenderableState()
       },
     }),
-    new LiveButton("set-visible-false-btn", {
+    new LiveButton(renderer, {
+      id: "set-visible-false-btn",
       position: "absolute",
       left: 2 + spacing,
       top: startY + 15,
@@ -404,7 +419,8 @@ export function run(renderer: CliRenderer): void {
   }
 
   // Add section labels
-  const rendererLabel = new TextRenderable("renderer_label", {
+  const rendererLabel = new TextRenderable(renderer, {
+    id: "renderer_label",
     content: "Renderer Control:",
     position: "absolute",
     left: 2,
@@ -415,7 +431,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(rendererLabel)
 
-  const renderableLabel = new TextRenderable("renderable_label", {
+  const renderableLabel = new TextRenderable(renderer, {
+    id: "renderable_label",
     content: "Renderable Management:",
     position: "absolute",
     left: 2,
@@ -426,7 +443,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(renderableLabel)
 
-  const liveLabel = new TextRenderable("live_label", {
+  const liveLabel = new TextRenderable(renderer, {
+    id: "live_label",
     content: "Live State Control:",
     position: "absolute",
     left: 2,
@@ -437,7 +455,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(liveLabel)
 
-  const visibilityLabel = new TextRenderable("visibility_label", {
+  const visibilityLabel = new TextRenderable(renderer, {
+    id: "visibility_label",
     content: "Visibility Control:",
     position: "absolute",
     left: 2,

--- a/packages/core/src/examples/mouse-interaction-demo.ts
+++ b/packages/core/src/examples/mouse-interaction-demo.ts
@@ -13,6 +13,7 @@ import {
   BoxRenderable,
   createTimeline,
   engine,
+  type RenderContext,
 } from "../index"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
 
@@ -46,10 +47,20 @@ class DraggableBox extends BoxRenderable {
   private originalBorderColor: RGBA
   private dragBorderColor: RGBA
 
-  constructor(id: string, x: number, y: number, width: number, height: number, color: RGBA, label: string) {
+  constructor(
+    ctx: RenderContext,
+    id: string,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    color: RGBA,
+    label: string,
+  ) {
     const bgColor = RGBA.fromValues(color.r, color.g, color.b, 0.8)
     const borderColor = RGBA.fromValues(color.r * 1.2, color.g * 1.2, color.b * 1.2, 1.0)
-    super(id, {
+    super(ctx, {
+      id,
       position: "absolute",
       left: x,
       top: y,
@@ -150,8 +161,8 @@ class DraggableBox extends BoxRenderable {
           const newX = event.x - this.dragOffsetX
           const newY = event.y - this.dragOffsetY
 
-          const boundedX = Math.max(0, Math.min(newX, (this.ctx?.width() || 80) - this.width))
-          const boundedY = Math.max(4, Math.min(newY, (this.ctx?.height() || 24) - this.height))
+          const boundedX = Math.max(0, Math.min(newX, this._ctx.width - this.width))
+          const boundedY = Math.max(4, Math.min(newY, this._ctx.height - this.height))
 
           this.centerX = boundedX + this.width / 2
           this.centerY = boundedY + this.height / 2
@@ -212,7 +223,8 @@ class MouseInteractionFrameBuffer extends FrameBufferRenderable {
   private readonly CURSOR_COLOR = RGBA.fromInts(255, 255, 255, 255)
 
   constructor(id: string, renderer: CliRenderer) {
-    super(id, {
+    super(renderer, {
+      id,
       width: renderer.terminalWidth,
       height: renderer.terminalHeight,
       zIndex: 0,
@@ -311,7 +323,8 @@ export function run(renderer: CliRenderer): void {
     engine.update(deltaTime)
   })
 
-  titleText = new TextRenderable("mouse_demo_title", {
+  titleText = new TextRenderable(renderer, {
+    id: "mouse_demo_title",
     content: "Mouse Interaction Demo with Draggable Objects",
     width: "100%",
     position: "absolute",
@@ -323,7 +336,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(titleText)
 
-  instructionsText = new TextRenderable("mouse_demo_instructions", {
+  instructionsText = new TextRenderable(renderer, {
+    id: "mouse_demo_instructions",
     content: t`Drag boxes around • Move mouse: turquoise trails
 Hold + move: orange drag trails • Click cells: toggle pink
 Scroll on boxes: shows direction • Escape: menu`,
@@ -341,10 +355,10 @@ Scroll on boxes: shows direction • Escape: menu`,
   renderer.root.add(demoContainer)
 
   draggableBoxes = [
-    new DraggableBox("drag-box-1", 10, 8, 20, 10, RGBA.fromInts(200, 100, 150), "Box 1"),
-    new DraggableBox("drag-box-2", 30, 12, 18, 10, RGBA.fromInts(100, 200, 150), "Box 2"),
-    new DraggableBox("drag-box-3", 50, 15, 20, 11, RGBA.fromInts(150, 150, 200), "Box 3"),
-    new DraggableBox("drag-box-4", 15, 20, 18, 11, RGBA.fromInts(200, 200, 100), "Box 4"),
+    new DraggableBox(renderer, "drag-box-1", 10, 8, 20, 10, RGBA.fromInts(200, 100, 150), "Box 1"),
+    new DraggableBox(renderer, "drag-box-2", 30, 12, 18, 10, RGBA.fromInts(100, 200, 150), "Box 2"),
+    new DraggableBox(renderer, "drag-box-3", 50, 15, 20, 11, RGBA.fromInts(150, 150, 200), "Box 3"),
+    new DraggableBox(renderer, "drag-box-4", 15, 20, 18, 11, RGBA.fromInts(200, 200, 100), "Box 4"),
   ]
 
   for (const box of draggableBoxes) {

--- a/packages/core/src/examples/nested-zindex-demo.ts
+++ b/packages/core/src/examples/nested-zindex-demo.ts
@@ -10,13 +10,15 @@ export function run(renderer: CliRenderer): void {
   renderer.start()
   renderer.setBackgroundColor("#001122")
 
-  const parentContainer = new GroupRenderable("parent-container", {
+  const parentContainer = new GroupRenderable(renderer, {
+    id: "parent-container",
     zIndex: 10,
     visible: true,
   })
   renderer.root.add(parentContainer)
 
-  const title = new TextRenderable("main-title", {
+  const title = new TextRenderable(renderer, {
+    id: "main-title",
     content: "Nested Render Objects & Z-Index Demo",
     position: "absolute",
     left: 10,
@@ -28,7 +30,8 @@ export function run(renderer: CliRenderer): void {
   parentContainer.add(title)
 
   // Parent group with high z-index
-  const parentGroupA = new GroupRenderable("parent-group-a", {
+  const parentGroupA = new GroupRenderable(renderer, {
+    id: "parent-group-a",
     position: "absolute",
     zIndex: 100,
     visible: true,
@@ -36,7 +39,8 @@ export function run(renderer: CliRenderer): void {
   parentContainer.add(parentGroupA)
 
   // Parent group with medium z-index
-  const parentGroupB = new GroupRenderable("parent-group-b", {
+  const parentGroupB = new GroupRenderable(renderer, {
+    id: "parent-group-b",
     position: "absolute",
     zIndex: 50,
     visible: true,
@@ -44,7 +48,8 @@ export function run(renderer: CliRenderer): void {
   parentContainer.add(parentGroupB)
 
   // Parent group with low z-index
-  const parentGroupC = new GroupRenderable("parent-group-c", {
+  const parentGroupC = new GroupRenderable(renderer, {
+    id: "parent-group-c",
     position: "absolute",
     zIndex: 20,
     visible: true,
@@ -52,7 +57,8 @@ export function run(renderer: CliRenderer): void {
   parentContainer.add(parentGroupC)
 
   // Group A - High Z-Index Parent (z=100)
-  const boxA1 = new BoxRenderable("box-a1", {
+  const boxA1 = new BoxRenderable(renderer, {
+    id: "box-a1",
     position: "absolute",
     left: 15,
     top: 8,
@@ -68,7 +74,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentGroupA.add(boxA1)
 
-  const textA1 = new TextRenderable("text-a1", {
+  const textA1 = new TextRenderable(renderer, {
+    id: "text-a1",
     content: "Child A1 (z=10)",
     position: "absolute",
     left: 17,
@@ -79,7 +86,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentGroupA.add(textA1)
 
-  const boxA2 = new BoxRenderable("box-a2", {
+  const boxA2 = new BoxRenderable(renderer, {
+    id: "box-a2",
     position: "absolute",
     left: 20,
     top: 11,
@@ -93,7 +101,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentGroupA.add(boxA2)
 
-  const textA2 = new TextRenderable("text-a2", {
+  const textA2 = new TextRenderable(renderer, {
+    id: "text-a2",
     content: "Child A2 (z=5)",
     position: "absolute",
     left: 22,
@@ -104,7 +113,8 @@ export function run(renderer: CliRenderer): void {
   parentGroupA.add(textA2)
 
   // Group B - Medium Z-Index Parent (z=50)
-  const boxB1 = new BoxRenderable("box-b1", {
+  const boxB1 = new BoxRenderable(renderer, {
+    id: "box-b1",
     position: "absolute",
     left: 30,
     top: 12,
@@ -120,7 +130,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentGroupB.add(boxB1)
 
-  const textB1 = new TextRenderable("text-b1", {
+  const textB1 = new TextRenderable(renderer, {
+    id: "text-b1",
     content: "Child B1 (z=20)",
     position: "absolute",
     left: 32,
@@ -131,7 +142,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentGroupB.add(textB1)
 
-  const boxB2 = new BoxRenderable("box-b2", {
+  const boxB2 = new BoxRenderable(renderer, {
+    id: "box-b2",
     position: "absolute",
     left: 35,
     top: 15,
@@ -145,7 +157,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentGroupB.add(boxB2)
 
-  const textB2 = new TextRenderable("text-b2", {
+  const textB2 = new TextRenderable(renderer, {
+    id: "text-b2",
     content: "Child B2 (z=15)",
     position: "absolute",
     left: 37,
@@ -156,7 +169,8 @@ export function run(renderer: CliRenderer): void {
   parentGroupB.add(textB2)
 
   // Group C - Low Z-Index Parent (z=20)
-  const boxC1 = new BoxRenderable("box-c1", {
+  const boxC1 = new BoxRenderable(renderer, {
+    id: "box-c1",
     position: "absolute",
     left: 45,
     top: 16,
@@ -172,7 +186,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentGroupC.add(boxC1)
 
-  const textC1 = new TextRenderable("text-c1", {
+  const textC1 = new TextRenderable(renderer, {
+    id: "text-c1",
     content: "Child C1 (z=30)",
     position: "absolute",
     left: 47,
@@ -183,7 +198,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentGroupC.add(textC1)
 
-  const boxC2 = new BoxRenderable("box-c2", {
+  const boxC2 = new BoxRenderable(renderer, {
+    id: "box-c2",
     position: "absolute",
     left: 50,
     top: 19,
@@ -197,7 +213,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentGroupC.add(boxC2)
 
-  const textC2 = new TextRenderable("text-c2", {
+  const textC2 = new TextRenderable(renderer, {
+    id: "text-c2",
     content: "Child C2 (z=25)",
     position: "absolute",
     left: 52,
@@ -207,7 +224,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentGroupC.add(textC2)
 
-  const explanation1 = new TextRenderable("explanation1", {
+  const explanation1 = new TextRenderable(renderer, {
+    id: "explanation1",
     content: "Key Concept: Parent z-index determines group layering, child z-index determines order within group",
     position: "absolute",
     left: 10,
@@ -217,7 +235,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentContainer.add(explanation1)
 
-  const explanation2 = new TextRenderable("explanation2", {
+  const explanation2 = new TextRenderable(renderer, {
+    id: "explanation2",
     content: "Even if Child C1 has z=30, it renders behind Parent A & B because Parent C has z=20",
     position: "absolute",
     left: 10,
@@ -227,7 +246,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentContainer.add(explanation2)
 
-  const phaseIndicator = new TextRenderable("phase-indicator", {
+  const phaseIndicator = new TextRenderable(renderer, {
+    id: "phase-indicator",
     content: "Animation Phase: 1/4",
     position: "absolute",
     left: 10,
@@ -238,7 +258,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentContainer.add(phaseIndicator)
 
-  const zIndexDisplay = new TextRenderable("zindex-display", {
+  const zIndexDisplay = new TextRenderable(renderer, {
+    id: "zindex-display",
     content: "Current Z-Indices - A:100, B:50, C:20",
     position: "absolute",
     left: 10,

--- a/packages/core/src/examples/opentui-demo.ts
+++ b/packages/core/src/examples/opentui-demo.ts
@@ -40,7 +40,8 @@ export function run(renderer: CliRenderer): void {
   tabController.addTab({
     title: "Text & Attributes",
     init: (tabGroup) => {
-      const textTitle = new TextRenderable("text-title", {
+      const textTitle = new TextRenderable(renderer, {
+        id: "text-title",
         content: "Text Styling & Color Gradients",
         position: "absolute",
         left: 10,
@@ -52,7 +53,8 @@ export function run(renderer: CliRenderer): void {
       tabGroup.add(textTitle)
 
       // Text attributes
-      const attrBold = new TextRenderable("attr-bold", {
+      const attrBold = new TextRenderable(renderer, {
+        id: "attr-bold",
         content: "Bold Text",
         position: "absolute",
         left: 10,
@@ -63,7 +65,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(attrBold)
 
-      const attrItalic = new TextRenderable("attr-italic", {
+      const attrItalic = new TextRenderable(renderer, {
+        id: "attr-italic",
         content: "Italic Text",
         position: "absolute",
         left: 10,
@@ -74,7 +77,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(attrItalic)
 
-      const attrUnderline = new TextRenderable("attr-underline", {
+      const attrUnderline = new TextRenderable(renderer, {
+        id: "attr-underline",
         content: "Underlined Text",
         position: "absolute",
         left: 10,
@@ -85,7 +89,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(attrUnderline)
 
-      const attrDim = new TextRenderable("attr-dim", {
+      const attrDim = new TextRenderable(renderer, {
+        id: "attr-dim",
         content: "Dim Text",
         position: "absolute",
         left: 10,
@@ -96,7 +101,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(attrDim)
 
-      const attrCombined = new TextRenderable("attr-combined", {
+      const attrCombined = new TextRenderable(renderer, {
+        id: "attr-combined",
         content: "Bold + Italic + Underline",
         position: "absolute",
         left: 10,
@@ -108,7 +114,8 @@ export function run(renderer: CliRenderer): void {
       tabGroup.add(attrCombined)
 
       // Color gradient
-      const gradientTitle = new TextRenderable("gradient-title", {
+      const gradientTitle = new TextRenderable(renderer, {
+        id: "gradient-title",
         content: "Rainbow Gradient:",
         position: "absolute",
         left: 10,
@@ -123,7 +130,8 @@ export function run(renderer: CliRenderer): void {
         const color = hsvToRgb(hue, 1, 1)
         const hexColor = rgbToHex(color)
 
-        const gradientPixel = new TextRenderable(`gradient-${i}`, {
+        const gradientPixel = new TextRenderable(renderer, {
+          id: `gradient-${i}`,
           content: "█",
           position: "absolute",
           left: 10 + i,
@@ -165,7 +173,8 @@ export function run(renderer: CliRenderer): void {
               existingPixel.setPosition({ left: x, top: y })
               existingPixel.fg = color
             } else {
-              const wheelPixel = new TextRenderable(pixelId, {
+              const wheelPixel = new TextRenderable(renderer, {
+                id: pixelId,
                 content: "█",
                 position: "absolute",
                 left: x,
@@ -205,7 +214,8 @@ export function run(renderer: CliRenderer): void {
   tabController.addTab({
     title: "Basics",
     init: (tabGroup) => {
-      const title = new TextRenderable("opentui-title", {
+      const title = new TextRenderable(renderer, {
+        id: "opentui-title",
         content: "Basic CLI Renderer Demo",
         position: "absolute",
         left: 10,
@@ -216,7 +226,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(title)
 
-      const box1 = new BoxRenderable("box1", {
+      const box1 = new BoxRenderable(renderer, {
+        id: "box1",
         position: "absolute",
         left: 10,
         top: 8,
@@ -230,7 +241,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(box1)
 
-      const box1Title = new TextRenderable("box1-title", {
+      const box1Title = new TextRenderable(renderer, {
+        id: "box1-title",
         content: "Simple Box",
         position: "absolute",
         left: 12,
@@ -241,7 +253,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(box1Title)
 
-      const box2 = new BoxRenderable("box2", {
+      const box2 = new BoxRenderable(renderer, {
+        id: "box2",
         position: "absolute",
         left: 35,
         top: 10,
@@ -255,7 +268,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(box2)
 
-      const box2Title = new TextRenderable("box2-title", {
+      const box2Title = new TextRenderable(renderer, {
+        id: "box2-title",
         content: "Double Border Box",
         position: "absolute",
         left: 37,
@@ -266,7 +280,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(box2Title)
 
-      const description = new TextRenderable("description", {
+      const description = new TextRenderable(renderer, {
+        id: "description",
         content: "This tab demonstrates basic box and text rendering with different border styles.",
         position: "absolute",
         left: 10,
@@ -276,7 +291,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(description)
 
-      const cursorInfo = new TextRenderable("cursor-info", {
+      const cursorInfo = new TextRenderable(renderer, {
+        id: "cursor-info",
         content: "Cursor: (0,0) - Style: block",
         position: "absolute",
         left: 10,
@@ -347,7 +363,8 @@ export function run(renderer: CliRenderer): void {
   tabController.addTab({
     title: "Borders",
     init: (tabGroup) => {
-      const borderTitle = new TextRenderable("border-title", {
+      const borderTitle = new TextRenderable(renderer, {
+        id: "border-title",
         content: "Border Styles & Partial Borders",
         position: "absolute",
         left: 10,
@@ -359,7 +376,8 @@ export function run(renderer: CliRenderer): void {
       tabGroup.add(borderTitle)
 
       // Different border styles
-      const singleBox = new BoxRenderable("single-box", {
+      const singleBox = new BoxRenderable(renderer, {
+        id: "single-box",
         position: "absolute",
         left: 10,
         top: 8,
@@ -372,7 +390,8 @@ export function run(renderer: CliRenderer): void {
         border: true,
       })
       tabGroup.add(singleBox)
-      const singleLabel = new TextRenderable("single-label", {
+      const singleLabel = new TextRenderable(renderer, {
+        id: "single-label",
         content: "Single",
         position: "absolute",
         left: 12,
@@ -383,7 +402,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(singleLabel)
 
-      const doubleBox = new BoxRenderable("double-box", {
+      const doubleBox = new BoxRenderable(renderer, {
+        id: "double-box",
         position: "absolute",
         left: 30,
         top: 8,
@@ -396,7 +416,8 @@ export function run(renderer: CliRenderer): void {
         border: true,
       })
       tabGroup.add(doubleBox)
-      const doubleLabel = new TextRenderable("double-label", {
+      const doubleLabel = new TextRenderable(renderer, {
+        id: "double-label",
         content: "Double",
         position: "absolute",
         left: 32,
@@ -407,7 +428,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(doubleLabel)
 
-      const roundedBox = new BoxRenderable("rounded-box", {
+      const roundedBox = new BoxRenderable(renderer, {
+        id: "rounded-box",
         position: "absolute",
         left: 50,
         top: 8,
@@ -420,7 +442,8 @@ export function run(renderer: CliRenderer): void {
         border: true,
       })
       tabGroup.add(roundedBox)
-      const roundedLabel = new TextRenderable("rounded-label", {
+      const roundedLabel = new TextRenderable(renderer, {
+        id: "rounded-label",
         content: "Rounded",
         position: "absolute",
         left: 52,
@@ -432,7 +455,8 @@ export function run(renderer: CliRenderer): void {
       tabGroup.add(roundedLabel)
 
       // Partial borders
-      const partialTitle = new TextRenderable("partial-title", {
+      const partialTitle = new TextRenderable(renderer, {
+        id: "partial-title",
         content: "Partial Borders:",
         position: "absolute",
         left: 10,
@@ -443,7 +467,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(partialTitle)
 
-      const partialLeft = new BoxRenderable("partial-left", {
+      const partialLeft = new BoxRenderable(renderer, {
+        id: "partial-left",
         position: "absolute",
         left: 10,
         top: 17,
@@ -456,7 +481,8 @@ export function run(renderer: CliRenderer): void {
         border: ["left"],
       })
       tabGroup.add(partialLeft)
-      const partialLeftLabel = new TextRenderable("partial-left-label", {
+      const partialLeftLabel = new TextRenderable(renderer, {
+        id: "partial-left-label",
         content: "Left Only",
         position: "absolute",
         left: 12,
@@ -466,7 +492,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(partialLeftLabel)
 
-      const partialAnimated = new BoxRenderable("partial-animated", {
+      const partialAnimated = new BoxRenderable(renderer, {
+        id: "partial-animated",
         position: "absolute",
         left: 30,
         top: 17,
@@ -479,7 +506,8 @@ export function run(renderer: CliRenderer): void {
         border: true,
       })
       tabGroup.add(partialAnimated)
-      const partialAnimatedLabel = new TextRenderable("partial-animated-label", {
+      const partialAnimatedLabel = new TextRenderable(renderer, {
+        id: "partial-animated-label",
         content: "Animated Borders",
         position: "absolute",
         left: 32,
@@ -489,7 +517,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(partialAnimatedLabel)
 
-      const partialPhase = new TextRenderable("partial-phase", {
+      const partialPhase = new TextRenderable(renderer, {
+        id: "partial-phase",
         content: "Phase: 1/8",
         position: "absolute",
         left: 30,
@@ -499,7 +528,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(partialPhase)
 
-      const customBorderTitle = new TextRenderable("custom-border-title", {
+      const customBorderTitle = new TextRenderable(renderer, {
+        id: "custom-border-title",
         content: "Custom Border Characters:",
         position: "absolute",
         left: 10,
@@ -552,7 +582,8 @@ export function run(renderer: CliRenderer): void {
         cross: "*",
       }
 
-      const asciiBox = new BoxRenderable("ascii-box", {
+      const asciiBox = new BoxRenderable(renderer, {
+        id: "ascii-box",
         position: "absolute",
         left: 10,
         top: 27,
@@ -566,7 +597,8 @@ export function run(renderer: CliRenderer): void {
         border: true,
       })
       tabGroup.add(asciiBox)
-      const asciiLabel = new TextRenderable("ascii-label", {
+      const asciiLabel = new TextRenderable(renderer, {
+        id: "ascii-label",
         content: "ASCII Border",
         position: "absolute",
         left: 12,
@@ -577,7 +609,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(asciiLabel)
 
-      const blockBox = new BoxRenderable("block-box", {
+      const blockBox = new BoxRenderable(renderer, {
+        id: "block-box",
         position: "absolute",
         left: 30,
         top: 27,
@@ -591,7 +624,8 @@ export function run(renderer: CliRenderer): void {
       })
       blockBox.customBorderChars = blockBorders
       tabGroup.add(blockBox)
-      const blockLabel = new TextRenderable("block-label", {
+      const blockLabel = new TextRenderable(renderer, {
+        id: "block-label",
         content: "Block Border",
         position: "absolute",
         left: 32,
@@ -602,7 +636,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(blockLabel)
 
-      const starBox = new BoxRenderable("star-box", {
+      const starBox = new BoxRenderable(renderer, {
+        id: "star-box",
         position: "absolute",
         left: 50,
         top: 27,
@@ -616,7 +651,8 @@ export function run(renderer: CliRenderer): void {
         border: true,
       })
       tabGroup.add(starBox)
-      const starLabel = new TextRenderable("star-label", {
+      const starLabel = new TextRenderable(renderer, {
+        id: "star-label",
         content: "Star Border",
         position: "absolute",
         left: 52,
@@ -663,7 +699,8 @@ export function run(renderer: CliRenderer): void {
   tabController.addTab({
     title: "Animation",
     init: (tabGroup) => {
-      const animTitle = new TextRenderable("anim-title", {
+      const animTitle = new TextRenderable(renderer, {
+        id: "anim-title",
         content: "Animation Demonstrations",
         position: "absolute",
         left: 10,
@@ -674,7 +711,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(animTitle)
 
-      const movingText = new TextRenderable("moving-text", {
+      const movingText = new TextRenderable(renderer, {
+        id: "moving-text",
         content: "Moving Text",
         position: "absolute",
         left: animPosition,
@@ -685,7 +723,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(movingText)
 
-      const animatedBox = new BoxRenderable("animated-box", {
+      const animatedBox = new BoxRenderable(renderer, {
+        id: "animated-box",
         position: "absolute",
         left: animPosition,
         top: 10,
@@ -699,7 +738,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(animatedBox)
 
-      const colorBox = new BoxRenderable("color-box", {
+      const colorBox = new BoxRenderable(renderer, {
+        id: "color-box",
         position: "absolute",
         left: 50,
         top: 12,
@@ -713,7 +753,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(colorBox)
 
-      const colorBoxTitle = new TextRenderable("color-box-title", {
+      const colorBoxTitle = new TextRenderable(renderer, {
+        id: "color-box-title",
         content: "Animated Color",
         position: "absolute",
         left: 52,
@@ -766,7 +807,8 @@ export function run(renderer: CliRenderer): void {
   tabController.addTab({
     title: "Titles",
     init: (tabGroup) => {
-      const layoutTitle = new TextRenderable("layout-title", {
+      const layoutTitle = new TextRenderable(renderer, {
+        id: "layout-title",
         content: "Box Titles",
         position: "absolute",
         left: 10,
@@ -778,7 +820,8 @@ export function run(renderer: CliRenderer): void {
       tabGroup.add(layoutTitle)
 
       // Boxes with titles and different alignments
-      const titledLeft = new BoxRenderable("titled-left", {
+      const titledLeft = new BoxRenderable(renderer, {
+        id: "titled-left",
         position: "absolute",
         left: 10,
         top: 8,
@@ -794,7 +837,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(titledLeft)
 
-      const titledCenter = new BoxRenderable("titled-center", {
+      const titledCenter = new BoxRenderable(renderer, {
+        id: "titled-center",
         position: "absolute",
         left: 35,
         top: 8,
@@ -810,7 +854,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(titledCenter)
 
-      const titledRight = new BoxRenderable("titled-right", {
+      const titledRight = new BoxRenderable(renderer, {
+        id: "titled-right",
         position: "absolute",
         left: 60,
         top: 8,
@@ -839,7 +884,8 @@ export function run(renderer: CliRenderer): void {
   tabController.addTab({
     title: "Interactive",
     init: (tabGroup) => {
-      const interactiveTitle = new TextRenderable("interactive-title", {
+      const interactiveTitle = new TextRenderable(renderer, {
+        id: "interactive-title",
         content: "Interactive Controls",
         position: "absolute",
         left: 10,
@@ -850,7 +896,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(interactiveTitle)
 
-      const interactiveBorder = new BoxRenderable("interactive-border", {
+      const interactiveBorder = new BoxRenderable(renderer, {
+        id: "interactive-border",
         position: "absolute",
         left: 15,
         top: 8,
@@ -864,7 +911,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(interactiveBorder)
 
-      const interactiveLabel = new TextRenderable("interactive-label", {
+      const interactiveLabel = new TextRenderable(renderer, {
+        id: "interactive-label",
         content: "Press keys to toggle borders",
         position: "absolute",
         left: 22,
@@ -875,7 +923,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(interactiveLabel)
 
-      const interactiveInstructions = new TextRenderable("interactive-instructions", {
+      const interactiveInstructions = new TextRenderable(renderer, {
+        id: "interactive-instructions",
         content: "Keyboard Controls:",
         position: "absolute",
         left: 10,
@@ -886,7 +935,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(interactiveInstructions)
 
-      const keyT = new TextRenderable("key-t", {
+      const keyT = new TextRenderable(renderer, {
+        id: "key-t",
         content: "T - Toggle top border",
         position: "absolute",
         left: 10,
@@ -896,7 +946,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(keyT)
 
-      const keyR = new TextRenderable("key-r", {
+      const keyR = new TextRenderable(renderer, {
+        id: "key-r",
         content: "R - Toggle right border",
         position: "absolute",
         left: 10,
@@ -906,7 +957,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(keyR)
 
-      const keyB = new TextRenderable("key-b", {
+      const keyB = new TextRenderable(renderer, {
+        id: "key-b",
         content: "B - Toggle bottom border",
         position: "absolute",
         left: 10,
@@ -916,7 +968,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(keyB)
 
-      const keyL = new TextRenderable("key-l", {
+      const keyL = new TextRenderable(renderer, {
+        id: "key-l",
         content: "L - Toggle left border",
         position: "absolute",
         left: 10,
@@ -926,7 +979,8 @@ export function run(renderer: CliRenderer): void {
       })
       tabGroup.add(keyL)
 
-      const borderState = new TextRenderable("border-state", {
+      const borderState = new TextRenderable(renderer, {
+        id: "border-state",
         content: "Active borders: All",
         position: "absolute",
         left: 10,

--- a/packages/core/src/examples/physx-planck-2d-demo.ts
+++ b/packages/core/src/examples/physx-planck-2d-demo.ts
@@ -68,13 +68,15 @@ export async function run(renderer: CliRenderer): Promise<void> {
   const initialTermWidth = renderer.terminalWidth
   const initialTermHeight = renderer.terminalHeight
 
-  const parentContainer = new GroupRenderable("planck-container", {
+  const parentContainer = new GroupRenderable(renderer, {
+    id: "planck-container",
     zIndex: 15,
     visible: true,
   })
   renderer.root.add(parentContainer)
 
-  const framebufferRenderable = new FrameBufferRenderable("planck-main", {
+  const framebufferRenderable = new FrameBufferRenderable(renderer, {
+    id: "planck-main",
     width: initialTermWidth,
     height: initialTermHeight,
     zIndex: 10,
@@ -170,7 +172,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   scene.add(groundMesh)
 
   // Create UI elements
-  const instructionsText = new TextRenderable("planck-instructions", {
+  const instructionsText = new TextRenderable(renderer, {
+    id: "planck-instructions",
     content: "Planck.js 2D Demo - Falling Crates (Instanced Sprites)",
     position: "absolute",
     left: 1,
@@ -180,7 +183,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(instructionsText)
 
-  const controlsText = new TextRenderable("planck-controls", {
+  const controlsText = new TextRenderable(renderer, {
+    id: "planck-controls",
     content: "Press: [Space] spawn crate, [E] explode crate, [R] reset, [T] toggle debug, [C] clear crates",
     position: "absolute",
     left: 1,
@@ -190,7 +194,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(controlsText)
 
-  const statsText = new TextRenderable("planck-stats", {
+  const statsText = new TextRenderable(renderer, {
+    id: "planck-stats",
     content: "",
     position: "absolute",
     left: 1,

--- a/packages/core/src/examples/physx-rapier-2d-demo.ts
+++ b/packages/core/src/examples/physx-rapier-2d-demo.ts
@@ -82,13 +82,15 @@ export async function run(renderer: CliRenderer): Promise<void> {
   const initialTermWidth = renderer.terminalWidth
   const initialTermHeight = renderer.terminalHeight
 
-  const parentContainer = new GroupRenderable("rapier-container", {
+  const parentContainer = new GroupRenderable(renderer, {
+    id: "rapier-container",
     zIndex: 15,
     visible: true,
   })
   renderer.root.add(parentContainer)
 
-  const framebufferRenderable = new FrameBufferRenderable("rapier-main", {
+  const framebufferRenderable = new FrameBufferRenderable(renderer, {
+    id: "rapier-main",
     width: initialTermWidth,
     height: initialTermHeight,
     zIndex: 10,
@@ -194,7 +196,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   scene.add(groundMesh)
 
   // Create UI elements
-  const instructionsText = new TextRenderable("rapier-instructions", {
+  const instructionsText = new TextRenderable(renderer, {
+    id: "rapier-instructions",
     content: "Rapier.js 2D Demo - Falling Crates (Instanced Sprites)",
     position: "absolute",
     left: 1,
@@ -204,7 +207,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(instructionsText)
 
-  const controlsText = new TextRenderable("rapier-controls", {
+  const controlsText = new TextRenderable(renderer, {
+    id: "rapier-controls",
     content: "Press: [Space] spawn crate, [E] explode crate, [R] reset, [T] toggle debug, [C] clear crates",
     position: "absolute",
     left: 1,
@@ -214,7 +218,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(controlsText)
 
-  const statsText = new TextRenderable("rapier-stats", {
+  const statsText = new TextRenderable(renderer, {
+    id: "rapier-stats",
     content: "",
     position: "absolute",
     left: 1,

--- a/packages/core/src/examples/relative-positioning-demo.ts
+++ b/packages/core/src/examples/relative-positioning-demo.ts
@@ -10,7 +10,8 @@ export function run(renderer: CliRenderer): void {
   renderer.start()
   renderer.setBackgroundColor("#001122")
 
-  const rootContainer = new GroupRenderable("root-container", {
+  const rootContainer = new GroupRenderable(renderer, {
+    id: "root-container",
     position: "relative",
     left: 0,
     top: 0,
@@ -19,7 +20,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(rootContainer)
 
-  const title = new TextRenderable("main-title", {
+  const title = new TextRenderable(renderer, {
+    id: "main-title",
     content: "Relative Positioning Demo - Child positions are relative to parent",
     position: "absolute",
     left: 5,
@@ -30,7 +32,8 @@ export function run(renderer: CliRenderer): void {
   })
   rootContainer.add(title)
 
-  const parentContainerA = new GroupRenderable("parent-container-a", {
+  const parentContainerA = new GroupRenderable(renderer, {
+    id: "parent-container-a",
     position: "absolute",
     left: 10,
     top: 5,
@@ -39,7 +42,8 @@ export function run(renderer: CliRenderer): void {
   })
   rootContainer.add(parentContainerA)
 
-  const parentBoxA = new BoxRenderable("parent-box-a", {
+  const parentBoxA = new BoxRenderable(renderer, {
+    id: "parent-box-a",
     left: 0,
     top: 0,
     width: 40,
@@ -57,7 +61,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentContainerA.add(parentBoxA)
 
-  const childA1 = new BoxRenderable("child-a1", {
+  const childA1 = new BoxRenderable(renderer, {
+    id: "child-a1",
     width: "auto",
     height: "auto",
     backgroundColor: "#440066",
@@ -73,7 +78,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentBoxA.add(childA1)
 
-  const childA2 = new BoxRenderable("child-a2", {
+  const childA2 = new BoxRenderable(renderer, {
+    id: "child-a2",
     width: "auto",
     height: "auto",
     backgroundColor: "#660044",
@@ -89,7 +95,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentBoxA.add(childA2)
 
-  const childA3 = new BoxRenderable("child-a3", {
+  const childA3 = new BoxRenderable(renderer, {
+    id: "child-a3",
     width: "auto",
     height: "auto",
     backgroundColor: "#440044",
@@ -105,7 +112,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentBoxA.add(childA3)
 
-  const parentContainerB = new GroupRenderable("parent-container-b", {
+  const parentContainerB = new GroupRenderable(renderer, {
+    id: "parent-container-b",
     position: "absolute",
     left: 50,
     top: 8,
@@ -114,7 +122,8 @@ export function run(renderer: CliRenderer): void {
   })
   rootContainer.add(parentContainerB)
 
-  const parentBoxB = new BoxRenderable("parent-box-b", {
+  const parentBoxB = new BoxRenderable(renderer, {
+    id: "parent-box-b",
     left: 0,
     top: 0,
     width: 40,
@@ -132,7 +141,8 @@ export function run(renderer: CliRenderer): void {
   })
   parentContainerB.add(parentBoxB)
 
-  const parentLabelB = new TextRenderable("parent-label-b", {
+  const parentLabelB = new TextRenderable(renderer, {
+    id: "parent-label-b",
     content: "Parent B Position: (50, 8)",
     fg: "#44FF44",
     attributes: TextAttributes.BOLD,
@@ -140,21 +150,24 @@ export function run(renderer: CliRenderer): void {
   })
   parentBoxB.add(parentLabelB)
 
-  const childB1 = new TextRenderable("child-b1", {
+  const childB1 = new TextRenderable(renderer, {
+    id: "child-b1",
     content: "Child at (1,3) - relative to parent",
     fg: "#88FF88",
     zIndex: 2,
   })
   parentBoxB.add(childB1)
 
-  const childB2 = new TextRenderable("child-b2", {
+  const childB2 = new TextRenderable(renderer, {
+    id: "child-b2",
     content: "Child at (1,5) - relative to parent",
     fg: "#88FF88",
     zIndex: 2,
   })
   parentBoxB.add(childB2)
 
-  const staticContainer = new GroupRenderable("static-container", {
+  const staticContainer = new GroupRenderable(renderer, {
+    id: "static-container",
     position: "absolute",
     left: 5,
     top: 20,
@@ -163,7 +176,8 @@ export function run(renderer: CliRenderer): void {
   })
   rootContainer.add(staticContainer)
 
-  const staticBox = new BoxRenderable("static-box", {
+  const staticBox = new BoxRenderable(renderer, {
+    id: "static-box",
     left: 0,
     top: 0,
     width: 40,
@@ -180,21 +194,24 @@ export function run(renderer: CliRenderer): void {
   })
   staticContainer.add(staticBox)
 
-  const staticChild1 = new TextRenderable("static-child1", {
+  const staticChild1 = new TextRenderable(renderer, {
+    id: "static-child1",
     content: "Static child at (2,2) - never moves",
     fg: "#FFFF88",
     zIndex: 2,
   })
   staticBox.add(staticChild1)
 
-  const staticChild2 = new TextRenderable("static-child2", {
+  const staticChild2 = new TextRenderable(renderer, {
+    id: "static-child2",
     content: "Static child at (2,4) - never moves",
     fg: "#FFFF88",
     zIndex: 2,
   })
   staticBox.add(staticChild2)
 
-  const explanation1 = new TextRenderable("explanation1", {
+  const explanation1 = new TextRenderable(renderer, {
+    id: "explanation1",
     content: "Key Concept: Parent A uses flex layout - children are arranged in a row",
     position: "absolute",
     left: 5,
@@ -205,7 +222,8 @@ export function run(renderer: CliRenderer): void {
   })
   rootContainer.add(explanation1)
 
-  const explanation2 = new TextRenderable("explanation2", {
+  const explanation2 = new TextRenderable(renderer, {
+    id: "explanation2",
     content: "When parent moves, children move with it while maintaining flex layout",
     position: "absolute",
     left: 5,
@@ -215,7 +233,8 @@ export function run(renderer: CliRenderer): void {
   })
   rootContainer.add(explanation2)
 
-  const explanation3 = new TextRenderable("explanation3", {
+  const explanation3 = new TextRenderable(renderer, {
+    id: "explanation3",
     content: "Flex children automatically fit parent width and grow/shrink as needed",
     position: "absolute",
     left: 5,
@@ -225,7 +244,8 @@ export function run(renderer: CliRenderer): void {
   })
   rootContainer.add(explanation3)
 
-  const controls = new TextRenderable("controls", {
+  const controls = new TextRenderable(renderer, {
+    id: "controls",
     content: "Controls: +/- to change animation speed",
     position: "absolute",
     left: 5,
@@ -236,7 +256,8 @@ export function run(renderer: CliRenderer): void {
   })
   rootContainer.add(controls)
 
-  const speedDisplay = new TextRenderable("speed-display", {
+  const speedDisplay = new TextRenderable(renderer, {
+    id: "speed-display",
     content: `Animation Speed: ${animationSpeed}ms (min: 500, max: 8000)`,
     position: "absolute",
     left: 5,

--- a/packages/core/src/examples/select-demo.ts
+++ b/packages/core/src/examples/select-demo.ts
@@ -90,13 +90,15 @@ export function run(rendererInstance: CliRenderer): void {
   renderer = rendererInstance
   renderer.setBackgroundColor("#001122")
 
-  const parentContainer = new GroupRenderable("parent-container", {
+  const parentContainer = new GroupRenderable(renderer, {
+    id: "parent-container",
     zIndex: 10,
     visible: true,
   })
   renderer.root.add(parentContainer)
 
-  selectElement = new SelectRenderable("demo-select", {
+  selectElement = new SelectRenderable(renderer, {
+    id: "demo-select",
     position: "absolute",
     left: 5,
     top: 2,
@@ -120,7 +122,8 @@ export function run(rendererInstance: CliRenderer): void {
 
   renderer.root.add(selectElement)
 
-  keyLegendDisplay = new TextRenderable("key-legend", {
+  keyLegendDisplay = new TextRenderable(renderer, {
+    id: "key-legend",
     content: t``,
     width: 40,
     height: 9,
@@ -132,7 +135,8 @@ export function run(rendererInstance: CliRenderer): void {
   })
   parentContainer.add(keyLegendDisplay)
 
-  statusDisplay = new TextRenderable("status-display", {
+  statusDisplay = new TextRenderable(renderer, {
+    id: "status-display",
     content: t``,
     width: 80,
     height: 8,

--- a/packages/core/src/examples/shader-cube-demo.ts
+++ b/packages/core/src/examples/shader-cube-demo.ts
@@ -90,7 +90,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   ]
 
   // Create parent container for all UI elements
-  const parentContainer = new GroupRenderable("shader-cube-container", {
+  const parentContainer = new GroupRenderable(renderer, {
+    id: "shader-cube-container",
     zIndex: 10,
     visible: true,
   })
@@ -120,7 +121,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   ]
 
   // Box in the background to show alpha channel works
-  const backgroundBox = new BoxRenderable("shader-cube-box", {
+  const backgroundBox = new BoxRenderable(renderer, {
+    id: "shader-cube-box",
     position: "absolute",
     left: 5,
     top: 5,
@@ -136,7 +138,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(backgroundBox)
 
-  const framebufferRenderable = new FrameBufferRenderable("shader-cube-main", {
+  const framebufferRenderable = new FrameBufferRenderable(renderer, {
+    id: "shader-cube-main",
     width: WIDTH,
     height: HEIGHT,
     zIndex: 10,
@@ -273,7 +276,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
 
   // Create UI elements
   let uiLine = 0
-  const lightVizText = new TextRenderable("shader-light-viz", {
+  const lightVizText = new TextRenderable(renderer, {
+    id: "shader-light-viz",
     content: "Light Visualization: ON (V to toggle)",
     position: "absolute",
     left: 0,
@@ -283,7 +287,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(lightVizText)
 
-  const lightColorText = new TextRenderable("shader-light-color", {
+  const lightColorText = new TextRenderable(renderer, {
+    id: "shader-light-color",
     content: "Point Light: Warm (C to change)",
     position: "absolute",
     left: 0,
@@ -293,7 +298,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(lightColorText)
 
-  const customLightsText = new TextRenderable("shader-custom-lights", {
+  const customLightsText = new TextRenderable(renderer, {
+    id: "shader-custom-lights",
     content: "Custom Lights: ON (L to toggle)",
     position: "absolute",
     left: 0,
@@ -303,7 +309,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(customLightsText)
 
-  const materialToggleText = new TextRenderable("shader-material-toggle", {
+  const materialToggleText = new TextRenderable(renderer, {
+    id: "shader-material-toggle",
     content: "Material: Auto-cycling (M to toggle, N to change)",
     position: "absolute",
     left: 0,
@@ -313,7 +320,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(materialToggleText)
 
-  const textureEffectsText = new TextRenderable("shader-texture-effects", {
+  const textureEffectsText = new TextRenderable(renderer, {
+    id: "shader-texture-effects",
     content: "Texture Effects: P-Specular [OFF] | B-Normal [OFF] | I-Emissive [OFF]",
     position: "absolute",
     left: 0,
@@ -323,7 +331,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(textureEffectsText)
 
-  const filterStatusText = new TextRenderable("shader-filter-status", {
+  const filterStatusText = new TextRenderable(renderer, {
+    id: "shader-filter-status",
     content: `Filter: ${filterFunctions[currentFilterIndex].name} (,/. to cycle)`,
     position: "absolute",
     left: 0,
@@ -333,7 +342,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(filterStatusText)
 
-  const param1StatusText = new TextRenderable("shader-param1-status", {
+  const param1StatusText = new TextRenderable(renderer, {
+    id: "shader-param1-status",
     content: ``,
     position: "absolute",
     left: 0,
@@ -344,7 +354,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   param1StatusText.visible = false
   parentContainer.add(param1StatusText)
 
-  const param2StatusText = new TextRenderable("shader-param2-status", {
+  const param2StatusText = new TextRenderable(renderer, {
+    id: "shader-param2-status",
     content: ``,
     position: "absolute",
     left: 0,
@@ -355,7 +366,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   param2StatusText.visible = false
   parentContainer.add(param2StatusText)
 
-  const controlsText = new TextRenderable("shader-controls", {
+  const controlsText = new TextRenderable(renderer, {
+    id: "shader-controls",
     content:
       "WASD: Move | QE: Rotate | ZX: Zoom | V: Light Viz | C: Light Color | L: Lights | M/N: Material | P/B/I: Maps | R: Reset | Space: Rotation | ,/. Filter | [/]{/} Param Adjust",
     position: "absolute",

--- a/packages/core/src/examples/simple-layout-example.ts
+++ b/packages/core/src/examples/simple-layout-example.ts
@@ -215,7 +215,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
   renderer = rendererInstance
   renderer.setBackgroundColor("#001122")
 
-  header = new BoxRenderable("header", {
+  header = new BoxRenderable(renderer, {
+    id: "header",
     zIndex: 0,
     width: "auto",
     height: 3,
@@ -225,7 +226,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  headerText = new TextRenderable("header-text", {
+  headerText = new TextRenderable(renderer, {
+    id: "header-text",
     content: "LAYOUT DEMO",
     fg: "#ffffff",
     bg: "transparent",
@@ -234,7 +236,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
 
   header.add(headerText)
 
-  contentArea = new GroupRenderable("content-area", {
+  contentArea = new GroupRenderable(renderer, {
+    id: "content-area",
     zIndex: 0,
     width: "auto",
     height: "auto",
@@ -243,7 +246,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     flexShrink: 1,
   })
 
-  sidebar = new BoxRenderable("sidebar", {
+  sidebar = new BoxRenderable(renderer, {
+    id: "sidebar",
     zIndex: 0,
     width: "auto",
     height: "auto",
@@ -257,7 +261,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  sidebarText = new TextRenderable("sidebar-text", {
+  sidebarText = new TextRenderable(renderer, {
+    id: "sidebar-text",
     content: "SIDEBAR",
     fg: "#ffffff",
     bg: "transparent",
@@ -266,7 +271,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
 
   sidebar.add(sidebarText)
 
-  mainContent = new BoxRenderable("main-content", {
+  mainContent = new BoxRenderable(renderer, {
+    id: "main-content",
     zIndex: 0,
     width: "auto",
     height: "auto",
@@ -280,7 +286,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  mainContentText = new TextRenderable("main-content-text", {
+  mainContentText = new TextRenderable(renderer, {
+    id: "main-content-text",
     content: "MAIN CONTENT",
     fg: "#1e293b",
     bg: "transparent",
@@ -289,7 +296,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
 
   mainContent.add(mainContentText)
 
-  rightSidebar = new BoxRenderable("right-sidebar", {
+  rightSidebar = new BoxRenderable(renderer, {
+    id: "right-sidebar",
     zIndex: 0,
     width: "auto",
     height: "auto",
@@ -303,7 +311,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  rightSidebarText = new TextRenderable("right-sidebar-text", {
+  rightSidebarText = new TextRenderable(renderer, {
+    id: "right-sidebar-text",
     content: "RIGHT",
     fg: "#ffffff",
     bg: "transparent",
@@ -312,7 +321,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
 
   rightSidebar.add(rightSidebarText)
 
-  footer = new BoxRenderable("footer", {
+  footer = new BoxRenderable(renderer, {
+    id: "footer",
     zIndex: 0,
     width: "auto",
     height: 3,
@@ -326,7 +336,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  footerText = new TextRenderable("footer-text", {
+  footerText = new TextRenderable(renderer, {
+    id: "footer-text",
     content: "",
     fg: "#ffffff",
     bg: "transparent",
@@ -335,7 +346,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
 
   footer.add(footerText)
 
-  moveableElement = new BoxRenderable("moveable", {
+  moveableElement = new BoxRenderable(renderer, {
+    id: "moveable",
     zIndex: 100,
     width: 8,
     height: 3,
@@ -351,7 +363,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  moveableText = new TextRenderable("moveable-text", {
+  moveableText = new TextRenderable(renderer, {
+    id: "moveable-text",
     content: "MOVE",
     fg: "#ffffff",
     bg: "transparent",
@@ -360,7 +373,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
 
   moveableElement.add(moveableText)
 
-  absolutePositionedBox = new BoxRenderable("absolute-positioned-box", {
+  absolutePositionedBox = new BoxRenderable(renderer, {
+    id: "absolute-positioned-box",
     zIndex: 150,
     width: 20,
     height: 3,
@@ -376,7 +390,8 @@ function createLayoutElements(rendererInstance: CliRenderer): void {
     border: true,
   })
 
-  absolutePositionedText = new TextRenderable("absolute-positioned-text", {
+  absolutePositionedText = new TextRenderable(renderer, {
+    id: "absolute-positioned-text",
     content: "BOTTOM RIGHT",
     fg: "#ffffff",
     bg: "transparent",

--- a/packages/core/src/examples/split-mode-demo.ts
+++ b/packages/core/src/examples/split-mode-demo.ts
@@ -45,7 +45,8 @@ class SplitModeAnimations {
       loop: true,
     })
 
-    this.container = new GroupRenderable("animation-container", {
+    this.container = new GroupRenderable(renderer, {
+      id: "animation-container",
       zIndex: 5,
       visible: true,
     })
@@ -57,7 +58,8 @@ class SplitModeAnimations {
   }
 
   private setupUI(): void {
-    const statusPanel = new BoxRenderable("status-panel", {
+    const statusPanel = new BoxRenderable(this.renderer, {
+      id: "status-panel",
       position: "absolute",
       left: 2,
       top: 5,
@@ -82,7 +84,8 @@ class SplitModeAnimations {
     ]
 
     systems.forEach((system, index) => {
-      const label = new TextRenderable(`${system.name.toLowerCase()}-label`, {
+      const label = new TextRenderable(this.renderer, {
+        id: `${system.name.toLowerCase()}-label`,
         content: `${system.name}:`,
         position: "absolute",
         left: 4,
@@ -92,7 +95,8 @@ class SplitModeAnimations {
       })
       this.container.add(label)
 
-      const bgBar = new BoxRenderable(`${system.name.toLowerCase()}-bg`, {
+      const bgBar = new BoxRenderable(this.renderer, {
+        id: `${system.name.toLowerCase()}-bg`,
         position: "absolute",
         left: 9,
         top: system.y,
@@ -103,7 +107,8 @@ class SplitModeAnimations {
       })
       this.container.add(bgBar)
 
-      const progressBar = new BoxRenderable(`${system.name.toLowerCase()}-progress`, {
+      const progressBar = new BoxRenderable(this.renderer, {
+        id: `${system.name.toLowerCase()}-progress`,
         position: "absolute",
         left: 9,
         top: system.y,
@@ -116,7 +121,8 @@ class SplitModeAnimations {
       this.systemLoadingBars.push(progressBar)
     })
 
-    const statsPanel = new BoxRenderable("stats-panel", {
+    const statsPanel = new BoxRenderable(this.renderer, {
+      id: "stats-panel",
       position: "absolute",
       left: 2,
       top: 14,
@@ -135,7 +141,8 @@ class SplitModeAnimations {
     this.statusCounters = []
     const counterLabels = ["PACKETS", "CONNECTIONS", "PROCESSES", "UPTIME"]
     counterLabels.forEach((label, index) => {
-      const counter = new TextRenderable(`counter-${index}`, {
+      const counter = new TextRenderable(this.renderer, {
+        id: `counter-${index}`,
         content: `${label}: 0`,
         position: "absolute",
         left: 4 + index * 15,
@@ -150,7 +157,8 @@ class SplitModeAnimations {
     this.movingOrbs = []
     const orbColors = ["#ff6b9d", "#4ecdc4", "#ffe66d"]
     orbColors.forEach((color, index) => {
-      const orb = new BoxRenderable(`orb-${index}`, {
+      const orb = new BoxRenderable(this.renderer, {
+        id: `orb-${index}`,
         position: "absolute",
         left: 2,
         top: 2,
@@ -166,7 +174,8 @@ class SplitModeAnimations {
     this.pulsingElements = []
     const pulseColors = ["#ff8a80", "#80cbc4", "#fff176"]
     pulseColors.forEach((color, index) => {
-      const pulse = new BoxRenderable(`pulse-${index}`, {
+      const pulse = new BoxRenderable(this.renderer, {
+        id: `pulse-${index}`,
         position: "absolute",
         left: this.renderer.width - 8 + index * 2,
         top: 1,
@@ -312,7 +321,8 @@ export function run(rendererInstance: CliRenderer): void {
 
   animationSystem = new SplitModeAnimations(rendererInstance)
 
-  text = new TextRenderable("demo-text", {
+  text = new TextRenderable(rendererInstance, {
+    id: "demo-text",
     position: "absolute",
     left: 2,
     top: 0,
@@ -322,7 +332,8 @@ export function run(rendererInstance: CliRenderer): void {
     content: t`${bold(fg("#00ffff")("◆ SPLIT MODE DEMO - ANIMATED DASHBOARD ◆"))}`,
   })
 
-  instructionsText = new TextRenderable("split-mode-instructions", {
+  instructionsText = new TextRenderable(rendererInstance, {
+    id: "split-mode-instructions",
     position: "absolute",
     left: 2,
     top: 19,

--- a/packages/core/src/examples/sprite-animation-demo.ts
+++ b/packages/core/src/examples/sprite-animation-demo.ts
@@ -48,13 +48,15 @@ export async function run(renderer: CliRenderer): Promise<void> {
   const initialTermWidth = renderer.terminalWidth
   const initialTermHeight = renderer.terminalHeight
 
-  const parentContainer = new GroupRenderable("sprite-animation-container", {
+  const parentContainer = new GroupRenderable(renderer, {
+    id: "sprite-animation-container",
     zIndex: 15,
     visible: true,
   })
   renderer.root.add(parentContainer)
 
-  const framebufferRenderable = new FrameBufferRenderable("main", {
+  const framebufferRenderable = new FrameBufferRenderable(renderer, {
+    id: "main",
     width: initialTermWidth,
     height: initialTermHeight,
     zIndex: 10,
@@ -114,7 +116,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   let isPerspectiveActive = true
   engine.setActiveCamera(pCamera)
 
-  const cameraModeText = new TextRenderable("cameraModeText", {
+  const cameraModeText = new TextRenderable(renderer, {
+    id: "cameraModeText",
     content: `Camera: Perspective (Press 'c' to switch)`,
     position: "absolute",
     left: 1,
@@ -374,7 +377,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
     await engine.drawScene(scene, framebuffer, deltaTime)
   })
 
-  const instructionsText = new TextRenderable("instructions", {
+  const instructionsText = new TextRenderable(renderer, {
+    id: "instructions",
     content:
       "Controls: c=camera, e=explode, r=restore, p=stress test, x=explode random, t=debug, u=supersample, `=console, ESC=back",
     position: "absolute",

--- a/packages/core/src/examples/sprite-particle-generator-demo.ts
+++ b/packages/core/src/examples/sprite-particle-generator-demo.ts
@@ -52,12 +52,14 @@ export async function run(renderer: CliRenderer): Promise<void> {
   const initialTermWidth = renderer.terminalWidth
   const initialTermHeight = renderer.terminalHeight
 
-  parentContainer = new GroupRenderable("particle-container", {
+  parentContainer = new GroupRenderable(renderer, {
+    id: "particle-container",
     zIndex: 15,
     visible: true,
   })
   renderer.root.add(parentContainer)
-  const framebufferRenderable = new FrameBufferRenderable("particle-main", {
+  const framebufferRenderable = new FrameBufferRenderable(renderer, {
+    id: "particle-main",
     width: initialTermWidth,
     height: initialTermHeight,
     zIndex: 10,
@@ -82,7 +84,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   scene.add(pCamera)
   engine.setActiveCamera(pCamera)
 
-  instructionsText = new TextRenderable("particle-instructions", {
+  instructionsText = new TextRenderable(renderer, {
+    id: "particle-instructions",
     content:
       "'g'(burst), 'a'(auto), 's'(stop), 'x'(clear), '1'(3D Static), '2'(2D Static), '3'(3D Animated), '4'(Custom), '5'(2D Animated)",
     position: "absolute",
@@ -93,7 +96,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(instructionsText)
 
-  particleCountText = new TextRenderable("particle-count", {
+  particleCountText = new TextRenderable(renderer, {
+    id: "particle-count",
     content: "Particles: 0",
     position: "absolute",
     left: 1,
@@ -103,7 +107,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(particleCountText)
 
-  configInfoText = new TextRenderable("particle-config-info", {
+  configInfoText = new TextRenderable(renderer, {
+    id: "particle-config-info",
     content: "Mode: 3D Static | Auto-spawning",
     position: "absolute",
     left: 1,

--- a/packages/core/src/examples/static-sprite-demo.ts
+++ b/packages/core/src/examples/static-sprite-demo.ts
@@ -25,13 +25,15 @@ export async function run(renderer: CliRenderer): Promise<void> {
   const TERM_WIDTH = renderer.terminalWidth
   const TERM_HEIGHT = renderer.terminalHeight
 
-  parentContainer = new GroupRenderable("static-sprite-container", {
+  parentContainer = new GroupRenderable(renderer, {
+    id: "static-sprite-container",
     zIndex: 15,
     visible: true,
   })
   renderer.root.add(parentContainer)
 
-  const framebufferRenderable = new FrameBufferRenderable("main", {
+  const framebufferRenderable = new FrameBufferRenderable(renderer, {
+    id: "main",
     width: TERM_WIDTH,
     height: TERM_HEIGHT,
     zIndex: 10,
@@ -64,7 +66,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   scene.add(camera)
   engine.setActiveCamera(camera)
 
-  const titleText = new TextRenderable("demo-title", {
+  const titleText = new TextRenderable(renderer, {
+    id: "demo-title",
     content: "Static THREE.Sprite Demo",
     position: "absolute",
     left: 1,
@@ -74,7 +77,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(titleText)
 
-  const statusText = new TextRenderable("status", {
+  const statusText = new TextRenderable(renderer, {
+    id: "status",
     content: "Loading sprite texture...",
     position: "absolute",
     left: 1,

--- a/packages/core/src/examples/styled-text-demo.ts
+++ b/packages/core/src/examples/styled-text-demo.ts
@@ -17,7 +17,6 @@ import { BoxRenderable } from "../renderables/Box"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
 import { getKeyHandler } from "../lib/KeyHandler"
 
-let renderer: CliRenderer | null = null
 let parentContainer: GroupRenderable | null = null
 let counter = 0
 let frameCallback: ((deltaTime: number) => Promise<void>) | null = null
@@ -29,11 +28,12 @@ let dashboardBox: BoxRenderable | null = null
 let complexDisplay: TextRenderable | null = null
 
 export function run(rendererInstance: CliRenderer): void {
-  renderer = rendererInstance
+  const renderer = rendererInstance
   renderer.start()
   renderer.setBackgroundColor("#001122")
 
-  parentContainer = new GroupRenderable("styled-text-container", {
+  parentContainer = new GroupRenderable(renderer, {
+    id: "styled-text-container",
     zIndex: 15,
     visible: true,
   })
@@ -48,7 +48,8 @@ With a ${bold(blue("window"))},
 And a ${blue("corvette")}
 And everything is blue`
 
-  const houseDisplay = new TextRenderable("house-text", {
+  const houseDisplay = new TextRenderable(renderer, {
+    id: "house-text",
     content: houseText,
     width: 30,
     height: 6,
@@ -65,7 +66,8 @@ ${bold(green("SUCCESS:"))} Data loaded
 ${bold(fg("#FFA500")("WARNING:"))} Low memory
 ${bgYellow(fg("black")(" NOTICE "))} System update available`
 
-  const statusDisplay = new TextRenderable("status-text", {
+  const statusDisplay = new TextRenderable(renderer, {
+    id: "status-text",
     content: statusText,
     width: 50,
     height: 6,
@@ -77,7 +79,8 @@ ${bgYellow(fg("black")(" NOTICE "))} System update available`
   parentContainer.add(statusDisplay)
 
   // Example 3 - Original dynamic text (updates every second)
-  dashboardBox = new BoxRenderable("dashboard-box", {
+  dashboardBox = new BoxRenderable(renderer, {
+    id: "dashboard-box",
     width: 72,
     height: 21,
     position: "absolute",
@@ -111,7 +114,8 @@ ${fg("#2ECC71")("Status:")} ${bold(fg("#E74C3C")("●"))} ${green("ALL SYSTEMS G
 
 ${bold(fg("#F1C40F")("Controls:"))} ${fg("#BDC3C7")("↑/↓ = Speed, ESC = Exit")}`
 
-  complexDisplay = new TextRenderable("complex-template", {
+  complexDisplay = new TextRenderable(renderer, {
+    id: "complex-template",
     content: initialText,
     left: 1,
     top: 1,
@@ -133,7 +137,8 @@ ${underline("Dynamic:")} ${bold(fg("#FF6B6B")(Math.sin(counter * 0.1) > 0 ? "UP"
       if (dynamicDisplay) {
         dynamicDisplay.content = dynamicText
       } else {
-        const newDynamicDisplay = new TextRenderable("dynamic-text", {
+        const newDynamicDisplay = new TextRenderable(renderer, {
+          id: "dynamic-text",
           content: dynamicText,
           width: 40,
           height: 4,
@@ -209,7 +214,8 @@ ${underline("Features demonstrated:")}
 • Dynamic updates with ${green("controllable frequency")}
 • Complex templates with ${red("many variables")}`
 
-  const instructionsDisplay = new TextRenderable("instructions", {
+  const instructionsDisplay = new TextRenderable(renderer, {
+    id: "instructions",
     content: instructionsText,
     width: 60,
     height: 12,
@@ -228,7 +234,8 @@ Boolean: ${red(true)}
 Float: ${blue((3.14159).toFixed(2))}
 Calculated: ${fg("#00FFFF")(Math.floor(Math.random() * 100))}`
 
-  const typesDisplay = new TextRenderable("types-text", {
+  const typesDisplay = new TextRenderable(renderer, {
+    id: "types-text",
     content: typesText,
     width: 30,
     height: 6,
@@ -264,7 +271,6 @@ export function destroy(rendererInstance: CliRenderer): void {
   startTime = Date.now()
   dashboardBox = null
   complexDisplay = null
-  renderer = null
 }
 
 if (import.meta.main) {

--- a/packages/core/src/examples/tab-select-demo.ts
+++ b/packages/core/src/examples/tab-select-demo.ts
@@ -86,13 +86,15 @@ export function run(rendererInstance: CliRenderer): void {
   renderer = rendererInstance
   renderer.setBackgroundColor("#001122")
 
-  parentContainer = new GroupRenderable("tab-select-container", {
+  parentContainer = new GroupRenderable(renderer, {
+    id: "tab-select-container",
     zIndex: 10,
     visible: true,
   })
   renderer.root.add(parentContainer)
 
-  tabSelect = new TabSelectRenderable("main-tabs", {
+  tabSelect = new TabSelectRenderable(renderer, {
+    id: "main-tabs",
     position: "absolute",
     left: 5,
     top: 2,
@@ -115,7 +117,8 @@ export function run(rendererInstance: CliRenderer): void {
 
   renderer.root.add(tabSelect)
 
-  keyLegendDisplay = new TextRenderable("key-legend", {
+  keyLegendDisplay = new TextRenderable(renderer, {
+    id: "key-legend",
     content: t``,
     width: 40,
     height: 10,
@@ -128,7 +131,8 @@ export function run(rendererInstance: CliRenderer): void {
   parentContainer.add(keyLegendDisplay)
 
   // Create status display
-  statusDisplay = new TextRenderable("status-display", {
+  statusDisplay = new TextRenderable(renderer, {
+    id: "status-display",
     content: t``,
     width: 80,
     height: 6,

--- a/packages/core/src/examples/text-selection-demo.ts
+++ b/packages/core/src/examples/text-selection-demo.ts
@@ -31,7 +31,8 @@ let allTextRenderables: (TextRenderable | TextRenderable)[] = []
 export function run(renderer: CliRenderer): void {
   renderer.setBackgroundColor("#0d1117")
 
-  mainContainer = new BoxRenderable("mainContainer", {
+  mainContainer = new BoxRenderable(renderer, {
+    id: "mainContainer",
     position: "absolute",
     left: 1,
     top: 1,
@@ -46,7 +47,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(mainContainer)
 
-  leftGroup = new GroupRenderable("leftGroup", {
+  leftGroup = new GroupRenderable(renderer, {
+    id: "leftGroup",
     position: "absolute",
     left: 2,
     top: 2,
@@ -54,7 +56,8 @@ export function run(renderer: CliRenderer): void {
   })
   mainContainer.add(leftGroup)
 
-  const box1 = new BoxRenderable("box1", {
+  const box1 = new BoxRenderable(renderer, {
+    id: "box1",
     width: 45,
     height: 7,
     backgroundColor: "#1e2936",
@@ -67,7 +70,8 @@ export function run(renderer: CliRenderer): void {
   })
   leftGroup.add(box1)
 
-  const text1 = new TextRenderable("text1", {
+  const text1 = new TextRenderable(renderer, {
+    id: "text1",
     content: "This is a paragraph in the first box.",
     zIndex: 21,
     fg: "#f0f6fc",
@@ -75,7 +79,8 @@ export function run(renderer: CliRenderer): void {
   box1.add(text1)
   allTextRenderables.push(text1)
 
-  const text2 = new TextRenderable("text2", {
+  const text2 = new TextRenderable(renderer, {
+    id: "text2",
     content: "It contains multiple lines of text",
     zIndex: 21,
     fg: "#f0f6fc",
@@ -83,7 +88,8 @@ export function run(renderer: CliRenderer): void {
   box1.add(text2)
   allTextRenderables.push(text2)
 
-  const text3 = new TextRenderable("text3", {
+  const text3 = new TextRenderable(renderer, {
+    id: "text3",
     content: "that can be selected independently.",
     zIndex: 21,
     fg: "#f0f6fc",
@@ -91,7 +97,8 @@ export function run(renderer: CliRenderer): void {
   box1.add(text3)
   allTextRenderables.push(text3)
 
-  const nestedBox = new BoxRenderable("nestedBox", {
+  const nestedBox = new BoxRenderable(renderer, {
+    id: "nestedBox",
     left: 2,
     top: 1,
     width: 31,
@@ -104,7 +111,8 @@ export function run(renderer: CliRenderer): void {
   })
   leftGroup.add(nestedBox)
 
-  const nestedText = new TextRenderable("nestedText", {
+  const nestedText = new TextRenderable(renderer, {
+    id: "nestedText",
     content: t`${yellow("Important:")} ${bold(cyan("Nested content"))} ${italic(green("with styles"))}`,
     width: 27,
     height: 1,
@@ -115,7 +123,8 @@ export function run(renderer: CliRenderer): void {
   nestedBox.add(nestedText)
   allTextRenderables.push(nestedText)
 
-  rightGroup = new GroupRenderable("rightGroup", {
+  rightGroup = new GroupRenderable(renderer, {
+    id: "rightGroup",
     position: "absolute",
     left: 48,
     top: 2,
@@ -123,7 +132,8 @@ export function run(renderer: CliRenderer): void {
   })
   mainContainer.add(rightGroup)
 
-  const box2 = new BoxRenderable("box2", {
+  const box2 = new BoxRenderable(renderer, {
+    id: "box2",
     left: 2,
     top: 0,
     width: 35,
@@ -139,7 +149,8 @@ export function run(renderer: CliRenderer): void {
   })
   rightGroup.add(box2)
 
-  const codeText1 = new TextRenderable("codeText1", {
+  const codeText1 = new TextRenderable(renderer, {
+    id: "codeText1",
     content: t`${magenta("function")} ${cyan("handleSelection")}() {`,
     zIndex: 21,
     selectionBg: "#4a5568",
@@ -147,7 +158,8 @@ export function run(renderer: CliRenderer): void {
   box2.add(codeText1)
   allTextRenderables.push(codeText1)
 
-  const codeText2 = new TextRenderable("codeText2", {
+  const codeText2 = new TextRenderable(renderer, {
+    id: "codeText2",
     content: t`  ${magenta("const")} selected = ${cyan("getSelectedText")}()`,
     zIndex: 21,
     selectionBg: "#4a5568",
@@ -155,7 +167,8 @@ export function run(renderer: CliRenderer): void {
   box2.add(codeText2)
   allTextRenderables.push(codeText2)
 
-  const codeText3 = new TextRenderable("codeText3", {
+  const codeText3 = new TextRenderable(renderer, {
+    id: "codeText3",
     content: t`  ${yellow("console")}.${green("log")}(selected)`,
     zIndex: 21,
     selectionBg: "#4a5568",
@@ -163,7 +176,8 @@ export function run(renderer: CliRenderer): void {
   box2.add(codeText3)
   allTextRenderables.push(codeText3)
 
-  const codeText4 = new TextRenderable("codeText4", {
+  const codeText4 = new TextRenderable(renderer, {
+    id: "codeText4",
     content: "}",
     zIndex: 21,
     fg: "#e6edf3",
@@ -171,7 +185,8 @@ export function run(renderer: CliRenderer): void {
   box2.add(codeText4)
   allTextRenderables.push(codeText4)
 
-  floatingBox = new BoxRenderable("floatingBox", {
+  floatingBox = new BoxRenderable(renderer, {
+    id: "floatingBox",
     position: "absolute",
     left: 90,
     top: 11,
@@ -186,7 +201,8 @@ export function run(renderer: CliRenderer): void {
   })
   renderer.root.add(floatingBox)
 
-  const multilineText = new TextRenderable("multilineText", {
+  const multilineText = new TextRenderable(renderer, {
+    id: "multilineText",
     content: t`${bold(cyan("Selection Demo"))}
 ${green("✓")} Cross-renderable selection
 ${green("✓")} Nested groups and boxes
@@ -198,7 +214,8 @@ ${green("✓")} Styled text support`,
   floatingBox.add(multilineText)
   allTextRenderables.push(multilineText)
 
-  const instructions = new TextRenderable("instructions", {
+  const instructions = new TextRenderable(renderer, {
+    id: "instructions",
     content: "Click and drag to select text across any elements. Press 'C' to clear selection.",
     left: 2,
     top: 17,
@@ -208,7 +225,8 @@ ${green("✓")} Styled text support`,
   mainContainer.add(instructions)
   allTextRenderables.push(instructions)
 
-  statusBox = new BoxRenderable("statusBox", {
+  statusBox = new BoxRenderable(renderer, {
+    id: "statusBox",
     position: "absolute",
     left: 1,
     top: 24,
@@ -224,35 +242,40 @@ ${green("✓")} Styled text support`,
   })
   renderer.root.add(statusBox)
 
-  statusText = new TextRenderable("statusText", {
+  statusText = new TextRenderable(renderer, {
+    id: "statusText",
     content: "No selection - try selecting across different nested elements",
     zIndex: 2,
     fg: "#f0f6fc",
   })
   statusBox.add(statusText)
 
-  selectionStartText = new TextRenderable("selectionStartText", {
+  selectionStartText = new TextRenderable(renderer, {
+    id: "selectionStartText",
     content: "",
     zIndex: 2,
     fg: "#7dd3fc",
   })
   statusBox.add(selectionStartText)
 
-  selectionMiddleText = new TextRenderable("selectionMiddleText", {
+  selectionMiddleText = new TextRenderable(renderer, {
+    id: "selectionMiddleText",
     content: "",
     zIndex: 2,
     fg: "#94a3b8",
   })
   statusBox.add(selectionMiddleText)
 
-  selectionEndText = new TextRenderable("selectionEndText", {
+  selectionEndText = new TextRenderable(renderer, {
+    id: "selectionEndText",
     content: "",
     zIndex: 2,
     fg: "#7dd3fc",
   })
   statusBox.add(selectionEndText)
 
-  debugText = new TextRenderable("debugText", {
+  debugText = new TextRenderable(renderer, {
+    id: "debugText",
     content: "",
     zIndex: 2,
     fg: "#e6edf3",

--- a/packages/core/src/examples/texture-loading-demo.ts
+++ b/packages/core/src/examples/texture-loading-demo.ts
@@ -42,13 +42,15 @@ export async function run(renderer: CliRenderer): Promise<void> {
   const WIDTH = renderer.terminalWidth
   const HEIGHT = renderer.terminalHeight
 
-  parentContainer = new GroupRenderable("texture-loading-container", {
+  parentContainer = new GroupRenderable(renderer, {
+    id: "texture-loading-container",
     zIndex: 15,
     visible: true,
   })
   renderer.root.add(parentContainer)
 
-  const framebufferRenderable = new FrameBufferRenderable("main", {
+  const framebufferRenderable = new FrameBufferRenderable(renderer, {
+    id: "main",
     width: WIDTH,
     height: HEIGHT,
     zIndex: 10,
@@ -96,14 +98,16 @@ export async function run(renderer: CliRenderer): Promise<void> {
 
   engine.setActiveCamera(cameraNode)
 
-  const titleText = new TextRenderable("demo-title", {
+  const titleText = new TextRenderable(renderer, {
+    id: "demo-title",
     content: "Texture Loading Demo",
     fg: "#FFFFFF",
     zIndex: 20,
   })
   parentContainer.add(titleText)
 
-  const statusText = new TextRenderable("status", {
+  const statusText = new TextRenderable(renderer, {
+    id: "status",
     content: "Loading texture...",
     position: "absolute",
     left: 0,
@@ -113,7 +117,8 @@ export async function run(renderer: CliRenderer): Promise<void> {
   })
   parentContainer.add(statusText)
 
-  const controlsText = new TextRenderable("controls", {
+  const controlsText = new TextRenderable(renderer, {
+    id: "controls",
     content: "WASD: Move | QE: Rotate | ZX: Zoom | R: Reset | Space: Toggle rotation | Escape: Return",
     position: "absolute",
     left: 0,

--- a/packages/core/src/examples/timeline-example.ts
+++ b/packages/core/src/examples/timeline-example.ts
@@ -44,13 +44,15 @@ class TimelineExample {
     this._mainTimeline.sync(this._subTimeline1, 0)
     this._mainTimeline.sync(this._subTimeline2, 3000)
 
-    this.parentContainer = new GroupRenderable("timeline-container", {
+    this.parentContainer = new GroupRenderable(renderer, {
+      id: "timeline-container",
       zIndex: 10,
       visible: true,
     })
     this.renderer.root.add(this.parentContainer)
 
-    this.boxObject = new BoxRenderable("box-object", {
+    this.boxObject = new BoxRenderable(renderer, {
+      id: "box-object",
       position: "absolute",
       left: 10,
       top: 8,
@@ -65,7 +67,8 @@ class TimelineExample {
     })
     this.parentContainer.add(this.boxObject)
 
-    const colorObject = new BoxRenderable("color-object", {
+    const colorObject = new BoxRenderable(renderer, {
+      id: "color-object",
       position: "absolute",
       left: 25,
       top: 8,
@@ -80,7 +83,8 @@ class TimelineExample {
     })
     this.parentContainer.add(colorObject)
 
-    const physicsObject = new BoxRenderable("physics-object", {
+    const physicsObject = new BoxRenderable(renderer, {
+      id: "physics-object",
       position: "absolute",
       left: 45,
       top: 8,
@@ -95,7 +99,8 @@ class TimelineExample {
     })
     this.parentContainer.add(physicsObject)
 
-    this.alternatingObject = new BoxRenderable("alternating-object", {
+    this.alternatingObject = new BoxRenderable(renderer, {
+      id: "alternating-object",
       position: "absolute",
       left: 1,
       top: 1,
@@ -110,7 +115,8 @@ class TimelineExample {
     })
     this.parentContainer.add(this.alternatingObject)
 
-    const mainTimelineBox = new BoxRenderable("main-timeline", {
+    const mainTimelineBox = new BoxRenderable(renderer, {
+      id: "main-timeline",
       position: "absolute",
       left: 2,
       top: 15,
@@ -125,7 +131,8 @@ class TimelineExample {
     })
     this.parentContainer.add(mainTimelineBox)
 
-    const subTimeline1Box = new BoxRenderable("sub-timeline-1", {
+    const subTimeline1Box = new BoxRenderable(renderer, {
+      id: "sub-timeline-1",
       position: "absolute",
       left: 2,
       top: 19,
@@ -140,7 +147,8 @@ class TimelineExample {
     })
     this.parentContainer.add(subTimeline1Box)
 
-    const subTimeline2Box = new BoxRenderable("sub-timeline-2", {
+    const subTimeline2Box = new BoxRenderable(renderer, {
+      id: "sub-timeline-2",
       position: "absolute",
       left: 35,
       top: 19,
@@ -155,7 +163,8 @@ class TimelineExample {
     })
     this.parentContainer.add(subTimeline2Box)
 
-    const statusBox = new BoxRenderable("status", {
+    const statusBox = new BoxRenderable(renderer, {
+      id: "status",
       position: "absolute",
       left: 2,
       top: 24,
@@ -170,7 +179,8 @@ class TimelineExample {
     })
     this.parentContainer.add(statusBox)
 
-    this.statusLine1 = new TextRenderable("status-line1", {
+    this.statusLine1 = new TextRenderable(renderer, {
+      id: "status-line1",
       content: "Timeline: Initializing...",
       position: "absolute",
       left: 4,
@@ -180,7 +190,8 @@ class TimelineExample {
     })
     this.parentContainer.add(this.statusLine1)
 
-    this.statusLine2 = new TextRenderable("status-line2", {
+    this.statusLine2 = new TextRenderable(renderer, {
+      id: "status-line2",
       content: "Box Position: x=0.0, y=0.0",
       position: "absolute",
       left: 4,
@@ -190,7 +201,8 @@ class TimelineExample {
     })
     this.parentContainer.add(this.statusLine2)
 
-    this.statusLine3 = new TextRenderable("status-line3", {
+    this.statusLine3 = new TextRenderable(renderer, {
+      id: "status-line3",
       content: "Box Scale/Rot: scale=1.0, rot=0.0",
       position: "absolute",
       left: 4,
@@ -200,7 +212,8 @@ class TimelineExample {
     })
     this.parentContainer.add(this.statusLine3)
 
-    this.statusLine4 = new TextRenderable("status-line4", {
+    this.statusLine4 = new TextRenderable(renderer, {
+      id: "status-line4",
       content: "Color: rgb(255, 0, 0)",
       position: "absolute",
       left: 4,
@@ -210,7 +223,8 @@ class TimelineExample {
     })
     this.parentContainer.add(this.statusLine4)
 
-    this.statusLine5 = new TextRenderable("status-line5", {
+    this.statusLine5 = new TextRenderable(renderer, {
+      id: "status-line5",
       content: "Color Opacity: 1.0",
       position: "absolute",
       left: 4,
@@ -220,7 +234,8 @@ class TimelineExample {
     })
     this.parentContainer.add(this.statusLine5)
 
-    this.statusLine6 = new TextRenderable("status-line6", {
+    this.statusLine6 = new TextRenderable(renderer, {
+      id: "status-line6",
       content: "Physics: v=0.0, a=0.0, m=1.0",
       position: "absolute",
       left: 4,
@@ -230,7 +245,8 @@ class TimelineExample {
     })
     this.parentContainer.add(this.statusLine6)
 
-    this.statusLine7 = new TextRenderable("status-line7", {
+    this.statusLine7 = new TextRenderable(renderer, {
+      id: "status-line7",
       content: "Progress: Main=0% Sub1=0% Sub2=0%",
       position: "absolute",
       left: 4,
@@ -240,7 +256,8 @@ class TimelineExample {
     })
     this.parentContainer.add(this.statusLine7)
 
-    this.statusLine8 = new TextRenderable("status-line8", {
+    this.statusLine8 = new TextRenderable(renderer, {
+      id: "status-line8",
       content: "Example Value: 0.000 (0.0 → 0.5)",
       position: "absolute",
       left: 4,
@@ -250,7 +267,8 @@ class TimelineExample {
     })
     this.parentContainer.add(this.statusLine8)
 
-    this.statusLine9 = new TextRenderable("status-line9", {
+    this.statusLine9 = new TextRenderable(renderer, {
+      id: "status-line9",
       content: "Alternating: x=65 (left/right loop=5)",
       position: "absolute",
       left: 4,
@@ -278,7 +296,8 @@ class TimelineExample {
     if (mainProgressBox) {
       mainProgressBox.width = Math.max(1, Math.floor(mainProgress))
     } else {
-      const newMainProgressBox = new BoxRenderable("main-progress", {
+      const newMainProgressBox = new BoxRenderable(this.renderer, {
+        id: "main-progress",
         position: "absolute",
         left: 3,
         top: 16,
@@ -294,7 +313,8 @@ class TimelineExample {
     if (sub1ProgressBox) {
       sub1ProgressBox.width = Math.max(1, Math.floor(sub1Progress))
     } else {
-      const newSub1ProgressBox = new BoxRenderable("sub1-progress", {
+      const newSub1ProgressBox = new BoxRenderable(this.renderer, {
+        id: "sub1-progress",
         position: "absolute",
         left: 3,
         top: 20,
@@ -310,7 +330,8 @@ class TimelineExample {
     if (sub2ProgressBox) {
       sub2ProgressBox.width = Math.max(1, Math.floor(sub2Progress))
     } else {
-      const newSub2ProgressBox = new BoxRenderable("sub2-progress", {
+      const newSub2ProgressBox = new BoxRenderable(this.renderer, {
+        id: "sub2-progress",
         position: "absolute",
         left: 36,
         top: 20,

--- a/packages/core/src/examples/transparency-demo.ts
+++ b/packages/core/src/examples/transparency-demo.ts
@@ -12,7 +12,7 @@ import {
   underline,
   fg,
 } from "../index"
-import type { CliRenderer } from "../index"
+import type { CliRenderer, RenderContext } from "../index"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
 
 let nextZIndex = 101
@@ -24,8 +24,18 @@ class DraggableTransparentBox extends BoxRenderable {
   private dragOffsetY = 0
   private alphaPercentage: number
 
-  constructor(id: string, x: number, y: number, width: number, height: number, bg: RGBA, zIndex: number) {
-    super(id, {
+  constructor(
+    ctx: RenderContext,
+    id: string,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    bg: RGBA,
+    zIndex: number,
+  ) {
+    super(ctx, {
+      id,
       width,
       height,
       zIndex,
@@ -71,8 +81,8 @@ class DraggableTransparentBox extends BoxRenderable {
           this.x = event.x - this.dragOffsetX
           this.y = event.y - this.dragOffsetY
 
-          this.x = Math.max(0, Math.min(this.x, (this.ctx?.width() || 80) - this.width))
-          this.y = Math.max(4, Math.min(this.y, (this.ctx?.height() || 24) - this.height))
+          this.x = Math.max(0, Math.min(this.x, this._ctx.width - this.width))
+          this.y = Math.max(4, Math.min(this.y, this._ctx.height - this.height))
 
           event.preventDefault()
         }
@@ -85,7 +95,8 @@ export function run(renderer: CliRenderer): void {
   renderer.start()
   renderer.setBackgroundColor("#0A0E14")
 
-  const parentContainer = new GroupRenderable("parent-container", {
+  const parentContainer = new GroupRenderable(renderer, {
+    id: "parent-container",
     zIndex: 10,
     visible: true,
   })
@@ -94,7 +105,8 @@ export function run(renderer: CliRenderer): void {
   const headerText = t`${bold(underline(fg("#00D4AA")("Interactive Alpha Transparency & Blending Demo - Drag the boxes!")))}
 ${fg("#A8A8B2")("Click and drag any transparent box to move it around • Watch how transparency layers blend")}`
 
-  const headerDisplay = new TextRenderable("header-text", {
+  const headerDisplay = new TextRenderable(renderer, {
+    id: "header-text",
     content: headerText,
     width: 85,
     height: 3,
@@ -106,7 +118,8 @@ ${fg("#A8A8B2")("Click and drag any transparent box to move it around • Watch 
   })
   parentContainer.add(headerDisplay)
 
-  const textUnderAlpha = new TextRenderable("text-under-alpha", {
+  const textUnderAlpha = new TextRenderable(renderer, {
+    id: "text-under-alpha",
     content: "This text should not be selectable",
     position: "absolute",
     left: 10,
@@ -118,7 +131,8 @@ ${fg("#A8A8B2")("Click and drag any transparent box to move it around • Watch 
   })
   parentContainer.add(textUnderAlpha)
 
-  const moreTextUnder = new TextRenderable("more-text-under", {
+  const moreTextUnder = new TextRenderable(renderer, {
+    id: "more-text-under",
     content: "Selectable text to show character preservation",
     position: "absolute",
     left: 15,
@@ -130,6 +144,7 @@ ${fg("#A8A8B2")("Click and drag any transparent box to move it around • Watch 
   parentContainer.add(moreTextUnder)
 
   const alphaBox50 = new DraggableTransparentBox(
+    renderer,
     "alpha-box-50",
     15,
     5,
@@ -142,6 +157,7 @@ ${fg("#A8A8B2")("Click and drag any transparent box to move it around • Watch 
   draggableBoxes.push(alphaBox50)
 
   const alphaBox75 = new DraggableTransparentBox(
+    renderer,
     "alpha-box-75",
     30,
     7,
@@ -154,6 +170,7 @@ ${fg("#A8A8B2")("Click and drag any transparent box to move it around • Watch 
   draggableBoxes.push(alphaBox75)
 
   const alphaBox25 = new DraggableTransparentBox(
+    renderer,
     "alpha-box-25",
     45,
     9,
@@ -166,6 +183,7 @@ ${fg("#A8A8B2")("Click and drag any transparent box to move it around • Watch 
   draggableBoxes.push(alphaBox25)
 
   const alphaGreen = new DraggableTransparentBox(
+    renderer,
     "alpha-green",
     20,
     11,
@@ -178,6 +196,7 @@ ${fg("#A8A8B2")("Click and drag any transparent box to move it around • Watch 
   draggableBoxes.push(alphaGreen)
 
   const alphaYellow = new DraggableTransparentBox(
+    renderer,
     "alpha-yellow",
     25,
     13,
@@ -190,6 +209,7 @@ ${fg("#A8A8B2")("Click and drag any transparent box to move it around • Watch 
   draggableBoxes.push(alphaYellow)
 
   const alphaOverlay = new DraggableTransparentBox(
+    renderer,
     "alpha-overlay",
     10,
     17,

--- a/packages/core/src/renderables/ASCIIFont.ts
+++ b/packages/core/src/renderables/ASCIIFont.ts
@@ -3,7 +3,7 @@ import { ASCIIFontSelectionHelper } from "../lib/selection"
 import { type fonts, measureText, renderFontToFrameBuffer, getCharacterPositions } from "../lib/ascii.font"
 import { RGBA, parseColor } from "../lib/RGBA"
 import { FrameBufferRenderable } from "./FrameBuffer"
-import type { SelectionState } from "../types"
+import type { RenderContext, SelectionState } from "../types"
 
 export interface ASCIIFontOptions extends RenderableOptions {
   text?: string
@@ -26,12 +26,12 @@ export class ASCIIFontRenderable extends FrameBufferRenderable {
 
   private selectionHelper: ASCIIFontSelectionHelper
 
-  constructor(id: string, options: ASCIIFontOptions) {
+  constructor(ctx: RenderContext, options: ASCIIFontOptions) {
     const font = options.font || "tiny"
     const text = options.text || ""
     const measurements = measureText({ text: text, font })
 
-    super(id, {
+    super(ctx, {
       ...options,
       width: measurements.width || 1,
       height: measurements.height || 1,

--- a/packages/core/src/renderables/Box.ts
+++ b/packages/core/src/renderables/Box.ts
@@ -10,6 +10,7 @@ import {
   getBorderSides,
 } from "../lib"
 import { type ColorInput, RGBA, parseColor } from "../lib/RGBA"
+import type { RenderContext } from "../types"
 
 export interface BoxOptions extends RenderableOptions {
   backgroundColor?: string | RGBA
@@ -46,8 +47,8 @@ export class BoxRenderable extends Renderable {
     focusedBorderColor: "#00AAFF",
   } satisfies Partial<BoxOptions>
 
-  constructor(id: string, options: BoxOptions) {
-    super(id, options)
+  constructor(ctx: RenderContext, options: BoxOptions) {
+    super(ctx, options)
 
     this._backgroundColor = parseColor(options.backgroundColor || this._defaultOptions.backgroundColor)
     this._border = options.border ?? this._defaultOptions.border

--- a/packages/core/src/renderables/FrameBuffer.ts
+++ b/packages/core/src/renderables/FrameBuffer.ts
@@ -1,5 +1,6 @@
 import { type RenderableOptions, Renderable } from "../Renderable"
 import { OptimizedBuffer } from "../buffer"
+import type { RenderContext } from "../types"
 
 export interface FrameBufferOptions extends RenderableOptions {
   width: number
@@ -11,10 +12,10 @@ export class FrameBufferRenderable extends Renderable {
   public frameBuffer: OptimizedBuffer
   protected respectAlpha: boolean
 
-  constructor(id: string, options: FrameBufferOptions) {
-    super(id, options)
+  constructor(ctx: RenderContext, options: FrameBufferOptions) {
+    super(ctx, options)
     this.respectAlpha = options.respectAlpha || false
-    this.frameBuffer = OptimizedBuffer.create(options.width, options.height, {
+    this.frameBuffer = OptimizedBuffer.create(options.width, options.height, this._ctx.widthMethod, {
       respectAlpha: this.respectAlpha,
     })
   }

--- a/packages/core/src/renderables/Group.ts
+++ b/packages/core/src/renderables/Group.ts
@@ -1,7 +1,8 @@
 import { Renderable, type RenderableOptions } from "../Renderable"
+import type { RenderContext } from "../types"
 
 export class GroupRenderable extends Renderable {
-  constructor(id: string, options: RenderableOptions) {
-    super(id, options)
+  constructor(ctx: RenderContext, options: RenderableOptions) {
+    super(ctx, options)
   }
 }

--- a/packages/core/src/renderables/Select.ts
+++ b/packages/core/src/renderables/Select.ts
@@ -3,6 +3,7 @@ import { fonts, measureText, renderFontToFrameBuffer } from "../lib/ascii.font"
 import type { ParsedKey } from "../lib/parse.keypress"
 import { RGBA, parseColor, type ColorInput } from "../lib/RGBA"
 import { Renderable, type RenderableOptions } from "../Renderable"
+import type { RenderContext } from "../types"
 
 export interface SelectOption {
   name: string
@@ -74,8 +75,8 @@ export class SelectRenderable extends Renderable {
     fastScrollStep: 5,
   } satisfies Partial<SelectRenderableOptions>
 
-  constructor(id: string, options: SelectRenderableOptions) {
-    super(id, { ...options, buffered: true })
+  constructor(ctx: RenderContext, options: SelectRenderableOptions) {
+    super(ctx, { ...options, buffered: true })
 
     this._backgroundColor = parseColor(options.backgroundColor || this._defaultOptions.backgroundColor)
     this._textColor = parseColor(options.textColor || this._defaultOptions.textColor)

--- a/packages/core/src/renderables/TabSelect.ts
+++ b/packages/core/src/renderables/TabSelect.ts
@@ -2,6 +2,7 @@ import { Renderable, type RenderableOptions } from "../Renderable"
 import { OptimizedBuffer } from "../buffer"
 import { RGBA, parseColor, type ColorInput } from "../lib/RGBA"
 import type { ParsedKey } from "../lib/parse.keypress"
+import type { RenderContext } from "../types"
 
 export interface TabSelectOption {
   name: string
@@ -66,10 +67,10 @@ export class TabSelectRenderable extends Renderable {
   private _showUnderline: boolean
   private _wrapSelection: boolean
 
-  constructor(id: string, options: TabSelectRenderableOptions) {
+  constructor(ctx: RenderContext, options: TabSelectRenderableOptions) {
     const calculatedHeight = calculateDynamicHeight(options.showUnderline ?? true, options.showDescription ?? true)
 
-    super(id, { ...options, height: calculatedHeight, buffered: true })
+    super(ctx, { ...options, height: calculatedHeight, buffered: true })
 
     this._backgroundColor = parseColor(options.backgroundColor || "transparent")
     this._textColor = parseColor(options.textColor || "#FFFFFF")

--- a/packages/core/src/renderables/Text.ts
+++ b/packages/core/src/renderables/Text.ts
@@ -3,7 +3,7 @@ import { TextSelectionHelper } from "../lib/selection"
 import { stringToStyledText, StyledText } from "../lib/styled-text"
 import { TextBuffer, type TextChunk } from "../text-buffer"
 import { RGBA, parseColor } from "../lib/RGBA"
-import type { SelectionState } from "../types"
+import { type SelectionState, type RenderContext } from "../types"
 import type { OptimizedBuffer } from "../buffer"
 import { MeasureMode } from "yoga-layout"
 
@@ -31,8 +31,8 @@ export class TextRenderable extends Renderable {
   private _plainText: string = ""
   private _lineInfo: { lineStarts: number[]; lineWidths: number[] } = { lineStarts: [], lineWidths: [] }
 
-  constructor(id: string, options: TextOptions) {
-    super(id, options)
+  constructor(ctx: RenderContext, options: TextOptions) {
+    super(ctx, options)
 
     this.selectionHelper = new TextSelectionHelper(
       () => this.x,
@@ -50,7 +50,7 @@ export class TextRenderable extends Renderable {
     this._selectionFg = options.selectionFg ? parseColor(options.selectionFg) : undefined
     this.selectable = options.selectable ?? true
 
-    this.textBuffer = TextBuffer.create(64)
+    this.textBuffer = TextBuffer.create(64, this._ctx.widthMethod)
 
     this.textBuffer.setDefaultFg(this._defaultFg)
     this.textBuffer.setDefaultBg(this._defaultBg)

--- a/packages/core/src/text-buffer.ts
+++ b/packages/core/src/text-buffer.ts
@@ -2,6 +2,7 @@ import type { StyledText } from "./lib/styled-text"
 import { RGBA } from "./lib/RGBA"
 import { resolveRenderLib, type RenderLib } from "./zig"
 import { type Pointer } from "bun:ffi"
+import { type WidthMethod } from "./types"
 
 export interface TextChunk {
   __isChunk: true
@@ -42,9 +43,9 @@ export class TextBuffer {
     this._capacity = capacity
   }
 
-  static create(capacity: number = 256): TextBuffer {
+  static create(capacity: number = 256, widthMethod: WidthMethod): TextBuffer {
     const lib = resolveRenderLib()
-    return lib.createTextBuffer(capacity)
+    return lib.createTextBuffer(capacity, widthMethod)
   }
 
   private syncBuffersAfterResize(): void {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,5 @@
+import type { RGBA } from "./lib/RGBA"
+
 export const TextAttributes = {
   NONE: 0,
   BOLD: 1 << 0, // 1
@@ -19,11 +21,20 @@ export enum DebugOverlayCorner {
   bottomRight = 3,
 }
 
+export type WidthMethod = "wcwidth" | "unicode"
+
 export interface RenderContext {
   addToHitGrid: (x: number, y: number, width: number, height: number, id: number) => void
-  width: () => number
-  height: () => number
+  width: number
+  height: number
   needsUpdate: () => void
+  setCursorPosition: (x: number, y: number, visible: boolean) => void
+  setCursorStyle: (style: CursorStyle, blinking: boolean) => void
+  setCursorColor: (color: RGBA) => void
+  widthMethod: WidthMethod
+  capabilities: any | null
+  requestLive: () => void
+  dropLive: () => void
 }
 
 export interface SelectionState {

--- a/packages/core/src/zig/build.zig
+++ b/packages/core/src/zig/build.zig
@@ -115,6 +115,16 @@ fn buildTargetFromQuery(
         .optimize = optimize,
         .link_libc = false,
     });
+
+    const zg_dep = b.dependency("zg", .{
+        // .cjk = false,
+        .optimize = optimize,
+        .target = target,
+    });
+    module.addImport("code_point", zg_dep.module("code_point"));
+    module.addImport("Graphemes", zg_dep.module("Graphemes"));
+    module.addImport("DisplayWidth", zg_dep.module("DisplayWidth"));
+
     target_output = b.addLibrary(.{
         .name = LIB_NAME,
         .root_module = module,

--- a/packages/core/src/zig/build.zig.zon
+++ b/packages/core/src/zig/build.zig.zon
@@ -1,0 +1,16 @@
+.{
+    .name = .opentui,
+    .version = "0.1.11",
+    .fingerprint = 0x5445027d063f5083,
+    .minimum_zig_version = "0.14.1",
+    .dependencies = .{
+        .zg = .{
+            .url = "https://codeberg.org/atman/zg/archive/v0.14.1.tar.gz",
+            .hash = "zg-0.14.1-oGqU3IQ_tALZIiBN026_NTaPJqU-Upm8P_C7QED2Rzm8",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+    },
+}

--- a/packages/core/src/zig/grapheme.zig
+++ b/packages/core/src/zig/grapheme.zig
@@ -1,0 +1,315 @@
+const std = @import("std");
+
+pub const GraphemePoolError = error{
+    OutOfMemory,
+    InvalidId,
+};
+
+// Encoding flags for char buffer entries (u32)
+// Bits 31-30: encoding type
+//   00xxxxxxxx: direct unicode scalar value (30 bits, as-is)
+//   10xxxxxxxx: grapheme start cell with pool ID (26 bits total payload)
+//   11xxxxxxxx: continuation cell marker for wide/grapheme rendering
+pub const CHAR_FLAG_GRAPHEME: u32 = 0x8000_0000;
+pub const CHAR_FLAG_CONTINUATION: u32 = 0xC000_0000;
+
+// For grapheme start and continuation cells:
+// Bits 29..28: right extent (u2), Bits 27..26: left extent (u2)
+pub const CHAR_EXT_RIGHT_SHIFT: u5 = 28;
+pub const CHAR_EXT_LEFT_SHIFT: u5 = 26;
+pub const CHAR_EXT_MASK: u32 = 0x3;
+
+// Low 26 bits carry the global grapheme ID payload for start cells
+pub const GRAPHEME_ID_MASK: u32 = 0x03FF_FFFF;
+
+/// Global slab-allocated pool for grapheme clusters (byte slices)
+/// This is total overkill probably, but fun
+/// ID layout (26-bit payload):
+/// [ class (3 bits) | slot_index (23 bits) ]
+pub const GraphemePool = struct {
+    const MAX_CLASSES: u5 = 5; // 0..4 => 8,16,32,64,128
+    const CLASS_SIZES = [_]u32{ 8, 16, 32, 64, 128 };
+    const SLOTS_PER_PAGE = [_]u32{ 256, 128, 64, 16, 8 };
+    const CLASS_BITS: u5 = 3;
+    const SLOT_BITS: u5 = 23;
+    const CLASS_MASK: u32 = (@as(u32, 1) << CLASS_BITS) - 1; // 0b111
+    const SLOT_MASK: u32 = (@as(u32, 1) << SLOT_BITS) - 1;
+
+    pub const IdPayload = u32;
+
+    allocator: std.mem.Allocator,
+    classes: [MAX_CLASSES]ClassPool,
+
+    const SlotHeader = packed struct {
+        len: u16,
+        refcount: u32,
+    };
+
+    pub fn init(allocator: std.mem.Allocator) GraphemePool {
+        var classes: [MAX_CLASSES]ClassPool = undefined;
+        var i: usize = 0;
+        while (i < MAX_CLASSES) : (i += 1) {
+            classes[i] = ClassPool.init(allocator, CLASS_SIZES[i], SLOTS_PER_PAGE[i]);
+        }
+        return .{ .allocator = allocator, .classes = classes };
+    }
+
+    pub fn deinit(self: *GraphemePool) void {
+        var i: usize = 0;
+        while (i < MAX_CLASSES) : (i += 1) {
+            self.classes[i].deinit();
+        }
+    }
+
+    fn classForSize(size: usize) u32 {
+        if (size <= 8) return 0;
+        if (size <= 16) return 1;
+        if (size <= 32) return 2;
+        if (size <= 64) return 3;
+        return 4; // up to 128
+    }
+
+    pub fn alloc(self: *GraphemePool, bytes: []const u8) GraphemePoolError!IdPayload {
+        const class_id: u32 = classForSize(bytes.len);
+        const slot_index = try self.classes[class_id].alloc(bytes);
+        if (slot_index > SLOT_MASK) return GraphemePoolError.OutOfMemory;
+        return (class_id << SLOT_BITS) | slot_index;
+    }
+
+    pub fn incref(self: *GraphemePool, id: IdPayload) void {
+        const class_id: u32 = (id >> SLOT_BITS) & CLASS_MASK;
+        const slot_index: u32 = id & SLOT_MASK;
+        self.classes[class_id].incref(slot_index);
+    }
+
+    pub fn decref(self: *GraphemePool, id: IdPayload) GraphemePoolError!void {
+        const class_id: u32 = (id >> SLOT_BITS) & CLASS_MASK;
+        const slot_index: u32 = id & SLOT_MASK;
+        try self.classes[class_id].decref(slot_index);
+    }
+
+    pub fn get(self: *GraphemePool, id: IdPayload) GraphemePoolError![]const u8 {
+        const class_id: u32 = (id >> SLOT_BITS) & CLASS_MASK;
+        const slot_index: u32 = id & SLOT_MASK;
+        return self.classes[class_id].get(slot_index);
+    }
+
+    const ClassPool = struct {
+        allocator: std.mem.Allocator,
+        slot_capacity: u32,
+        slots_per_page: u32,
+        slot_size_bytes: usize,
+        slots: std.ArrayListUnmanaged(u8),
+        free_list: std.ArrayListUnmanaged(u32),
+        num_slots: u32,
+
+        pub fn init(allocator: std.mem.Allocator, slot_capacity: u32, slots_per_page: u32) ClassPool {
+            const slot_size_bytes = @sizeOf(SlotHeader) + slot_capacity;
+            return .{
+                .allocator = allocator,
+                .slot_capacity = slot_capacity,
+                .slots_per_page = slots_per_page,
+                .slot_size_bytes = slot_size_bytes,
+                .slots = .{},
+                .free_list = .{},
+                .num_slots = 0,
+            };
+        }
+
+        pub fn deinit(self: *ClassPool) void {
+            self.slots.deinit(self.allocator);
+            self.free_list.deinit(self.allocator);
+        }
+
+        fn grow(self: *ClassPool) GraphemePoolError!void {
+            const add_bytes = self.slot_size_bytes * self.slots_per_page;
+
+            try self.slots.ensureTotalCapacity(self.allocator, self.slots.items.len + add_bytes);
+            try self.slots.appendNTimes(self.allocator, 0, add_bytes);
+
+            var i: u32 = 0;
+            while (i < self.slots_per_page) : (i += 1) {
+                try self.free_list.append(self.allocator, self.num_slots + i);
+            }
+            self.num_slots += self.slots_per_page;
+        }
+
+        fn slotPtr(self: *ClassPool, slot_index: u32) *align(1) u8 {
+            const offset: usize = @as(usize, slot_index) * self.slot_size_bytes;
+            return &self.slots.items[offset];
+        }
+
+        pub fn alloc(self: *ClassPool, bytes: []const u8) GraphemePoolError!u32 {
+            if (bytes.len > self.slot_capacity) {
+                @panic("ClassPool.alloc: bytes.len > slot_capacity");
+            }
+            if (self.free_list.items.len == 0) try self.grow();
+
+            const slot_index = self.free_list.pop().?;
+            const p = self.slotPtr(slot_index);
+            const header_ptr = @as(*SlotHeader, @ptrCast(@alignCast(p)));
+
+            header_ptr.* = .{ .len = @intCast(@min(bytes.len, self.slot_capacity)), .refcount = 0 };
+
+            const base_ptr = @as([*]u8, @ptrCast(p));
+            const data_ptr = base_ptr + @sizeOf(SlotHeader);
+
+            @memcpy(data_ptr[0..header_ptr.len], bytes[0..header_ptr.len]);
+
+            return slot_index;
+        }
+
+        pub fn incref(self: *ClassPool, slot_index: u32) void {
+            const p = self.slotPtr(slot_index);
+            const header_ptr = @as(*SlotHeader, @ptrCast(@alignCast(p)));
+            header_ptr.refcount +%= 1;
+        }
+
+        pub fn decref(self: *ClassPool, slot_index: u32) GraphemePoolError!void {
+            const p = self.slotPtr(slot_index);
+            const header_ptr = @as(*SlotHeader, @ptrCast(@alignCast(p)));
+
+            if (header_ptr.refcount == 0) return GraphemePoolError.InvalidId;
+
+            header_ptr.refcount -%= 1;
+
+            if (header_ptr.refcount == 0) {
+                try self.free_list.append(self.allocator, slot_index);
+            }
+        }
+
+        pub fn get(self: *ClassPool, slot_index: u32) GraphemePoolError![]const u8 {
+            if (slot_index >= self.num_slots) return GraphemePoolError.InvalidId;
+
+            const p = self.slotPtr(slot_index);
+            const header_ptr = @as(*SlotHeader, @ptrCast(@alignCast(p)));
+            const base_ptr = @as([*]u8, @ptrCast(p));
+            const data_ptr = base_ptr + @sizeOf(SlotHeader);
+
+            return data_ptr[0..header_ptr.len];
+        }
+    };
+};
+
+// Bit manipulation functions for encoded char values
+
+pub fn isGraphemeChar(c: u32) bool {
+    return (c & 0xC000_0000) == CHAR_FLAG_GRAPHEME;
+}
+
+pub fn isContinuationChar(c: u32) bool {
+    return (c & 0xC000_0000) == CHAR_FLAG_CONTINUATION;
+}
+
+pub fn isClusterChar(c: u32) bool {
+    return (c & 0x8000_0000) == 0x8000_0000;
+}
+
+pub fn graphemeIdFromChar(c: u32) u32 {
+    return c & GRAPHEME_ID_MASK;
+}
+
+pub fn charRightExtent(c: u32) u32 {
+    return (c >> CHAR_EXT_RIGHT_SHIFT) & CHAR_EXT_MASK;
+}
+
+pub fn charLeftExtent(c: u32) u32 {
+    return (c >> CHAR_EXT_LEFT_SHIFT) & CHAR_EXT_MASK;
+}
+
+pub fn packGraphemeStart(gid: u32, total_width: u32) u32 {
+    const width_minus_one: u32 = if (total_width == 0) 0 else @intCast(@min(total_width - 1, 3));
+    const right: u32 = width_minus_one;
+    const left: u32 = 0;
+    return CHAR_FLAG_GRAPHEME |
+        ((right & CHAR_EXT_MASK) << CHAR_EXT_RIGHT_SHIFT) |
+        ((left & CHAR_EXT_MASK) << CHAR_EXT_LEFT_SHIFT) |
+        (gid & GRAPHEME_ID_MASK);
+}
+
+pub fn packContinuation(left: u32, right: u32, gid: u32) u32 {
+    return CHAR_FLAG_CONTINUATION |
+        ((@min(left, 3) & CHAR_EXT_MASK) << CHAR_EXT_LEFT_SHIFT) |
+        ((@min(right, 3) & CHAR_EXT_MASK) << CHAR_EXT_RIGHT_SHIFT) |
+        (gid & GRAPHEME_ID_MASK);
+}
+
+pub fn encodedCharWidth(c: u32) u32 {
+    if (isContinuationChar(c)) {
+        const left = charLeftExtent(c);
+        const right = charRightExtent(c);
+        return left + 1 + right;
+    } else if (isGraphemeChar(c)) {
+        return charRightExtent(c) + 1;
+    } else {
+        return 1;
+    }
+}
+
+var GLOBAL_POOL_STORAGE: ?GraphemePool = null;
+
+pub fn initGlobalPool(allocator: std.mem.Allocator) *GraphemePool {
+    if (GLOBAL_POOL_STORAGE == null) {
+        GLOBAL_POOL_STORAGE = GraphemePool.init(allocator);
+    }
+    return &GLOBAL_POOL_STORAGE.?;
+}
+
+pub fn deinitGlobalPool() void {
+    if (GLOBAL_POOL_STORAGE) |*p| {
+        p.deinit();
+        GLOBAL_POOL_STORAGE = null;
+    }
+}
+
+pub const GraphemeTracker = struct {
+    pool: *GraphemePool,
+    used_ids: std.AutoHashMap(u32, void),
+
+    pub fn init(allocator: std.mem.Allocator, pool: *GraphemePool) GraphemeTracker {
+        return .{
+            .pool = pool,
+            .used_ids = std.AutoHashMap(u32, void).init(allocator),
+        };
+    }
+
+    fn decRefAll(self: *GraphemeTracker) void {
+        var it = self.used_ids.keyIterator();
+        while (it.next()) |idp| {
+            self.pool.decref(idp.*) catch {};
+        }
+    }
+
+    pub fn deinit(self: *GraphemeTracker) void {
+        self.decRefAll();
+        self.used_ids.deinit();
+    }
+
+    pub fn clear(self: *GraphemeTracker) void {
+        self.decRefAll();
+        self.used_ids.clearRetainingCapacity();
+    }
+
+    pub fn add(self: *GraphemeTracker, id: u32) void {
+        const res = self.used_ids.getOrPut(id) catch |err| {
+            std.debug.panic("GraphemeTracker.add failed: {}\n", .{err});
+        };
+        if (!res.found_existing) {
+            self.pool.incref(id);
+        }
+    }
+
+    pub fn remove(self: *GraphemeTracker, id: u32) void {
+        if (self.used_ids.remove(id)) {
+            self.pool.decref(id) catch {};
+        }
+    }
+
+    pub fn contains(self: *const GraphemeTracker, id: u32) bool {
+        return self.used_ids.contains(id);
+    }
+
+    pub fn hasAny(self: *const GraphemeTracker) bool {
+        return self.used_ids.count() > 0;
+    }
+};

--- a/packages/core/src/zig/gwidth.zig
+++ b/packages/core/src/zig/gwidth.zig
@@ -1,0 +1,83 @@
+// https://github.com/rockorager/libvaxis/blob/main/src/gwidth.zig
+// MIT License
+// Copyright (c) 2023 Tim Culverhouse
+
+const std = @import("std");
+const unicode = std.unicode;
+const testing = std.testing;
+const DisplayWidth = @import("DisplayWidth");
+const code_point = @import("code_point");
+
+/// the method to use when calculating the width of a grapheme
+pub const WidthMethod = enum {
+    wcwidth,
+    unicode,
+    no_zwj,
+};
+
+/// returns the width of the provided string, as measured by the method chosen
+pub fn gwidth(str: []const u8, method: WidthMethod, data: *const DisplayWidth) u16 {
+    switch (method) {
+        .unicode => {
+            return @intCast(data.strWidth(str));
+        },
+        .wcwidth => {
+            var total: u16 = 0;
+            var iter: code_point.Iterator = .{ .bytes = str };
+            while (iter.next()) |cp| {
+                const w: u16 = switch (cp.code) {
+                    // undo an override in zg for emoji skintone selectors
+                    0x1f3fb...0x1f3ff,
+                    => 2,
+                    else => @max(0, data.codePointWidth(cp.code)),
+                };
+                total += w;
+            }
+            return total;
+        },
+        .no_zwj => {
+            var iter = std.mem.splitSequence(u8, str, "\u{200D}");
+            var result: u16 = 0;
+            while (iter.next()) |s| {
+                result += gwidth(s, .unicode, data);
+            }
+            return result;
+        },
+    }
+}
+
+test "gwidth: a" {
+    const alloc = testing.allocator_instance.allocator();
+    const data = try DisplayWidth.init(alloc);
+    defer data.deinit(alloc);
+    try testing.expectEqual(1, gwidth("a", .unicode, &data));
+    try testing.expectEqual(1, gwidth("a", .wcwidth, &data));
+    try testing.expectEqual(1, gwidth("a", .no_zwj, &data));
+}
+
+test "gwidth: emoji with ZWJ" {
+    const alloc = testing.allocator_instance.allocator();
+    const data = try DisplayWidth.init(alloc);
+    defer data.deinit(alloc);
+    try testing.expectEqual(2, gwidth("👩‍🚀", .unicode, &data));
+    try testing.expectEqual(4, gwidth("👩‍🚀", .wcwidth, &data));
+    try testing.expectEqual(4, gwidth("👩‍🚀", .no_zwj, &data));
+}
+
+test "gwidth: emoji with VS16 selector" {
+    const alloc = testing.allocator_instance.allocator();
+    const data = try DisplayWidth.init(alloc);
+    defer data.deinit(alloc);
+    try testing.expectEqual(2, gwidth("\xE2\x9D\xA4\xEF\xB8\x8F", .unicode, &data));
+    try testing.expectEqual(1, gwidth("\xE2\x9D\xA4\xEF\xB8\x8F", .wcwidth, &data));
+    try testing.expectEqual(2, gwidth("\xE2\x9D\xA4\xEF\xB8\x8F", .no_zwj, &data));
+}
+
+test "gwidth: emoji with skin tone selector" {
+    const alloc = testing.allocator_instance.allocator();
+    const data = try DisplayWidth.init(alloc);
+    defer data.deinit(alloc);
+    try testing.expectEqual(2, gwidth("👋🏿", .unicode, &data));
+    try testing.expectEqual(4, gwidth("👋🏿", .wcwidth, &data));
+    try testing.expectEqual(2, gwidth("👋🏿", .no_zwj, &data));
+}

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -1,0 +1,390 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const atomic = std.atomic;
+const AnyWriter = std.io.AnyWriter;
+const assert = std.debug.assert;
+const ansi = @import("ansi.zig");
+const gwidth = @import("gwidth.zig");
+
+const WidthMethod = gwidth.WidthMethod;
+const log = std.log.scoped(.terminal);
+
+/// Terminal capability detection and management
+pub const Terminal = @This();
+
+pub const Capabilities = struct {
+    kitty_keyboard: bool = false,
+    kitty_graphics: bool = false,
+    rgb: bool = false,
+    unicode: WidthMethod = .wcwidth,
+    sgr_pixels: bool = false,
+    color_scheme_updates: bool = false,
+    explicit_width: bool = false,
+    scaled_text: bool = false,
+    sixel: bool = false,
+    focus_tracking: bool = false,
+    sync: bool = false,
+    bracketed_paste: bool = false,
+    hyperlinks: bool = false,
+};
+
+pub const MouseLevel = enum {
+    none,
+    basic, // click only
+    drag, // click + drag
+    motion, // all motion
+    pixels, // pixel coordinates
+};
+
+pub const CursorStyle = enum {
+    block,
+    line,
+    underline,
+};
+
+pub const Options = struct {
+    kitty_keyboard_flags: u8 = 0b00001,
+};
+
+caps: Capabilities = .{},
+opts: Options = .{},
+
+state: struct {
+    alt_screen: bool = false,
+    kitty_keyboard: bool = false,
+    bracketed_paste: bool = false,
+    mouse: bool = false,
+    pixel_mouse: bool = false,
+    color_scheme_updates: bool = false,
+    focus_tracking: bool = false,
+    cursor: struct {
+        row: u16 = 0,
+        col: u16 = 0,
+        x: u32 = 1, // 1-based for rendering
+        y: u32 = 1, // 1-based for rendering
+        visible: bool = true,
+        style: CursorStyle = .block,
+        blinking: bool = false,
+        color: [4]f32 = .{ 1.0, 1.0, 1.0, 1.0 }, // RGBA
+    } = .{},
+} = .{},
+
+pub fn init(opts: Options) Terminal {
+    return .{
+        .opts = opts,
+    };
+}
+
+pub fn deinit(self: *Terminal, tty: AnyWriter) void {
+    self.resetState(tty) catch {};
+}
+
+pub fn resetState(self: *Terminal, tty: AnyWriter) !void {
+    try tty.writeAll(ansi.ANSI.showCursor);
+    try tty.writeAll(ansi.ANSI.reset);
+
+    if (self.state.kitty_keyboard) {
+        try self.setKittyKeyboard(tty, false, 0);
+    }
+
+    if (self.state.mouse) {
+        try self.setMouseMode(tty, false);
+    }
+
+    if (self.state.bracketed_paste) {
+        try self.setBracketedPaste(tty, false);
+    }
+
+    if (self.state.focus_tracking) {
+        try self.setFocusTracking(tty, false);
+    }
+
+    if (self.state.alt_screen) {
+        try tty.writeAll(ansi.ANSI.home);
+        try tty.writeAll(ansi.ANSI.eraseBelowCursor);
+        try self.exitAltScreen(tty);
+    } else {
+        try tty.writeByte('\r');
+        var i: u16 = 0;
+        while (i < self.state.cursor.row) : (i += 1) {
+            try tty.writeAll(ansi.ANSI.reverseIndex);
+        }
+        try tty.writeAll(ansi.ANSI.eraseBelowCursor);
+    }
+
+    if (self.state.color_scheme_updates) {
+        try tty.writeAll(ansi.ANSI.colorSchemeReset);
+        self.state.color_scheme_updates = false;
+    }
+}
+
+pub fn enterAltScreen(self: *Terminal, tty: AnyWriter) !void {
+    try tty.writeAll(ansi.ANSI.switchToAlternateScreen);
+    self.state.alt_screen = true;
+}
+
+pub fn exitAltScreen(self: *Terminal, tty: AnyWriter) !void {
+    try tty.writeAll(ansi.ANSI.switchToMainScreen);
+    self.state.alt_screen = false;
+}
+
+pub fn queryTerminalSend(self: *Terminal, tty: AnyWriter) !void {
+    self.checkEnvironmentOverrides();
+
+    try tty.writeAll(ansi.ANSI.decrqmSgrPixels ++
+        ansi.ANSI.decrqmUnicode ++
+        ansi.ANSI.decrqmColorScheme ++
+        ansi.ANSI.decrqmFocus ++
+        ansi.ANSI.decrqmBracketedPaste ++
+        ansi.ANSI.decrqmSync ++
+
+        // Explicit width detection
+        ansi.ANSI.home ++
+        ansi.ANSI.explicitWidthQuery ++
+        ansi.ANSI.cursorPositionRequest ++
+
+        // Scaled text detection
+        ansi.ANSI.home ++
+        ansi.ANSI.scaledTextQuery ++
+        ansi.ANSI.cursorPositionRequest ++
+
+        // Version and capability queries
+        ansi.ANSI.xtversion ++
+        ansi.ANSI.csiUQuery ++
+        ansi.ANSI.kittyGraphicsQuery ++
+        ansi.ANSI.primaryDeviceAttrs ++
+        ansi.ANSI.sixelGeometryQuery);
+}
+
+pub fn enableDetectedFeatures(self: *Terminal, tty: AnyWriter) !void {
+    switch (builtin.os.tag) {
+        .windows => {
+            // Windows-specific defaults for ConPTY
+            self.caps.rgb = true;
+            self.caps.bracketed_paste = true;
+        },
+        else => {
+            self.checkEnvironmentOverrides();
+
+            // NOTE: Not enabling kitty keyboard by default even when it is supported
+            // Higher levels do not support that yet and stdin handling may move to native
+
+            if (self.caps.unicode == .unicode and !self.caps.explicit_width) {
+                try tty.writeAll(ansi.ANSI.unicodeSet);
+            }
+
+            if (self.caps.bracketed_paste) {
+                try self.setBracketedPaste(tty, true);
+            }
+
+            if (self.caps.focus_tracking) {
+                try self.setFocusTracking(tty, true);
+            }
+        },
+    }
+}
+
+fn checkEnvironmentOverrides(self: *Terminal) void {
+    var env_map = std.process.getEnvMap(std.heap.page_allocator) catch return;
+    defer env_map.deinit();
+
+    if (env_map.get("TERM_PROGRAM")) |prog| {
+        if (std.mem.eql(u8, prog, "vscode")) {
+            // VSCode has limited capability
+            self.caps.kitty_keyboard = false;
+            self.caps.kitty_graphics = false;
+            self.caps.unicode = .unicode;
+        } else if (std.mem.eql(u8, prog, "Apple_Terminal")) {
+            self.caps.unicode = .wcwidth;
+        }
+    }
+
+    if (env_map.get("COLORTERM")) |colorterm| {
+        if (std.mem.eql(u8, colorterm, "truecolor") or
+            std.mem.eql(u8, colorterm, "24bit"))
+        {
+            self.caps.rgb = true;
+        }
+    }
+
+    if (env_map.get("TERMUX_VERSION")) |_| {
+        self.caps.unicode = .wcwidth;
+    }
+
+    if (env_map.get("VHS_RECORD")) |_| {
+        self.caps.unicode = .wcwidth;
+        self.caps.kitty_keyboard = false;
+        self.caps.kitty_graphics = false;
+    }
+
+    if (env_map.get("OPENTUI_FORCE_WCWIDTH")) |_| {
+        self.caps.unicode = .wcwidth;
+    }
+    if (env_map.get("OPENTUI_FORCE_UNICODE")) |_| {
+        self.caps.unicode = .unicode;
+    }
+}
+
+// TODO: Allow pixel mouse mode to be enabled,
+// currently does not make sense and is not supported by higher levels
+pub fn setMouseMode(self: *Terminal, tty: AnyWriter, enable: bool) !void {
+    if (enable) {
+        self.state.mouse = true;
+        try tty.writeAll(ansi.ANSI.enableMouseTracking);
+        try tty.writeAll(ansi.ANSI.enableButtonEventTracking);
+        try tty.writeAll(ansi.ANSI.enableAnyEventTracking);
+        try tty.writeAll(ansi.ANSI.enableSGRMouseMode);
+    } else {
+        self.state.mouse = false;
+        self.state.pixel_mouse = false;
+        try tty.writeAll(ansi.ANSI.disableAnyEventTracking);
+        try tty.writeAll(ansi.ANSI.disableButtonEventTracking);
+        try tty.writeAll(ansi.ANSI.disableMouseTracking);
+        try tty.writeAll(ansi.ANSI.disableSGRMouseMode);
+    }
+}
+
+pub fn setBracketedPaste(self: *Terminal, tty: AnyWriter, enable: bool) !void {
+    const seq = if (enable) ansi.ANSI.bracketedPasteSet else ansi.ANSI.bracketedPasteReset;
+    try tty.writeAll(seq);
+    self.state.bracketed_paste = enable;
+}
+
+pub fn setFocusTracking(self: *Terminal, tty: AnyWriter, enable: bool) !void {
+    const seq = if (enable) ansi.ANSI.focusSet else ansi.ANSI.focusReset;
+    try tty.writeAll(seq);
+    self.state.focus_tracking = enable;
+}
+
+pub fn setKittyKeyboard(self: *Terminal, tty: AnyWriter, enable: bool, flags: u8) !void {
+    if (enable) {
+        if (!self.state.kitty_keyboard) {
+            try tty.print(ansi.ANSI.csiUPush, .{flags});
+            self.state.kitty_keyboard = true;
+        }
+    } else {
+        if (self.state.kitty_keyboard) {
+            try tty.writeAll(ansi.ANSI.csiUPop);
+            self.state.kitty_keyboard = false;
+        }
+    }
+}
+
+/// The responses look like these:
+/// kitty - '\x1B[?1016;2$y\x1B[?2027;0$y\x1B[?2031;2$y\x1B[?1004;1$y\x1B[?2026;2$y\x1B[1;2R\x1B[1;3R\x1BP>|kitty(0.40.1)\x1B\\\x1B[?0u\x1B_Gi=1;EINVAL:Zero width/height not allowed\x1B\\\x1B[?62;c'
+/// ghostty - '\x1B[?1016;1$y\x1B[?2027;1$y\x1B[?2031;2$y\x1B[?1004;1$y\x1B[?2004;2$y\x1B[?2026;2$y\x1B[1;1R\x1B[1;1R\x1BP>|ghostty 1.1.3\x1B\\\x1B[?0u\x1B_Gi=1;OK\x1B\\\x1B[?62;22c'
+/// tmux - '\x1B[1;1R\x1B[1;1R\x1BP>|tmux 3.5a\x1B\\\x1B[?1;2;4c\x1B[?2;3;0S'
+/// vscode - '\x1B[?1016;2$y'
+/// alacritty - '\x1B[?1016;0$y\x1B[?2027;0$y\x1B[?2031;0$y\x1B[?1004;2$y\x1B[?2004;2$y\x1B[?2026;2$y\x1B[1;1R\x1B[1;1R\x1B[?0u\x1B[?6c'
+///
+/// Parsing these is not complete yet
+pub fn processCapabilityResponse(self: *Terminal, response: []const u8) void {
+    // DECRPM responses
+    if (std.mem.indexOf(u8, response, "1016;2$y")) |_| {
+        self.caps.sgr_pixels = true;
+    }
+    if (std.mem.indexOf(u8, response, "2027;2$y")) |_| {
+        self.caps.unicode = .unicode;
+    }
+    if (std.mem.indexOf(u8, response, "2031;2$y")) |_| {
+        self.caps.color_scheme_updates = true;
+    }
+    if (std.mem.indexOf(u8, response, "1004;1$y") != null or std.mem.indexOf(u8, response, "1004;2$y") != null) {
+        self.caps.focus_tracking = true;
+    }
+    if (std.mem.indexOf(u8, response, "2026;2$y")) |_| {
+        self.caps.sync = true;
+    }
+    if (std.mem.indexOf(u8, response, "2004;1$y") != null or std.mem.indexOf(u8, response, "2004;2$y") != null) {
+        self.caps.bracketed_paste = true;
+    }
+
+    // Explicit width detection - cursor position report [1;2R means explicit width supported
+    if (std.mem.indexOf(u8, response, "\x1b[1;2R")) |_| {
+        self.caps.explicit_width = true;
+    }
+
+    // Scaled text detection - cursor position report [1;3R means scaled text supported
+    if (std.mem.indexOf(u8, response, "\x1b[1;3R")) |_| {
+        self.caps.scaled_text = true;
+    }
+
+    // Kitty detection
+    if (std.mem.indexOf(u8, response, "kitty")) |_| {
+        self.caps.kitty_keyboard = true;
+        self.caps.kitty_graphics = true;
+        self.caps.unicode = .unicode;
+        self.caps.rgb = true;
+        self.caps.sixel = true;
+        self.caps.bracketed_paste = true;
+        self.caps.hyperlinks = true;
+    }
+
+    // Sixel detection via device attributes (capability 4 in DA1 response ending with 'c')
+    if (std.mem.indexOf(u8, response, ";c")) |pos| {
+        var start: usize = 0;
+        if (pos >= 4) {
+            start = pos;
+            while (start > 0 and response[start] != '\x1b') {
+                start -= 1;
+            }
+
+            const da_response = response[start .. pos + 2];
+
+            if (std.mem.indexOf(u8, da_response, "\x1b[?") == 0) {
+                if (std.mem.indexOf(u8, da_response, "4;") != null or std.mem.indexOf(u8, da_response, ";4;") != null or std.mem.indexOf(u8, da_response, ";4c") != null) {
+                    self.caps.sixel = true;
+                }
+            }
+        }
+    }
+
+    // Kitty graphics response
+    if (std.mem.indexOf(u8, response, "\x1b_G")) |_| {
+        if (std.mem.indexOf(u8, response, "OK")) |_| {
+            self.caps.kitty_graphics = true;
+        }
+    }
+}
+
+pub fn getCapabilities(self: *Terminal) Capabilities {
+    return self.caps;
+}
+
+pub fn setCursorPosition(self: *Terminal, x: u32, y: u32, visible: bool) void {
+    self.state.cursor.x = @max(1, x);
+    self.state.cursor.y = @max(1, y);
+    self.state.cursor.visible = visible;
+
+    // Update 0-based coordinates for terminal operations
+    self.state.cursor.col = @intCast(@max(0, x - 1));
+    self.state.cursor.row = @intCast(@max(0, y - 1));
+}
+
+pub fn setCursorStyle(self: *Terminal, style: CursorStyle, blinking: bool) void {
+    self.state.cursor.style = style;
+    self.state.cursor.blinking = blinking;
+}
+
+pub fn setCursorColor(self: *Terminal, color: [4]f32) void {
+    self.state.cursor.color = color;
+}
+
+pub fn getCursorPosition(self: *Terminal) struct { x: u32, y: u32, visible: bool } {
+    return .{
+        .x = self.state.cursor.x,
+        .y = self.state.cursor.y,
+        .visible = self.state.cursor.visible,
+    };
+}
+
+pub fn getCursorStyle(self: *Terminal) struct { style: CursorStyle, blinking: bool } {
+    return .{
+        .style = self.state.cursor.style,
+        .blinking = self.state.cursor.blinking,
+    };
+}
+
+pub fn getCursorColor(self: *Terminal) [4]f32 {
+    return self.state.cursor.color;
+}

--- a/packages/react/src/reconciler/host-config.ts
+++ b/packages/react/src/reconciler/host-config.ts
@@ -39,7 +39,7 @@ export const hostConfig: HostConfig<
       throw new Error(`[Reconciler] Unknown component type: ${type}`)
     }
 
-    return new components[type](id, {})
+    return new components[type](rootContainerInstance.ctx, {})
   },
 
   // Append a child to a parent
@@ -101,7 +101,8 @@ export const hostConfig: HostConfig<
   // Create text instance
   createTextInstance(text: string, rootContainerInstance: Container, hostContext: HostContext) {
     const components = getComponentCatalogue()
-    return new components["text"](getNextId("text"), {
+    return new components["text"](rootContainerInstance.ctx, {
+      id: getNextId("text"),
       content: text,
     }) as TextInstance
   },

--- a/packages/react/src/types/components.ts
+++ b/packages/react/src/types/components.ts
@@ -8,6 +8,7 @@ import type {
   InputRenderableOptions,
   Renderable,
   RenderableOptions,
+  RenderContext,
   SelectOption,
   SelectRenderable,
   SelectRenderableOptions,
@@ -36,17 +37,20 @@ export type ReactProps<TRenderable = unknown> = {
 
 /** Base type for any renderable constructor */
 export type RenderableConstructor<TRenderable extends Renderable = Renderable> = new (
-  id: string,
+  ctx: RenderContext,
   options: any,
 ) => TRenderable
 
 /** Extract the options type from a renderable constructor */
-type ExtractRenderableOptions<TConstructor> = TConstructor extends new (id: string, options: infer TOptions) => any
+type ExtractRenderableOptions<TConstructor> = TConstructor extends new (
+  ctx: RenderContext,
+  options: infer TOptions,
+) => any
   ? TOptions
   : never
 
 /** Extract the renderable type from a constructor */
-type ExtractRenderable<TConstructor> = TConstructor extends new (id: string, options: any) => infer TRenderable
+type ExtractRenderable<TConstructor> = TConstructor extends new (ctx: RenderContext, options: any) => infer TRenderable
   ? TRenderable
   : never
 

--- a/packages/solid/examples/components/mouse-demo.tsx
+++ b/packages/solid/examples/components/mouse-demo.tsx
@@ -1,4 +1,16 @@
-import { BoxRenderable, OptimizedBuffer, RGBA, MouseEvent, t, bold, underline, fg, CliRenderer } from "@opentui/core"
+import {
+  BoxRenderable,
+  OptimizedBuffer,
+  RGBA,
+  MouseEvent,
+  t,
+  bold,
+  underline,
+  fg,
+  type RenderContext,
+} from "@opentui/core"
+import { useContext } from "solid-js"
+import { RendererContext } from "../../src/elements/hooks"
 
 let nextZIndex = 101
 class DraggableTransparentBox extends BoxRenderable {
@@ -16,8 +28,8 @@ class DraggableTransparentBox extends BoxRenderable {
     this.screenSizeY = 52
   }
 
-  constructor(id: string, x: number, y: number, width: number, height: number, bg: RGBA, zIndex: number) {
-    super(id, {
+  constructor(ctx: RenderContext, x: number, y: number, width: number, height: number, bg: RGBA, zIndex: number) {
+    super(ctx, {
       width,
       height,
       zIndex,
@@ -86,8 +98,8 @@ class DraggableTransparentBox extends BoxRenderable {
           this.x = event.x - this.dragOffsetX
           this.y = event.y - this.dragOffsetY
 
-          this.x = Math.max(0, Math.min(this.x, (this.ctx?.width() || 80) - this.width))
-          this.y = Math.max(4, Math.min(this.y, (this.ctx?.height() || 24) - this.height))
+          this.x = Math.max(0, Math.min(this.x, this._ctx.width - this.width))
+          this.y = Math.max(4, Math.min(this.y, this._ctx.height - this.height))
 
           event.preventDefault()
         }
@@ -97,8 +109,12 @@ class DraggableTransparentBox extends BoxRenderable {
 }
 
 export default function MouseDraggableScene() {
+  const solidRenderer = useContext(RendererContext)
+  if (!solidRenderer) {
+    throw new Error("No renderer found")
+  }
   const alphaBox50 = new DraggableTransparentBox(
-    "alpha-box-50",
+    solidRenderer,
     15,
     5,
     25,

--- a/packages/solid/src/elements/text-node.ts
+++ b/packages/solid/src/elements/text-node.ts
@@ -1,4 +1,4 @@
-import { Renderable, TextRenderable, type TextChunk, type TextOptions } from "@opentui/core"
+import { Renderable, TextRenderable, type RenderContext, type TextChunk, type TextOptions } from "@opentui/core"
 import { type DomNode, insertNode as insertRenderable } from "../reconciler"
 import { getNextId } from "../utils/id-counter"
 import { log } from "../utils/log"
@@ -140,7 +140,9 @@ export class TextNode {
       return lastChild
     }
 
-    const ghostNode = new GhostTextRenderable(getNextId(GHOST_NODE_TAG), {})
+    const ghostNode = new GhostTextRenderable(parent.ctx, {
+      id: getNextId(GHOST_NODE_TAG),
+    })
 
     insertRenderable(parent, ghostNode, anchor)
 
@@ -149,8 +151,8 @@ export class TextNode {
 }
 
 class GhostTextRenderable extends TextRenderable {
-  constructor(id: string, options: TextOptions) {
-    super(id, options)
+  constructor(ctx: RenderContext, options: TextOptions) {
+    super(ctx, options)
   }
 
   static isGhostNode(node: DomNode) {

--- a/packages/solid/src/reconciler.ts
+++ b/packages/solid/src/reconciler.ts
@@ -12,10 +12,11 @@ import {
   type TextChunk,
 } from "@opentui/core"
 import { createRenderer } from "solid-js/universal"
-import { elements, type Element } from "./elements"
+import { elements, RendererContext, type Element } from "./elements"
 import { TextNode } from "./elements/text-node"
 import { getNextId } from "./utils/id-counter"
 import { log } from "./utils/log"
+import { useContext } from "solid-js"
 
 export type DomNode = Renderable | TextNode
 
@@ -72,7 +73,11 @@ export const {
   createElement(tagName: string): DomNode {
     log("Creating element:", tagName)
     const id = getNextId(tagName)
-    const element = new elements[tagName as Element](id, {})
+    const solidRenderer = useContext(RendererContext)
+    if (!solidRenderer) {
+      throw new Error("No renderer found")
+    }
+    const element = new elements[tagName as Element](solidRenderer, { id })
     log("Element created with id:", id)
     return element
   },


### PR DESCRIPTION
- Supports graphemes in native `OptimizedBuffer` and `TextBuffer`
- adds the `zg` dependency for the zig build, to  iterate grapheme clusters and measure their width
- Adds terminal capability detection, currently using explicit width when available and setting preffered `WidthMethod`
- Cursor state is now Renderer scoped, not global anymore
- In ts `OptimizedBuffer` and `TextBuffer` now need a mandatory width method value (will be taken from the renderer in most cases, as the renderer holds the capabilities for the terminal)
- Refactors `Renderable` constructor to now take a `RenderContext` (the renderer implements this context), moving the `id` into options and making it optional to use a custom id.
- Made react and solid reconcilers `RenderContext` aware
- Fixes a mouse capture bug where renderables would not be draggable anymore after dropping

Note: There are still known issues with unicode/grapheme rendering across terminals, help wanted.