### PR TITLE
fix(ci): fix pkg-pr-new workflow for native binary packages

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -32,15 +32,14 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Build core
-        run: bun run build
+      - name: Build core (all platforms via cross-compilation)
+        run: bun scripts/build.ts --native --all && bun scripts/build.ts --lib
         working-directory: packages/core
 
       - name: Get native package directories
         id: native-packages
         run: |
-          cd packages/core/node_modules
-          NATIVE_DIRS=$(find . -maxdepth 1 -type d -name 'opentui-*' -printf '%p ' | tr -d '\n' | sed 's/ $//')
+          NATIVE_DIRS=$(find ./packages/core/node_modules/@opentui -maxdepth 1 -type d -name 'core-*' -printf '%p ' | sed 's/ $//')
           echo "dirs=$NATIVE_DIRS" >> $GITHUB_OUTPUT
           echo "Found native packages: $NATIVE_DIRS"
 
@@ -54,5 +53,8 @@ jobs:
 
       - name: Publish preview packages
         run: |
-          CORE_DIRS="./packages/core/dist ${{ steps.native-packages.outputs.dirs }}"
-          npx pkg-pr-new publish --no-template $CORE_DIRS './packages/react/dist' './packages/solid/dist'
+          npx pkg-pr-new publish --no-template \
+            './packages/core/dist' \
+            ${{ steps.native-packages.outputs.dirs }} \
+            './packages/react/dist' \
+            './packages/solid/dist'


### PR DESCRIPTION
The pkg-pr-new workflow wasn't publishing native binaries because:

1. `bun run build` only builds for the current platform - need `--all` flag for cross-compilation
2. `find` was looking for `opentui-*` but packages are at `@opentui/core-*`