### PR TITLE
fix(OSC4): tmux 3.6 has native support for OSC4 and should not be wrapped

### DIFF
--- a/packages/core/src/lib/terminal-palette.ts
+++ b/packages/core/src/lib/terminal-palette.ts
@@ -63,20 +63,20 @@ export class TerminalPalette implements TerminalPaletteDetector {
   private writeFn: WriteFunction
   private activeListeners: Array<{ event: string; handler: (...args: any[]) => void }> = []
   private activeTimers: Array<NodeJS.Timeout> = []
-  private inTmux: boolean
+  private inLegacyTmux: boolean
 
-  constructor(stdin: NodeJS.ReadStream, stdout: NodeJS.WriteStream, writeFn?: WriteFunction, isTmux?: boolean) {
+  constructor(stdin: NodeJS.ReadStream, stdout: NodeJS.WriteStream, writeFn?: WriteFunction, isLegacyTmux?: boolean) {
     this.stdin = stdin
     this.stdout = stdout
     this.writeFn = writeFn || ((data: string | Buffer) => stdout.write(data))
-    this.inTmux = isTmux ?? false
+    this.inLegacyTmux = isLegacyTmux ?? false
   }
 
   /**
    * Write an OSC sequence, wrapping for tmux if needed
    */
   private writeOsc(osc: string): boolean {
-    const data = this.inTmux ? wrapForTmux(osc) : osc
+    const data = this.inLegacyTmux ? wrapForTmux(osc) : osc
     return this.writeFn(data)
   }
 
@@ -340,7 +340,7 @@ export function createTerminalPalette(
   stdin: NodeJS.ReadStream,
   stdout: NodeJS.WriteStream,
   writeFn?: WriteFunction,
-  isTmux?: boolean,
+  isLegacyTmux?: boolean,
 ): TerminalPaletteDetector {
-  return new TerminalPalette(stdin, stdout, writeFn, isTmux)
+  return new TerminalPalette(stdin, stdout, writeFn, isLegacyTmux)
 }

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1752,8 +1752,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     if (!this._paletteDetector) {
-      const isTmux = this.capabilities?.terminal?.name?.toLowerCase()?.includes("tmux")
-      this._paletteDetector = createTerminalPalette(this.stdin, this.stdout, this.writeOut.bind(this), isTmux)
+      const isLegacyTmux =
+        this.capabilities?.terminal?.name?.toLowerCase()?.includes("tmux") &&
+        this.capabilities?.terminal?.version?.localeCompare("3.6") < 0
+      this._paletteDetector = createTerminalPalette(this.stdin, this.stdout, this.writeOut.bind(this), isLegacyTmux)
     }
 
     this._paletteDetectionPromise = this._paletteDetector.detect(options).then((result) => {


### PR DESCRIPTION
#354 fix was only working for tmux<3.6 because it doesn't have native OSC4 support, so OSC4 sequence needed escaping.
But, tmux 3.6 has native OSC4 support and wrapping the sequence in a tmux escape prevent OSC4 to work with tmux 3.6.

This fixes sst/opencode#3688 for tmux 3.6 (regression was introduced by upgrading to OpenTUI 0.1.51 in https://github.com/sst/opencode/commit/204a31b6bbad951e1e03d985c2edc62165062a4e.

