### PR TITLE
fix(build): add libc linkage for test module

### DIFF
--- a/packages/core/src/zig/build.zig
+++ b/packages/core/src/zig/build.zig
@@ -107,6 +107,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("test.zig"),
         .target = native_target,
         .optimize = .Debug,
+        .link_libc = true,
     });
     applyDependencies(b, test_mod, .Debug, native_target);
     const run_test = b.addRunArtifact(b.addTest(.{


### PR DESCRIPTION
The clipboard tests introduced in #546 added test_utils.zig with extern "c" declarations for setenv/unsetenv, but build.zig was not updated to link libc for the test module.

Fix #612