### PR TITLE
refactor(console): improve log entry handling and add destroy method

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1373,7 +1373,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     this._stdinBuffer.destroy()
-    this._console.deactivate()
+    this._console.destroy()
     this.disableStdoutInterception()
 
     if (this._splitHeight > 0) {


### PR DESCRIPTION
- Introduced a private listener for log entries.
- Updated the destroy method to properly clean up the entry listener from the terminal console cache.

Fixes:
> "Possible EventTarget memory leak detected. 11 entry listeners added to [TerminalConsoleCache]. MaxListeners is undefined. Use events.setMaxListeners() to increase limit"
