### PR TITLE
fix: hide terminal cursor when showCursor is false

### DIFF
--- a/packages/core/src/renderables/EditBufferRenderable.ts
+++ b/packages/core/src/renderables/EditBufferRenderable.ts
@@ -279,7 +279,6 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
   set showCursor(value: boolean) {
     if (this._showCursor !== value) {
       this._showCursor = value
-      // Hide cursor when showCursor changes to false while focused
       if (!value && this._focused) {
         this._ctx.setCursorPosition(0, 0, false)
       }

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1391,6 +1391,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.lib.setCursorColor(this.rendererPtr, color)
   }
 
+  public getCursorState() {
+    return this.lib.getCursorState(this.rendererPtr)
+  }
+
   public addPostProcessFn(processFn: (buffer: OptimizedBuffer, deltaTime: number) => void): void {
     this.postProcessFns.push(processFn)
   }

--- a/packages/core/src/zig-structs.ts
+++ b/packages/core/src/zig-structs.ts
@@ -95,3 +95,15 @@ export const MeasureResultStruct = defineStruct([
   ["lineCount", "u32"],
   ["maxWidth", "u32"],
 ])
+
+export const CursorStateStruct = defineStruct([
+  ["x", "u32"],
+  ["y", "u32"],
+  ["visible", "bool_u8"],
+  ["style", "u8"],
+  ["blinking", "bool_u8"],
+  ["r", "f32"],
+  ["g", "f32"],
+  ["b", "f32"],
+  ["a", "f32"],
+])

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -17,6 +17,7 @@ import {
   EncodedCharStruct,
   LineInfoStruct,
   MeasureResultStruct,
+  CursorStateStruct,
 } from "./zig-structs"
 import { isBunfsPath } from "./lib/bunfs"
 
@@ -223,6 +224,10 @@ function getOpenTUILib(libPath?: string) {
       returns: "void",
     },
     setCursorColor: {
+      args: ["ptr", "ptr"],
+      returns: "void",
+    },
+    getCursorState: {
       args: ["ptr", "ptr"],
       returns: "void",
     },
@@ -1173,6 +1178,15 @@ export interface LogicalCursor {
   offset: number
 }
 
+export interface CursorState {
+  x: number
+  y: number
+  visible: boolean
+  style: CursorStyle
+  blinking: boolean
+  color: RGBA
+}
+
 export interface RenderLib {
   createRenderer: (width: number, height: number, options?: { testing: boolean }) => Pointer | null
   destroyRenderer: (renderer: Pointer) => void
@@ -1277,6 +1291,7 @@ export interface RenderLib {
   setCursorPosition: (renderer: Pointer, x: number, y: number, visible: boolean) => void
   setCursorStyle: (renderer: Pointer, style: CursorStyle, blinking: boolean) => void
   setCursorColor: (renderer: Pointer, color: RGBA) => void
+  getCursorState: (renderer: Pointer) => CursorState
   setDebugOverlay: (renderer: Pointer, enabled: boolean, corner: DebugOverlayCorner) => void
   clearTerminal: (renderer: Pointer) => void
   setTerminalTitle: (renderer: Pointer, title: string) => void
@@ -1956,6 +1971,27 @@ class FFIRenderLib implements RenderLib {
 
   public setCursorColor(renderer: Pointer, color: RGBA) {
     this.opentui.symbols.setCursorColor(renderer, color.buffer)
+  }
+
+  public getCursorState(renderer: Pointer): CursorState {
+    const cursorBuffer = new ArrayBuffer(CursorStateStruct.size)
+    this.opentui.symbols.getCursorState(renderer, ptr(cursorBuffer))
+    const struct = CursorStateStruct.unpack(cursorBuffer)
+
+    const styleMap: Record<number, CursorStyle> = {
+      0: "block",
+      1: "line",
+      2: "underline",
+    }
+
+    return {
+      x: struct.x,
+      y: struct.y,
+      visible: struct.visible,
+      style: styleMap[struct.style] || "block",
+      blinking: struct.blinking,
+      color: RGBA.fromValues(struct.r, struct.g, struct.b, struct.a),
+    }
   }
 
   public render(renderer: Pointer, force: boolean) {

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -197,6 +197,42 @@ export fn setCursorColor(rendererPtr: *renderer.CliRenderer, color: [*]const f32
     rendererPtr.terminal.setCursorColor(utils.f32PtrToRGBA(color));
 }
 
+pub const ExternalCursorState = extern struct {
+    x: u32,
+    y: u32,
+    visible: bool,
+    style: u8,
+    blinking: bool,
+    r: f32,
+    g: f32,
+    b: f32,
+    a: f32,
+};
+
+export fn getCursorState(rendererPtr: *renderer.CliRenderer, outPtr: *ExternalCursorState) void {
+    const pos = rendererPtr.terminal.getCursorPosition();
+    const style = rendererPtr.terminal.getCursorStyle();
+    const color = rendererPtr.terminal.getCursorColor();
+
+    const styleTag: u8 = switch (style.style) {
+        .block => 0,
+        .line => 1,
+        .underline => 2,
+    };
+
+    outPtr.* = .{
+        .x = pos.x,
+        .y = pos.y,
+        .visible = pos.visible,
+        .style = styleTag,
+        .blinking = style.blinking,
+        .r = color[0],
+        .g = color[1],
+        .b = color[2],
+        .a = color[3],
+    };
+}
+
 export fn setDebugOverlay(rendererPtr: *renderer.CliRenderer, enabled: bool, corner: u8) void {
     const cornerEnum: renderer.DebugOverlayCorner = switch (corner) {
         0 => .topLeft,

--- a/packages/solid/tests/cursor-behavior.test.tsx
+++ b/packages/solid/tests/cursor-behavior.test.tsx
@@ -1,0 +1,320 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test"
+import { testRender } from "../index"
+import { createSignal } from "solid-js"
+
+let testSetup: Awaited<ReturnType<typeof testRender>>
+
+describe("Textarea Cursor Behavior Tests", () => {
+  beforeEach(async () => {
+    if (testSetup) {
+      testSetup.renderer.destroy()
+    }
+  })
+
+  afterEach(() => {
+    if (testSetup) {
+      testSetup.renderer.destroy()
+    }
+  })
+
+  describe("Cursor Visibility", () => {
+    it("should show cursor when textarea is focused", async () => {
+      testSetup = await testRender(() => <textarea focused initialValue="Hello" width={20} height={5} />, {
+        width: 30,
+        height: 10,
+      })
+
+      await testSetup.renderOnce()
+
+      const cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+    })
+
+    it("should not change cursor state when textarea is never focused", async () => {
+      testSetup = await testRender(() => <textarea initialValue="Hello" width={20} height={5} />, {
+        width: 30,
+        height: 10,
+      })
+
+      const beforeRender = testSetup.renderer.getCursorState()
+
+      await testSetup.renderOnce()
+
+      const afterRender = testSetup.renderer.getCursorState()
+
+      expect(afterRender.visible).toBe(beforeRender.visible)
+      expect(afterRender.x).toBe(beforeRender.x)
+      expect(afterRender.y).toBe(beforeRender.y)
+    })
+
+    it("should hide cursor when showCursor is set to false while focused", async () => {
+      const [showCursor, setShowCursor] = createSignal(true)
+
+      testSetup = await testRender(
+        () => <textarea focused initialValue="Hello" width={20} height={5} showCursor={showCursor()} />,
+        { width: 30, height: 10 },
+      )
+
+      await testSetup.renderOnce()
+
+      let cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+
+      setShowCursor(false)
+      await testSetup.renderOnce()
+
+      cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(false)
+    })
+
+    it("should show cursor again when showCursor is set back to true", async () => {
+      const [showCursor, setShowCursor] = createSignal(true)
+
+      testSetup = await testRender(
+        () => <textarea focused initialValue="Hello" width={20} height={5} showCursor={showCursor()} />,
+        { width: 30, height: 10 },
+      )
+
+      await testSetup.renderOnce()
+      let cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+
+      setShowCursor(false)
+      await testSetup.renderOnce()
+      cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(false)
+
+      setShowCursor(true)
+      await testSetup.renderOnce()
+      cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+    })
+
+    it("should hide cursor when textarea loses focus", async () => {
+      const [isFocused, setIsFocused] = createSignal(true)
+
+      testSetup = await testRender(
+        () => <textarea focused={isFocused()} initialValue="Hello" width={20} height={5} />,
+        { width: 30, height: 10 },
+      )
+
+      await testSetup.renderOnce()
+      let cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+
+      setIsFocused(false)
+      await testSetup.renderOnce()
+
+      cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(false)
+    })
+
+    it("should show cursor when textarea gains focus", async () => {
+      const [isFocused, setIsFocused] = createSignal(false)
+
+      testSetup = await testRender(
+        () => <textarea focused={isFocused()} initialValue="Hello" width={20} height={5} />,
+        { width: 30, height: 10 },
+      )
+
+      await testSetup.renderOnce()
+      let cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(false)
+
+      setIsFocused(true)
+      await testSetup.renderOnce()
+
+      cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+    })
+
+    it("should not show cursor if showCursor is false even when focused", async () => {
+      testSetup = await testRender(
+        () => <textarea focused initialValue="Hello" width={20} height={5} showCursor={false} />,
+        { width: 30, height: 10 },
+      )
+
+      await testSetup.renderOnce()
+
+      const cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(false)
+    })
+  })
+
+  describe("Cursor Position", () => {
+    it("should position cursor at the end of text initially", async () => {
+      testSetup = await testRender(() => <textarea focused initialValue="Hello" width={20} height={5} />, {
+        width: 30,
+        height: 10,
+      })
+
+      await testSetup.renderOnce()
+
+      const cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+      expect(cursorState.x).toBeGreaterThan(0)
+      expect(cursorState.y).toBeGreaterThan(0)
+    })
+
+    it("should update cursor position when typing", async () => {
+      testSetup = await testRender(() => <textarea focused initialValue="X" width={20} height={5} />, {
+        width: 30,
+        height: 10,
+      })
+
+      await testSetup.renderOnce()
+
+      const initialState = testSetup.renderer.getCursorState()
+      const initialX = initialState.x
+
+      await testSetup.mockInput.typeText("ABC")
+      await testSetup.renderOnce()
+
+      const afterTypingState = testSetup.renderer.getCursorState()
+      expect(afterTypingState.x).toBe(initialX + 3)
+    })
+
+    it("should position cursor correctly with multiline text", async () => {
+      testSetup = await testRender(() => <textarea focused initialValue={"Line1\nLine2"} width={20} height={5} />, {
+        width: 30,
+        height: 10,
+      })
+
+      await testSetup.renderOnce()
+
+      const cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+      expect(cursorState.x).toBeGreaterThan(0)
+      expect(cursorState.y).toBeGreaterThanOrEqual(1)
+    })
+
+    it("should update cursor position when navigating with arrow keys", async () => {
+      testSetup = await testRender(() => <textarea focused initialValue="Hello" width={20} height={5} />, {
+        width: 30,
+        height: 10,
+      })
+
+      await testSetup.renderOnce()
+
+      const initialState = testSetup.renderer.getCursorState()
+      expect(initialState.visible).toBe(true)
+      const initialX = initialState.x
+
+      testSetup.mockInput.pressArrow("left")
+      await testSetup.renderOnce()
+
+      const afterLeftState = testSetup.renderer.getCursorState()
+      expect(afterLeftState.visible).toBe(true)
+      expect(afterLeftState.x).toBeLessThanOrEqual(initialX)
+    })
+  })
+
+  describe("Cursor Style and Color", () => {
+    it("should apply default cursor style when focused", async () => {
+      testSetup = await testRender(() => <textarea focused initialValue="Hello" width={20} height={5} />, {
+        width: 30,
+        height: 10,
+      })
+
+      await testSetup.renderOnce()
+
+      const cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+      expect(cursorState.style).toBe("block")
+      expect(cursorState.blinking).toBe(true)
+    })
+
+    it("should apply custom cursor style", async () => {
+      testSetup = await testRender(
+        () => (
+          <textarea
+            focused
+            initialValue="Hello"
+            width={20}
+            height={5}
+            cursorStyle={{ style: "line", blinking: false }}
+          />
+        ),
+        { width: 30, height: 10 },
+      )
+
+      await testSetup.renderOnce()
+
+      const cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+      expect(cursorState.style).toBe("line")
+      expect(cursorState.blinking).toBe(false)
+    })
+
+    it("should apply custom cursor color", async () => {
+      testSetup = await testRender(
+        () => <textarea focused initialValue="Hello" width={20} height={5} cursorColor="#ff0000" />,
+        { width: 30, height: 10 },
+      )
+
+      await testSetup.renderOnce()
+
+      const cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+      expect(cursorState.color.r).toBeCloseTo(1, 1)
+      expect(cursorState.color.g).toBeCloseTo(0, 1)
+      expect(cursorState.color.b).toBeCloseTo(0, 1)
+    })
+  })
+
+  describe("Cursor with Multiple Textareas", () => {
+    it("should only show cursor for the focused textarea", async () => {
+      const [focused1, setFocused1] = createSignal(true)
+      const [focused2, setFocused2] = createSignal(false)
+
+      testSetup = await testRender(
+        () => (
+          <box>
+            <textarea focused={focused1()} initialValue="First" width={20} height={3} />
+            <textarea focused={focused2()} initialValue="Second" width={20} height={3} />
+          </box>
+        ),
+        { width: 30, height: 10 },
+      )
+
+      await testSetup.renderOnce()
+
+      let cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+      const firstY = cursorState.y
+
+      setFocused1(false)
+      setFocused2(true)
+      await testSetup.renderOnce()
+
+      cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+      expect(cursorState.y).toBeGreaterThan(firstY)
+    })
+
+    it("should hide cursor when all textareas are unfocused", async () => {
+      const [focused1, setFocused1] = createSignal(true)
+      const [focused2, setFocused2] = createSignal(false)
+
+      testSetup = await testRender(
+        () => (
+          <box>
+            <textarea focused={focused1()} initialValue="First" width={20} height={3} />
+            <textarea focused={focused2()} initialValue="Second" width={20} height={3} />
+          </box>
+        ),
+        { width: 30, height: 10 },
+      )
+
+      await testSetup.renderOnce()
+      let cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(true)
+
+      setFocused1(false)
+      await testSetup.renderOnce()
+
+      cursorState = testSetup.renderer.getCursorState()
+      expect(cursorState.visible).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
When `showCursor` prop changes from `true` to `false`, the cursor was still visible because `renderCursor` just returned early without hiding the cursor.

This fix calls `setCursorPosition(0, 0, false)` to hide the terminal cursor when `showCursor` is false or the component is not focused.