### PR TITLE
fix: improve nested buffer alpha blending and fix ascii background bug

### DIFF
--- a/packages/core/src/examples/framebuffer-demo.ts
+++ b/packages/core/src/examples/framebuffer-demo.ts
@@ -97,6 +97,53 @@ export function run(renderer: CliRenderer): void {
     }
   }
 
+
+  const nestedBox = new BoxRenderable(renderer, {
+    id: "nested-box",
+    width: 20,
+    height: 10,
+    position: "absolute",
+    left: 4,
+    top: 4,
+    buffered: true,
+  })
+
+  const inset0 = {
+    position: "absolute" as const,
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+  }
+
+  nestedBox.add(new BoxRenderable(renderer, {
+    ...inset0,
+    border: true,
+    title: 'Nested example',
+    backgroundColor: RGBA.fromInts(120, 0, 120, 120),
+  }));
+
+
+  const nestedInnerBox = new BoxRenderable(renderer, {
+    id: "nested-inner-box",
+    width: 10,
+    height: 4,
+    position: "absolute",
+    left: 5,
+    top: 3,
+    buffered: true,
+  })
+
+  nestedInnerBox.add(new BoxRenderable(renderer, {
+    ...inset0,
+    border: true,
+    title: 'Inner',
+    backgroundColor: RGBA.fromInts(0, 255, 0, 10),
+  }));
+
+  nestedBox.add(nestedInnerBox);
+  renderer.root.add(nestedBox);
+
   const boxObj = new BoxRenderable(renderer, {
     id: "moving-box",
     width: 20,

--- a/packages/core/src/examples/framebuffer-demo.ts
+++ b/packages/core/src/examples/framebuffer-demo.ts
@@ -121,30 +121,32 @@ export function run(renderer: CliRenderer): void {
     zIndex: 2,
   })
 
-  boxObj.add(boxWrapper);
+  boxObj.add(boxWrapper)
 
-  boxWrapper.add(new ASCIIFontRenderable(renderer, {
-    id: "moving-box-ascii",
-    text: 'ASCII',
-    width: 20,
-    height: 10,
-    position: 'absolute',
-    left: 2,
-    top: 5,
-    right:0,
-    bottom:0,
-    zIndex: 2,
-  }))
+  boxWrapper.add(
+    new ASCIIFontRenderable(renderer, {
+      id: "moving-box-ascii",
+      text: "ASCII",
+      width: 20,
+      height: 10,
+      position: "absolute",
+      left: 2,
+      top: 5,
+      right: 0,
+      bottom: 0,
+      zIndex: 2,
+    }),
+  )
 
   const boxFrame = new FrameBufferRenderable(renderer, {
     id: "moving-box-buffer",
     width: 20,
     height: 10,
-    position: 'absolute',
+    position: "absolute",
     left: 0,
     top: 0,
-    right:0,
-    bottom:0,
+    right: 0,
+    bottom: 0,
     zIndex: 1,
     respectAlpha: true,
   })

--- a/packages/core/src/examples/framebuffer-demo.ts
+++ b/packages/core/src/examples/framebuffer-demo.ts
@@ -117,7 +117,8 @@ export function run(renderer: CliRenderer): void {
     top: 0,
     right: 0,
     bottom: 0,
-    backgroundColor: RGBA.fromInts(0, 120, 120, 255),
+    backgroundColor: RGBA.fromInts(0, 120, 120, 150),
+    zIndex: 2,
   })
 
   boxObj.add(boxWrapper);
@@ -132,6 +133,7 @@ export function run(renderer: CliRenderer): void {
     top: 5,
     right:0,
     bottom:0,
+    zIndex: 2,
   }))
 
   const boxFrame = new FrameBufferRenderable(renderer, {

--- a/packages/core/src/examples/framebuffer-demo.ts
+++ b/packages/core/src/examples/framebuffer-demo.ts
@@ -132,6 +132,7 @@ export function run(renderer: CliRenderer): void {
     top: 5,
     right:0,
     bottom:0,
+    bg: RGBA.fromInts(255,255,0,60),
   }))
 
   const boxFrame = new FrameBufferRenderable(renderer, {

--- a/packages/core/src/examples/framebuffer-demo.ts
+++ b/packages/core/src/examples/framebuffer-demo.ts
@@ -132,7 +132,6 @@ export function run(renderer: CliRenderer): void {
     top: 5,
     right:0,
     bottom:0,
-    bg: RGBA.fromInts(255,255,0,60),
   }))
 
   const boxFrame = new FrameBufferRenderable(renderer, {
@@ -198,24 +197,24 @@ export function run(renderer: CliRenderer): void {
     10,
     2,
     RGBA.fromInts(255, 255, 255),
-    RGBA.fromInts(0, 120, 180, 200),
+    RGBA.fromInts(0, 120, 180, 180),
     TextAttributes.BOLD,
   )
   overlayBuffer.drawText(
     "This overlay has transparent",
     5,
     5,
-    RGBA.fromInts(255, 255, 255),
-    RGBA.fromInts(0, 120, 180, 200),
+    RGBA.fromInts(255, 0, 255),
+    RGBA.fromInts(0, 120, 180, 180),
   )
   overlayBuffer.drawText(
     "cells that let content below",
     5,
     6,
     RGBA.fromInts(255, 255, 255),
-    RGBA.fromInts(0, 120, 180, 200),
+    RGBA.fromInts(0, 120, 180, 180),
   )
-  overlayBuffer.drawText("show through!", 5, 7, RGBA.fromInts(255, 255, 255), RGBA.fromInts(0, 120, 180, 200))
+  overlayBuffer.drawText("show through!", 5, 7, RGBA.fromInts(255, 255, 255), RGBA.fromInts(0, 120, 180, 180))
 
   const ballObj = new FrameBufferRenderable(renderer, {
     id: "ball",
@@ -509,7 +508,7 @@ export function run(renderer: CliRenderer): void {
         10,
         2,
         RGBA.fromInts(255, 255, 255),
-        RGBA.fromInts(255, 255, 255, 200),
+        RGBA.fromInts(255, 255, 255, 180),
         TextAttributes.BOLD,
       )
       overlayBuffer.drawText(
@@ -517,16 +516,16 @@ export function run(renderer: CliRenderer): void {
         5,
         5,
         RGBA.fromInts(255, 255, 255),
-        RGBA.fromInts(255, 255, 255, 200),
+        RGBA.fromInts(255, 255, 255, 180),
       )
       overlayBuffer.drawText(
         "cells that let content below",
         5,
         6,
         RGBA.fromInts(255, 255, 255),
-        RGBA.fromInts(255, 255, 255, 200),
+        RGBA.fromInts(255, 255, 255, 180),
       )
-      overlayBuffer.drawText("show through!", 5, 7, RGBA.fromInts(255, 255, 255), RGBA.fromInts(255, 255, 255, 200))
+      overlayBuffer.drawText("show through!", 5, 7, RGBA.fromInts(255, 255, 255), RGBA.fromInts(255, 255, 255, 180))
     }
   })
 

--- a/packages/core/src/examples/framebuffer-demo.ts
+++ b/packages/core/src/examples/framebuffer-demo.ts
@@ -97,7 +97,6 @@ export function run(renderer: CliRenderer): void {
     }
   }
 
-
   const nestedBox = new BoxRenderable(renderer, {
     id: "nested-box",
     width: 20,
@@ -116,13 +115,14 @@ export function run(renderer: CliRenderer): void {
     bottom: 0,
   }
 
-  nestedBox.add(new BoxRenderable(renderer, {
-    ...inset0,
-    border: true,
-    title: 'Nested example',
-    backgroundColor: RGBA.fromInts(120, 0, 120, 120),
-  }));
-
+  nestedBox.add(
+    new BoxRenderable(renderer, {
+      ...inset0,
+      border: true,
+      title: "Nested example",
+      backgroundColor: RGBA.fromInts(120, 0, 120, 120),
+    }),
+  )
 
   const nestedInnerBox = new BoxRenderable(renderer, {
     id: "nested-inner-box",
@@ -134,15 +134,17 @@ export function run(renderer: CliRenderer): void {
     buffered: true,
   })
 
-  nestedInnerBox.add(new BoxRenderable(renderer, {
-    ...inset0,
-    border: true,
-    title: 'Inner',
-    backgroundColor: RGBA.fromInts(0, 255, 0, 10),
-  }));
+  nestedInnerBox.add(
+    new BoxRenderable(renderer, {
+      ...inset0,
+      border: true,
+      title: "Inner",
+      backgroundColor: RGBA.fromInts(0, 255, 0, 10),
+    }),
+  )
 
-  nestedBox.add(nestedInnerBox);
-  renderer.root.add(nestedBox);
+  nestedBox.add(nestedInnerBox)
+  renderer.root.add(nestedBox)
 
   const boxObj = new BoxRenderable(renderer, {
     id: "moving-box",

--- a/packages/core/src/examples/framebuffer-demo.ts
+++ b/packages/core/src/examples/framebuffer-demo.ts
@@ -8,6 +8,7 @@ import {
   TextRenderable,
   FrameBufferRenderable,
   BoxRenderable,
+  ASCIIFontRenderable,
 } from "../index"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
 
@@ -96,7 +97,7 @@ export function run(renderer: CliRenderer): void {
     }
   }
 
-  const boxObj = new FrameBufferRenderable(renderer, {
+  const boxObj = new BoxRenderable(renderer, {
     id: "moving-box",
     width: 20,
     height: 10,
@@ -104,9 +105,52 @@ export function run(renderer: CliRenderer): void {
     left: 10,
     top: 10,
     zIndex: 1,
+    buffered: true,
+    // TODO: This color is not visible, investigate
+    backgroundColor: RGBA.fromInts(0, 120, 120, 255),
   })
+
+  const boxWrapper = new BoxRenderable(renderer, {
+    id: "moving-box-wrapper",
+    position: "absolute",
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: RGBA.fromInts(0, 120, 120, 255),
+  })
+
+  boxObj.add(boxWrapper);
+
+  boxWrapper.add(new ASCIIFontRenderable(renderer, {
+    id: "moving-box-ascii",
+    text: 'ASCII',
+    width: 20,
+    height: 10,
+    position: 'absolute',
+    left: 2,
+    top: 5,
+    right:0,
+    bottom:0,
+  }))
+
+  const boxFrame = new FrameBufferRenderable(renderer, {
+    id: "moving-box-buffer",
+    width: 20,
+    height: 10,
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    right:0,
+    bottom:0,
+    zIndex: 1,
+    respectAlpha: true,
+  })
+
+  boxObj.add(boxFrame)
+
   renderer.root.add(boxObj)
-  const boxBuffer = boxObj.frameBuffer
+  const boxBuffer = boxFrame.frameBuffer
 
   const boxColor = RGBA.fromInts(80, 30, 100, 128)
   boxBuffer.fillRect(0, 0, 20, 10, boxColor)

--- a/packages/core/src/zig/buffer.zig
+++ b/packages/core/src/zig/buffer.zig
@@ -92,16 +92,18 @@ fn blendColors(overlay: RGBA, base: RGBA, backgroundMode: bool) RGBA {
     }
 
     const alpha = overlay[3];
-    var perceptualAlpha: f32 = undefined;
+    var perceptualAlpha: f32 = alpha;
 
-    // For overlay-on-text blending, use perceptual curve for better visual
-    // For high alpha values (>0.8), use a more aggressive curve
-    if (alpha > 0.8) {
-        const normalizedHighAlpha = (alpha - 0.8) * 5.0;
-        const curvedHighAlpha = std.math.pow(f32, normalizedHighAlpha, 0.2);
-        perceptualAlpha = 0.8 + (curvedHighAlpha * 0.2);
-    } else {
-        perceptualAlpha = std.math.pow(f32, alpha, 0.9);
+    if (!backgroundMode) {
+        // For overlay-on-text blending, use perceptual curve for better visual
+        // For high alpha values (>0.8), use a more aggressive curve
+        if (alpha > 0.8) {
+            const normalizedHighAlpha = (alpha - 0.8) * 5.0;
+            const curvedHighAlpha = std.math.pow(f32, normalizedHighAlpha, 0.2);
+            perceptualAlpha = 0.8 + (curvedHighAlpha * 0.2);
+        } else {
+            perceptualAlpha = std.math.pow(f32, alpha, 0.9);
+        }
     }
 
     const overlayVec = Vec3f{ overlay[0], overlay[1], overlay[2] };


### PR DESCRIPTION
Noticed that the background of ASCII characters weren't preserved when rendered inside a framebuffer. Made some changes to skip rendering invisible foreground and background colors.

While working on that I had to also change the blending algorithm for background colors, as it was also causing subtle issues with ASCII fonts. It can be seen in the videos below, where before the overlay text bg looks more frosted, whereas in the after video it's more actual color blending. Maybe we can add color blending modes in the future to leave the preference to the user.

Before:

https://github.com/user-attachments/assets/a8fe7c1c-8e44-4e7f-9baa-9e30fac2eecd


After:

https://github.com/user-attachments/assets/ef942023-fdad-4824-abd2-6471008a9fbb


