### PR TITLE
Replace npx with bunx

### DIFF
--- a/packages/core/scripts/build.ts
+++ b/packages/core/scripts/build.ts
@@ -248,7 +248,7 @@ if (buildLib) {
 
   const tsconfigBuildPath = join(rootDir, "tsconfig.build.json")
 
-  const tscResult: SpawnSyncReturns<Buffer> = spawnSync("npx", ["tsc", "-p", tsconfigBuildPath], {
+  const tscResult: SpawnSyncReturns<Buffer> = spawnSync("bunx", ["tsc", "-p", tsconfigBuildPath], {
     cwd: rootDir,
     stdio: "inherit",
   })

--- a/packages/react/scripts/build.ts
+++ b/packages/react/scripts/build.ts
@@ -99,7 +99,7 @@ console.log("Generating TypeScript declarations...")
 
 const tsconfigBuildPath = join(rootDir, "tsconfig.build.json")
 
-const tscResult: SpawnSyncReturns<Buffer> = spawnSync("npx", ["tsc", "-p", tsconfigBuildPath], {
+const tscResult: SpawnSyncReturns<Buffer> = spawnSync("bunx", ["tsc", "-p", tsconfigBuildPath], {
   cwd: rootDir,
   stdio: "inherit",
 })

--- a/packages/solid/scripts/build.ts
+++ b/packages/solid/scripts/build.ts
@@ -87,7 +87,7 @@ console.log("Generating TypeScript declarations...")
 
 const tsconfigBuildPath = join(rootDir, "tsconfig.build.json")
 
-const tscResult: SpawnSyncReturns<Buffer> = spawnSync("npx", ["tsc", "-p", tsconfigBuildPath], {
+const tscResult: SpawnSyncReturns<Buffer> = spawnSync("bunx", ["tsc", "-p", tsconfigBuildPath], {
   cwd: rootDir,
   stdio: "inherit",
 })

--- a/packages/vue/scripts/build.ts
+++ b/packages/vue/scripts/build.ts
@@ -107,7 +107,7 @@ const tsconfigBuild = {
 
 writeFileSync(tsconfigBuildPath, JSON.stringify(tsconfigBuild, null, 2))
 
-const tscResult: SpawnSyncReturns<Buffer> = spawnSync("npx", ["tsc", "-p", tsconfigBuildPath], {
+const tscResult: SpawnSyncReturns<Buffer> = spawnSync("bunx", ["tsc", "-p", tsconfigBuildPath], {
   cwd: rootDir,
   stdio: "inherit",
 })


### PR DESCRIPTION
Whilst working in the repo to try and get the Go bindings working I ran into this issue where Node/NPM was required even though this is a bun project. 

This is a very small change to switch the npx usage for bunx & removes the node/npm dependency 