### PR TITLE
feat(solid): add extend ability to align with @opentui/react

### DIFF
--- a/packages/solid/examples/components/ExampleSelector.tsx
+++ b/packages/solid/examples/components/ExampleSelector.tsx
@@ -7,6 +7,7 @@ import MouseScene from "./mouse-demo.tsx"
 import TextStyleScene from "./text-style-demo.tsx"
 import TextSelectionDemo from "./text-selection-demo.tsx"
 import TabSelectDemo from "./tab-select-demo.tsx"
+import ExtendDemo from "./extend-demo.tsx"
 
 const EXAMPLES = [
   {
@@ -38,6 +39,11 @@ const EXAMPLES = [
     name: "Tab Select Demo",
     description: "Tab selection demo",
     scene: "tab-select-demo",
+  },
+  {
+    name: "Extend Demo",
+    description: "Extend demo",
+    scene: "extend-demo",
   },
 ]
 
@@ -108,6 +114,9 @@ const ExampleSelector = () => {
       </Match>
       <Match when={selectedScene() === "tab-select-demo"}>
         <TabSelectDemo />
+      </Match>
+      <Match when={selectedScene() === "extend-demo"}>
+        <ExtendDemo />
       </Match>
       <Match when={selected() === -1}>
         <box style={{ height: terminalDimensions().height, backgroundColor: "#001122", padding: 1 }}>

--- a/packages/solid/examples/components/extend-demo.tsx
+++ b/packages/solid/examples/components/extend-demo.tsx
@@ -1,0 +1,63 @@
+import { BoxRenderable, OptimizedBuffer, RGBA, type BoxOptions, type RenderContext } from "@opentui/core"
+import { extend } from "@opentui/solid"
+
+// Custom renderable that extends BoxRenderable
+class ConsoleButtonRenderable extends BoxRenderable {
+  private _label: string = "Button"
+
+  constructor(ctx: RenderContext, options: BoxOptions & { label?: string }) {
+    super(ctx, options)
+
+    if (options.label) {
+      this._label = options.label
+    }
+
+    // Set some default styling for buttons
+    this.borderStyle = "single"
+    this.padding = 2
+  }
+
+  protected override renderSelf(buffer: OptimizedBuffer): void {
+    super.renderSelf(buffer)
+
+    const centerX = this.x + Math.floor(this.width / 2 - this._label.length / 2)
+    const centerY = this.y + Math.floor(this.height / 2)
+
+    buffer.drawText(this._label, centerX, centerY, RGBA.fromInts(255, 255, 255, 255))
+  }
+
+  get label(): string {
+    return this._label
+  }
+
+  set label(value: string) {
+    this._label = value
+    this.needsUpdate()
+  }
+}
+
+// TypeScript module augmentation for proper typing
+declare module "@opentui/solid" {
+  interface OpenTUIComponents {
+    consoleButton: typeof ConsoleButtonRenderable
+  }
+}
+
+// Extend the component catalogue
+extend({ consoleButton: ConsoleButtonRenderable })
+
+// Example usage component
+export default function ExtendExample() {
+  return (
+    <consoleButton
+      label="Another Button"
+      style={{
+        border: true,
+        backgroundColor: "green",
+      }}
+      onMouseUp={() => {
+        console.log("Mouse up")
+      }}
+    />
+  )
+}

--- a/packages/solid/examples/components/text-selection-demo.tsx
+++ b/packages/solid/examples/components/text-selection-demo.tsx
@@ -1,6 +1,6 @@
 import { bold, cyan, green, italic, magenta, Selection, yellow } from "@opentui/core"
 import { ConsolePosition } from "@opentui/core/src/console"
-import { render, useRenderer, useSelectionHandler, type TextStyle } from "@opentui/solid"
+import { render, useRenderer, useSelectionHandler, type TextProps } from "@opentui/solid"
 import { createEffect, createSignal, onMount, type Ref } from "solid-js"
 
 const words = ["Hello", "World", "OpenTUI", "SolidJS", "ReactJS", "TypeScript", "JavaScript", "CSS", "HTML", "JSX"]
@@ -22,7 +22,7 @@ export default function TextSelectionDemo() {
   const [selectionMiddleText, setSelectionMiddleText] = createSignal("")
   const [selectionEndText, setSelectionEndText] = createSignal("")
 
-  const section1TextStyle: TextStyle = {
+  const section1TextStyle: TextProps["style"] = {
     fg: "#f0f6fc",
     zIndex: 21,
   }

--- a/packages/solid/index.ts
+++ b/packages/solid/index.ts
@@ -23,4 +23,5 @@ export const render = async (node: () => JSX.Element, renderConfig: CliRendererC
 
 export * from "./src/reconciler"
 export * from "./src/elements"
+export * from "./src/types/elements"
 export { type JSX }

--- a/packages/solid/jsx-runtime.d.ts
+++ b/packages/solid/jsx-runtime.d.ts
@@ -4,11 +4,11 @@ import type {
   BoxProps,
   ExtendedIntrinsicElements,
   InputProps,
+  OpenTUIComponents,
   SelectProps,
   TabSelectProps,
   TextProps,
 } from "./src/types/elements"
-import type { OpenTUIComponents } from "@opentui/solid"
 
 declare namespace JSX {
   // Replace Node with Renderable

--- a/packages/solid/jsx-runtime.d.ts
+++ b/packages/solid/jsx-runtime.d.ts
@@ -1,12 +1,14 @@
 import { Renderable } from "@opentui/core"
-import {
-  ASCIIFontElementProps,
-  BoxElementProps,
-  InputElementProps,
-  SelectElementProps,
-  TabSelectElementProps,
-  TextElementProps,
-} from "./src/elements/index"
+import type {
+  AsciiFontProps,
+  BoxProps,
+  ExtendedIntrinsicElements,
+  InputProps,
+  SelectProps,
+  TabSelectProps,
+  TextProps,
+} from "./src/types/elements"
+import type { OpenTUIComponents } from "@opentui/solid"
 
 declare namespace JSX {
   // Replace Node with Renderable
@@ -14,13 +16,13 @@ declare namespace JSX {
 
   interface ArrayElement extends Array<Element> {}
 
-  interface IntrinsicElements {
-    ascii_font: ASCIIFontElementProps
-    box: BoxElementProps
-    input: InputElementProps
-    select: SelectElementProps
-    tab_select: TabSelectElementProps
-    text: TextElementProps
+  interface IntrinsicElements extends ExtendedIntrinsicElements<OpenTUIComponents> {
+    box: BoxProps
+    text: TextProps
+    input: InputProps
+    select: SelectProps
+    ascii_font: AsciiFontProps
+    tab_select: TabSelectProps
   }
 
   interface ElementChildrenAttribute {

--- a/packages/solid/src/elements/index.ts
+++ b/packages/solid/src/elements/index.ts
@@ -1,17 +1,3 @@
-import type {
-  ASCIIFontOptions,
-  BoxOptions,
-  InputRenderableOptions,
-  Renderable,
-  RenderableOptions,
-  SelectOption,
-  SelectRenderableOptions,
-  StyledText,
-  TabSelectOption,
-  TabSelectRenderableOptions,
-  TextChunk,
-  TextOptions,
-} from "@opentui/core"
 import {
   ASCIIFontRenderable,
   BoxRenderable,
@@ -20,87 +6,40 @@ import {
   TabSelectRenderable,
   TextRenderable,
 } from "@opentui/core"
-import type { JSX, Ref } from "solid-js"
+import type { RenderableConstructor } from "../types/elements"
 export * from "./hooks"
 
-export const elements = {
-  ascii_font: ASCIIFontRenderable,
+export const baseComponents = {
   box: BoxRenderable,
+  text: TextRenderable,
   input: InputRenderable,
   select: SelectRenderable,
+  ascii_font: ASCIIFontRenderable,
   tab_select: TabSelectRenderable,
-  text: TextRenderable,
-}
-export type Element = keyof typeof elements
-
-type RenderableNonStyleKeys = "buffered"
-
-type ElementProps<
-  T extends RenderableOptions<K>,
-  K extends Renderable = Renderable,
-  NonStyleKeys extends keyof T = RenderableNonStyleKeys,
-> = {
-  style?: Omit<T, NonStyleKeys | RenderableNonStyleKeys>
-  ref?: Ref<K>
-} & T
-// } & Pick<T, NonStyleKeys>;
-
-type ContainerProps = { children?: JSX.Element }
-
-export type BoxElementProps = ElementProps<BoxOptions, BoxRenderable, "title"> & ContainerProps
-export type BoxStyle = BoxElementProps["style"]
-
-export type InputElementProps = ElementProps<
-  InputRenderableOptions,
-  InputRenderable,
-  "value" | "maxLength" | "placeholder"
-> & {
-  onInput?: (value: string) => void
-  onSubmit?: (value: string) => void
-  onChange?: (value: string) => void
-  focused?: boolean
-}
-export type InputStyle = InputElementProps["style"]
-
-type TabSelectEventCallback = (index: number, option: TabSelectOption) => void
-export type TabSelectElementProps = ElementProps<
-  TabSelectRenderableOptions,
-  TabSelectRenderable,
-  "options" | "showScrollArrows" | "showDescription" | "wrapSelection"
-> & {
-  onSelect?: TabSelectEventCallback
-  onChange?: TabSelectEventCallback
-  focused?: boolean
-}
-export type TabSelectStyle = TabSelectElementProps["style"]
-
-type SelectEventCallback = (index: number, option: SelectOption) => void
-
-export type SelectElementProps = ElementProps<
-  SelectRenderableOptions,
-  SelectRenderable,
-  "options" | "showScrollIndicator" | "wrapSelection" | "fastScrollStep"
-> & {
-  onSelect?: SelectEventCallback
-  onChange?: SelectEventCallback
-  focused?: boolean
-}
-export type SelectStyle = SelectElementProps["style"]
-
-type TextChildTypes = (string & {}) | number | boolean | null | undefined
-type TextProps = {
-  children: TextChildTypes | StyledText | TextChunk | Array<TextChildTypes | TextChunk>
 }
 
-export type ASCIIFontElementProps = ElementProps<
-  ASCIIFontOptions,
-  ASCIIFontRenderable,
-  "text" | "selectable" // NonStyleKeys
-> & {
-  // TODO: Needs more work to support children
-  // children?: TextChildTypes | Array<TextChildTypes>;
-}
-export type ASCIIFontStyle = ASCIIFontElementProps["style"]
+type ComponentCatalogue = Record<string, RenderableConstructor>
 
-export type TextElementProps = ElementProps<TextOptions, TextRenderable, "content" | "selectable"> & TextProps
-export type TextStyle = TextElementProps["style"]
+export const componentCatalogue: ComponentCatalogue = { ...baseComponents }
+
+/**
+ * Extend the component catalogue with new renderable components
+ *
+ * @example
+ * ```tsx
+ * // Extend with an object of components
+ * extend({
+ *   consoleButton: ConsoleButtonRenderable,
+ *   customBox: CustomBoxRenderable
+ * })
+ * ```
+ */
+export function extend<T extends ComponentCatalogue>(objects: T): void {
+  Object.assign(componentCatalogue, objects)
+}
+
+export function getComponentCatalogue(): ComponentCatalogue {
+  return componentCatalogue
+}
+
+export type { ExtendedComponentProps, ExtendedIntrinsicElements, RenderableConstructor } from "../types/elements"

--- a/packages/solid/src/reconciler.ts
+++ b/packages/solid/src/reconciler.ts
@@ -11,12 +11,12 @@ import {
   TextRenderable,
   type TextChunk,
 } from "@opentui/core"
+import { useContext } from "solid-js"
 import { createRenderer } from "solid-js/universal"
-import { elements, RendererContext, type Element } from "./elements"
+import { getComponentCatalogue, RendererContext } from "./elements"
 import { TextNode } from "./elements/text-node"
 import { getNextId } from "./utils/id-counter"
 import { log } from "./utils/log"
-import { useContext } from "solid-js"
 
 export type DomNode = Renderable | TextNode
 
@@ -77,7 +77,13 @@ export const {
     if (!solidRenderer) {
       throw new Error("No renderer found")
     }
-    const element = new elements[tagName as Element](solidRenderer, { id })
+    const elements = getComponentCatalogue()
+
+    if (!elements[tagName]) {
+      throw new Error(`[Reconciler] Unknown component type: ${tagName}`)
+    }
+
+    const element = new elements[tagName](solidRenderer, { id })
     log("Element created with id:", id)
     return element
   },

--- a/packages/solid/src/types/elements.ts
+++ b/packages/solid/src/types/elements.ts
@@ -1,0 +1,147 @@
+import type {
+  ASCIIFontOptions,
+  ASCIIFontRenderable,
+  BoxOptions,
+  BoxRenderable,
+  InputRenderable,
+  InputRenderableOptions,
+  Renderable,
+  RenderableOptions,
+  RenderContext,
+  SelectOption,
+  SelectRenderable,
+  SelectRenderableOptions,
+  StyledText,
+  TabSelectOption,
+  TabSelectRenderable,
+  TabSelectRenderableOptions,
+  TextChunk,
+  TextOptions,
+  TextRenderable,
+} from "@opentui/core"
+import type { JSX, Ref } from "solid-js"
+
+// ============================================================================
+// Core Type System
+// ============================================================================
+
+/** Properties that should not be included in the style prop */
+export type NonStyledProps =
+  | "id"
+  | "buffered"
+  | "live"
+  | "enableLayout"
+  | "selectable"
+  | "renderAfter"
+  | "renderBefore"
+  | `on${string}`
+
+/** Solid-specific props for all components */
+export type ElementProps<TRenderable = unknown> = {
+  ref?: Ref<TRenderable>
+}
+
+/** Base type for any renderable constructor */
+export type RenderableConstructor<TRenderable extends Renderable = Renderable> = new (
+  ctx: RenderContext,
+  options: any,
+) => TRenderable
+
+/** Extract the options type from a renderable constructor */
+type ExtractRenderableOptions<TConstructor> = TConstructor extends new (
+  ctx: RenderContext,
+  options: infer TOptions,
+) => any
+  ? TOptions
+  : never
+
+/** Extract the renderable type from a constructor */
+type ExtractRenderable<TConstructor> = TConstructor extends new (ctx: RenderContext, options: any) => infer TRenderable
+  ? TRenderable
+  : never
+
+/** Determine which properties should be excluded from styling for different renderable types */
+export type GetNonStyledProperties<TConstructor> =
+  TConstructor extends RenderableConstructor<TextRenderable>
+    ? NonStyledProps | "content"
+    : TConstructor extends RenderableConstructor<BoxRenderable>
+      ? NonStyledProps | "title"
+      : TConstructor extends RenderableConstructor<ASCIIFontRenderable>
+        ? NonStyledProps | "text" | "selectable"
+        : TConstructor extends RenderableConstructor<InputRenderable>
+          ? NonStyledProps | "placeholder" | "value"
+          : NonStyledProps
+
+// ============================================================================
+// Component Props System
+// ============================================================================
+
+/** Base props for container components that accept children */
+type ContainerProps<TOptions> = TOptions & { children?: JSX.Element }
+
+/** Smart component props that automatically determine excluded properties */
+type ComponentProps<TOptions extends RenderableOptions<TRenderable>, TRenderable extends Renderable> = TOptions & {
+  style?: Partial<Omit<TOptions, GetNonStyledProperties<RenderableConstructor<TRenderable>>>>
+} & ElementProps<TRenderable>
+
+/** Valid text content types for Text component children */
+type TextChildren = (string & {}) | number | boolean | null | undefined
+
+// ============================================================================
+// Built-in Component Props
+// ============================================================================
+
+export type TextProps = ComponentProps<TextOptions, TextRenderable> & {
+  children?: TextChildren | StyledText | TextChunk | Array<TextChildren | StyledText | TextChunk>
+}
+
+export type BoxProps = ComponentProps<ContainerProps<BoxOptions>, BoxRenderable>
+
+export type InputProps = ComponentProps<InputRenderableOptions, InputRenderable> & {
+  focused?: boolean
+  onInput?: (value: string) => void
+  onChange?: (value: string) => void
+  onSubmit?: (value: string) => void
+}
+
+export type SelectProps = ComponentProps<SelectRenderableOptions, SelectRenderable> & {
+  focused?: boolean
+  onChange?: (index: number, option: SelectOption | null) => void
+  onSelect?: (index: number, option: SelectOption | null) => void
+}
+
+export type AsciiFontProps = ComponentProps<ASCIIFontOptions, ASCIIFontRenderable>
+
+export type TabSelectProps = ComponentProps<TabSelectRenderableOptions, TabSelectRenderable> & {
+  focused?: boolean
+  onChange?: (index: number, option: TabSelectOption | null) => void
+  onSelect?: (index: number, option: TabSelectOption | null) => void
+}
+
+// ============================================================================
+// Extended/Dynamic Component System
+// ============================================================================
+
+/** Convert renderable constructor to component props with proper style exclusions */
+export type ExtendedComponentProps<
+  TConstructor extends RenderableConstructor,
+  TOptions = ExtractRenderableOptions<TConstructor>,
+> = TOptions & {
+  children?: JSX.Element
+  style?: Partial<Omit<TOptions, GetNonStyledProperties<TConstructor>>>
+} & ElementProps<ExtractRenderable<TConstructor>>
+
+/** Helper type to create JSX element properties from a component catalogue */
+export type ExtendedIntrinsicElements<TComponentCatalogue extends Record<string, RenderableConstructor>> = {
+  [TComponentName in keyof TComponentCatalogue]: ExtendedComponentProps<TComponentCatalogue[TComponentName]>
+}
+
+/**
+ * Global augmentation interface for extended components
+ * This will be augmented by user code using module augmentation
+ */
+export interface OpenTUIComponents {
+  [componentName: string]: RenderableConstructor
+}
+
+// Note: JSX.IntrinsicElements extension is handled in jsx-namespace.d.ts

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "Preserve",
     "moduleDetection": "force",
     "jsx": "preserve",
+    "jsxImportSource": "@opentui/solid",
     "allowJs": true,
 
     // Bundler mode


### PR DESCRIPTION
## Description

- align with `@opentui/react` and allow renderable extension with the `extend` method
- clean up types + filter out non style-able properties
- this changes the namings of the type exports (_so might break type checking of consumers if they have explicitly imported the types_) ⚠️ 
 