### PR TITLE
Fix(#134) Solid empty scroll box issue

### DIFF
--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -199,6 +199,10 @@ export class ScrollBoxRenderable extends BoxRenderable {
     this.content.remove(id)
   }
 
+  public getChildren(): Renderable[] {
+    return this.content.getChildren()
+  }
+
   protected onMouseEvent(event: MouseEvent): void {
     if (event.type === "scroll") {
       let dir = event.scroll?.direction


### PR DESCRIPTION
Fixes: #134

Was caused be asymmetry in add/remove child methods directly passing through to content renderable but not getChildren resulting in an infinite loop in solid reconciler when solid tries to get the first child of scroll box but isn't able to remove it and tries again and again:

logs:
```logs.txt
[Reconciler] No next sibling found for node: box-2
[Reconciler] Removing node: box-1 from parent: scrollbox-1
[Reconciler] Getting first child of node: scrollbox-1
[Reconciler] First child found: renderable-3 for node: scrollbox-1
[Reconciler] Removing node: renderable-3 from parent: scrollbox-1
[Reconciler] Getting first child of node: scrollbox-1
[Reconciler] First child found: renderable-3 for node: scrollbox-1
[Reconciler] Removing node: renderable-3 from parent: scrollbox-1
[Reconciler] Getting first child of node: scrollbox-1
[Reconciler] First child found: renderable-3 for node: scrollbox-1
[Reconciler] Removing node: renderable-3 from parent: scrollbox-1
[Reconciler] Getting first child of node: scrollbox-1
[Reconciler] First child found: renderable-3 for node: scrollbox-1
[Reconciler] Removing node: renderable-3 from parent: scrollbox-1
[Reconciler] Getting first child of node: scrollbox-1
[Reconciler] First child found: renderable-3 for node: scrollbox-1
[Reconciler] Removing node: renderable-3 from parent: scrollbox-1
[Reconciler] Getting first child of node: scrollbox-1
```
