### PR TITLE
add pkg.pr.new CI workflow for preview releases

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -36,6 +36,14 @@ jobs:
         run: bun run build
         working-directory: packages/core
 
+      - name: Get native package directories
+        id: native-packages
+        run: |
+          cd packages/core/node_modules
+          NATIVE_DIRS=$(find . -maxdepth 1 -type d -name 'opentui-*' -printf '%p ' | tr -d '\n' | sed 's/ $//')
+          echo "dirs=$NATIVE_DIRS" >> $GITHUB_OUTPUT
+          echo "Found native packages: $NATIVE_DIRS"
+
       - name: Build react
         run: bun run build --ci
         working-directory: packages/react
@@ -45,4 +53,6 @@ jobs:
         working-directory: packages/solid
 
       - name: Publish preview packages
-        run: npx pkg-pr-new publish --no-template './packages/core/dist' './packages/react/dist' './packages/solid/dist'
+        run: |
+          CORE_DIRS="./packages/core/dist ${{ steps.native-packages.outputs.dirs }}"
+          npx pkg-pr-new publish --no-template $CORE_DIRS './packages/react/dist' './packages/solid/dist'


### PR DESCRIPTION
Closes #449

Adds a GitHub Actions workflow that publishes preview packages on every push and PR using [pkg.pr.new](https://pkg.pr.new).

This enables users to test changes from any commit/PR without waiting for a release:
```
npm i https://pkg.pr.new/@opentui/core@<commit>
```

Publishes all 4 packages: core, react, solid, vue.

**Example:** See [remorses/opentui#5](https://github.com/remorses/opentui/pull/5) for a working example of how pkg.pr.new comments look on PRs.

**Note:** Requires the [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) to be installed on this repo (this is why the "Publish Preview" check is currently failing).