### PR TITLE
fix(windows): handle Ctrl+C gracefully with ConPTY terminal restoration

### DIFF
--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -1503,7 +1503,7 @@ const win32 = if (builtin.os.tag == .windows) struct {
 
     fn ctrlHandler(ctrlType: DWORD) callconv(WINAPI) BOOL {
         if (ctrlType == CTRL_C_EVENT) {
-            const handle = GetStdHandle(STD_INPUT_HANDLE);
+            const handle = GetStdHandle(STD_INPUT_HANDLE) orelse return FALSE;
             if (handle == INVALID_HANDLE_VALUE) return FALSE;
 
             var records = [_]INPUT_RECORD{


### PR DESCRIPTION
On Windows with ConPTY (Windows Terminal), Ctrl+C triggers CTRL_C_EVENT at the Windows API level, but ConPTY does not pass the 0x03 byte through to stdin. This caused immediate process termination without giving the TUI a chance to restore terminal state (exit alternate screen, disable raw mode, etc.).
Add SetConsoleCtrlHandler to intercept CTRL_C_EVENT and inject 0x03 into stdin via WriteConsoleInputW, allowing the existing graceful shutdown code path to execute.
- installCtrlCHandler(): registers the handler (no-op on non-Windows)
- removeCtrlCHandler(): unregisters the handler (no-op on non-Windows)