### PR TITLE
testing: make TestRecorder timestamps deterministic

### DIFF
--- a/packages/core/src/testing/test-recorder.test.ts
+++ b/packages/core/src/testing/test-recorder.test.ts
@@ -207,18 +207,18 @@ describe("TestRecorder", () => {
   })
 
   test("should capture timestamps in increasing order", async () => {
+    let time = 0
+    recorder = new TestRecorder(renderer, { now: () => time })
     recorder.rec()
 
-    const text = new TextRenderable(renderer, { content: "Timestamp Test" })
-    renderer.root.add(text)
-    await Bun.sleep(1)
-
-    await Bun.sleep(10)
+    await renderOnce()
+    time += 10
     await renderOnce()
 
     const frames = recorder.recordedFrames
     expect(frames.length).toBe(2)
     expect(frames[1].timestamp).toBeGreaterThan(frames[0].timestamp)
+    expect(frames[1].timestamp - frames[0].timestamp).toBe(10)
 
     recorder.stop()
   })

--- a/packages/core/src/testing/test-recorder.ts
+++ b/packages/core/src/testing/test-recorder.ts
@@ -21,6 +21,7 @@ export interface RecordedFrame {
 
 export interface TestRecorderOptions {
   recordBuffers?: RecordBuffersOptions
+  now?: () => number
 }
 
 /**
@@ -36,10 +37,12 @@ export class TestRecorder {
   private originalRenderNative?: () => void
   private decoder = new TextDecoder()
   private recordBuffers: RecordBuffersOptions
+  private now: () => number
 
   constructor(renderer: TestRenderer, options?: TestRecorderOptions) {
     this.renderer = renderer
     this.recordBuffers = options?.recordBuffers || {}
+    this.now = options?.now ?? (() => performance.now())
   }
 
   /**
@@ -53,7 +56,7 @@ export class TestRecorder {
     this.recording = true
     this.frames = []
     this.frameNumber = 0
-    this.startTime = Date.now()
+    this.startTime = this.now()
 
     // Store the original renderNative method
     this.originalRenderNative = this.renderer["renderNative"].bind(this.renderer)
@@ -117,7 +120,7 @@ export class TestRecorder {
 
     const recordedFrame: RecordedFrame = {
       frame,
-      timestamp: Date.now() - this.startTime,
+      timestamp: this.now() - this.startTime,
       frameNumber: this.frameNumber++,
     }
 


### PR DESCRIPTION
Allow an injected clock to drive recording timestamps so tests avoid wall-clock races.

Test now drives time explicitly (advance 10ms between renders), so the timestamps are deterministic.