### PR TITLE
fix(solid): init border when supporting props are present

### DIFF
--- a/packages/solid/tests/__snapshots__/layout.test.tsx.snap
+++ b/packages/solid/tests/__snapshots__/layout.test.tsx.snap
@@ -185,3 +185,40 @@ exports[`SolidJS Renderer Integration Tests Empty and Edge Cases should handle v
      
 "
 `;
+
+exports[`SolidJS Renderer Integration Tests Box Layout Rendering should auto-enable border when borderColor is set 1`] = `
+"┌──────────────────┐     
+│Colored Border    │     
+│                  │     
+│                  │     
+└──────────────────┘     
+                         
+                         
+                         
+"
+`;
+
+exports[`SolidJS Renderer Integration Tests Box Layout Rendering should auto-enable border when focusedBorderColor is set 1`] = `
+"┌──────────────────┐     
+│Focused Border    │     
+│                  │     
+│                  │     
+└──────────────────┘     
+                         
+                         
+                         
+"
+`;
+
+
+exports[`SolidJS Renderer Integration Tests Box Layout Rendering should auto-enable border when borderStyle is set 1`] = `
+"┌──────────────────┐     
+│With Border       │     
+│                  │     
+│                  │     
+└──────────────────┘     
+                         
+                         
+                         
+"
+`;

--- a/packages/solid/tests/layout.test.tsx
+++ b/packages/solid/tests/layout.test.tsx
@@ -172,6 +172,60 @@ describe("SolidJS Renderer Integration Tests", () => {
       const frame = testSetup.captureCharFrame()
       expect(frame).toMatchSnapshot()
     })
+
+    it("should auto-enable border when borderStyle is set", async () => {
+      testSetup = await testRender(
+        () => (
+          <box style={{ width: 20, height: 5 }} borderStyle="single">
+            <text>With Border</text>
+          </box>
+        ),
+        {
+          width: 25,
+          height: 8,
+        },
+      )
+
+      await testSetup.renderOnce()
+      const frame = testSetup.captureCharFrame()
+      expect(frame).toMatchSnapshot()
+    })
+
+    it("should auto-enable border when borderColor is set", async () => {
+      testSetup = await testRender(
+        () => (
+          <box style={{ width: 20, height: 5 }} borderColor="cyan">
+            <text>Colored Border</text>
+          </box>
+        ),
+        {
+          width: 25,
+          height: 8,
+        },
+      )
+
+      await testSetup.renderOnce()
+      const frame = testSetup.captureCharFrame()
+      expect(frame).toMatchSnapshot()
+    })
+
+    it("should auto-enable border when focusedBorderColor is set", async () => {
+      testSetup = await testRender(
+        () => (
+          <box style={{ width: 20, height: 5 }} focusedBorderColor="yellow">
+            <text>Focused Border</text>
+          </box>
+        ),
+        {
+          width: 25,
+          height: 8,
+        },
+      )
+
+      await testSetup.renderOnce()
+      const frame = testSetup.captureCharFrame()
+      expect(frame).toMatchSnapshot()
+    })
   })
 
   describe("Reactive Updates", () => {


### PR DESCRIPTION
## Fix: Auto-enable border when border props are set in Solid

Fixes #186

### Problem
In Solid, setting `borderStyle`, `borderColor`, or `focusedBorderColor` on `<box>` elements doesn't display borders unless `border` is explicitly set to `true`. This behavior differs from React, where borders appear automatically.

```tsx
// Works in React, doesn't work in Solid
<box borderStyle="single">
  <text>Content</text>
</box>
```

### Root Cause
The Box constructor has logic to auto-enable borders when border-related props are provided. However:
- **React reconciler**: Passes all props during construction ✅
- **Solid reconciler**: Only passes `{ id }` during construction, sets props via setters afterwards ❌
    - `createElement` doesn't have access to props

### Solution
Extracted border initialization logic into a private `initializeBorder()` method and call it from the property setters for:
- `borderStyle`
- `borderColor`
- `focusedBorderColor`

This ensures borders are auto-enabled regardless of when/how props are set.

### Testing
Added test cases in `packages/solid/tests/layout.test.tsx` verifying borders auto-enable for all border-related props.