### PR TITLE
fix(utf8): use col_offset for CJK word wrap boundary detection

### DIFF
--- a/packages/core/src/zig/buffer.zig
+++ b/packages/core/src/zig/buffer.zig
@@ -865,7 +865,7 @@ pub const OptimizedBuffer = struct {
             } else {
                 if (byte_offset >= text.len) break;
                 grapheme_bytes = text[byte_offset .. byte_offset + 1];
-                g_width = 1;
+                g_width = @intCast(utf8.getWidthAt(text, byte_offset, tab_width, self.width_method));
                 byte_offset += 1;
             }
 
@@ -1195,7 +1195,7 @@ pub const OptimizedBuffer = struct {
                         const cp_len = std.unicode.utf8ByteSequenceLength(chunk_bytes[byte_offset]) catch 1;
                         const next_byte_offset = @min(byte_offset + cp_len, chunk_bytes.len);
                         grapheme_bytes = chunk_bytes[byte_offset..next_byte_offset];
-                        g_width = 1; // Assuming width 1 for non-special characters (ASCII mostly)
+                        g_width = @intCast(utf8.getWidthAt(chunk_bytes, byte_offset, text_buffer.tab_width, text_buffer.width_method));
                         byte_offset = next_byte_offset;
                     }
 

--- a/packages/core/src/zig/edit-buffer.zig
+++ b/packages/core/src/zig/edit-buffer.zig
@@ -677,7 +677,7 @@ pub const EditBuffer = struct {
                     const local_cursor_col = if (cursor.col > cols_before) cursor.col - cols_before else 0;
 
                     for (wrap_offsets) |wrap_break| {
-                        const break_col = @as(u32, wrap_break.char_offset);
+                        const break_col = @as(u32, wrap_break.col_offset);
                         // If we've passed the cursor chunk, any break is valid
                         // If we're in the cursor chunk, break must be after cursor position
                         if (passed_cursor or break_col > local_cursor_col) {
@@ -728,7 +728,7 @@ pub const EditBuffer = struct {
                 };
 
                 for (wrap_offsets) |wrap_break| {
-                    const break_col = cols_before + @as(u32, wrap_break.char_offset) + 1;
+                    const break_col = cols_before + @as(u32, wrap_break.col_offset) + 1;
                     if (break_col < cursor.col) {
                         last_boundary = break_col;
                     }

--- a/packages/core/src/zig/text-buffer-view.zig
+++ b/packages/core/src/zig/text-buffer-view.zig
@@ -258,7 +258,7 @@ pub const UnifiedTextBufferView = struct {
         var first_boundary: ?u32 = null;
 
         for (wrap_offsets) |wrap_break| {
-            const offset = @as(u32, wrap_break.char_offset);
+            const offset = @as(u32, wrap_break.col_offset);
             if (offset < char_offset_in_chunk) continue;
 
             const local_offset = offset - char_offset_in_chunk;
@@ -937,7 +937,7 @@ pub const UnifiedTextBufferView = struct {
                             var saved_wrap_idx = wrap_idx;
                             while (wrap_idx < wrap_offsets.len) : (wrap_idx += 1) {
                                 const wrap_break = wrap_offsets[wrap_idx];
-                                const offset = @as(u32, wrap_break.char_offset);
+                                const offset = @as(u32, wrap_break.col_offset);
                                 if (offset < char_offset) continue;
                                 const width_to_boundary = offset - char_offset + 1;
                                 if (width_to_boundary > remaining_on_line or width_to_boundary > remaining_in_chunk) break;


### PR DESCRIPTION
CJK characters have display width 2. But the code counted them as width 1 when calculating word wrap boundaries. This caused incorrect wrap positions.

## Changes
- Add `col_offset` field to `WrapBreak` struct. This field tracks display column position.
- Use `col_offset` instead of `char_offset` in wrap boundary detection.
- Use dynamic width calculation for non-ASCII characters in buffer drawing.

## Test
- Add native test for CJK word wrap with mixed scripts (Korean, English, Chinese, Japanese).

Fixes #255