### PR TITLE
fix: ensure cursor color reset in some terminals

### DIFF
--- a/packages/core/src/zig/ansi.zig
+++ b/packages/core/src/zig/ansi.zig
@@ -56,7 +56,8 @@ pub const ANSI = struct {
         std.fmt.format(writer, "\x1b]66;w={d};{s}\x1b\\", .{ width, text }) catch return AnsiError.WriteFailed;
     }
 
-    pub const resetCursorColor = "\x1b]12;default\x07";
+    pub const resetCursorColor = "\x1b]112\x07";
+    pub const resetCursorColorFallback = "\x1b]12;default\x07";
     pub const saveCursorState = "\x1b[s";
     pub const restoreCursorState = "\x1b[u";
 

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -285,6 +285,7 @@ pub const CliRenderer = struct {
             // ansi.ANSI.moveToOutput(direct, 1, consoleEndLine) catch {};
         }
 
+        direct.writeAll(ansi.ANSI.resetCursorColorFallback) catch {};
         direct.writeAll(ansi.ANSI.resetCursorColor) catch {};
         direct.writeAll(ansi.ANSI.restoreCursorState) catch {};
         direct.writeAll(ansi.ANSI.defaultCursorStyle) catch {};


### PR DESCRIPTION
The cursor color wasn't resetting when program is terminated while an input is focused. As I see `112` is the correct ANSI code for resetting cursor color, but I also kept the old code to be sure.

https://github.com/user-attachments/assets/2126aeab-e503-417c-9d67-52f1359e6ffb

