### PR TITLE
docs: add zig as requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ This monorepo contains the following packages:
 
 ## Install
 
+NOTE: You must have [Zig](https://ziglang.org/learn/getting-started/) installed on your system to build the packages.
+
 ### TypeScript/JavaScript
 
 ```bash


### PR DESCRIPTION
addresses issue #3 where readme needs more specific instructions for building opentui packages.