### PR TITLE
export flushSync from react package

### DIFF
--- a/packages/react/src/reconciler/reconciler.ts
+++ b/packages/react/src/reconciler/reconciler.ts
@@ -6,6 +6,8 @@ import { hostConfig } from "./host-config"
 
 export const reconciler = ReactReconciler(hostConfig)
 
+export const flushSync = reconciler.flushSync
+
 export function _render(element: React.ReactNode, root: RootRenderable) {
   const container = reconciler.createContainer(
     root,

--- a/packages/react/src/reconciler/renderer.ts
+++ b/packages/react/src/reconciler/renderer.ts
@@ -3,7 +3,9 @@ import React, { type ReactNode } from "react"
 import type { OpaqueRoot } from "react-reconciler"
 import { AppContext } from "../components/app"
 import { ErrorBoundary } from "../components/error-boundary"
-import { _render, reconciler } from "./reconciler"
+import { _render, reconciler, flushSync } from "./reconciler"
+
+export { flushSync }
 
 export type Root = {
   render: (node: ReactNode) => void


### PR DESCRIPTION
Exports `flushSync` from `@opentui/react` so users can force synchronous updates in concurrent mode.

Since this is a custom renderer, `flushSync` from `react-dom` isn't available, so it needs to be exported from the reconciler.