### PR TITLE
ci(pkg-pr-new): use commit SHA in comments to prevent duplicate deps

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Publish preview packages
         run: |
-          npx pkg-pr-new publish --no-template \
+          npx pkg-pr-new publish --no-template --commentWithSha \
             './packages/core/dist' \
             ${{ steps.native-packages.outputs.dirs }} \
             './packages/react/dist' \


### PR DESCRIPTION
Adds `--commentWithSha` to pkg-pr-new publish command.

This is required to prevent duplicate dependencies when installing preview packages. Without this, @opentui/react uses a URL with a PR number in its dependencies (e.g. `@opentui/core@0.0.0-pr.123`), but if another commit is pushed, the resolved package changes while the URL stays the same.

With `--commentWithSha`, the URLs use commit hashes instead, so @opentui/react's dependency on @opentui/core will resolve to the exact same package, preventing duplicate @opentui/core entries in node_modules.