### PR TITLE
fix: Normalize file path for tree-sitter language loading

### DIFF
--- a/packages/core/src/lib/tree-sitter/parser.worker.ts
+++ b/packages/core/src/lib/tree-sitter/parser.worker.ts
@@ -170,9 +170,10 @@ class ParserWorker {
       return undefined
     }
 
+    // Normalize path for Windows compatibility - tree-sitter expects forward slashes
+    const normalizedPath = result.filePath.replaceAll("\\", "/")
+
     try {
-      // Normalize path for Windows compatibility - tree-sitter expects forward slashes
-      const normalizedPath = result.filePath.replaceAll("\\", "/")
       const language = await Language.load(normalizedPath)
       return language
     } catch (error) {


### PR DESCRIPTION
Fixes highlighting and markdown formatting for opencode on windows

<img width="1088" height="795" alt="image" src="https://github.com/user-attachments/assets/c0511a14-0661-420f-8d64-aeec88ae1222" />


Replaces backslashes with forward slashes in file paths to ensure compatibility with tree-sitter on Windows systems.