### PR TITLE
fix(web): prevent iOS font size inflation on code editor tab switch

### DIFF
--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -665,6 +665,8 @@ pre {
 .code-editor-body {
   display: none;
   padding: var(--space-2xl) var(--section-padding-x);
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 .code-editor-body[data-active="true"] {
@@ -683,6 +685,8 @@ pre {
   text-align: right;
   user-select: none;
   min-width: 24px;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 .code-editor-body pre {
@@ -691,6 +695,8 @@ pre {
   line-height: 1.7;
   margin: 0;
   background: transparent;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 .code-editor-body .keyword {


### PR DESCRIPTION
On iOS, when toggling panels the examples, the font size compounds. Added text-size-adjust: 100% to code editor elements to keep font size. 

I didn't test if this fixes it, but if it turns out not to, i'll set up a tunnel and make sure i can debug it end-to-end. 