### PR TITLE
chore: downgrade xtversion detection log from info to debug

### DIFF
--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -6,7 +6,6 @@ const ansi = @import("ansi.zig");
 const utf8 = @import("utf8.zig");
 
 const WidthMethod = utf8.WidthMethod;
-const log = std.log.scoped(.terminal);
 
 /// Terminal capability detection and management
 pub const Terminal = @This();
@@ -572,11 +571,6 @@ fn parseXtversion(self: *Terminal, term_str: []const u8) void {
     }
 
     self.term_info.from_xtversion = true;
-
-    log.debug("Terminal detected via xtversion: {s} {s}", .{
-        self.term_info.name[0..self.term_info.name_len],
-        self.term_info.version[0..self.term_info.version_len],
-    });
 }
 
 pub fn getTerminalInfo(self: *Terminal) TerminalInfo {


### PR DESCRIPTION
In the latest _opencode_  dev release, "0.0.0-dev-202601091759" , and I started getting this log while TUI is being loaded:

info(terminal): Terminal detected via xtversion: tmux next-3.5


https://github.com/user-attachments/assets/61835133-aab6-420a-91c9-6b759386de9c

---

## reproducing

```sh
git checkout v0.1.71
```

```
bun run build
```

```sh
bun run packages/react/examples/basic.tsx
```

output:

<img width="683" height="306" alt="image" src="https://github.com/user-attachments/assets/cd48b2b8-0ab1-4e8b-95f6-8bea947706ab" />
