### PR TITLE
fix(editor-view): clear stale glyphs when text shrinks

### DIFF
--- a/packages/core/src/zig/editor-view.zig
+++ b/packages/core/src/zig/editor-view.zig
@@ -757,6 +757,10 @@ pub const EditorView = struct {
 
         try placeholder.setStyledText(chunks);
 
+        if (self.placeholder_active) {
+            self.text_buffer_view.virtual_lines_dirty = true;
+        }
+
         self.updatePlaceholderVisibility();
     }
 


### PR DESCRIPTION
Closes https://github.com/anomalyco/opentui/issues/635 (reiterated below)

I was adding mode-specific placeholder text in `opencode`, such that shell mode shows a relevant bash example rather than the normal prompt example.

That exposed a rendering bug in OpenTUI: when switching from the longer normal-mode placeholder to the shorter shell-mode placeholder, trailing characters from the old placeholder stayed visible. Example:

**1. Build mode placeholder** (all good)
<img width="1620" height="416" alt="CleanShot 2026-02-05 at 18 55 20@2x" src="https://github.com/user-attachments/assets/a2fcc14d-6f59-4ee3-8f50-5d24fd8c3fea" />

**2. When switching to bash mode** (OH NO! DEAR GOD NO!)
<img width="483" height="299" alt="image" src="https://github.com/user-attachments/assets/a3c34b82-5b81-4e9c-aa0e-a34ca9ac10f7" />

As you can see, the last bits of `"Fix broken tests"` aren't cleared as one might expect, leaving us with the hideous: `Run a command... "pwd"roken tests`

## The Cause
Two things combined:
- `EditorView` placeholder updates while placeholder is active did not always force virtual line recomputation.
- The default alpha-blending path preserves destination chars for transparent-space overlays, which, while useful in certain contexts, led to the unwanted visual artifact in this case.

## The Fix
- `packages/core/src/zig/editor-view.zig`
  - Mark virtual lines dirty when placeholder styled text changes while placeholder is active.

## Regression Coverage
- `packages/core/src/zig/tests/editor-view_test.zig`
  - `EditorView - placeholder long to short clears tail without full buffer clear`
  - `EditorView - placeholder clear preserves existing background`

These tests fail without the full fix and pass with it.