### PR TITLE
web: fix mobile layout and navigation issues

### DIFF
--- a/packages/web/src/layouts/Docs.astro
+++ b/packages/web/src/layouts/Docs.astro
@@ -9,6 +9,7 @@ interface Props {
 const { title, description } = Astro.props
 
 const currentPath = Astro.url.pathname
+const isActive = (path: string) => currentPath === path || currentPath === `${path}/`
 ---
 
 <Base title={title} description={description}>
@@ -40,8 +41,8 @@ const currentPath = Astro.url.pathname
             </svg>
           </button>
           <nav class="nav">
-            <a href="/docs/getting-started">Docs</a>
             <a href="https://github.com/anomalyco/opentui" target="_blank" rel="noopener noreferrer">GitHub</a>
+            <a href="/docs/getting-started">Docs</a>
           </nav>
         </div>
       </header>
@@ -53,45 +54,41 @@ const currentPath = Astro.url.pathname
             <div class="sidebar-section">
               <div class="sidebar-title">Getting Started</div>
               <ul class="sidebar-links">
-                <li>
-                  <a href="/docs/getting-started" class:list={{ active: currentPath === "/docs/getting-started" || currentPath === "/docs/getting-started/" }}>
-                    Introduction
-                  </a>
-                </li>
+                <li><a href="/docs/getting-started" class:list={{ active: isActive("/docs/getting-started") }}>Introduction</a></li>
               </ul>
             </div>
 
             <div class="sidebar-section">
               <div class="sidebar-title">Core Concepts</div>
               <ul class="sidebar-links">
-                <li><a href="/docs/core-concepts/renderer">Renderer</a></li>
-                <li><a href="/docs/core-concepts/renderables">Renderables</a></li>
-                <li><a href="/docs/core-concepts/constructs">Constructs</a></li>
-                <li><a href="/docs/core-concepts/renderables-vs-constructs">Renderables vs Constructs</a></li>
-                <li><a href="/docs/core-concepts/layout">Layout</a></li>
-                <li><a href="/docs/core-concepts/keyboard">Keyboard</a></li>
-                <li><a href="/docs/core-concepts/console">Console</a></li>
-                <li><a href="/docs/core-concepts/colors">Colors</a></li>
+                <li><a href="/docs/core-concepts/renderer" class:list={{ active: isActive("/docs/core-concepts/renderer") }}>Renderer</a></li>
+                <li><a href="/docs/core-concepts/renderables" class:list={{ active: isActive("/docs/core-concepts/renderables") }}>Renderables</a></li>
+                <li><a href="/docs/core-concepts/constructs" class:list={{ active: isActive("/docs/core-concepts/constructs") }}>Constructs</a></li>
+                <li><a href="/docs/core-concepts/renderables-vs-constructs" class:list={{ active: isActive("/docs/core-concepts/renderables-vs-constructs") }}>Renderables vs Constructs</a></li>
+                <li><a href="/docs/core-concepts/layout" class:list={{ active: isActive("/docs/core-concepts/layout") }}>Layout</a></li>
+                <li><a href="/docs/core-concepts/keyboard" class:list={{ active: isActive("/docs/core-concepts/keyboard") }}>Keyboard</a></li>
+                <li><a href="/docs/core-concepts/console" class:list={{ active: isActive("/docs/core-concepts/console") }}>Console</a></li>
+                <li><a href="/docs/core-concepts/colors" class:list={{ active: isActive("/docs/core-concepts/colors") }}>Colors</a></li>
               </ul>
             </div>
 
             <div class="sidebar-section">
               <div class="sidebar-title">Components</div>
               <ul class="sidebar-links">
-                <li><a href="/docs/components/text">Text</a></li>
-                <li><a href="/docs/components/box">Box</a></li>
-                <li><a href="/docs/components/input">Input</a></li>
-                <li><a href="/docs/components/select">Select</a></li>
-                <li><a href="/docs/components/scrollbox">ScrollBox</a></li>
-                <li><a href="/docs/components/code">Code</a></li>
+                <li><a href="/docs/components/text" class:list={{ active: isActive("/docs/components/text") }}>Text</a></li>
+                <li><a href="/docs/components/box" class:list={{ active: isActive("/docs/components/box") }}>Box</a></li>
+                <li><a href="/docs/components/input" class:list={{ active: isActive("/docs/components/input") }}>Input</a></li>
+                <li><a href="/docs/components/select" class:list={{ active: isActive("/docs/components/select") }}>Select</a></li>
+                <li><a href="/docs/components/scrollbox" class:list={{ active: isActive("/docs/components/scrollbox") }}>ScrollBox</a></li>
+                <li><a href="/docs/components/code" class:list={{ active: isActive("/docs/components/code") }}>Code</a></li>
               </ul>
             </div>
 
             <div class="sidebar-section">
               <div class="sidebar-title">Bindings</div>
               <ul class="sidebar-links">
-                <li><a href="/docs/bindings/solid">Solid.js</a></li>
-                <li><a href="/docs/bindings/react">React</a></li>
+                <li><a href="/docs/bindings/solid" class:list={{ active: isActive("/docs/bindings/solid") }}>Solid.js</a></li>
+                <li><a href="/docs/bindings/react" class:list={{ active: isActive("/docs/bindings/react") }}>React</a></li>
               </ul>
             </div>
           </aside>
@@ -149,6 +146,14 @@ const currentPath = Astro.url.pathname
     // Close menu when clicking a link (for navigation)
     sidebar?.querySelectorAll('a').forEach((link) => {
       link.addEventListener('click', closeMenu)
+    })
+
+    // Wrap tables in scrollable containers
+    document.querySelectorAll('.content table').forEach((table) => {
+      const wrapper = document.createElement('div')
+      wrapper.className = 'table-wrapper'
+      table.parentNode?.insertBefore(wrapper, table)
+      wrapper.appendChild(table)
     })
 
     document.querySelectorAll('pre[data-code]').forEach((pre) => {

--- a/packages/web/src/pages/index.astro
+++ b/packages/web/src/pages/index.astro
@@ -69,15 +69,15 @@ const features = [
           </svg>
         </button>
         <nav class="landing-nav">
-          <a href="/docs/getting-started">Docs</a>
           <a href="https://github.com/anomalyco/opentui" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="/docs/getting-started">Docs</a>
         </nav>
       </header>
 
       <!-- Mobile nav overlay -->
       <nav class="mobile-nav" id="landing-mobile-nav">
-        <a href="/docs/getting-started">Docs</a>
         <a href="https://github.com/anomalyco/opentui" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="/docs/getting-started">Docs</a>
       </nav>
 
       <!-- Content -->

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -127,6 +127,7 @@ pre {
   border-left: 1px solid var(--color-border);
   border-right: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
+  overflow-x: clip;
 }
 
 /* Header */
@@ -808,6 +809,7 @@ pre {
   border-left: 1px solid var(--color-border);
   border-right: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
+  overflow-x: clip;
 }
 
 /* Header */
@@ -961,7 +963,7 @@ pre {
 .sidebar-links a {
   display: block;
   padding: 4px 0;
-  color: var(--color-text-weak);
+  color: var(--color-text);
   font-size: 13px;
   transition: color 0.15s;
 }
@@ -980,6 +982,7 @@ pre {
 .content {
   max-width: var(--content-width);
   min-width: 0;
+  overflow-wrap: break-word;
 }
 
 .content > *:first-child {
@@ -1006,13 +1009,22 @@ pre {
   margin-bottom: var(--space-xs);
 }
 
+.content a {
+  text-decoration: underline;
+  text-underline-offset: 0.25rem;
+}
+
+.content a:hover {
+  text-decoration: underline;
+}
+
 .content p {
   margin-bottom: var(--space-md);
 }
 
 .content pre {
   position: relative;
-  background: var(--color-bg-weak);
+  background: var(--color-bg-weak) !important;
   padding: var(--space-md);
   border-radius: 6px;
   overflow-x: auto;
@@ -1073,6 +1085,33 @@ pre {
 .content pre code {
   background: none;
   padding: 0;
+}
+
+/* Tables */
+.table-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: var(--space-md) 0;
+}
+
+.content table {
+  border-collapse: collapse;
+  font-size: 13px;
+  width: max-content;
+  min-width: 100%;
+}
+
+.content th,
+.content td {
+  padding: var(--space-sm) var(--space-md);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.content th {
+  font-weight: 500;
+  color: var(--color-text-strong);
 }
 
 /* Footer */
@@ -1151,6 +1190,15 @@ pre {
     transition:
       opacity 0.2s ease,
       visibility 0.2s ease;
+  }
+
+  .sidebar-title {
+    font-size: 14px;
+  }
+
+  .sidebar-links a {
+    font-size: 15px;
+    padding: 8px 0;
   }
 
   /* Mobile nav open state */


### PR DESCRIPTION
Tables in documentation pages overflow the viewport on mobile, causing
a page-level horizontal scrollbar. Wrap tables in scrollable
containers and add basic table styling.

Sidebar links only highlighted the active page for the first entry.
While at it, made sidebar links less gray by using --color-text
instead of --color-text-weak, and bump mobile font sizes for better
readability and touch targets.

Swap GitHub and Docs link order in the navigation bar on both the
landing page and docs layout (for priority). Add underline styling to
content links. Force code block background color to override Shiki
inline styles.
