### PR TITLE
fix(web): update site config and links for GitHub Pages deployment

### DIFF
--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -10,7 +10,8 @@ const copyButtonTransformer = {
 
 export default defineConfig({
   integrations: [mdx()],
-  site: "https://opentui.com",
+  site: "https://anomalyco.github.io",
+  base: "/opentui",
   markdown: {
     shikiConfig: {
       theme: "min-light",

--- a/packages/web/src/content/docs/core-concepts/constructs.mdx
+++ b/packages/web/src/content/docs/core-concepts/constructs.mdx
@@ -204,4 +204,4 @@ renderer.root.add(
 
 ## Next Steps
 
-See [Renderables vs Constructs](/docs/core-concepts/renderables-vs-constructs) for a detailed comparison of when to use each approach.
+See [Renderables vs Constructs](/opentui/docs/core-concepts/renderables-vs-constructs) for a detailed comparison of when to use each approach.

--- a/packages/web/src/content/docs/core-concepts/renderables.mdx
+++ b/packages/web/src/content/docs/core-concepts/renderables.mdx
@@ -116,7 +116,7 @@ const panel = new BoxRenderable(renderer, {
 })
 ```
 
-See the [Layout](/docs/core-concepts/layout) page for complete details.
+See the [Layout](/opentui/docs/core-concepts/layout) page for complete details.
 
 ## Focus Management
 

--- a/packages/web/src/content/docs/getting-started.mdx
+++ b/packages/web/src/content/docs/getting-started.mdx
@@ -71,16 +71,16 @@ renderer.root.add(
 
 ### Core concepts
 
-- [Renderer](/docs/core-concepts/renderer) - The rendering engine
-- [Layout](/docs/core-concepts/layout) - Flexbox positioning
-- [Constructs](/docs/core-concepts/constructs) - The declarative component API
+- [Renderer](/opentui/docs/core-concepts/renderer) - The rendering engine
+- [Layout](/opentui/docs/core-concepts/layout) - Flexbox positioning
+- [Constructs](/opentui/docs/core-concepts/constructs) - The declarative component API
 
 ### Components
 
-- [Text](/docs/components/text), [Box](/docs/components/box) - Display and layout
-- [Input](/docs/components/input), [Select](/docs/components/select) - User interaction
+- [Text](/opentui/docs/components/text), [Box](/opentui/docs/components/box) - Display and layout
+- [Input](/opentui/docs/components/input), [Select](/opentui/docs/components/select) - User interaction
 
 ### Framework bindings
 
-- [React](/docs/bindings/react)
-- [Solid.js](/docs/bindings/solid)
+- [React](/opentui/docs/bindings/react)
+- [Solid.js](/opentui/docs/bindings/solid)

--- a/packages/web/src/layouts/Base.astro
+++ b/packages/web/src/layouts/Base.astro
@@ -17,7 +17,7 @@ const {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <title>{title}</title>
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/opentui/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Inter:opsz,wght@14..32,100..900&display=swap" rel="stylesheet" />

--- a/packages/web/src/layouts/Docs.astro
+++ b/packages/web/src/layouts/Docs.astro
@@ -17,7 +17,7 @@ const currentPath = Astro.url.pathname
       <!-- Header -->
       <header class="header">
         <div class="header-content">
-          <a href="/" class="logo">
+          <a href="/opentui/" class="logo">
             <svg class="logo-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
               <rect x="2" y="3" width="20" height="18" fill="currentColor" />
               <rect x="6" y="8" width="3" height="8" fill="hsl(0, 20%, 99%)" />
@@ -40,7 +40,7 @@ const currentPath = Astro.url.pathname
             </svg>
           </button>
           <nav class="nav">
-            <a href="/docs/getting-started">Docs</a>
+            <a href="/opentui/docs/getting-started">Docs</a>
             <a href="https://github.com/anomalyco/opentui" target="_blank" rel="noopener noreferrer">GitHub</a>
           </nav>
         </div>
@@ -54,7 +54,7 @@ const currentPath = Astro.url.pathname
               <div class="sidebar-title">Getting Started</div>
               <ul class="sidebar-links">
                 <li>
-                  <a href="/docs/getting-started" class:list={{ active: currentPath === "/docs/getting-started" || currentPath === "/docs/getting-started/" }}>
+                  <a href="/opentui/docs/getting-started" class:list={{ active: currentPath === "/opentui/docs/getting-started" || currentPath === "/opentui/docs/getting-started/" }}>
                     Introduction
                   </a>
                 </li>
@@ -64,34 +64,34 @@ const currentPath = Astro.url.pathname
             <div class="sidebar-section">
               <div class="sidebar-title">Core Concepts</div>
               <ul class="sidebar-links">
-                <li><a href="/docs/core-concepts/renderer">Renderer</a></li>
-                <li><a href="/docs/core-concepts/renderables">Renderables</a></li>
-                <li><a href="/docs/core-concepts/constructs">Constructs</a></li>
-                <li><a href="/docs/core-concepts/renderables-vs-constructs">Renderables vs Constructs</a></li>
-                <li><a href="/docs/core-concepts/layout">Layout</a></li>
-                <li><a href="/docs/core-concepts/keyboard">Keyboard</a></li>
-                <li><a href="/docs/core-concepts/console">Console</a></li>
-                <li><a href="/docs/core-concepts/colors">Colors</a></li>
+                <li><a href="/opentui/docs/core-concepts/renderer">Renderer</a></li>
+                <li><a href="/opentui/docs/core-concepts/renderables">Renderables</a></li>
+                <li><a href="/opentui/docs/core-concepts/constructs">Constructs</a></li>
+                <li><a href="/opentui/docs/core-concepts/renderables-vs-constructs">Renderables vs Constructs</a></li>
+                <li><a href="/opentui/docs/core-concepts/layout">Layout</a></li>
+                <li><a href="/opentui/docs/core-concepts/keyboard">Keyboard</a></li>
+                <li><a href="/opentui/docs/core-concepts/console">Console</a></li>
+                <li><a href="/opentui/docs/core-concepts/colors">Colors</a></li>
               </ul>
             </div>
 
             <div class="sidebar-section">
               <div class="sidebar-title">Components</div>
               <ul class="sidebar-links">
-                <li><a href="/docs/components/text">Text</a></li>
-                <li><a href="/docs/components/box">Box</a></li>
-                <li><a href="/docs/components/input">Input</a></li>
-                <li><a href="/docs/components/select">Select</a></li>
-                <li><a href="/docs/components/scrollbox">ScrollBox</a></li>
-                <li><a href="/docs/components/code">Code</a></li>
+                <li><a href="/opentui/docs/components/text">Text</a></li>
+                <li><a href="/opentui/docs/components/box">Box</a></li>
+                <li><a href="/opentui/docs/components/input">Input</a></li>
+                <li><a href="/opentui/docs/components/select">Select</a></li>
+                <li><a href="/opentui/docs/components/scrollbox">ScrollBox</a></li>
+                <li><a href="/opentui/docs/components/code">Code</a></li>
               </ul>
             </div>
 
             <div class="sidebar-section">
               <div class="sidebar-title">Bindings</div>
               <ul class="sidebar-links">
-                <li><a href="/docs/bindings/solid">Solid.js</a></li>
-                <li><a href="/docs/bindings/react">React</a></li>
+                <li><a href="/opentui/docs/bindings/solid">Solid.js</a></li>
+                <li><a href="/opentui/docs/bindings/react">React</a></li>
               </ul>
             </div>
           </aside>

--- a/packages/web/src/pages/404.astro
+++ b/packages/web/src/pages/404.astro
@@ -7,7 +7,7 @@ import Base from "../layouts/Base.astro"
     <div class="landing-container">
       <!-- Header -->
       <header class="landing-header">
-        <a href="/" class="landing-logo">
+        <a href="/opentui/" class="landing-logo">
           <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <rect x="2" y="3" width="20" height="18" fill="currentColor" />
             <rect x="6" y="8" width="3" height="8" fill="hsl(0, 20%, 99%)" />
@@ -15,7 +15,7 @@ import Base from "../layouts/Base.astro"
           OpenTUI
         </a>
         <nav class="landing-nav">
-          <a href="/docs/getting-started">Docs</a>
+          <a href="/opentui/docs/getting-started">Docs</a>
           <a href="https://github.com/anomalyco/opentui" target="_blank" rel="noopener noreferrer">GitHub</a>
         </nav>
       </header>
@@ -26,7 +26,7 @@ import Base from "../layouts/Base.astro"
           <div class="error-code">404</div>
           <h1>Page not found</h1>
           <p>The page you're looking for doesn't exist or has been moved.</p>
-          <a href="/" class="btn-dark">
+          <a href="/opentui/" class="btn-dark">
             <span>Back to home</span>
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M6.5 12L17 12M13 16.5L17.5 12L13 7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/>
@@ -38,7 +38,7 @@ import Base from "../layouts/Base.astro"
       <!-- Footer -->
       <footer class="landing-footer">
         <div class="landing-footer-cell"><a href="https://github.com/anomalyco/opentui" target="_blank" rel="noopener noreferrer">GitHub</a></div>
-        <div class="landing-footer-cell"><a href="/docs/getting-started">Docs</a></div>
+        <div class="landing-footer-cell"><a href="/opentui/docs/getting-started">Docs</a></div>
       </footer>
     </div>
   </main>

--- a/packages/web/src/pages/index.astro
+++ b/packages/web/src/pages/index.astro
@@ -46,7 +46,7 @@ const features = [
     <div class="landing-container">
       <!-- Header -->
       <header class="landing-header">
-        <a href="/" class="landing-logo">
+        <a href="/opentui/" class="landing-logo">
           <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <rect x="2" y="3" width="20" height="18" fill="currentColor" />
             <rect x="6" y="8" width="3" height="8" fill="hsl(0, 20%, 99%)" />
@@ -69,14 +69,14 @@ const features = [
           </svg>
         </button>
         <nav class="landing-nav">
-          <a href="/docs/getting-started">Docs</a>
+          <a href="/opentui/docs/getting-started">Docs</a>
           <a href="https://github.com/anomalyco/opentui" target="_blank" rel="noopener noreferrer">GitHub</a>
         </nav>
       </header>
 
       <!-- Mobile nav overlay -->
       <nav class="mobile-nav" id="landing-mobile-nav">
-        <a href="/docs/getting-started">Docs</a>
+        <a href="/opentui/docs/getting-started">Docs</a>
         <a href="https://github.com/anomalyco/opentui" target="_blank" rel="noopener noreferrer">GitHub</a>
       </nav>
 
@@ -243,7 +243,7 @@ renderer.root.<span class="function">add</span>(
               </ul>
               
               <div class="what-actions">
-                <a href="/docs/getting-started" class="btn-dark">
+                <a href="/opentui/docs/getting-started" class="btn-dark">
                   <span>Read docs</span>
                   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M6.5 12L17 12M13 16.5L17.5 12L13 7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"/>
@@ -261,7 +261,7 @@ renderer.root.<span class="function">add</span>(
         <!-- Footer -->
         <footer class="landing-footer">
           <div class="landing-footer-cell"><a href="https://github.com/anomalyco/opentui" target="_blank" rel="noopener noreferrer">GitHub</a></div>
-          <div class="landing-footer-cell"><a href="/docs/getting-started">Docs</a></div>
+          <div class="landing-footer-cell"><a href="/opentui/docs/getting-started">Docs</a></div>
         </footer>
       </div>
     </div>


### PR DESCRIPTION
Changed site URL to anomalyco.github.io and added /opentui base path.

Revert this to the original when deploying to the main domain.