### PR TITLE
fix: don't run pkg-pr on non code changes

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -2,11 +2,19 @@ name: Publish Preview Packages
 
 on:
   pull_request:
+    paths:
+      - "packages/core/**"
+      - "packages/react/**"
+      - "packages/solid/**"
   push:
     branches:
       - "**"
     tags:
       - "!**"
+    paths:
+      - "packages/core/**"
+      - "packages/react/**"
+      - "packages/solid/**"
 
 permissions: {}
 


### PR DESCRIPTION
## Description

This skips the pkg publish for non code changes as web is internal! We could do the same for all of the build opentui/* workflows but they're marked as required in the status checks 😅 I could add a `skip` to each of those that always passes but would rather leave those for soundness 