### PR TITLE
Add support for PuTTY ALT+arrow key sequences

### DIFF
--- a/packages/core/src/lib/parse.keypress.test.ts
+++ b/packages/core/src/lib/parse.keypress.test.ts
@@ -1783,3 +1783,57 @@ test("parseKeypress - meta+arrow keys with uppercase F and B (old style)", () =>
   expect(metaB.shift).toBe(false)
   expect(metaB.ctrl).toBe(false)
 })
+
+test("parseKeypress - PuTTY double ESC sequences for ALT+arrow keys", () => {
+  // PuTTY in default mode sends double ESC for ALT+arrow keys
+  // Format: ESC ESC [A-D
+
+  // PuTTY ALT+Up: ESC ESC [A
+  const puttyAltUp = parseKeypress("\x1b\x1b[A")!
+  expect(puttyAltUp.name).toBe("up")
+  expect(puttyAltUp.meta).toBe(true)
+  expect(puttyAltUp.option).toBe(true)
+  expect(puttyAltUp.ctrl).toBe(false)
+  expect(puttyAltUp.shift).toBe(false)
+  expect(puttyAltUp.sequence).toBe("\x1b\x1b[A")
+
+  // PuTTY ALT+Down: ESC ESC [B
+  const puttyAltDown = parseKeypress("\x1b\x1b[B")!
+  expect(puttyAltDown.name).toBe("down")
+  expect(puttyAltDown.meta).toBe(true)
+  expect(puttyAltDown.option).toBe(true)
+  expect(puttyAltDown.ctrl).toBe(false)
+  expect(puttyAltDown.shift).toBe(false)
+  expect(puttyAltDown.sequence).toBe("\x1b\x1b[B")
+
+  // PuTTY ALT+Right: ESC ESC [C
+  const puttyAltRight = parseKeypress("\x1b\x1b[C")!
+  expect(puttyAltRight.name).toBe("right")
+  expect(puttyAltRight.meta).toBe(true)
+  expect(puttyAltRight.option).toBe(true)
+  expect(puttyAltRight.ctrl).toBe(false)
+  expect(puttyAltRight.shift).toBe(false)
+  expect(puttyAltRight.sequence).toBe("\x1b\x1b[C")
+
+  // PuTTY ALT+Left: ESC ESC [D
+  const puttyAltLeft = parseKeypress("\x1b\x1b[D")!
+  expect(puttyAltLeft.name).toBe("left")
+  expect(puttyAltLeft.meta).toBe(true)
+  expect(puttyAltLeft.option).toBe(true)
+  expect(puttyAltLeft.ctrl).toBe(false)
+  expect(puttyAltLeft.shift).toBe(false)
+  expect(puttyAltLeft.sequence).toBe("\x1b\x1b[D")
+
+  // Ensure normal arrow keys (single ESC) are NOT interpreted as ALT+arrow
+  const normalUp = parseKeypress("\x1b[A")!
+  expect(normalUp.name).toBe("up")
+  expect(normalUp.meta).toBe(false)
+  expect(normalUp.option).toBe(false)
+  expect(normalUp.ctrl).toBe(false)
+  expect(normalUp.shift).toBe(false)
+
+  const normalRight = parseKeypress("\x1b[C")!
+  expect(normalRight.name).toBe("right")
+  expect(normalRight.meta).toBe(false)
+  expect(normalRight.option).toBe(false)
+})

--- a/packages/core/src/lib/parse.keypress.ts
+++ b/packages/core/src/lib/parse.keypress.ts
@@ -6,6 +6,8 @@ const metaKeyCodeRe = /^(?:\x1b)([a-zA-Z0-9])$/
 
 const fnKeyRe = /^(?:\x1b+)(O|N|\[|\[\[)(?:(\d+)(?:;(\d+))?([~^$])|(?:1;)?(\d+)?([a-zA-Z]))/
 
+const altArrowKeyRe = /^(?:\x1b\x1b)(\[)([A-D])$/
+
 const keyName: Record<string, string> = {
   /* xterm/gnome ESC O letter */
   OP: "f1",
@@ -323,6 +325,15 @@ export const parseKeypress = (s: Buffer | string = "", options: ParseKeypressOpt
     key.meta = true
     key.ctrl = true
     key.name = String.fromCharCode(s.charCodeAt(1) + "a".charCodeAt(0) - 1)
+  } else if ((parts = altArrowKeyRe.exec(s))) {
+    // ALT + arrow keys (PuTTY double ESC sequences: ESC ESC [A-D)
+    key.meta = true
+    key.option = true
+    const arrowCode = parts[1] + parts[2]
+    const arrowKeyName = keyName[arrowCode]
+    if (arrowKeyName) {
+      key.name = arrowKeyName
+    }
   } else if ((parts = fnKeyRe.exec(s))) {
     const segs = [...s]
 

--- a/packages/core/src/lib/stdin-buffer.ts
+++ b/packages/core/src/lib/stdin-buffer.ts
@@ -34,6 +34,22 @@ function isCompleteSequence(data: string): "complete" | "incomplete" | "not-esca
 
   const afterEsc = data.slice(1)
 
+  // Double ESC sequences (used by PuTTY for ALT+keys)
+  if (afterEsc.startsWith(ESC)) {
+    // Two ESCs followed by [ means we might have ESC ESC [X (ALT+arrow)
+    if (data.length === 2) {
+      return "incomplete"
+    }
+    if (data.length === 3 && data[2] === "[") {
+      return "incomplete"
+    }
+    // Check for double ESC + CSI arrow key (ESC ESC [A-D)
+    if (data.length >= 4 && data[2] === "[" && data[3] >= "A" && data[3] <= "D") {
+      return "complete"
+    }
+    return "complete"
+  }
+
   // CSI sequences: ESC [
   if (afterEsc.startsWith("[")) {
     // Check for old-style mouse sequence: ESC[M + 3 bytes


### PR DESCRIPTION
Adds recognition for double ESC sequences generated by PuTTY terminal when ALT+arrow keys are pressed (format: ESC ESC [A-D).

Updates the keypress parser to properly identify these sequences and mark them with meta/option flags while ensuring regular arrow keys still work correctly.

Enhances terminal compatibility for users of PuTTY in default mode.