### PR TITLE
fix(input): set printable sequence for modifyOtherKeys chars

### DIFF
--- a/packages/core/src/lib/parse.keypress.test.ts
+++ b/packages/core/src/lib/parse.keypress.test.ts
@@ -1501,6 +1501,20 @@ test("parseKeypress - fallback to raw parsing when Kitty option is enabled but s
   expect(normalCtrl?.ctrl).toBe(true)
 })
 
+test("parseKeypress - modifyOtherKeys digits", () => {
+  const shiftOne = parseKeypress("\x1b[27;2;49~")!
+  expect(shiftOne.name).toBe("1")
+  expect(shiftOne.shift).toBe(true)
+  expect(shiftOne.ctrl).toBe(false)
+  expect(shiftOne.meta).toBe(false)
+  expect(shiftOne.option).toBe(false)
+  expect(shiftOne.number).toBe(true)
+  expect(shiftOne.sequence).toBe("1")
+  expect(shiftOne.raw).toBe("\x1b[27;2;49~")
+  expect(shiftOne.eventType).toBe("press")
+  expect(shiftOne.source).toBe("raw")
+})
+
 test("parseKeypress - modifyOtherKeys modified enter keys", () => {
   // Terminals with modifyOtherKeys mode enabled send special escape sequences for modified keys
   // Format: CSI 27 ; modifier ; code ~ where code 13 is enter/return

--- a/packages/core/src/lib/parse.keypress.ts
+++ b/packages/core/src/lib/parse.keypress.ts
@@ -250,7 +250,12 @@ export const parseKeypress = (s: Buffer | string = "", options: ParseKeypressOpt
       key.name = "backspace"
     } else {
       // For other character codes, use the character itself
-      key.name = String.fromCharCode(charCode)
+      const char = String.fromCharCode(charCode)
+      key.name = char
+      key.sequence = char
+      if (charCode >= 48 && charCode <= 57) {
+        key.number = true
+      }
     }
 
     return key


### PR DESCRIPTION
modifyOtherKeys (CSI 27;mod;code~) currently decodes name and
modifiers but leaves sequence as the raw ESC sequence. Textarea
inserts from sequence and rejects control chars (< 32), so sequences
like ESC [27;2;49~ (Shift+1 on AZERTY in WezTerm) never insert text.

Terminals that send plain "1" take the single-byte digit path and
work.

For printable codes, set sequence to the decoded character and mark
digits as number=true. This mirrors the single-byte digit behavior, so
text insertion now sees "1" instead of ESC and passes the guard.

Raw is preserved and special keys (return/escape/tab/space/backspace)
still keep their raw sequences, so control/navigation handling does
not change.

Keybinding lookup continues to use name+modifiers, so shortcuts are
unaffected.

This addresses an issue reported in opencode https://github.com/anomalyco/opencode/issues/10577
