### PR TITLE
fix: snapshot renderable handlers so they don't get in-flight events

### DIFF
--- a/packages/core/src/lib/KeyHandler.ts
+++ b/packages/core/src/lib/KeyHandler.ts
@@ -147,6 +147,9 @@ export class InternalKeyHandler extends KeyHandler {
     }
 
     const renderableSet = this.renderableHandlers.get(event)
+    // Snapshot the handler list so listeners added during dispatch (e.g., via focus changes)
+    // do not receive the in-flight key event.
+    const renderableHandlers = renderableSet && renderableSet.size > 0 ? [...renderableSet] : []
     let hasRenderableListeners = false
 
     if (renderableSet && renderableSet.size > 0) {
@@ -157,7 +160,7 @@ export class InternalKeyHandler extends KeyHandler {
         if (keyEvent.defaultPrevented) return hasGlobalListeners || hasRenderableListeners
       }
 
-      for (const handler of renderableSet) {
+      for (const handler of renderableHandlers) {
         try {
           handler(...args)
         } catch (error) {

--- a/packages/core/src/renderables/Select.test.ts
+++ b/packages/core/src/renderables/Select.test.ts
@@ -617,6 +617,41 @@ describe("SelectRenderable", () => {
       expect(lastOption).toEqual(sampleOptions[2])
     })
 
+    test("should not reuse the same keypress after focusing another select", async () => {
+      const { select: first } = await createSelectRenderable(currentRenderer, {
+        width: 20,
+        height: 5,
+        options: sampleOptions,
+        selectedIndex: 1,
+      })
+      const { select: second } = await createSelectRenderable(currentRenderer, {
+        width: 20,
+        height: 5,
+        options: [
+          { name: "A", description: "A" },
+          { name: "B", description: "B" },
+        ],
+      })
+
+      let firstSelections = 0
+      let secondSelections = 0
+
+      first.on(SelectRenderableEvents.ITEM_SELECTED, () => {
+        firstSelections++
+        second.focus()
+      })
+      second.on(SelectRenderableEvents.ITEM_SELECTED, () => {
+        secondSelections++
+      })
+
+      first.focus()
+      currentMockInput.pressKey("RETURN")
+
+      expect(firstSelections).toBe(1)
+      expect(secondSelections).toBe(0)
+      expect(second.focused).toBe(true)
+    })
+
     test("should emit events even when movement is blocked", async () => {
       const { select } = await createSelectRenderable(currentRenderer, {
         width: 20,


### PR DESCRIPTION
Fix #346 