### PR TITLE
fix(keypress): set option flag for legacy terminal Option+Backspace

### DIFF
--- a/packages/core/src/lib/parse.keypress.test.ts
+++ b/packages/core/src/lib/parse.keypress.test.ts
@@ -752,6 +752,22 @@ test("parseKeypress - backspace key with modifiers (modifyOtherKeys format)", ()
   expect(metaBackspace.shift).toBe(false)
 })
 
+test("parseKeypress - legacy terminal Option+Backspace", () => {
+  const legacyMetaBackspace = parseKeypress("\x1b\x7f")!
+  expect(legacyMetaBackspace.name).toBe("backspace")
+  expect(legacyMetaBackspace.meta).toBe(true)
+  expect(legacyMetaBackspace.option).toBe(true)
+  expect(legacyMetaBackspace.ctrl).toBe(false)
+  expect(legacyMetaBackspace.shift).toBe(false)
+
+  const legacyMetaBackspaceBS = parseKeypress("\x1b\b")!
+  expect(legacyMetaBackspaceBS.name).toBe("backspace")
+  expect(legacyMetaBackspaceBS.meta).toBe(true)
+  expect(legacyMetaBackspaceBS.option).toBe(true)
+  expect(legacyMetaBackspaceBS.ctrl).toBe(false)
+  expect(legacyMetaBackspaceBS.shift).toBe(false)
+})
+
 test("parseKeypress - backspace key with modifiers (Kitty keyboard protocol)", () => {
   // Backspace key in Kitty protocol uses code 127
   // Ctrl+Backspace: \x1b[127;5u

--- a/packages/core/src/lib/parse.keypress.ts
+++ b/packages/core/src/lib/parse.keypress.ts
@@ -270,8 +270,11 @@ export const parseKeypress = (s: Buffer | string = "", options: ParseKeypressOpt
   } else if (s === "\b" || s === "\x1b\b" || s === "\x7f" || s === "\x1b\x7f") {
     // backspace or ctrl+h
     // On OSX, \x7f is also backspace
+    // ESC prefix indicates Alt/Option modifier (legacy terminal encoding)
     key.name = "backspace"
-    key.meta = s.charAt(0) === "\x1b"
+    const hasEscPrefix = s.charAt(0) === "\x1b"
+    key.meta = hasEscPrefix
+    key.option = hasEscPrefix
   } else if (s === "\x1b" || s === "\x1b\x1b") {
     // escape key
     key.name = "escape"


### PR DESCRIPTION
## Summary
- Set `option: true` when parsing legacy terminal sequences for Option+Backspace (`\x1b\x7f` and `\x1b\b`)
- This ensures consistency with modern escape sequences (modifyOtherKeys and Kitty keyboard protocol) which already set the option flag
- Added tests for legacy terminal Option+Backspace parsing

## Background
Legacy terminals (like Terminal.app on macOS) send `\x1b\x7f` (ESC + DEL) for Option+Backspace. Previously, only `meta: true` was set for this sequence, while the `option` flag was only set for modern escape sequences.

This change ensures consistent behavior across all terminal types.