### PR TITLE
fix(diff): add fg prop to support light mode themes

### DIFF
--- a/packages/core/src/renderables/Diff.test.ts
+++ b/packages/core/src/renderables/Diff.test.ts
@@ -2479,3 +2479,191 @@ test("DiffRenderable - line numbers update correctly after resize causes wrappin
   leftCodeRenderable.off("line-info-change", lineInfoChangeListener)
   renderer.destroy()
 })
+
+test("DiffRenderable - fg prop is passed to CodeRenderable on construction", async () => {
+  const syntaxStyle = SyntaxStyle.fromStyles({
+    default: { fg: RGBA.fromValues(1, 1, 1, 1) },
+  })
+  const customFg = "#000000"
+
+  const diffRenderable = new DiffRenderable(currentRenderer, {
+    id: "test-diff",
+    diff: simpleDiff,
+    view: "unified",
+    syntaxStyle,
+    fg: customFg,
+    width: "100%",
+    height: "100%",
+  })
+
+  currentRenderer.root.add(diffRenderable)
+  await renderOnce()
+
+  expect(diffRenderable.fg).toEqual(RGBA.fromHex(customFg))
+
+  const leftCodeRenderable = (diffRenderable as any).leftCodeRenderable
+  expect(leftCodeRenderable).toBeDefined()
+  expect(leftCodeRenderable.fg).toEqual(RGBA.fromHex(customFg))
+})
+
+test("DiffRenderable - fg prop can be updated via setter", async () => {
+  const syntaxStyle = SyntaxStyle.fromStyles({
+    default: { fg: RGBA.fromValues(1, 1, 1, 1) },
+  })
+  const initialFg = "#000000"
+  const updatedFg = "#333333"
+
+  const diffRenderable = new DiffRenderable(currentRenderer, {
+    id: "test-diff",
+    diff: simpleDiff,
+    view: "unified",
+    syntaxStyle,
+    fg: initialFg,
+    width: "100%",
+    height: "100%",
+  })
+
+  currentRenderer.root.add(diffRenderable)
+  await renderOnce()
+
+  diffRenderable.fg = updatedFg
+  await renderOnce()
+
+  expect(diffRenderable.fg).toEqual(RGBA.fromHex(updatedFg))
+
+  const leftCodeRenderable = (diffRenderable as any).leftCodeRenderable
+  expect(leftCodeRenderable.fg).toEqual(RGBA.fromHex(updatedFg))
+})
+
+test("DiffRenderable - fg prop is passed to both CodeRenderables in split view", async () => {
+  const syntaxStyle = SyntaxStyle.fromStyles({
+    default: { fg: RGBA.fromValues(1, 1, 1, 1) },
+  })
+  const customFg = "#222222"
+
+  const diffRenderable = new DiffRenderable(currentRenderer, {
+    id: "test-diff",
+    diff: simpleDiff,
+    view: "split",
+    syntaxStyle,
+    fg: customFg,
+    width: "100%",
+    height: "100%",
+  })
+
+  currentRenderer.root.add(diffRenderable)
+  await renderOnce()
+
+  expect(diffRenderable.fg).toEqual(RGBA.fromHex(customFg))
+
+  const leftCodeRenderable = (diffRenderable as any).leftCodeRenderable
+  const rightCodeRenderable = (diffRenderable as any).rightCodeRenderable
+
+  expect(leftCodeRenderable).toBeDefined()
+  expect(rightCodeRenderable).toBeDefined()
+  expect(leftCodeRenderable.fg).toEqual(RGBA.fromHex(customFg))
+  expect(rightCodeRenderable.fg).toEqual(RGBA.fromHex(customFg))
+})
+
+test("DiffRenderable - fg prop updates both CodeRenderables in split view", async () => {
+  const syntaxStyle = SyntaxStyle.fromStyles({
+    default: { fg: RGBA.fromValues(1, 1, 1, 1) },
+  })
+  const initialFg = "#111111"
+  const updatedFg = "#444444"
+
+  const diffRenderable = new DiffRenderable(currentRenderer, {
+    id: "test-diff",
+    diff: simpleDiff,
+    view: "split",
+    syntaxStyle,
+    fg: initialFg,
+    width: "100%",
+    height: "100%",
+  })
+
+  currentRenderer.root.add(diffRenderable)
+  await renderOnce()
+
+  const leftCodeRenderable = (diffRenderable as any).leftCodeRenderable
+  const rightCodeRenderable = (diffRenderable as any).rightCodeRenderable
+
+  diffRenderable.fg = updatedFg
+  await renderOnce()
+
+  expect(diffRenderable.fg).toEqual(RGBA.fromHex(updatedFg))
+  expect(leftCodeRenderable.fg).toEqual(RGBA.fromHex(updatedFg))
+  expect(rightCodeRenderable.fg).toEqual(RGBA.fromHex(updatedFg))
+})
+
+test("DiffRenderable - fg prop defaults to undefined when not specified", async () => {
+  const syntaxStyle = SyntaxStyle.fromStyles({
+    default: { fg: RGBA.fromValues(1, 1, 1, 1) },
+  })
+
+  const diffRenderable = new DiffRenderable(currentRenderer, {
+    id: "test-diff",
+    diff: simpleDiff,
+    view: "unified",
+    syntaxStyle,
+    width: "100%",
+    height: "100%",
+  })
+
+  currentRenderer.root.add(diffRenderable)
+  await renderOnce()
+
+  expect(diffRenderable.fg).toBeUndefined()
+})
+
+test("DiffRenderable - fg prop can be set to undefined to clear it", async () => {
+  const syntaxStyle = SyntaxStyle.fromStyles({
+    default: { fg: RGBA.fromValues(1, 1, 1, 1) },
+  })
+  const initialFg = "#000000"
+
+  const diffRenderable = new DiffRenderable(currentRenderer, {
+    id: "test-diff",
+    diff: simpleDiff,
+    view: "unified",
+    syntaxStyle,
+    fg: initialFg,
+    width: "100%",
+    height: "100%",
+  })
+
+  currentRenderer.root.add(diffRenderable)
+  await renderOnce()
+
+  expect(diffRenderable.fg).toEqual(RGBA.fromHex(initialFg))
+
+  diffRenderable.fg = undefined
+  await renderOnce()
+
+  expect(diffRenderable.fg).toBeUndefined()
+})
+
+test("DiffRenderable - fg prop accepts RGBA directly", async () => {
+  const syntaxStyle = SyntaxStyle.fromStyles({
+    default: { fg: RGBA.fromValues(1, 1, 1, 1) },
+  })
+  const customFg = RGBA.fromValues(0.2, 0.2, 0.2, 1)
+
+  const diffRenderable = new DiffRenderable(currentRenderer, {
+    id: "test-diff",
+    diff: simpleDiff,
+    view: "unified",
+    syntaxStyle,
+    fg: customFg,
+    width: "100%",
+    height: "100%",
+  })
+
+  currentRenderer.root.add(diffRenderable)
+  await renderOnce()
+
+  expect(diffRenderable.fg).toEqual(customFg)
+
+  const leftCodeRenderable = (diffRenderable as any).leftCodeRenderable
+  expect(leftCodeRenderable.fg).toEqual(customFg)
+})

--- a/packages/core/src/renderables/Diff.ts
+++ b/packages/core/src/renderables/Diff.ts
@@ -22,6 +22,7 @@ export interface DiffRenderableOptions extends RenderableOptions<DiffRenderable>
   view?: "unified" | "split"
 
   // CodeRenderable options
+  fg?: string | RGBA
   filetype?: string
   syntaxStyle?: SyntaxStyle
   wrapMode?: "word" | "char" | "none"
@@ -55,6 +56,7 @@ export class DiffRenderable extends Renderable {
   private _parseError: Error | null = null
 
   // CodeRenderable options
+  private _fg?: RGBA
   private _filetype?: string
   private _syntaxStyle?: SyntaxStyle
   private _wrapMode?: "word" | "char" | "none"
@@ -114,6 +116,7 @@ export class DiffRenderable extends Renderable {
     this._view = options.view ?? "unified"
 
     // CodeRenderable options
+    this._fg = options.fg ? parseColor(options.fg) : undefined
     this._filetype = options.filetype
     this._syntaxStyle = options.syntaxStyle
     this._wrapMode = options.wrapMode
@@ -323,6 +326,7 @@ export class DiffRenderable extends Renderable {
         syntaxStyle: this._syntaxStyle ?? SyntaxStyle.create(),
         width: "100%",
         height: "100%",
+        ...(this._fg !== undefined && { fg: this._fg }),
         ...(drawUnstyledText !== undefined && { drawUnstyledText }),
         ...(this._selectionBg !== undefined && { selectionBg: this._selectionBg }),
         ...(this._selectionFg !== undefined && { selectionFg: this._selectionFg }),
@@ -356,6 +360,9 @@ export class DiffRenderable extends Renderable {
       }
       if (this._selectionFg !== undefined) {
         existingRenderable.selectionFg = this._selectionFg
+      }
+      if (this._fg !== undefined) {
+        existingRenderable.fg = this._fg
       }
 
       return existingRenderable
@@ -1144,6 +1151,23 @@ export class DiffRenderable extends Renderable {
     if (this._conceal !== value) {
       this._conceal = value
       this.rebuildView()
+    }
+  }
+
+  public get fg(): RGBA | undefined {
+    return this._fg
+  }
+
+  public set fg(value: string | RGBA | undefined) {
+    const parsed = value ? parseColor(value) : undefined
+    if (this._fg !== parsed) {
+      this._fg = parsed
+      if (this.leftCodeRenderable) {
+        this.leftCodeRenderable.fg = parsed
+      }
+      if (this.rightCodeRenderable) {
+        this.rightCodeRenderable.fg = parsed
+      }
     }
   }
 }


### PR DESCRIPTION
Fix unreadable diff text on light mode themes by adding `fg` prop.

## Problem
When using DiffRenderable with light mode themes, syntax-unhighlighted tokens render as white text (hardcoded default in CodeRenderable), making them invisible on light backgrounds.
This is problematic on OpenCode light theme diff editor where no syntax highlighting is supported- the letters are all rendered as white.

## Solution
Add `fg` prop to DiffRenderable, allowing consumers to pass a foreground color that propagates to underlying CodeRenderables.

## Changes
- Add `fg` option to DiffRenderableOptions
- Pass `fg` to CodeRenderables on construction and updates
- Add getter/setter for dynamic updates
- Add 7 tests
