### PR TITLE
feat(terminal-palette): add tmux OSC sequence passthrough support

### DIFF
--- a/packages/core/src/lib/terminal-palette.ts
+++ b/packages/core/src/lib/terminal-palette.ts
@@ -57,13 +57,6 @@ function wrapForTmux(osc: string): string {
   return `\x1bPtmux;${escaped}\x1b\\`
 }
 
-/**
- * Check if running inside tmux
- */
-function isTmux(): boolean {
-  return !!process.env.TMUX
-}
-
 export class TerminalPalette implements TerminalPaletteDetector {
   private stdin: NodeJS.ReadStream
   private stdout: NodeJS.WriteStream
@@ -72,11 +65,11 @@ export class TerminalPalette implements TerminalPaletteDetector {
   private activeTimers: Array<NodeJS.Timeout> = []
   private inTmux: boolean
 
-  constructor(stdin: NodeJS.ReadStream, stdout: NodeJS.WriteStream, writeFn?: WriteFunction) {
+  constructor(stdin: NodeJS.ReadStream, stdout: NodeJS.WriteStream, writeFn?: WriteFunction, isTmux?: boolean) {
     this.stdin = stdin
     this.stdout = stdout
     this.writeFn = writeFn || ((data: string | Buffer) => stdout.write(data))
-    this.inTmux = isTmux()
+    this.inTmux = isTmux ?? false
   }
 
   /**
@@ -347,6 +340,7 @@ export function createTerminalPalette(
   stdin: NodeJS.ReadStream,
   stdout: NodeJS.WriteStream,
   writeFn?: WriteFunction,
+  isTmux?: boolean,
 ): TerminalPaletteDetector {
-  return new TerminalPalette(stdin, stdout, writeFn)
+  return new TerminalPalette(stdin, stdout, writeFn, isTmux)
 }

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1751,7 +1751,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     if (!this._paletteDetector) {
-      this._paletteDetector = createTerminalPalette(this.stdin, this.stdout, this.writeOut.bind(this))
+      const isTmux = this.capabilities?.terminal?.name?.toLowerCase()?.includes("tmux")
+      this._paletteDetector = createTerminalPalette(this.stdin, this.stdout, this.writeOut.bind(this), isTmux)
     }
 
     this._paletteDetectionPromise = this._paletteDetector.detect(options).then((result) => {


### PR DESCRIPTION
- wrap OSC sequences for tmux using DCS format (ESC P tmux; ...)
- detect tmux environment and automatically wrap sequences when needed
- consolidate OSC writes through new writeOsc() method for cleaner passthrough handling