### PR TITLE
fix: map keypad keys to printable characters in Kitty keyboard protocol

### DIFF
--- a/packages/core/src/lib/parse.keypress-kitty.test.ts
+++ b/packages/core/src/lib/parse.keypress-kitty.test.ts
@@ -228,6 +228,53 @@ test("parseKeypress - Kitty keyboard keypad keys", () => {
   expect(kpEnter?.name).toBe("kpenter")
 })
 
+test("parseKeypress - Kitty keyboard keypad keys generate correct characters", () => {
+  const options: ParseKeypressOptions = { useKittyKeyboard: true }
+
+  // Keypad digits should produce their character in sequence
+  const kp0 = parseKeypress("\x1b[57400u", options)
+  expect(kp0?.name).toBe("kp0")
+  expect(kp0?.sequence).toBe("0")
+
+  const kp1 = parseKeypress("\x1b[57401u", options)
+  expect(kp1?.name).toBe("kp1")
+  expect(kp1?.sequence).toBe("1")
+
+  const kp9 = parseKeypress("\x1b[57409u", options)
+  expect(kp9?.name).toBe("kp9")
+  expect(kp9?.sequence).toBe("9")
+
+  // Keypad operators
+  const kpPlus = parseKeypress("\x1b[57414u", options)
+  expect(kpPlus?.name).toBe("kpplus")
+  expect(kpPlus?.sequence).toBe("+")
+
+  const kpMinus = parseKeypress("\x1b[57413u", options)
+  expect(kpMinus?.name).toBe("kpminus")
+  expect(kpMinus?.sequence).toBe("-")
+
+  const kpMultiply = parseKeypress("\x1b[57412u", options)
+  expect(kpMultiply?.name).toBe("kpmultiply")
+  expect(kpMultiply?.sequence).toBe("*")
+
+  const kpDivide = parseKeypress("\x1b[57411u", options)
+  expect(kpDivide?.name).toBe("kpdivide")
+  expect(kpDivide?.sequence).toBe("/")
+
+  const kpDecimal = parseKeypress("\x1b[57410u", options)
+  expect(kpDecimal?.name).toBe("kpdecimal")
+  expect(kpDecimal?.sequence).toBe(".")
+
+  const kpEqual = parseKeypress("\x1b[57416u", options)
+  expect(kpEqual?.name).toBe("kpequal")
+  expect(kpEqual?.sequence).toBe("=")
+
+  // kpenter should NOT produce text (it's like return key)
+  const kpEnter = parseKeypress("\x1b[57415u", options)
+  expect(kpEnter?.name).toBe("kpenter")
+  expect(kpEnter?.sequence).toBe("\x1b[57415u") // should be raw sequence, not a character
+})
+
 test("parseKeypress - Kitty keyboard media keys", () => {
   const options: ParseKeypressOptions = { useKittyKeyboard: true }
 

--- a/packages/core/src/lib/parse.keypress-kitty.ts
+++ b/packages/core/src/lib/parse.keypress-kitty.ts
@@ -379,20 +379,46 @@ export function parseKittyKeyboard(sequence: string): ParsedKey | null {
     }
   }
 
+  // Map keypad keys to their printable character equivalents
+  const keypadCharMap: Record<string, string> = {
+    kp0: "0",
+    kp1: "1",
+    kp2: "2",
+    kp3: "3",
+    kp4: "4",
+    kp5: "5",
+    kp6: "6",
+    kp7: "7",
+    kp8: "8",
+    kp9: "9",
+    kpdecimal: ".",
+    kpdivide: "/",
+    kpmultiply: "*",
+    kpminus: "-",
+    kpplus: "+",
+    kpequal: "=",
+  }
+
   // Handle text generation for printable characters
   if (text === "") {
-    // Check if this is a printable character (not a key name like "up", "f1", etc.)
-    const isPrintable = key.name.length > 0 && !kittyKeyMap[codepoint]
-    if (isPrintable) {
-      // Use shifted codepoint if shift is active and we have one
-      if (key.shift && shiftedCodepoint) {
-        text = String.fromCodePoint(shiftedCodepoint)
-      } else if (key.shift && key.name.length === 1) {
-        // When shift is pressed but terminal didn't provide shifted codepoint,
-        // convert the character to uppercase (works for Unicode including Cyrillic)
-        text = key.name.toLocaleUpperCase()
-      } else {
-        text = key.name
+    // Check if this is a keypad key that maps to a printable character
+    const keypadChar = keypadCharMap[key.name]
+    if (keypadChar) {
+      text = keypadChar
+    } else {
+      // Check if this is a printable character (not a key name like "up", "f1", etc.)
+      const isPrintable = key.name.length > 0 && !kittyKeyMap[codepoint]
+      if (isPrintable) {
+        // Use shifted codepoint if shift is active and we have one
+        if (key.shift && shiftedCodepoint) {
+          text = String.fromCodePoint(shiftedCodepoint)
+        } else if (key.shift && key.name.length === 1) {
+          // When shift is pressed but terminal didn't provide shifted codepoint,
+          // convert the character to uppercase (works for Unicode including Cyrillic)
+          text = key.name.toLocaleUpperCase()
+        } else {
+          text = key.name
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- Maps keypad keys (kp0-kp9, kpplus, kpminus, etc.) to their printable character equivalents
- Adds comprehensive test cases for keypad character generation

## Problem

When using Kitty keyboard protocol, keypad keys are correctly identified with names like `kp0`, `kp1`, `kpplus`, etc., but the `sequence` field doesn't contain the corresponding printable character. This causes input fields (textarea, input) to not accept keypad input since they rely on the sequence to insert text.

For example:
- Main keyboard `1` produces: `name="1"`, `sequence="1"` ✓
- Numpad `1` produces: `name="kp1"`, `sequence="\x1b[57401u"` ✗ (should be `"1"`)

## Solution

Added a `keypadCharMap` to convert keypad key names to their printable character equivalents:
- `kp0`-`kp9` → `"0"`-`"9"`
- `kpplus` → `"+"`
- `kpminus` → `"-"`
- `kpmultiply` → `"*"`
- `kpdivide` → `"/"`
- `kpdecimal` → `"."`
- `kpequal` → `"="`

Note: `kpenter` is intentionally NOT mapped since it should behave like the return key, not insert a character.

## Testing

Added test cases to verify keypad keys produce the correct characters in their sequence field.