### PR TITLE
fix: enable bracketed paste (and more) on win

### DIFF
--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -177,33 +177,29 @@ pub fn queryTerminalSend(self: *Terminal, tty: anytype) !void {
 }
 
 pub fn enableDetectedFeatures(self: *Terminal, tty: anytype, use_kitty_keyboard: bool) !void {
-    switch (builtin.os.tag) {
-        .windows => {
-            // Windows-specific defaults for ConPTY
-            self.caps.rgb = true;
-            self.caps.bracketed_paste = true;
-        },
-        else => {
-            self.checkEnvironmentOverrides();
+    if (builtin.os.tag == .windows) {
+        // Windows-specific defaults for ConPTY
+        self.caps.rgb = true;
+        self.caps.bracketed_paste = true;
+    }
+    
+    self.checkEnvironmentOverrides();
 
-            if (!self.state.modify_other_keys and !self.state.kitty_keyboard) {
-                try self.setModifyOtherKeys(tty, true);
-            }
-
-            if (self.caps.kitty_keyboard and use_kitty_keyboard) {
-                if (self.state.modify_other_keys) {
-                    try self.setModifyOtherKeys(tty, false);
-                }
-                try self.setKittyKeyboard(tty, true, self.opts.kitty_keyboard_flags);
-            }
-
-            if (self.caps.unicode == .unicode and !self.caps.explicit_width) {
-                try tty.writeAll(ansi.ANSI.unicodeSet);
-            }
-        },
+    if (!self.state.modify_other_keys and !self.state.kitty_keyboard) {
+        try self.setModifyOtherKeys(tty, true);
     }
 
-    // Enable features if supported (common to all platforms)
+    if (self.caps.kitty_keyboard and use_kitty_keyboard) {
+        if (self.state.modify_other_keys) {
+            try self.setModifyOtherKeys(tty, false);
+        }
+        try self.setKittyKeyboard(tty, true, self.opts.kitty_keyboard_flags);
+    }
+
+    if (self.caps.unicode == .unicode and !self.caps.explicit_width) {
+        try tty.writeAll(ansi.ANSI.unicodeSet);
+    }
+
     if (self.caps.bracketed_paste) {
         try self.setBracketedPaste(tty, true);
     }


### PR DESCRIPTION
Sibling of https://github.com/sst/opencode/pull/4401
<img width="688" height="733" alt="image" src="https://github.com/user-attachments/assets/5559315b-8fa2-4108-b7b9-8027b2ca4727" />
Unsure if there are more non windows things that should be platform agnostic?