### PR TITLE
Add word jumping utils mimicking VSCode alt-arrow shortcuts

### DIFF
--- a/packages/core/src/lib/word-jumps.test.ts
+++ b/packages/core/src/lib/word-jumps.test.ts
@@ -71,7 +71,7 @@ describe("word-jumping", () => {
       const caret = text.indexOf("|")
       const cleanText = text.replace("|", "")
       const result = nextWordEndCrossLines(cleanText, caret)
-      expect(cleanText.slice(0, result) + "|" + cleanText.slice(result)).toMatchInlineSnapshot(`"hello_world|_case"`)
+      expect(cleanText.slice(0, result) + "|" + cleanText.slice(result)).toMatchInlineSnapshot(`"hello_world_case|"`)
     })
 
     test("handles end of text", () => {
@@ -164,7 +164,7 @@ describe("word-jumping", () => {
       const caret = text.indexOf("|")
       const cleanText = text.replace("|", "")
       const result = previousWordStartCrossLines(cleanText, caret)
-      expect(cleanText.slice(0, result) + "|" + cleanText.slice(result)).toMatchInlineSnapshot(`"hello_world_|case"`)
+      expect(cleanText.slice(0, result) + "|" + cleanText.slice(result)).toMatchInlineSnapshot(`"|hello_world_case"`)
     })
 
     test("handles beginning of text", () => {

--- a/packages/core/src/lib/word-jumps.ts
+++ b/packages/core/src/lib/word-jumps.ts
@@ -1,4 +1,4 @@
-const PUNCTUATION = new Set(Array.from(",./\\;:'\"`~!@#$%^&*()-_=+[]{}<>?|"))
+const PUNCTUATION = new Set(Array.from(",./\\;:'\"`~!@#$%^&*()-=+[]{}<>?|"))
 
 const isWhitespace = (ch: string) => ch === " " || ch === "\t"
 const isNewline = (ch: string) => ch === "\n" || ch === "\r"


### PR DESCRIPTION
In preparation of #75 

I [already implemented this feature into Zed](https://github.com/zed-industries/zed/pull/31977) so I am adding it here too, I already spent a lot of time to understand all the nuances
