### PR TITLE
fix(core): guard MarkdownRenderable.getStyle against undefined syntaxStyle

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -129,6 +129,10 @@ export class MarkdownRenderable extends Renderable {
   }
 
   private getStyle(group: string): StyleDefinition | undefined {
+    // The solid reconciler applies props via setters in JSX declaration order.
+    // If `content` is set before `syntaxStyle`, updateBlocks() runs before
+    // _syntaxStyle is initialized.
+    if (!this._syntaxStyle) return undefined
     let style = this._syntaxStyle.getStyle(group)
     if (!style && group.includes(".")) {
       const baseName = group.split(".")[0]


### PR DESCRIPTION
## Summary

- Guards `MarkdownRenderable.getStyle()` against `_syntaxStyle` being undefined when the Solid reconciler sets `content` before `syntaxStyle`

## Problem

The `@opentui/solid` reconciler creates elements with `new Element(ctx, { id })` — only `{ id }` is passed in constructor options. Props are then applied via setters in **JSX declaration order**.

When a consumer writes:

```tsx
<markdown content={props.content} syntaxStyle={props.syntaxStyle()} ... />
```

The `content` setter fires first, triggering `updateBlocks()` → `createChunk()` → `getStyle()`, which accesses `this._syntaxStyle` — still `undefined` because the `syntaxStyle` setter hasn't run yet.

This crashes with:

```
TypeError: undefined is not an object (evaluating 'this._syntaxStyle.getStyle')
```

### Note

There's an existing branch `fix(solid)-prop-initialization-before-insert` that attempts to fix this at the Solid/babel level. This PR takes a complementary approach — defensive guard in `MarkdownRenderable` itself, so the component is resilient regardless of prop order.

## Fix

- Early-return `undefined` from `getStyle()` when `_syntaxStyle` is uninitialized
- Blocks render unstyled initially; once `syntaxStyle` setter runs, `_styleDirty` triggers `rerenderBlocks()` on the next render cycle with correct styles

## Test plan

- [x] Verified fix resolves the crash in [gent](https://github.com/cevr/gent) TUI (streaming markdown with `<markdown content={...} syntaxStyle={...} />`)
- [x] TypeScript compiles clean (no new errors in `Markdown.ts`)
- [ ] Visual: markdown renders with correct syntax highlighting after initial unstyled frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)