### PR TITLE
More efficient `useKeyboard`

### DIFF
--- a/packages/react/src/hooks/use-event.tsx
+++ b/packages/react/src/hooks/use-event.tsx
@@ -1,0 +1,22 @@
+import { useCallback, useLayoutEffect, useRef } from "react"
+
+/**
+ * Returns a stable callback that always calls the latest version of the provided handler.
+ * This prevents unnecessary re-renders and effect re-runs while ensuring the callback
+ * always has access to the latest props and state.
+ *
+ * Useful for event handlers that need to be passed to effects with empty dependency arrays
+ * or memoized child components.
+ */
+export function useEvent<T extends (...args: any[]) => any>(handler: T): T {
+  const handlerRef = useRef<T>(handler)
+
+  useLayoutEffect(() => {
+    handlerRef.current = handler
+  })
+
+  return useCallback((...args: Parameters<T>) => {
+    const fn = handlerRef.current
+    return fn(...args)
+  }, []) as T
+}

--- a/packages/react/src/hooks/use-keyboard.tsx
+++ b/packages/react/src/hooks/use-keyboard.tsx
@@ -13,5 +13,5 @@ export const useKeyboard = (handler: (key: ParsedKey) => void) => {
     return () => {
       keyHandler?.off("keypress", stableHandler)
     }
-  }, [])
+  }, [keyHandler, stableHandler])
 }

--- a/packages/react/src/hooks/use-keyboard.tsx
+++ b/packages/react/src/hooks/use-keyboard.tsx
@@ -1,15 +1,17 @@
 import type { ParsedKey } from "@opentui/core"
 import { useEffect } from "react"
 import { useAppContext } from "../components/app"
+import { useEvent } from "./use-event"
 
 export const useKeyboard = (handler: (key: ParsedKey) => void) => {
   const { keyHandler } = useAppContext()
+  const stableHandler = useEvent(handler)
 
   useEffect(() => {
-    keyHandler?.on("keypress", handler)
+    keyHandler?.on("keypress", stableHandler)
 
     return () => {
-      keyHandler?.off("keypress", handler)
+      keyHandler?.off("keypress", stableHandler)
     }
-  }, [keyHandler, handler])
+  }, [])
 }


### PR DESCRIPTION
I added useEvent which let you create a stable function that always uses the latest version

This way there is no need to pass handler to the useEffect dependencies (which would usually be different on every render)