### PR TITLE
fix(renderer): respect alpha channel for transparent background

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -888,10 +888,15 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     if (space > 0) {
       const backgroundColor = this.backgroundColor.toInts()
       const newlines = " ".repeat(this.width) + "\n".repeat(space)
-      clear =
-        ANSI.setRgbBackground(backgroundColor[0], backgroundColor[1], backgroundColor[2]) +
-        newlines +
-        ANSI.resetBackground
+      // Check if background is transparent (alpha = 0)
+      if (backgroundColor[3] === 0) {
+        clear = newlines
+      } else {
+        clear =
+          ANSI.setRgbBackground(backgroundColor[0], backgroundColor[1], backgroundColor[2]) +
+          newlines +
+          ANSI.resetBackground
+      }
     }
 
     this.writeOut(flush + move + output + clear)


### PR DESCRIPTION
## Summary
- Fix transparent background not working when theme specifies `"background": "none"`
- Check alpha channel before emitting ANSI RGB background escape codes

## Problem
When `backgroundColor` has `alpha = 0` (transparent), the renderer was still calling `ANSI.setRgbBackground()`, which overrides the terminal's native transparency settings with a solid color (typically black).

## Solution
Added a simple alpha check before setting RGB background:
```typescript
if (backgroundColor[3] === 0) {
  clear = newlines
} else {
  clear = ANSI.setRgbBackground(...) + newlines + ANSI.resetBackground
}
```

## Test plan
- [x] Create custom theme with `"background": { "dark": "none", "light": "none" }`
- [x] Apply theme in opencode
- [x] Verify terminal's transparent background shows through

Tested with:
- Terminal: Kitty (GPU-accelerated with transparency support)
- OS: Arch Linux