### PR TITLE
fix(renderer): disable mouse tracking on destroy

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -2219,6 +2219,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       },
       true,
     )
+    this._useMouse = false
     this.setCapturedRenderable(undefined)
 
     this.stdin.removeListener("data", this.stdinListener)

--- a/packages/core/src/tests/renderer.useMouse.test.ts
+++ b/packages/core/src/tests/renderer.useMouse.test.ts
@@ -44,4 +44,18 @@ describe("useMouse configuration", () => {
 
     renderer.destroy()
   })
+
+  test("destroy disables mouse tracking", async () => {
+    const { renderer } = await createTestRenderer({
+      useMouse: true,
+      exitOnCtrlC: false,
+      useAlternateScreen: false,
+    })
+
+    expect(renderer.useMouse).toBe(true)
+
+    renderer.destroy()
+
+    expect(renderer.useMouse).toBe(false)
+  })
 })

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -114,6 +114,7 @@ state: struct {
     bracketed_paste: bool = false,
     mouse: bool = false,
     mouse_movement: bool = true,
+    mouse_was_enabled: bool = false,
     pixel_mouse: bool = false,
     color_scheme_updates: bool = false,
     focus_tracking: bool = false,
@@ -175,8 +176,8 @@ pub fn resetState(self: *Terminal, tty: anytype) !void {
         try self.setModifyOtherKeys(tty, false);
     }
 
-    if (self.state.mouse) {
-        try self.setMouseMode(tty, false, self.state.mouse_movement);
+    if (self.state.mouse_was_enabled) {
+        try self.forceDisableMouseMode(tty);
     }
 
     if (self.state.bracketed_paste) {
@@ -497,6 +498,13 @@ fn checkEnvironmentOverrides(self: *Terminal) void {
     }
 }
 
+fn writeMouseDisableSequences(tty: anytype) !void {
+    try tty.writeAll(ansi.ANSI.disableAnyEventTracking);
+    try tty.writeAll(ansi.ANSI.disableButtonEventTracking);
+    try tty.writeAll(ansi.ANSI.disableMouseTracking);
+    try tty.writeAll(ansi.ANSI.disableSGRMouseMode);
+}
+
 // TODO: Allow pixel mouse mode to be enabled,
 // currently does not make sense and is not supported by higher levels
 pub fn setMouseMode(self: *Terminal, tty: anytype, enable: bool, enable_movement: bool) !void {
@@ -509,6 +517,9 @@ pub fn setMouseMode(self: *Terminal, tty: anytype, enable: bool, enable_movement
     if (enable) {
         self.state.mouse = true;
         self.state.mouse_movement = enable_movement;
+        // Arms the shutdown cleanup path so resetState() will still emit mouse
+        // disable sequences even if a later best-effort disable silently fails.
+        self.state.mouse_was_enabled = true;
         if (!enable_movement) {
             // Some terminals treat ?1000/?1002/?1003 as one family and let the
             // last sequence win. Reset any-event tracking first, then enable
@@ -524,11 +535,16 @@ pub fn setMouseMode(self: *Terminal, tty: anytype, enable: bool, enable_movement
     } else {
         self.state.mouse = false;
         self.state.pixel_mouse = false;
-        try tty.writeAll(ansi.ANSI.disableAnyEventTracking);
-        try tty.writeAll(ansi.ANSI.disableButtonEventTracking);
-        try tty.writeAll(ansi.ANSI.disableMouseTracking);
-        try tty.writeAll(ansi.ANSI.disableSGRMouseMode);
+        try writeMouseDisableSequences(tty);
     }
+}
+
+// Best-effort shutdown path: emit the reset sequences even if tracked state
+// already drifted to false because earlier writes failed.
+pub fn forceDisableMouseMode(self: *Terminal, tty: anytype) !void {
+    self.state.mouse = false;
+    self.state.pixel_mouse = false;
+    try writeMouseDisableSequences(tty);
 }
 
 pub fn setBracketedPaste(self: *Terminal, tty: anytype, enable: bool) !void {

--- a/packages/core/src/zig/tests/terminal_test.zig
+++ b/packages/core/src/zig/tests/terminal_test.zig
@@ -205,6 +205,10 @@ const TestWriter = struct {
         try self.buffer.appendSlice(self.allocator, data);
     }
 
+    pub fn writeByte(self: *TestWriter, byte: u8) !void {
+        try self.buffer.append(self.allocator, byte);
+    }
+
     pub fn print(self: *TestWriter, comptime fmt: []const u8, args: anytype) !void {
         try self.buffer.writer(self.allocator).print(fmt, args);
     }
@@ -751,4 +755,41 @@ test "restoreTerminalModes - respects mouse movement setting" {
     try testing.expect(idx_enable_mouse < idx_enable_button);
     try testing.expect(idx_enable_button < idx_enable_sgr);
     try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.enableAnyEventTracking) == null);
+}
+
+test "resetState - force-disables mouse when cleanup is pending and state drifted false" {
+    var term = Terminal.init(.{});
+    term.state.mouse = false;
+    term.state.mouse_movement = false;
+    term.state.mouse_was_enabled = true;
+
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.resetState(&writer);
+
+    const output = writer.getWritten();
+    const idx_disable_any = std.mem.indexOf(u8, output, ansi.ANSI.disableAnyEventTracking).?;
+    const idx_disable_button = std.mem.indexOf(u8, output, ansi.ANSI.disableButtonEventTracking).?;
+    const idx_disable_mouse = std.mem.indexOf(u8, output, ansi.ANSI.disableMouseTracking).?;
+    const idx_disable_sgr = std.mem.indexOf(u8, output, ansi.ANSI.disableSGRMouseMode).?;
+    try testing.expect(idx_disable_any < idx_disable_button);
+    try testing.expect(idx_disable_button < idx_disable_mouse);
+    try testing.expect(idx_disable_mouse < idx_disable_sgr);
+    try testing.expect(!term.state.mouse);
+}
+
+test "resetState - skips mouse disable when mouse was never enabled" {
+    var term = Terminal.init(.{});
+
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.resetState(&writer);
+
+    const output = writer.getWritten();
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.disableAnyEventTracking) == null);
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.disableButtonEventTracking) == null);
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.disableMouseTracking) == null);
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.disableSGRMouseMode) == null);
 }


### PR DESCRIPTION
The destroy path was not explicitly disabling mouse tracking before tearing down native resources. 

Best-effort mouse cleanup now lives in native terminal shutdown instead of
TypeScript destroy state. Track whether mouse was ever enabled so teardown
still emits disable sequences after state drift, while skipping unnecessary
resets when mouse was never active.# Please enter the commit message for your
changes.

Fixes: #509