### PR TITLE
fix(core): skip stdout writes in testing mode for writeOut functions

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -496,8 +496,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.stdout = stdout
     this.realStdoutWrite = stdout.write
     this.lib = lib
-    this._terminalWidth = stdout.columns
-    this._terminalHeight = stdout.rows
+    this._terminalWidth = stdout.columns ?? width
+    this._terminalHeight = stdout.rows ?? height
     this.width = width
     this.height = height
     this._useThread = config.useThread === undefined ? false : config.useThread

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -828,6 +828,7 @@ pub const CliRenderer = struct {
 
     pub fn writeOut(self: *CliRenderer, data: []const u8) void {
         if (data.len == 0) return;
+        if (self.testing) return;
 
         if (self.useThread) {
             self.renderMutex.lock();
@@ -844,6 +845,8 @@ pub const CliRenderer = struct {
     }
 
     pub fn writeOutMultiple(self: *CliRenderer, data_slices: []const []const u8) void {
+        if (self.testing) return;
+
         if (self.useThread) {
             self.renderMutex.lock();
             while (self.renderInProgress) {


### PR DESCRIPTION
Without this change, the TUI was being rendered to the terminal when using the test renderer, polluting test output.

- Add early return in `writeOut()` and `writeOutMultiple()` when `self.testing` is true
- Use passed dimensions as fallback for `terminalWidth`/`terminalHeight` in non-TTY environments