### PR TITLE
Support for Bracketed Paste

### DIFF
--- a/packages/core/docs/getting-started.md
+++ b/packages/core/docs/getting-started.md
@@ -97,12 +97,12 @@ The `parseColor()` utility function accepts both RGBA objects and color strings 
 
 ## Keyboard
 
-OpenTUI provides a global keyboard handler that parses terminal input and provides structured key events. The `getKeyHandler()` function returns a singleton EventEmitter that emits `keypress` events with detailed key information.
+OpenTUI provides a keyboard handler that parses terminal input and provides structured key events. Get the handler via `renderer.keyInput`, an EventEmitter that emits `keypress` and `paste` events with detailed key information.
 
 ```typescript
-import { getKeyHandler, type ParsedKey } from "@opentui/core"
+import { type ParsedKey } from "@opentui/core"
 
-const keyHandler = getKeyHandler()
+const keyHandler = renderer.keyInput
 
 keyHandler.on("keypress", (key: ParsedKey) => {
   console.log("Key name:", key.name)

--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -115,6 +115,8 @@ export interface RenderableOptions<T extends BaseRenderable = BaseRenderable> ex
   onMouseOut?: (this: T, event: MouseEvent) => void
   onMouseScroll?: (this: T, event: MouseEvent) => void
 
+  onPaste?: (this: T, text: string) => void
+
   onKeyDown?: (key: ParsedKey) => void
 
   onSizeChange?: (this: T) => void
@@ -220,6 +222,7 @@ export abstract class Renderable extends BaseRenderable {
   private _sizeChangeListener: (() => void) | undefined = undefined
   private _mouseListener: ((event: MouseEvent) => void) | null = null
   private _mouseListeners: Partial<Record<MouseEventType, (event: MouseEvent) => void>> = {}
+  private _pasteListener: ((text: string) => void) | undefined = undefined
   private _keyListeners: Partial<Record<"down", (key: ParsedKey) => void>> = {}
 
   protected yogaNode: YogaNode
@@ -364,6 +367,7 @@ export abstract class Renderable extends BaseRenderable {
     }
 
     this.pasteHandler = (text: string) => {
+      this._pasteListener?.call(this, text)
       if (this.handlePaste) {
         this.handlePaste(text)
       }
@@ -1420,6 +1424,13 @@ export abstract class Renderable extends BaseRenderable {
     else delete this._mouseListeners["scroll"]
   }
 
+  public set onPaste(handler: ((text: string) => void) | undefined) {
+    this._pasteListener = handler
+  }
+  public get onPaste(): ((text: string) => void) | undefined {
+    return this._pasteListener
+  }
+
   public set onKeyDown(handler: ((key: ParsedKey) => void) | undefined) {
     if (handler) this._keyListeners["down"] = handler
     else delete this._keyListeners["down"]
@@ -1446,6 +1457,7 @@ export abstract class Renderable extends BaseRenderable {
     this.onMouseOver = options.onMouseOver
     this.onMouseOut = options.onMouseOut
     this.onMouseScroll = options.onMouseScroll
+    this.onPaste = options.onPaste
     this.onKeyDown = options.onKeyDown
     this.onSizeChange = options.onSizeChange
   }

--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -212,6 +212,8 @@ export abstract class Renderable extends BaseRenderable {
   protected _focusable: boolean = false
   protected _focused: boolean = false
   protected keypressHandler: ((key: ParsedKey) => void) | null = null
+  protected pasteHandler: ((text: string) => void) | null = null
+
   private _live: boolean = false
   protected _liveCount: number = 0
 
@@ -361,7 +363,14 @@ export abstract class Renderable extends BaseRenderable {
       }
     }
 
+    this.pasteHandler = (text: string) => {
+      if (this.handlePaste) {
+        this.handlePaste(text)
+      }
+    }
+
     this.ctx.keyInput.on("keypress", this.keypressHandler)
+    this.ctx.keyInput.on("paste", this.pasteHandler)
     this.emit(RenderableEvents.FOCUSED)
   }
 
@@ -374,6 +383,11 @@ export abstract class Renderable extends BaseRenderable {
     if (this.keypressHandler) {
       this.ctx.keyInput.off("keypress", this.keypressHandler)
       this.keypressHandler = null
+    }
+
+    if (this.pasteHandler) {
+      this.ctx.keyInput.off("paste", this.pasteHandler)
+      this.pasteHandler = null
     }
 
     this.emit(RenderableEvents.BLURRED)
@@ -408,6 +422,7 @@ export abstract class Renderable extends BaseRenderable {
   }
 
   public handleKeyPress?(key: ParsedKey | string): boolean
+  public handlePaste?(text: string): void
 
   public findDescendantById(id: string): Renderable | undefined {
     for (const child of this._childrenInLayoutOrder) {

--- a/packages/core/src/ansi.ts
+++ b/packages/core/src/ansi.ts
@@ -31,4 +31,8 @@ export const ANSI = {
   disableSGRMouseMode: "\x1b[?1006l",
 
   clearRendererSpace: (height: number) => `\x1b[${height}A\x1b[1G\x1b[J`,
+
+  // Bracketed paste mode
+  bracketedPasteStart: "\u001b[200~",
+  bracketedPasteEnd: "\u001b[201~",
 }

--- a/packages/core/src/examples/hast-syntax-highlighting-demo.ts
+++ b/packages/core/src/examples/hast-syntax-highlighting-demo.ts
@@ -1,6 +1,5 @@
 import { CliRenderer, createCliRenderer, TextRenderable, BoxRenderable, type ParsedKey } from "../index"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
-import { getKeyHandler } from "../lib/KeyHandler"
 import { parseColor } from "../lib/RGBA"
 import { hastToStyledText, SyntaxStyle, type HASTElement } from "../lib/hast-styled-text"
 
@@ -104,12 +103,12 @@ export function run(rendererInstance: CliRenderer): void {
     }
   }
 
-  getKeyHandler().on("keypress", keyboardHandler)
+  rendererInstance.keyInput.on("keypress", keyboardHandler)
 }
 
 export function destroy(rendererInstance: CliRenderer): void {
   if (keyboardHandler) {
-    getKeyHandler().off("keypress", keyboardHandler)
+    rendererInstance.keyInput.off("keypress", keyboardHandler)
     keyboardHandler = null
   }
 

--- a/packages/core/src/examples/index.ts
+++ b/packages/core/src/examples/index.ts
@@ -49,7 +49,6 @@ import * as liveStateExample from "./live-state-demo"
 import * as fullUnicodeExample from "./full-unicode-demo"
 import * as textNodeDemo from "./text-node-demo"
 import * as textWrapExample from "./text-wrap"
-import { getKeyHandler } from "../lib/KeyHandler"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
 
 interface Example {
@@ -386,7 +385,7 @@ class ExampleSelector {
   }
 
   private setupKeyboardHandling(): void {
-    getKeyHandler().on("keypress", (key: ParsedKey) => {
+    this.renderer.keyInput.on("keypress", (key: ParsedKey) => {
       if (!this.inMenu) {
         switch (key.name) {
           case "escape":

--- a/packages/core/src/examples/input-demo.ts
+++ b/packages/core/src/examples/input-demo.ts
@@ -11,7 +11,6 @@ import {
 } from "../index"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
 import { TextRenderable } from "../renderables/Text"
-import { getKeyHandler } from "../lib/KeyHandler"
 
 let nameInput: InputRenderable | null = null
 let emailInput: InputRenderable | null = null
@@ -337,13 +336,13 @@ export function run(rendererInstance: CliRenderer): void {
     }
   }
 
-  getKeyHandler().on("keypress", keyboardHandler)
+  rendererInstance.keyInput.on("keypress", keyboardHandler)
   nameInput.focus()
 }
 
 export function destroy(rendererInstance: CliRenderer): void {
   if (keyboardHandler) {
-    getKeyHandler().off("keypress", keyboardHandler)
+    rendererInstance.keyInput.off("keypress", keyboardHandler)
     keyboardHandler = null
   }
 

--- a/packages/core/src/examples/input-select-layout-demo.ts
+++ b/packages/core/src/examples/input-select-layout-demo.ts
@@ -1,7 +1,6 @@
 import { CliRenderer, BoxRenderable, TextRenderable, createCliRenderer, type ParsedKey } from "../index"
 import { InputRenderable, InputRenderableEvents } from "../renderables/Input"
 import { SelectRenderable, SelectRenderableEvents, type SelectOption } from "../renderables/Select"
-import { getKeyHandler } from "../lib/KeyHandler"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
 
 let renderer: CliRenderer | null = null
@@ -371,12 +370,12 @@ function handleKeyPress(key: ParsedKey): void {
 
 export function run(rendererInstance: CliRenderer): void {
   createLayoutElements(rendererInstance)
-  getKeyHandler().on("keypress", handleKeyPress)
+  rendererInstance.keyInput.on("keypress", handleKeyPress)
   updateDisplay()
 }
 
 export function destroy(rendererInstance: CliRenderer): void {
-  getKeyHandler().off("keypress", handleKeyPress)
+  rendererInstance.keyInput.off("keypress", handleKeyPress)
 
   if (renderer) {
     renderer.off("resize", handleResize)

--- a/packages/core/src/examples/lib/standalone-keys.ts
+++ b/packages/core/src/examples/lib/standalone-keys.ts
@@ -1,8 +1,7 @@
 import { resolveRenderLib, type CliRenderer, type ParsedKey } from "../.."
-import { getKeyHandler } from "../../lib/KeyHandler"
 
 export function setupCommonDemoKeys(renderer: CliRenderer) {
-  getKeyHandler().on("keypress", (key: ParsedKey) => {
+  renderer.keyInput.on("keypress", (key: ParsedKey) => {
     if (key.name === "`" || key.name === '"') {
       renderer.console.toggle()
     } else if (key.name === ".") {

--- a/packages/core/src/examples/scroll-example.ts
+++ b/packages/core/src/examples/scroll-example.ts
@@ -13,7 +13,6 @@ import {
 } from "../index"
 import { ScrollBoxRenderable } from "../renderables/ScrollBox"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
-import { getKeyHandler } from "../lib/KeyHandler"
 
 let scrollBox: ScrollBoxRenderable | null = null
 let renderer: CliRenderer | null = null
@@ -173,7 +172,7 @@ export function run(rendererInstance: CliRenderer): void {
     }
   }
 
-  getKeyHandler().on("keypress", (key) => {
+  rendererInstance.keyInput.on("keypress", (key) => {
     if (key.name === "a" && scrollBox) {
       const currentState = scrollBox.verticalScrollBar?.showArrows ?? false
       scrollBox.verticalScrollBar!.showArrows = !currentState

--- a/packages/core/src/examples/select-demo.ts
+++ b/packages/core/src/examples/select-demo.ts
@@ -12,7 +12,6 @@ import {
 } from "../index"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
 import { TextRenderable } from "../renderables/Text"
-import { getKeyHandler } from "../lib/KeyHandler"
 
 let selectElement: SelectRenderable | null = null
 let renderer: CliRenderer | null = null
@@ -204,13 +203,13 @@ export function run(rendererInstance: CliRenderer): void {
     }
   }
 
-  getKeyHandler().on("keypress", keyboardHandler)
+  rendererInstance.keyInput.on("keypress", keyboardHandler)
   selectElement.focus()
 }
 
 export function destroy(rendererInstance: CliRenderer): void {
   if (keyboardHandler) {
-    getKeyHandler().off("keypress", keyboardHandler)
+    rendererInstance.keyInput.off("keypress", keyboardHandler)
     keyboardHandler = null
   }
 

--- a/packages/core/src/examples/simple-layout-example.ts
+++ b/packages/core/src/examples/simple-layout-example.ts
@@ -1,5 +1,4 @@
 import { CliRenderer, BoxRenderable, TextRenderable, createCliRenderer, type ParsedKey } from "../index"
-import { getKeyHandler } from "../lib/KeyHandler"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
 
 interface LayoutDemo {
@@ -536,7 +535,7 @@ function applyCurrentDemo(): void {
 
 export function run(rendererInstance: CliRenderer): void {
   createLayoutElements(rendererInstance)
-  getKeyHandler().on("keypress", handleKeyPress)
+  rendererInstance.keyInput.on("keypress", handleKeyPress)
   currentDemoIndex = 0
   applyCurrentDemo()
 }
@@ -547,7 +546,7 @@ export function destroy(rendererInstance: CliRenderer): void {
     autoAdvanceTimeout = null
   }
 
-  getKeyHandler().off("keypress", handleKeyPress)
+  rendererInstance.keyInput.off("keypress", handleKeyPress)
 
   if (renderer) {
     renderer.off("resize", handleResize)

--- a/packages/core/src/examples/slider-demo.ts
+++ b/packages/core/src/examples/slider-demo.ts
@@ -1,7 +1,6 @@
 import { type CliRenderer, createCliRenderer, t, fg, bold, BoxRenderable, TextRenderable } from "../index"
 import { SliderRenderable } from "../renderables/Slider"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
-import { getKeyHandler } from "../lib/KeyHandler"
 
 let horizontalSlider1: SliderRenderable | null = null
 let horizontalSlider2: SliderRenderable | null = null
@@ -549,7 +548,7 @@ ${fg("#565f89")("2w")}`,
     }
   }
 
-  getKeyHandler().on("keypress", keyboardHandler)
+  rendererInstance.keyInput.on("keypress", keyboardHandler)
 
   // Set up animation frame callback for animated sliders
   frameCallback = async (deltaTime: number) => {
@@ -572,7 +571,7 @@ ${fg("#565f89")("2w")}`,
 
 export function destroy(rendererInstance: CliRenderer): void {
   if (keyboardHandler) {
-    getKeyHandler().off("keypress", keyboardHandler)
+    rendererInstance.keyInput.off("keypress", keyboardHandler)
     keyboardHandler = null
   }
 

--- a/packages/core/src/examples/split-mode-demo.ts
+++ b/packages/core/src/examples/split-mode-demo.ts
@@ -1,6 +1,5 @@
 import { createCliRenderer, TextRenderable, t, type CliRenderer, BoxRenderable, bold, fg } from "../index"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
-import { getKeyHandler } from "../lib/KeyHandler"
 import { createTimeline, type JSAnimation, Timeline } from "../animation/Timeline"
 
 let text: TextRenderable | null = null
@@ -398,12 +397,12 @@ export function run(rendererInstance: CliRenderer): void {
     }
   }
 
-  getKeyHandler().on("keypress", keyHandler)
+  rendererInstance.keyInput.on("keypress", keyHandler)
 }
 
 export function destroy(rendererInstance: CliRenderer): void {
   if (keyHandler) {
-    getKeyHandler().off("keypress", keyHandler)
+    rendererInstance.keyInput.off("keypress", keyHandler)
     keyHandler = null
   }
 

--- a/packages/core/src/examples/sticky-scroll-example.ts
+++ b/packages/core/src/examples/sticky-scroll-example.ts
@@ -1,7 +1,6 @@
 import { BoxRenderable, type CliRenderer, createCliRenderer, TextRenderable, t, fg, bold } from "../index"
 import { ScrollBoxRenderable } from "../renderables/ScrollBox"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
-import { getKeyHandler } from "../lib/KeyHandler"
 
 let scrollBox: ScrollBoxRenderable | null = null
 let renderer: CliRenderer | null = null
@@ -258,7 +257,7 @@ export function run(rendererInstance: CliRenderer): void {
     addItem(false)
   }
 
-  getKeyHandler().on("keypress", (key) => {
+  rendererInstance.keyInput.on("keypress", (key) => {
     if (key.name === "s" && scrollBox) {
       // Toggle sticky scroll
       const currentSticky = scrollBox.stickyScroll

--- a/packages/core/src/examples/styled-text-demo.ts
+++ b/packages/core/src/examples/styled-text-demo.ts
@@ -14,7 +14,6 @@ import {
 } from "../index"
 import { TextRenderable } from "../renderables/Text"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
-import { getKeyHandler } from "../lib/KeyHandler"
 
 let parentContainer: BoxRenderable | null = null
 let counter = 0
@@ -199,7 +198,7 @@ ${bold(fg("#F1C40F")("Controls:"))} ${fg("#BDC3C7")("↑/↓ = Speed, ESC = Exit
       updateFrequency = Math.min(60, updateFrequency + 1)
     }
   }
-  getKeyHandler().on("keypress", keyboardHandler)
+  rendererInstance.keyInput.on("keypress", keyboardHandler)
 
   const instructionsText = t`${bold("Styled Text Demo")}
 ${fg("#888")("ESC to return, ↑/↓ to control speed")}
@@ -254,7 +253,7 @@ export function destroy(rendererInstance: CliRenderer): void {
   }
 
   if (keyboardHandler) {
-    getKeyHandler().off("keypress", keyboardHandler)
+    rendererInstance.keyInput.off("keypress", keyboardHandler)
     keyboardHandler = null
   }
 

--- a/packages/core/src/examples/tab-select-demo.ts
+++ b/packages/core/src/examples/tab-select-demo.ts
@@ -12,7 +12,6 @@ import {
 } from "../index"
 import { setupCommonDemoKeys } from "./lib/standalone-keys"
 import { TextRenderable } from "../renderables/Text"
-import { getKeyHandler } from "../lib/KeyHandler"
 
 let tabSelect: TabSelectRenderable | null = null
 let renderer: CliRenderer | null = null
@@ -183,13 +182,13 @@ export function run(rendererInstance: CliRenderer): void {
     }
   }
 
-  getKeyHandler().on("keypress", keyboardHandler)
+  rendererInstance.keyInput.on("keypress", keyboardHandler)
   tabSelect.focus()
 }
 
 export function destroy(rendererInstance: CliRenderer): void {
   if (keyboardHandler) {
-    getKeyHandler().off("keypress", keyboardHandler)
+    rendererInstance.keyInput.off("keypress", keyboardHandler)
     keyboardHandler = null
   }
 

--- a/packages/core/src/lib/KeyHandler.test.ts
+++ b/packages/core/src/lib/KeyHandler.test.ts
@@ -1,0 +1,190 @@
+import { test, expect, afterAll } from "bun:test"
+import { KeyHandler } from "./KeyHandler"
+import type { ParsedKey } from "./KeyHandler"
+import { createTestRenderer } from "../testing/test-renderer"
+import { EventEmitter } from "events"
+
+const { renderer, mockInput } = await createTestRenderer({})
+
+function createKeyHandler(useKittyKeyboard: boolean = false): KeyHandler {
+  if (!renderer) {
+    throw new Error("Renderer not initialized")
+  }
+
+  return new KeyHandler(renderer.stdin, useKittyKeyboard)
+}
+
+afterAll(() => {
+  if (renderer) {
+    renderer.destroy()
+  }
+})
+
+test("KeyHandler - constructor uses process.stdin by default", () => {
+  const originalStdin = process.stdin
+
+  // Mock process.stdin temporarily
+  const mockStdin = Object.assign(new EventEmitter(), {
+    setRawMode: () => {},
+    resume: () => {},
+    setEncoding: () => {},
+  })
+
+  Object.defineProperty(process, "stdin", {
+    value: mockStdin,
+    writable: true,
+  })
+
+  try {
+    const handler = new KeyHandler()
+
+    let receivedKey: ParsedKey | undefined
+    handler.on("keypress", (key: ParsedKey) => {
+      receivedKey = key
+    })
+
+    mockStdin.emit("data", Buffer.from("a"))
+
+    expect(receivedKey).toEqual({
+      name: "a",
+      ctrl: false,
+      meta: false,
+      shift: false,
+      option: false,
+      number: false,
+      sequence: "a",
+      raw: "a",
+      eventType: "press",
+    })
+
+    handler.destroy()
+  } finally {
+    Object.defineProperty(process, "stdin", {
+      value: originalStdin,
+      writable: true,
+    })
+  }
+})
+
+test("KeyHandler - emits keypress events", () => {
+  const handler = createKeyHandler()
+
+  let receivedKey: ParsedKey | undefined
+  handler.on("keypress", (key: ParsedKey) => {
+    receivedKey = key
+  })
+
+  mockInput.pressKey("a")
+
+  expect(receivedKey).toEqual({
+    name: "a",
+    ctrl: false,
+    meta: false,
+    shift: false,
+    option: false,
+    number: false,
+    sequence: "a",
+    raw: "a",
+    eventType: "press",
+  })
+
+  handler.destroy()
+})
+
+test("KeyHandler - handles paste mode", () => {
+  const handler = createKeyHandler()
+
+  let receivedPaste: string | undefined
+  handler.on("paste", (text: string) => {
+    receivedPaste = text
+  })
+
+  mockInput.pasteBracketedText("pasted content")
+
+  expect(receivedPaste).toBe("pasted content")
+
+  handler.destroy()
+})
+
+test("KeyHandler - handles paste with multiple parts", () => {
+  const handler = createKeyHandler()
+
+  let receivedPaste: string | undefined
+  handler.on("paste", (text: string) => {
+    receivedPaste = text
+  })
+
+  mockInput.pasteBracketedText("chunk1chunk2chunk3")
+
+  expect(receivedPaste).toBe("chunk1chunk2chunk3")
+
+  handler.destroy()
+})
+
+test("KeyHandler - strips ANSI codes in paste mode", () => {
+  const handler = createKeyHandler()
+
+  let receivedPaste: string | undefined
+  handler.on("paste", (text: string) => {
+    receivedPaste = text
+  })
+
+  mockInput.pasteBracketedText("text with \x1b[31mred\x1b[0m color")
+
+  expect(receivedPaste).toBe("text with red color")
+
+  handler.destroy()
+})
+
+test("KeyHandler - constructor accepts useKittyKeyboard parameter", () => {
+  // Test that constructor accepts the parameter without throwing
+  const handler1 = createKeyHandler(false)
+  const handler2 = createKeyHandler(true)
+
+  expect(handler1).toBeDefined()
+  expect(handler2).toBeDefined()
+
+  handler1.destroy()
+  handler2.destroy()
+})
+
+test("KeyHandler - destroy method cleans up properly", () => {
+  const handler = createKeyHandler()
+
+  expect(() => handler.destroy()).not.toThrow()
+})
+
+test("KeyHandler - handles Buffer input", () => {
+  const handler = createKeyHandler()
+
+  let receivedKey: ParsedKey | undefined
+  handler.on("keypress", (key: ParsedKey) => {
+    receivedKey = key
+  })
+
+  mockInput.pressKey("c")
+
+  expect(receivedKey).toEqual({
+    name: "c",
+    ctrl: false,
+    meta: false,
+    shift: false,
+    option: false,
+    number: false,
+    sequence: "c",
+    raw: "c",
+    eventType: "press",
+  })
+
+  handler.destroy()
+})
+
+test("KeyHandler - event inheritance from EventEmitter", () => {
+  const handler = createKeyHandler()
+
+  expect(typeof handler.on).toBe("function")
+  expect(typeof handler.emit).toBe("function")
+  expect(typeof handler.removeListener).toBe("function")
+
+  handler.destroy()
+})

--- a/packages/core/src/lib/KeyHandler.ts
+++ b/packages/core/src/lib/KeyHandler.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "events"
 import { parseKeypress, type ParsedKey } from "./parse.keypress"
+import { ANSI } from "../ansi"
 
 export type { ParsedKey }
 
@@ -30,12 +31,12 @@ export class KeyHandler extends EventEmitter<KeyHandlerEventMap> {
     this.stdin.setEncoding("utf8")
     this.listener = (key: Buffer) => {
       let data = key.toString()
-      if (data.startsWith("\u001b[200~")) {
+      if (data.startsWith(ANSI.bracketedPasteStart)) {
         this.pasteMode = true
       }
       if (this.pasteMode) {
         this.pasteBuffer.push(Bun.stripANSI(data))
-        if (data.endsWith("\u001b[201~")) {
+        if (data.endsWith(ANSI.bracketedPasteEnd)) {
           this.pasteMode = false
           this.emit("paste", this.pasteBuffer.join(""))
           this.pasteBuffer = []

--- a/packages/core/src/lib/KeyHandler.ts
+++ b/packages/core/src/lib/KeyHandler.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from "events"
 import { parseKeypress, type ParsedKey } from "./parse.keypress"
-import { singleton } from "../singleton"
 
 export type { ParsedKey }
 
@@ -52,15 +51,5 @@ export class KeyHandler extends EventEmitter<KeyHandlerEventMap> {
     if (this.stdin.setRawMode) {
       this.stdin.setRawMode(false)
     }
-    keyHandler = null
   }
-}
-
-let keyHandler: KeyHandler | null = null
-
-export function getKeyHandler(useKittyKeyboard: boolean = false): KeyHandler {
-  if (!keyHandler) {
-    keyHandler = singleton("KeyHandler", () => new KeyHandler(process.stdin, useKittyKeyboard))
-  }
-  return keyHandler
 }

--- a/packages/core/src/renderables/Input.test.ts
+++ b/packages/core/src/renderables/Input.test.ts
@@ -263,6 +263,29 @@ describe("InputRenderable", () => {
       expect(input.value).toBe("hexllo")
       expect(input.cursorPosition).toBe(3)
     })
+
+    it("should handle onPaste option", () => {
+      let pasteText = ""
+      let pasteCalled = false
+
+      const { input } = createInputRenderable({
+        width: 20,
+        height: 1,
+        onPaste: (text: string) => {
+          pasteText = text
+          pasteCalled = true
+        },
+      })
+
+      input.focus()
+
+      mockInput.pasteBracketedText("pasted text")
+      // NOTE: The input itself does not automatically insert the pasted text for now,
+      // as the whole InputRenderable will get replaced by and EditBuffer that handles it
+      expect(input.value).toBe("")
+      expect(pasteCalled).toBe(true)
+      expect(pasteText).toBe("pasted text")
+    })
   })
 
   describe("Multiple Input Focus Management", () => {

--- a/packages/core/src/renderables/Input.ts
+++ b/packages/core/src/renderables/Input.ts
@@ -190,7 +190,7 @@ export class InputRenderable extends Renderable {
     }
   }
 
-  private insertText(text: string): void {
+  public insertText(text: string): void {
     if (this._value.length + text.length > this._maxLength) {
       return
     }
@@ -204,7 +204,7 @@ export class InputRenderable extends Renderable {
     this.emit(InputRenderableEvents.INPUT, this._value)
   }
 
-  private deleteCharacter(direction: "backward" | "forward"): void {
+  public deleteCharacter(direction: "backward" | "forward"): void {
     if (direction === "backward" && this._cursorPosition > 0) {
       const beforeCursor = this._value.substring(0, this._cursorPosition - 1)
       const afterCursor = this._value.substring(this._cursorPosition)

--- a/packages/core/src/renderables/Input.ts
+++ b/packages/core/src/renderables/Input.ts
@@ -277,10 +277,6 @@ export class InputRenderable extends Renderable {
     return false
   }
 
-  public handlePaste(text: string): void {
-    this.insertText(text)
-  }
-
   public set maxLength(maxLength: number) {
     this._maxLength = maxLength
     if (this._value.length > maxLength) {

--- a/packages/core/src/renderables/Input.ts
+++ b/packages/core/src/renderables/Input.ts
@@ -277,6 +277,10 @@ export class InputRenderable extends Renderable {
     return false
   }
 
+  public handlePaste(text: string): void {
+    this.insertText(text)
+  }
+
   public set maxLength(maxLength: number) {
     this._maxLength = maxLength
     if (this._value.length > maxLength) {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -17,7 +17,7 @@ import { Selection } from "./lib/selection"
 import { EventEmitter } from "events"
 import { singleton } from "./singleton"
 import { getObjectsInViewport } from "./lib/objects-in-viewport"
-import { getKeyHandler, KeyHandler } from "./lib/KeyHandler"
+import { KeyHandler } from "./lib/KeyHandler"
 
 export interface CliRendererConfig {
   stdin?: NodeJS.ReadStream
@@ -115,7 +115,6 @@ const rendererTracker = singleton("RendererTracker", () => {
     removeRenderer: (renderer: CliRenderer) => {
       renderers.delete(renderer)
       if (renderers.size === 0) {
-        getKeyHandler().destroy()
         process.stdin.pause()
       }
     },

--- a/packages/core/src/testing/mock-keys.ts
+++ b/packages/core/src/testing/mock-keys.ts
@@ -1,4 +1,5 @@
 import type { CliRenderer } from "../renderer"
+import { ANSI } from "../ansi"
 
 export const KeyCodes = {
   // Control keys
@@ -150,6 +151,10 @@ export function createMockKeys(renderer: CliRenderer) {
     pressKey(KeyCodes.CTRL_C)
   }
 
+  const pasteBracketedText = (text: string): Promise<void> => {
+    return pressKeys([ANSI.bracketedPasteStart, text, ANSI.bracketedPasteEnd])
+  }
+
   return {
     pressKeys,
     pressKey,
@@ -160,5 +165,6 @@ export function createMockKeys(renderer: CliRenderer) {
     pressBackspace,
     pressArrow,
     pressCtrlC,
+    pasteBracketedText,
   }
 }

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -188,6 +188,9 @@ fn checkEnvironmentOverrides(self: *Terminal) void {
     var env_map = std.process.getEnvMap(std.heap.page_allocator) catch return;
     defer env_map.deinit();
 
+    // Always just try to enable bracketed paste, even if it was reported as not supported
+    self.caps.bracketed_paste = true;
+
     if (env_map.get("TERM_PROGRAM")) |prog| {
         if (std.mem.eql(u8, prog, "vscode")) {
             // VSCode has limited capability

--- a/packages/react/src/reconciler/renderer.ts
+++ b/packages/react/src/reconciler/renderer.ts
@@ -1,11 +1,12 @@
-import { createCliRenderer, getKeyHandler, type CliRendererConfig } from "@opentui/core"
+import { createCliRenderer, type CliRendererConfig } from "@opentui/core"
 import React, { type ReactNode } from "react"
 import { AppContext } from "../components/app"
 import { _render } from "./reconciler"
 
-const keyHandler = getKeyHandler()
-
 export async function render(node: ReactNode, rendererConfig: CliRendererConfig = {}): Promise<void> {
   const renderer = await createCliRenderer(rendererConfig)
-  _render(React.createElement(AppContext.Provider, { value: { keyHandler, renderer } }, node), renderer.root)
+  _render(
+    React.createElement(AppContext.Provider, { value: { keyHandler: renderer.keyInput, renderer } }, node),
+    renderer.root,
+  )
 }

--- a/packages/solid/examples/components/input-demo.tsx
+++ b/packages/solid/examples/components/input-demo.tsx
@@ -1,18 +1,24 @@
-import { useRenderer } from "@opentui/solid"
+import type { InputRenderable } from "@opentui/core"
+import { usePaste, useRenderer } from "@opentui/solid"
 import { createSignal, onMount } from "solid-js"
 
 const InputScene = () => {
   const renderer = useRenderer()
+  const [nameValue, setNameValue] = createSignal("")
+  let inputRef: InputRenderable | null = null
+
+  usePaste((text) => {
+    inputRef?.insertText(text)
+  })
+
   onMount(() => {
     renderer.setBackgroundColor("#001122")
   })
 
-  const [nameValue, setNameValue] = createSignal("")
-
   return (
     <box height={4} border>
       <text>Name: {nameValue()}</text>
-      <input focused onInput={(value) => setNameValue(value)} />
+      <input ref={(r) => (inputRef = r)} focused onInput={(value) => setNameValue(value)} />
     </box>
   )
 }

--- a/packages/solid/src/elements/hooks.ts
+++ b/packages/solid/src/elements/hooks.ts
@@ -61,6 +61,18 @@ export const useKeyboard = (callback: (key: ParsedKey) => void) => {
   })
 }
 
+export const usePaste = (callback: (text: string) => void) => {
+  const renderer = useRenderer()
+  const keyHandler = renderer.keyInput
+  onMount(() => {
+    keyHandler.on("paste", callback)
+  })
+
+  onCleanup(() => {
+    keyHandler.off("paste", callback)
+  })
+}
+
 /**
  * @deprecated renamed to useKeyboard
  */

--- a/packages/solid/src/elements/hooks.ts
+++ b/packages/solid/src/elements/hooks.ts
@@ -1,5 +1,4 @@
 import {
-  getKeyHandler,
   Selection,
   Timeline,
   type AnimationOptions,
@@ -51,7 +50,8 @@ export const useTerminalDimensions = () => {
 }
 
 export const useKeyboard = (callback: (key: ParsedKey) => void) => {
-  const keyHandler = getKeyHandler()
+  const renderer = useRenderer()
+  const keyHandler = renderer.keyInput
   onMount(() => {
     keyHandler.on("keypress", callback)
   })

--- a/packages/solid/tests/events.test.tsx
+++ b/packages/solid/tests/events.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, afterEach } from "bun:test"
 import { testRender } from "../index"
 import { createSignal } from "solid-js"
 import { createSpy } from "./utils/spy"
+import { usePaste } from "../src/elements/hooks"
 
 let testSetup: Awaited<ReturnType<typeof testRender>>
 
@@ -316,6 +317,32 @@ describe("SolidJS Renderer Integration Tests", () => {
       frame = testSetup.captureCharFrame()
       expect(frame).toContain("Static: Updated")
       expect(frame).toContain("Direct content")
+    })
+
+    it("should handle usePaste hook", async () => {
+      const pasteSpy = createSpy()
+      const [pastedText, setPastedText] = createSignal("")
+
+      const TestComponent = () => {
+        usePaste((text) => {
+          pasteSpy(text)
+          setPastedText(text)
+        })
+
+        return (
+          <box>
+            <text>Pasted: {pastedText()}</text>
+          </box>
+        )
+      }
+
+      testSetup = await testRender(() => <TestComponent />, { width: 30, height: 5 })
+
+      await testSetup.mockInput.pasteBracketedText("pasted content")
+
+      expect(pasteSpy.callCount()).toBe(1)
+      expect(pasteSpy.calls[0]?.[0]).toBe("pasted content")
+      expect(pastedText()).toBe("pasted content")
     })
   })
 })

--- a/packages/vue/example/App.vue
+++ b/packages/vue/example/App.vue
@@ -6,8 +6,8 @@ import StyledText from "./Styled-Text.vue"
 import TabSelect from "./TabSelect.vue"
 import ScrollBox from "./ScrollBox.vue"
 import { ref } from "vue"
-import { getKeyHandler } from "@opentui/core"
 import ExtendExample from "./ExtendExample.vue"
+import { useCliRenderer } from ".."
 
 const exampleOptions = [
   { name: "ASCII", description: "Assci text example", value: "ascii" },
@@ -29,7 +29,8 @@ const onSelectExample = (i: number) => {
   selectedExample.value = selectedOption
 }
 
-getKeyHandler().on("keypress", (key) => {
+const renderer = useCliRenderer()
+renderer.keyInput.on("keypress", (key) => {
   if (key.name === "escape") {
     selectedExample.value = null
   }

--- a/packages/vue/example/Counter.vue
+++ b/packages/vue/example/Counter.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { getKeyHandler, RGBA, type ParsedKey } from "@opentui/core"
-import { computed, onUnmounted, ref } from "vue"
+import { RGBA, type ParsedKey } from "@opentui/core"
+import { onUnmounted, ref } from "vue"
+import { useCliRenderer } from ".."
 
 const count = ref(0)
 
@@ -22,10 +23,11 @@ function handleKeyPress(key: ParsedKey): void {
   }
 }
 
-getKeyHandler().on("keypress", handleKeyPress)
+const renderer = useCliRenderer()
+renderer.keyInput.on("keypress", handleKeyPress)
 
 onUnmounted(() => {
-  getKeyHandler().off("keypress", handleKeyPress)
+  renderer.keyInput.off("keypress", handleKeyPress)
 })
 
 const textStyles = { fg: RGBA.fromHex("#0000ff") }

--- a/packages/vue/example/LoginForm.vue
+++ b/packages/vue/example/LoginForm.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { bold, fg, italic, t, TextAttributes, getKeyHandler, type ParsedKey } from "@opentui/core"
+import { bold, fg, italic, t, TextAttributes, type ParsedKey } from "@opentui/core"
 import { ref, onMounted, onUnmounted, computed } from "vue"
+import { useCliRenderer } from ".."
 
 const username = ref("")
 const password = ref("")
@@ -29,12 +30,13 @@ const handleSubmit = () => {
   }
 }
 
+const renderer = useCliRenderer()
 onMounted(() => {
-  getKeyHandler().on("keypress", handleKeyPress)
+  renderer.keyInput.on("keypress", handleKeyPress)
 })
 
 onUnmounted(() => {
-  getKeyHandler().off("keypress", handleKeyPress)
+  renderer.keyInput.off("keypress", handleKeyPress)
 })
 
 const titleTextStyles = {

--- a/packages/vue/src/composables/useKeyboard.ts
+++ b/packages/vue/src/composables/useKeyboard.ts
@@ -1,5 +1,5 @@
 // packages/vue/src/composables/useKeyboard.ts
-import { getKeyHandler, type ParsedKey } from "@opentui/core"
+import { type ParsedKey } from "@opentui/core"
 import { onMounted, onUnmounted } from "vue"
 import { useCliRenderer } from "./useCliRenderer"
 
@@ -7,10 +7,10 @@ export const useKeyboard = (handler: (key: ParsedKey) => void) => {
   const renderer = useCliRenderer()
 
   onMounted(() => {
-    getKeyHandler()?.on("keypress", handler)
+    renderer.keyInput.on("keypress", handler)
   })
 
   onUnmounted(() => {
-    getKeyHandler()?.off("keypress", handler)
+    renderer.keyInput.off("keypress", handler)
   })
 }


### PR DESCRIPTION
Note: The input renderable/element does not automatically insert pasted text. Needs to be captured and inserted. The input renderable will be backed by an EditBuffer soon that will handle paste properly. Check the solidjs input demo on how to hook it up.