### PR TITLE
ci(pkg-pr-new): use commit SHA and bun in preview comments

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Publish preview packages
         run: |
-          npx pkg-pr-new publish --no-template \
+          npx pkg-pr-new publish --no-template --commentWithSha --bun \
             './packages/core/dist' \
             ${{ steps.native-packages.outputs.dirs }} \
             './packages/react/dist' \


### PR DESCRIPTION
Adds `--commentWithSha --bun` flags to pkg-pr-new publish command.

Commit hash is required because that's what pkg-pr-new uses for the @opentui/core dependency URL. Using anything else (like PR number) causes duplicate @opentui/core in node_modules.