### PR TITLE
fix(core): correct colors in Apple Terminal and add 256-color fallback 

### DIFF
--- a/packages/core/src/zig/ansi.zig
+++ b/packages/core/src/zig/ansi.zig
@@ -32,6 +32,14 @@ pub const ANSI = struct {
         writer.print("\x1b[48;2;{d};{d};{d}m", .{ r, g, b }) catch return AnsiError.WriteFailed;
     }
 
+    pub fn fgColor256Output(writer: anytype, index: u8) AnsiError!void {
+        writer.print("\x1b[38;5;{d}m", .{index}) catch return AnsiError.WriteFailed;
+    }
+
+    pub fn bgColor256Output(writer: anytype, index: u8) AnsiError!void {
+        writer.print("\x1b[48;5;{d}m", .{index}) catch return AnsiError.WriteFailed;
+    }
+
     // Text attribute constants
     pub const bold = "\x1b[1m";
     pub const dim = "\x1b[2m";

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -36,7 +36,7 @@ fn rgbaComponentToU8(component: f32) u8 {
 fn rgbToAnsi256(r: u8, g: u8, b: u8) u8 {
     if (r == g and g == b) {
         if (r < 8) return 16;
-        if (r > 248) return 231;
+        if (r >= 248) return 231;
         return @intCast(232 + ((@as(u16, r) - 8) / 10));
     }
 


### PR DESCRIPTION
## Summary
- Disable truecolor and explicit width probing for Apple Terminal to avoid incorrect color output.
- Add 256-color fallback rendering when truecolor is not supported.
- Route renderer color output through capability-aware selection (24-bit vs 256).

## Snapshot

### Before

<img width="1316" height="994" alt="image" src="https://github.com/user-attachments/assets/2a6f0abb-aef0-44ff-8f68-23d0a1ef38ca" />
<img width="1076" height="742" alt="image" src="https://github.com/user-attachments/assets/8bab30c1-af0e-4365-a6cf-78e9b66e1f90" />

### After

<img width="1544" height="926" alt="image" src="https://github.com/user-attachments/assets/9eefbe6a-22b6-4444-988e-f1da7a1bc228" />
<img width="1544" height="926" alt="image" src="https://github.com/user-attachments/assets/40be6aa0-5b6e-4144-b4fa-2b59ec67d95d" />
