### PR TITLE
fix(core): recognize Ctrl+Backspace on Windows Terminal and WSL

### DIFF
--- a/packages/core/src/lib/parse.keypress.test.ts
+++ b/packages/core/src/lib/parse.keypress.test.ts
@@ -2,6 +2,13 @@ import { test, expect } from "bun:test"
 import { parseKeypress, nonAlphanumericKeys, type ParsedKey, type KeyEventType } from "./parse.keypress"
 import { Buffer } from "node:buffer"
 
+const isWindowsTerminal = (): boolean => {
+  if (process.platform === "win32") return true
+  if (process.env.WSL_DISTRO_NAME) return true
+  if (process.env.WSL_INTEROP) return true
+  return false
+}
+
 test("parseKeypress - basic letters", () => {
   expect(parseKeypress("a")).toEqual({
     name: "a",
@@ -133,7 +140,7 @@ test("parseKeypress - special keys", () => {
   expect(backspaceB.sequence).toBe("\b")
   expect(backspaceB.raw).toBe("\b")
   expect(backspaceB.source).toBe("raw")
-  if (process.platform === "win32") {
+  if (isWindowsTerminal()) {
     expect(backspaceB.name).toBe("backspace")
   } else {
     expect(backspaceB.name).toBe("h")
@@ -769,7 +776,7 @@ test("parseKeypress - backspace key with modifiers (modifyOtherKeys format)", ()
 
 test("parseKeypress - raw backspace sequences (platform-aware)", () => {
   const ctrlHOrBackspace = parseKeypress("\b")!
-  if (process.platform === "win32") {
+  if (isWindowsTerminal()) {
     expect(ctrlHOrBackspace.name).toBe("backspace")
     expect(ctrlHOrBackspace.ctrl).toBe(true)
   } else {
@@ -779,7 +786,7 @@ test("parseKeypress - raw backspace sequences (platform-aware)", () => {
   expect(ctrlHOrBackspace.meta).toBe(false)
 
   const altCtrlHOrBackspace = parseKeypress("\x1b\b")!
-  if (process.platform === "win32") {
+  if (isWindowsTerminal()) {
     expect(altCtrlHOrBackspace.name).toBe("backspace")
     expect(altCtrlHOrBackspace.ctrl).toBe(true)
   } else {
@@ -1466,7 +1473,7 @@ test("parseKeypress - does not filter valid key sequences that might look simila
 
   const backspace = parseKeypress("\b")
   expect(backspace).not.toBeNull()
-  if (process.platform === "win32") {
+  if (isWindowsTerminal()) {
     expect(backspace?.name).toBe("backspace")
   } else {
     expect(backspace?.name).toBe("h")

--- a/packages/core/src/lib/parse.keypress.ts
+++ b/packages/core/src/lib/parse.keypress.ts
@@ -106,6 +106,20 @@ const isCtrlKey = (code: string) => {
   return ["Oa", "Ob", "Oc", "Od", "Oe", "[2^", "[3^", "[5^", "[6^", "[7^", "[8^"].includes(code)
 }
 
+/**
+ * Detect if running on Windows or in WSL (Windows Subsystem for Linux).
+ * In WSL, process.platform returns 'linux' but the terminal emulator (Windows Terminal)
+ * still sends Windows-style key sequences like \b for Ctrl+Backspace.
+ */
+const isWindowsTerminal = (): boolean => {
+  if (process.platform === "win32") return true
+  // Check for WSL via environment variable (more reliable than reading /proc/version)
+  if (process.env.WSL_DISTRO_NAME) return true
+  // Also check for WSL_INTEROP which is set in WSL2
+  if (process.env.WSL_INTEROP) return true
+  return false
+}
+
 export type KeyEventType = "press" | "repeat" | "release"
 
 export interface ParsedKey {
@@ -273,21 +287,15 @@ export const parseKeypress = (s: Buffer | string = "", options: ParseKeypressOpt
     key.name = "backspace"
     key.meta = s.length === 2 // \x1b\x7f = Alt+Backspace
   } else if (s === "\b" || s === "\x1b\b") {
-    // \b (ASCII 8) has different meanings depending on platform:
-    // - Windows Terminal: Ctrl+Backspace sends \b → should be "backspace" with ctrl=true
-    // - Unix/macOS: \b = Ctrl+H → should be "h" with ctrl=true (handled by generic ctrl+letter below)
-    // We use platform detection to maintain backwards compatibility
-    if (process.platform === "win32") {
+    // \b (ASCII 8): Windows Terminal sends this for Ctrl+Backspace, Unix terminals for Ctrl+H
+    if (isWindowsTerminal()) {
       key.name = "backspace"
       key.ctrl = true
-      key.meta = s.length === 2 // \x1b\b = Alt+Ctrl+Backspace
+      key.meta = s.length === 2
     } else {
-      // On non-Windows, treat \b as Ctrl+H (traditional Unix behavior)
-      // This falls through to the ctrl+letter handler below by NOT matching here
-      // But since we're in an else-if, we need to handle it explicitly
       key.name = "h"
       key.ctrl = true
-      key.meta = s.length === 2 // \x1b\b = Alt+Ctrl+H
+      key.meta = s.length === 2
     }
   } else if (s === "\x1b" || s === "\x1b\x1b") {
     // escape key


### PR DESCRIPTION
## Summary

- Fix Ctrl+Backspace not triggering `delete-word-backward` on Windows Terminal and WSL

## Problem

Windows Terminal and WSL terminals send different byte sequences for backspace:
- **Regular Backspace**: `\x7f` (ASCII 127, DEL)
- **Ctrl+Backspace**: `\b` (ASCII 8)

The current parser treats both as plain backspace without setting `ctrl: true`, so keybindings like `ctrl+backspace` → `delete-word-backward` never trigger.

### Additional WSL Complexity

In WSL, `process.platform` returns `'linux'`, not `'win32'`, even though Windows Terminal sends Windows-style key sequences. This required detecting WSL via environment variables (`WSL_DISTRO_NAME`, `WSL_INTEROP`).

## Solution

Added `isWindowsTerminal()` helper that detects:
1. Native Windows (`process.platform === 'win32'`)
2. WSL (`WSL_DISTRO_NAME` or `WSL_INTEROP` environment variables)

| Platform | `\b` Handling | Result |
|----------|-----------------|--------|
| Windows/WSL | Ctrl+Backspace | `{ name: "backspace", ctrl: true }` |
| macOS/Linux | Ctrl+H (unchanged) | `{ name: "h", ctrl: true }` |

## Testing

- All 41 tests pass
- Tests use the same `isWindowsTerminal()` helper for platform-aware assertions
- Manually verified in WSL with Windows Terminal

Fixes anomalyco/opencode#6991