### PR TITLE
Pass through mouse down event when starting selection

### DIFF
--- a/packages/core/src/examples/mouse-interaction-demo.ts
+++ b/packages/core/src/examples/mouse-interaction-demo.ts
@@ -402,7 +402,9 @@ Scroll on boxes: shows direction • Escape: menu`,
         content: "This should be cut off to the right",
         width: 25,
         height: 25,
-        selectable: false,
+        onMouse: (event: MouseEvent) => {
+          console.log("mouse", event.type)
+        },
       }),
     ),
   ]

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -669,6 +669,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
           maybeRenderable.shouldStartSelection(mouseEvent.x, mouseEvent.y)
         ) {
           this.startSelection(maybeRenderable, mouseEvent.x, mouseEvent.y)
+          const event = new MouseEvent(maybeRenderable, mouseEvent)
+          maybeRenderable.processMouseEvent(event)
           return true
         }
       }

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -662,7 +662,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.lastOverRenderableNum = maybeRenderableId
       const maybeRenderable = Renderable.renderablesByNumber.get(maybeRenderableId)
 
-      if (mouseEvent.type === "drag" && this.selectionState && !this.selectionState.isSelecting) {
+      if (mouseEvent.type === "down" && mouseEvent.button === MouseButton.LEFT) {
         if (
           maybeRenderable &&
           maybeRenderable.selectable &&
@@ -685,13 +685,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
       if (mouseEvent.type === "down" && mouseEvent.button === MouseButton.LEFT && this.selectionState) {
         this.clearSelection()
-      }
-
-      if (mouseEvent.type === "down") {
-        if (maybeRenderable && maybeRenderable.selectable) {
-          console.log("prepareStartSelection", mouseEvent.x, mouseEvent.y)
-          this.prepareStartSelection(maybeRenderable, mouseEvent.x, mouseEvent.y)
-        }
       }
 
       if (!sameElement && (mouseEvent.type === "drag" || mouseEvent.type === "move")) {
@@ -1221,31 +1214,16 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.selectionContainers = []
   }
 
-  private prepareStartSelection(renderable: Renderable, x: number, y: number): void {
-    if (renderable.selectable && renderable.shouldStartSelection(x, y)) {
-      this.clearSelection()
-      this.selectionState = {
-        anchor: { x, y },
-        focus: { x, y },
-        isActive: false,
-        isSelecting: false,
-      }
-      console.log("setting state", x, y, this.selectionState)
-    }
-  }
-
   private startSelection(startRenderable: Renderable, x: number, y: number): void {
+    this.clearSelection()
     this.selectionContainers.push(startRenderable.parent || this.root)
 
     this.selectionState = {
-      ...(this.selectionState || {
-        anchor: { x, y },
-        focus: { x, y },
-      }),
+      anchor: { x, y },
+      focus: { x, y },
       isActive: true,
       isSelecting: true,
     }
-    console.log("starting selection", x, y, this.selectionState)
 
     this.currentSelection = new Selection({ x, y }, { x, y })
     this.notifySelectablesOfSelectionChange()


### PR DESCRIPTION
When a renderable is `selectable`, it will start the selection, but pass through the `mousedown` event, so when releasing the button immediately, no selection happens and `mousedown` can be handled by the renderable. To avoid actually selecting the text in a text renderable one still has to set `selectable=false`, for a button component for example. So you can have both.

Should solve #112 

