### PR TITLE
chore: update repository name in install script

### DIFF
--- a/packages/core/src/examples/install.sh
+++ b/packages/core/src/examples/install.sh
@@ -4,7 +4,7 @@ set -e
 # OpenTUI Examples Installation Script
 # Downloads and runs the latest opentui-examples binary
 
-REPO="sst/opentui"
+REPO="anomalyco/opentui"
 GITHUB_API="https://api.github.com/repos/$REPO"
 
 RED='\033[0;31m'


### PR DESCRIPTION
Quick update so the install script doesn't crash out trying to find a release it can't find.