### PR TITLE
Show error stack trace when an error is thrown in React render

### DIFF
--- a/packages/react/src/reconciler/renderer.ts
+++ b/packages/react/src/reconciler/renderer.ts
@@ -2,12 +2,17 @@ import { createCliRenderer, engine, type CliRendererConfig } from "@opentui/core
 import React, { type ReactNode } from "react"
 import { AppContext } from "../components/app"
 import { _render } from "./reconciler"
+import { ErrorBoundary } from "../components/error-boundary"
 
 export async function render(node: ReactNode, rendererConfig: CliRendererConfig = {}): Promise<void> {
   const renderer = await createCliRenderer(rendererConfig)
   engine.attach(renderer)
   _render(
-    React.createElement(AppContext.Provider, { value: { keyHandler: renderer.keyInput, renderer } }, node),
+    React.createElement(
+      AppContext.Provider,
+      { value: { keyHandler: renderer.keyInput, renderer } },
+      React.createElement(ErrorBoundary, null, node),
+    ),
     renderer.root,
   )
 }


### PR DESCRIPTION
Added an ErrorBoundary component that displays the error stack trace instead of a black screen

<img width="1146" height="488" alt="Screenshot 2025-10-06 at 13 33 17" src="https://github.com/user-attachments/assets/648acae3-fca3-4677-bd93-9519465b3f75" />
