### PR TITLE
Fix(core): insertBefore not rendering conditional children with siblings after them

### DIFF
--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -1121,10 +1121,11 @@ export abstract class Renderable extends BaseRenderable {
     if (renderable.parent === this) {
       this.yogaNode.removeChild(renderable.getLayoutNode())
       this._childrenInLayoutOrder.splice(this._childrenInLayoutOrder.indexOf(renderable), 1)
-    } else if (renderable.parent) {
+    } else {
       this.replaceParent(renderable)
       this.needsZIndexSort = true
       this.renderableMapById.set(renderable.id, renderable)
+      this._childrenInZIndexOrder.push(renderable)
 
       if (typeof renderable.onLifecyclePass === "function") {
         this._ctx.registerLifecyclePass(renderable)

--- a/packages/core/src/tests/renderable.test.ts
+++ b/packages/core/src/tests/renderable.test.ts
@@ -194,6 +194,19 @@ describe("Renderable - Child Management", () => {
     expect(children[2].id).toBe("child2")
   })
 
+  test("insertBefore makes new child accessible", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const child1 = new TestRenderable(testRenderer, { id: "child1" })
+    const child2 = new TestRenderable(testRenderer, { id: "child2" })
+    const newChild = new TestRenderable(testRenderer, { id: "newChild" })
+
+    parent.add(child1)
+    parent.add(child2)
+    parent.insertBefore(newChild, child2)
+
+    expect(parent.getRenderable("newChild")).toBe(newChild)
+  })
+
   test("handles adding destroyed renderable", () => {
     const parent = new TestRenderable(testRenderer, { id: "parent" })
     const child = new TestRenderable(testRenderer, { id: "child" })


### PR DESCRIPTION
Resolves https://github.com/sst/opentui/issues/197

## Issue

Conditional React elements with sibling elements after them were not rendering. For example:

```tsx
{foo ? <box>content</box> : null}
<box>sibling after conditional</box>  // This caused the bug
```

## Root Cause

`insertBefore()` had `else if (renderable.parent)` that only handled children transferring from different parents. New children (where `renderable.parent` is null) had **no initialization code at all** - they weren't added to either tracking array or registered in the parent's map.

Children need to be in both:
- `_childrenInLayoutOrder` (for layout)
- `_childrenInZIndexOrder` (for rendering)

New children were missing both, making them invisible and inaccessible.

## Fix

Changed `else if (renderable.parent)` to `else` to handle both transferred children AND new children. Added missing `_childrenInZIndexOrder.push(renderable)` to ensure children are properly tracked for rendering.

## Test

Added test verifying `insertBefore()` makes new children accessible via `getRenderable()`.