### PR TITLE
feat(textarea): add super+arrow key bindings for Kitty Keyboard mode

### DIFF
--- a/packages/core/src/renderables/Textarea.ts
+++ b/packages/core/src/renderables/Textarea.ts
@@ -110,6 +110,16 @@ const defaultTextareaKeybindings: KeyBinding[] = [
   { name: "right", meta: true, shift: true, action: "select-word-forward" },
   { name: "left", meta: true, shift: true, action: "select-word-backward" },
   { name: "backspace", meta: true, action: "delete-word-backward" },
+
+  // super (cmd/win) + arrow keys for Kitty Keyboard mode
+  { name: "left", super: true, action: "visual-line-home" },
+  { name: "right", super: true, action: "visual-line-end" },
+  { name: "up", super: true, action: "buffer-home" },
+  { name: "down", super: true, action: "buffer-end" },
+  { name: "left", super: true, shift: true, action: "select-visual-line-home" },
+  { name: "right", super: true, shift: true, action: "select-visual-line-end" },
+  { name: "up", super: true, shift: true, action: "select-buffer-home" },
+  { name: "down", super: true, shift: true, action: "select-buffer-end" },
 ]
 
 export interface SubmitEvent {}


### PR DESCRIPTION
Add cmd+arrow key bindings for textarea navigation on Mac when using Kitty Keyboard protocol.

- super+left/right → go to visual line start/end
- super+up/down → go to buffer start/end
- super+shift variants for selection

Closes #437