### PR TITLE
fix: reset flex properties on style removal

### DIFF
--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -665,9 +665,6 @@ export abstract class Renderable extends BaseRenderable {
       node.setFlexShrink(this._flexShrink)
     }
 
-    // Always initialize flex layout properties unconditionally to ensure
-    // consistent defaults and avoid coupling to Yoga's internal defaults.
-    // This matches the pattern used for flexGrow/flexShrink above.
     node.setFlexDirection(parseFlexDirection(options.flexDirection))
     node.setFlexWrap(parseWrap(options.flexWrap))
     node.setAlignItems(parseAlignItems(options.alignItems))

--- a/packages/core/src/lib/yoga.options.test.ts
+++ b/packages/core/src/lib/yoga.options.test.ts
@@ -444,11 +444,11 @@ describe("parseAlignItems", () => {
     expect(parseAlignItems("space-evenly")).toBe(Align.SpaceEvenly)
   })
 
-  test("handles null - returns Stretch (CSS default for align-items)", () => {
+  test("returns Stretch for null", () => {
     expect(parseAlignItems(null)).toBe(Align.Stretch)
   })
 
-  test("handles undefined - returns Stretch (CSS default for align-items)", () => {
+  test("returns Stretch for undefined", () => {
     expect(parseAlignItems(undefined)).toBe(Align.Stretch)
   })
 

--- a/packages/core/src/lib/yoga.options.ts
+++ b/packages/core/src/lib/yoga.options.ts
@@ -69,8 +69,6 @@ export function parseAlign(value: string | null | undefined): Align {
   }
 }
 
-// parseAlignItems returns Stretch as default (CSS flexbox spec default for align-items)
-// This differs from parseAlign which returns Auto (used for align-self where auto means inherit)
 export function parseAlignItems(value: string | null | undefined): Align {
   if (value == null) {
     return Align.Stretch

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -20,11 +20,9 @@ function initEventListeners(instance: Instance, eventName: string, listener: any
 }
 
 function setStyle(instance: Instance, styles: any, oldStyles: any) {
-  // Clear removed style keys first
   if (oldStyles != null && typeof oldStyles === "object") {
     for (const styleName in oldStyles) {
       if (oldStyles.hasOwnProperty(styleName)) {
-        // If the key existed in old styles but not in new styles, reset it
         if (styles == null || !styles.hasOwnProperty(styleName)) {
           // @ts-expect-error props are not strongly typed in the reconciler
           instance[styleName] = null
@@ -33,7 +31,6 @@ function setStyle(instance: Instance, styles: any, oldStyles: any) {
     }
   }
 
-  // Set new/changed style keys
   if (styles != null && typeof styles === "object") {
     for (const styleName in styles) {
       if (styles.hasOwnProperty(styleName)) {

--- a/packages/react/tests/layout.test.tsx
+++ b/packages/react/tests/layout.test.tsx
@@ -485,12 +485,7 @@ describe("React Renderer | Layout Tests", () => {
   })
 
   describe("Layout Property Reset on Component Change (Issue #391)", () => {
-    it("should use default alignItems when conditionally switching components with React state", async () => {
-      // This test reproduces the exact bug from issue #391:
-      // When React state changes cause a component tree to switch between
-      // <box alignItems="center"> to <box> (without alignItems),
-      // the text position should reset to default alignment
-
+    it("should reset alignItems when conditionally switching components", async () => {
       let setToggle: (value: boolean) => void
 
       function TestComponent() {
@@ -513,33 +508,25 @@ describe("React Renderer | Layout Tests", () => {
 
       testSetup = await testRender(<TestComponent />, { width: 40, height: 5 })
 
-      // Initial render with centered alignment
       await testSetup.renderOnce()
       const centeredFrame = testSetup.captureCharFrame()
-
-      // Verify text is centered (has leading spaces)
       const centeredLines = centeredFrame.split("\n")
       const centeredTextLine = centeredLines.find((line) => line.includes("Centered"))
       expect(centeredTextLine).toBeDefined()
       expect(centeredTextLine!.trimStart()).not.toBe(centeredTextLine)
 
-      // Toggle state to switch to non-centered component
       act(() => {
         setToggle(true)
       })
       await testSetup.renderOnce()
       const defaultFrame = testSetup.captureCharFrame()
-
-      // Text should now be at the start (default alignment), NOT centered or right-aligned
       const defaultLines = defaultFrame.split("\n")
       const defaultTextLine = defaultLines.find((line) => line.includes("Default"))
       expect(defaultTextLine).toBeDefined()
-      // Default aligned text should start at position 0 (no leading spaces before text)
       expect(defaultTextLine!.indexOf("Default")).toBe(0)
     })
 
-    it("should correctly align text when box has no explicit alignItems", async () => {
-      // Verify that a box without alignItems uses the default (stretch)
+    it("should use default alignment when alignItems is not specified", async () => {
       testSetup = await testRender(
         <box width={40} height={3}>
           <text>Left aligned</text>
@@ -552,17 +539,13 @@ describe("React Renderer | Layout Tests", () => {
 
       await testSetup.renderOnce()
       const frame = testSetup.captureCharFrame()
-
-      // Text should start at position 0
       const lines = frame.split("\n")
       const textLine = lines.find((line) => line.includes("Left aligned"))
       expect(textLine).toBeDefined()
       expect(textLine!.indexOf("Left aligned")).toBe(0)
     })
 
-    it("should reset alignItems when style prop removes the property", async () => {
-      // Tests the setStyle reset logic directly: same element, style prop changes
-      // from {alignItems: "center"} to {} (property removed)
+    it("should reset alignItems when removed from style prop", async () => {
       let setStyle: (style: Record<string, string>) => void
 
       function TestComponent() {
@@ -578,24 +561,18 @@ describe("React Renderer | Layout Tests", () => {
 
       testSetup = await testRender(<TestComponent />, { width: 40, height: 5 })
 
-      // Initial render with centered alignment
       await testSetup.renderOnce()
       const centeredFrame = testSetup.captureCharFrame()
-
-      // Verify text is centered
       const centeredLines = centeredFrame.split("\n")
       const centeredTextLine = centeredLines.find((line) => line.includes("Test"))
       expect(centeredTextLine).toBeDefined()
       expect(centeredTextLine!.trimStart()).not.toBe(centeredTextLine)
 
-      // Remove alignItems from style (empty object)
       act(() => {
         setStyle({})
       })
       await testSetup.renderOnce()
       const defaultFrame = testSetup.captureCharFrame()
-
-      // Text should now be at position 0 (default alignment after reset)
       const defaultLines = defaultFrame.split("\n")
       const defaultTextLine = defaultLines.find((line) => line.includes("Test"))
       expect(defaultTextLine).toBeDefined()


### PR DESCRIPTION
## Fix flex state change bug

Fixes #391

### Problem

When switching from `<box alignItems="center">` to `<box>` via React state, alignment stuck at previous value instead of resetting to default.

### Root Causes

1. `setStyle` didn't reset removed style properties to `null`
2. Flex properties only set conditionally—removing them left stale Yoga node values
3. `parseAlign` defaulted to `Auto`, not `Stretch` (CSS spec for `align-items`)

### Changes

- **`yoga.options.ts`**: Added `parseAlignItems()` defaulting to `Stretch`
- **`Renderable.ts`**: Set flex properties unconditionally; use `parseAlignItems` for `alignItems`
- **`utils/index.ts`**: Reset removed style keys to `null` in `setStyle`

### References

Per [MDN align-items](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items):
> Initial value: `normal`. For flex items, the keyword behaves as `stretch`.

Per [W3C CSS Flexbox Level 1](https://www.w3.org/TR/css-flexbox-1/):
> The official specification for flexbox alignment behavior.

Per [Yoga Layout Styling](https://www.yogalayout.dev/docs/styling/):
> Documents Yoga's defaults and differences from web CSS (notably `align-content` defaults to `flex-start`—but `align-items` is not listed, meaning it follows CSS default of `stretch`).

### Verification

```sh
cd packages/react && bun test layout.test.tsx
# 21 pass, 0 fail
```

Tests added:
- `should use default alignItems when conditionally switching components with React state`
- `should correctly align text when box has no explicit alignItems`
- `should reset alignItems when style prop removes the property`