### PR TITLE
fix: add keypad Enter key (OM) mapping for application mode

### DIFF
--- a/packages/core/src/lib/parse.keypress.test.ts
+++ b/packages/core/src/lib/parse.keypress.test.ts
@@ -1783,3 +1783,22 @@ test("parseKeypress - meta+arrow keys with uppercase F and B (old style)", () =>
   expect(metaB.shift).toBe(false)
   expect(metaB.ctrl).toBe(false)
 })
+
+test("parseKeypress - keypad enter (application mode)", () => {
+  // When keypad is in application mode, keypad Enter sends ESC O M (\x1bOM)
+  expect(parseKeypress("\x1bOM")).toEqual({
+    eventType: "press",
+    name: "return",
+    ctrl: false,
+    meta: false,
+    shift: false,
+    option: false,
+    number: false,
+    sequence: "\x1bOM",
+    raw: "\x1bOM",
+    source: "raw",
+    code: "OM",
+    super: false,
+    hyper: false,
+  })
+})

--- a/packages/core/src/lib/parse.keypress.ts
+++ b/packages/core/src/lib/parse.keypress.ts
@@ -48,6 +48,8 @@ const keyName: Record<string, string> = {
   OE: "clear",
   OF: "end",
   OH: "home",
+  /* keypad enter (application mode) */
+  OM: "return",
   /* xterm/rxvt ESC [ number ~ */
   "[1~": "home",
   "[2~": "insert",


### PR DESCRIPTION
## Summary

- Adds `OM` -> `return` mapping to the keyName table in `parse.keypress.ts`
- Adds test case for keypad Enter key parsing

## Problem

When the numpad (keypad) is in application mode, pressing the numpad Enter key sends the escape sequence `ESC O M` (`\x1bOM`). This sequence was not being recognized, causing the numpad Enter key to not function in applications using opentui (such as opencode).

## Solution

Added the `OM: "return"` mapping to the keyName object, similar to how other application mode keys (OA, OB, OC, OD, etc.) are mapped.

## Testing

Added a test case that verifies `\x1bOM` is correctly parsed as a return key event.