### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenTUI
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sst/opentui)
+
 OpenTUI is a TypeScript library for building terminal user interfaces (TUIs). It is currently in
 development and is not ready for production use. It will be the foundational TUI framework for both
 [opencode](https://opencode.ai) and [terminaldotshop](https://terminal.shop).


### PR DESCRIPTION
Hi! This PR adds a badge for DeepWiki to the README: https://deepwiki.com/sst/opentui.

While there's limited documentation for OpenTUI, DeepWiki provides a good way to learn about OpenTUI internals, or even "ask" DeepWiki/Devin concrete questions. The wiki and the answers are grounded in the code, so it's a way for exploring the codebase or just getting usage guidance.

Unfortunately, the auto-indexing of the codebase is lagging behind:

> Last indexed: 28 September 2025 ([e8a0ab](https://github.com/sst/opentui/commits/e8a0ab09))

But a user can request to get the repository re-indexed. I did that, but I'm guessing they have a long queue (it's been a couple of days). It suggests adding a badge for automatic reindexing, so this is what I did.

<img width="251" height="198" alt="Screenshot 2025-10-28 at 00 29 29" src="https://github.com/user-attachments/assets/d598cabc-c3d7-48f5-8de8-3f233039e2a6" />