### PR TITLE
fix: trigger render on raf to run animation request

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -354,7 +354,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     global.requestAnimationFrame = (callback: FrameRequestCallback) => {
       const id = CliRenderer.animationFrameId++
       this.animationRequest.set(id, callback)
-      this.intermediateRender()
+      this.requestLive()
       return id
     }
     global.cancelAnimationFrame = (handle: number) => {
@@ -1130,7 +1130,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     const frameRequests = Array.from(this.animationRequest.values())
     this.animationRequest.clear()
     const animationRequestStart = performance.now()
-    await Promise.all(frameRequests.map((callback) => callback(deltaTime)))
+    frameRequests.forEach((callback) => {
+      callback(deltaTime)
+      this.dropLive()
+    })
     const animationRequestEnd = performance.now()
     const animationRequestTime = animationRequestEnd - animationRequestStart
 

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -354,6 +354,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     global.requestAnimationFrame = (callback: FrameRequestCallback) => {
       const id = CliRenderer.animationFrameId++
       this.animationRequest.set(id, callback)
+      this.intermediateRender()
       return id
     }
     global.cancelAnimationFrame = (handle: number) => {
@@ -1129,7 +1130,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     const frameRequests = Array.from(this.animationRequest.values())
     this.animationRequest.clear()
     const animationRequestStart = performance.now()
-    frameRequests.forEach((callback) => callback(deltaTime))
+    await Promise.all(frameRequests.map((callback) => callback(deltaTime)))
     const animationRequestEnd = performance.now()
     const animationRequestTime = animationRequestEnd - animationRequestStart
 


### PR DESCRIPTION
## Description

- handles triggering a render on `requestAnimationFrame` to run the callbacks
- closes #131 and #148 