### PR TITLE
feat(ssh): add @opentui/ssh package with stream-mode renderer migration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,23 @@
         "solid-js": "1.9.9",
       },
     },
+    "packages/ssh": {
+      "name": "@opentui/ssh",
+      "version": "0.1.0",
+      "dependencies": {
+        "@opentui/core": "workspace:*",
+        "ssh2": "^1.16.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/node": "^24.0.0",
+        "@types/ssh2": "^1.15.1",
+        "typescript": "^5",
+      },
+      "peerDependencies": {
+        "bun": ">=1.2.0",
+      },
+    },
     "packages/web": {
       "name": "@opentui/web",
       "version": "0.0.1",
@@ -354,13 +371,49 @@
 
     "@opentui/core": ["@opentui/core@workspace:packages/core"],
 
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.1.77", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SNqmygCMEsPCW7xWjzCZ5caBf36xaprwVdAnFijGDOuIzLA4iaDa6um8cj3TJh7awenN3NTRsuRc7OuH42UH+g=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.1.77", "", { "os": "darwin", "cpu": "x64" }, "sha512-/8fsa03swEHTQt/9NrGm98kemlU+VuTURI/OFZiH53vPDRrOYIYoa4Jyga/H7ZMcG+iFhkq97zIe+0Kw95LGmA=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.1.77", "", { "os": "linux", "cpu": "arm64" }, "sha512-QfUXZJPc69OvqoMu+AlLgjqXrwu4IeqcBuUWYMuH8nPTeLsVUc3CBbXdV2lv9UDxWzxzrxdS4ALPaxvmEv9lsQ=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.1.77", "", { "os": "linux", "cpu": "x64" }, "sha512-Kmfx0yUKnPj67AoXYIgL7qQo0QVsUG5Iw8aRtv6XFzXqa5SzBPhaKkKZ9yHPjOmTalZquUs+9zcCRNKpYYuL7A=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.1.77", "", { "os": "win32", "cpu": "arm64" }, "sha512-HGTscPXc7gdd23Nh1DbzUNjog1I+5IZp95XPtLftGTpjrWs60VcetXcyJqK2rQcXNxewJK5yDyaa5QyMjfEhCQ=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.1.77", "", { "os": "win32", "cpu": "x64" }, "sha512-c7GijsbvVgnlzd2murIbwuwrGbcv76KdUw6WlVv7a0vex50z6xJCpv1keGzpe0QfxrZ/6fFEFX7JnwGLno0wjA=="],
+
     "@opentui/react": ["@opentui/react@workspace:packages/react"],
 
     "@opentui/solid": ["@opentui/solid@workspace:packages/solid"],
 
+    "@opentui/ssh": ["@opentui/ssh@workspace:packages/ssh"],
+
     "@opentui/web": ["@opentui/web@workspace:packages/web"],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hPERz4IgXCM6Y6GdEEsJAFceyJMt29f3HlFzsvE/k+TQjChRhar6S+JggL35b9VmFfsdxyCOOTPqgnSrdV0etA=="],
+
+    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.3.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-SaWIxsRQYiT/eA60bqA4l8iNO7cJ6YD8ie82RerRp9voceBxPIZiwX4y20cTKy5qNaSGr9LxfYq7vDywTipiog=="],
+
+    "@oven/bun-darwin-x64-baseline": ["@oven/bun-darwin-x64-baseline@1.3.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-ArHVWpCRZI3vGLoN2/8ud8Kzqlgn1Gv+fNw+pMB9x18IzgAEhKxFxsWffnoaH21amam4tAOhpeewRIgdNtB0Cw=="],
+
+    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.3.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-rq0nNckobtS+ONoB95/Frfqr8jCtmSjjjEZlN4oyUx0KEBV11Vj4v3cDVaWzuI34ryL8FCog3HaqjfKn8R82Tw=="],
+
+    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.3.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-HvJmhrfipL7GtuqFz6xNpmf27NGcCOMwCalPjNR6fvkLpe8A7Z1+QbxKKjOglelmlmZc3Vi2TgDUtxSqfqOToQ=="],
+
+    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.3.8", "", { "os": "linux", "cpu": "x64" }, "sha512-YDgqVx1MI8E0oDbCEUSkAMBKKGnUKfaRtMdLh9Bjhu7JQacQ/ZCpxwi4HPf5Q0O1TbWRrdxGw2tA2Ytxkn7s1Q=="],
+
+    "@oven/bun-linux-x64-baseline": ["@oven/bun-linux-x64-baseline@1.3.8", "", { "os": "linux", "cpu": "x64" }, "sha512-3IkS3TuVOzMqPW6Gg9/8FEoKF/rpKZ9DZUfNy9GQ54+k4PGcXpptU3+dy8D4iDFCt4qe6bvoiAOdM44OOsZ+Wg=="],
+
+    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.3.8", "", { "os": "linux", "cpu": "x64" }, "sha512-o7Jm5zL4aw9UBs3BcZLVbgGm2V4F10MzAQAV+ziKzoEfYmYtvDqRVxgKEq7BzUOVy4LgfrfwzEXw5gAQGRrhQQ=="],
+
+    "@oven/bun-linux-x64-musl-baseline": ["@oven/bun-linux-x64-musl-baseline@1.3.8", "", { "os": "linux", "cpu": "x64" }, "sha512-5g8XJwHhcTh8SGoKO7pR54ILYDbuFkGo+68DOMTiVB5eLxuLET+Or/camHgk4QWp3nUS5kNjip4G8BE8i0rHVQ=="],
+
+    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.3.8", "", { "os": "win32", "cpu": "x64" }, "sha512-UDI3rowMm/tI6DIynpE4XqrOhr+1Ztk1NG707Wxv2nygup+anTswgCwjfjgmIe78LdoRNFrux2GpeolhQGW6vQ=="],
+
+    "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.8", "", { "os": "win32", "cpu": "x64" }, "sha512-K6qBUKAZLXsjAwFxGTG87dsWlDjyDl2fqjJr7+x7lmv2m+aSEzmLOK+Z5pSvGkpjBp3LXV35UUgj8G0UTd0pPg=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
@@ -464,6 +517,8 @@
 
     "@types/react-reconciler": ["@types/react-reconciler@0.32.3", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-cMi5ZrLG7UtbL7LTK6hq9w/EZIRk4Mf1Z5qHoI+qBh7/WkYkFXQ7gOto2yfUvPzF5ERMAhaXS5eTQ2SAnHjLzA=="],
 
+    "@types/ssh2": ["@types/ssh2@1.15.5", "", { "dependencies": { "@types/node": "^18.11.18" } }, "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ=="],
+
     "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
 
     "@types/three": ["@types/three@0.177.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": "*", "@webgpu/types": "*", "fflate": "~0.8.2", "meshoptimizer": "~0.18.1" } }, "sha512-/ZAkn4OLUijKQySNci47lFO+4JLE1TihEjsGWPUT+4jWqxtwOPPEwJV1C3k5MEx0mcBPCdkFjzRzDOnHEI1R+A=="],
@@ -500,6 +555,8 @@
 
     "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
 
+    "asn1": ["asn1@0.2.6", "", { "dependencies": { "safer-buffer": "~2.1.0" } }, "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="],
+
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
     "astro": ["astro@5.16.11", "", { "dependencies": { "@astrojs/compiler": "^2.13.0", "@astrojs/internal-helpers": "0.7.5", "@astrojs/markdown-remark": "6.3.10", "@astrojs/telemetry": "3.3.0", "@capsizecss/unpack": "^4.0.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "acorn": "^8.15.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "boxen": "8.0.1", "ci-info": "^4.3.1", "clsx": "^2.1.1", "common-ancestor-path": "^1.0.1", "cookie": "^1.1.1", "cssesc": "^3.0.0", "debug": "^4.4.3", "deterministic-object-hash": "^2.0.2", "devalue": "^5.6.2", "diff": "^8.0.3", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.0", "estree-walker": "^3.0.3", "flattie": "^1.1.1", "fontace": "~0.4.0", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.1", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "p-limit": "^6.2.0", "p-queue": "^8.1.1", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.3", "prompts": "^2.4.2", "rehype": "^13.0.2", "semver": "^7.7.3", "shiki": "^3.20.0", "smol-toml": "^1.6.0", "svgo": "^4.0.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.1", "unist-util-visit": "^5.0.0", "unstorage": "^1.17.3", "vfile": "^6.0.3", "vite": "^6.4.1", "vitefu": "^1.1.1", "xxhash-wasm": "^1.1.0", "yargs-parser": "^21.1.1", "yocto-spinner": "^0.2.3", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1", "zod-to-ts": "^1.2.0" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "astro.js" } }, "sha512-Z7kvkTTT5n6Hn5lCm6T3WU6pkxx84Hn25dtQ6dR7ATrBGq9eVa8EuB/h1S8xvaoVyCMZnIESu99Z9RJfdLRLDA=="],
@@ -524,6 +581,8 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ=="],
 
+    "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
+
     "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
@@ -535,6 +594,10 @@
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
+
+    "bun": ["bun@1.3.8", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.3.8", "@oven/bun-darwin-x64": "1.3.8", "@oven/bun-darwin-x64-baseline": "1.3.8", "@oven/bun-linux-aarch64": "1.3.8", "@oven/bun-linux-aarch64-musl": "1.3.8", "@oven/bun-linux-x64": "1.3.8", "@oven/bun-linux-x64-baseline": "1.3.8", "@oven/bun-linux-x64-musl": "1.3.8", "@oven/bun-linux-x64-musl-baseline": "1.3.8", "@oven/bun-windows-x64": "1.3.8", "@oven/bun-windows-x64-baseline": "1.3.8" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-TmmtMGQSXY3o0enSMMkvR5g7Dw/2n2oylAUprLVdqA8pDPBoKbzgOmmgHOtvnfRznFppl+Gu2cid3vgAjcNoSg=="],
 
     "bun-ffi-structs": ["bun-ffi-structs@0.1.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w=="],
 
@@ -587,6 +650,8 @@
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cookie-es": ["cookie-es@1.2.2", "", {}, "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="],
+
+    "cpu-features": ["cpu-features@0.0.10", "", { "dependencies": { "buildcheck": "~0.0.6", "nan": "^2.19.0" } }, "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA=="],
 
     "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
 
@@ -922,6 +987,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nan": ["nan@2.25.0", "", {}, "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
@@ -1076,6 +1143,8 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "sax": ["sax@1.4.3", "", {}, "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ=="],
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
@@ -1105,6 +1174,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "ssh2": ["ssh2@1.17.0", "", { "dependencies": { "asn1": "^0.2.6", "bcrypt-pbkdf": "^1.0.2" }, "optionalDependencies": { "cpu-features": "~0.0.10", "nan": "^2.23.0" } }, "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ=="],
 
     "stage-js": ["stage-js@1.0.0-alpha.17", "", {}, "sha512-AzlMO+t51v6cFvKZ+Oe9DJnL1OXEH5s9bEy6di5aOrUpcP7PCzI/wIeXF0u3zg0L89gwnceoKxrLId0ZpYnNXw=="],
 
@@ -1145,6 +1216,8 @@
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
@@ -1246,6 +1319,8 @@
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
+    "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -1285,6 +1360,8 @@
     "@opentui/solid/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
     "@opentui/web/@types/bun/bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+
+    "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/packages/core/src/console.ts
+++ b/packages/core/src/console.ts
@@ -693,6 +693,10 @@ export class TerminalConsole extends EventEmitter {
   }
 
   public toggle(): void {
+    if (!this.renderer.useConsole) {
+      return
+    }
+
     if (this.isVisible) {
       if (this.isFocused) {
         this.hide()
@@ -719,6 +723,10 @@ export class TerminalConsole extends EventEmitter {
   }
 
   public show(): void {
+    if (!this.renderer.useConsole) {
+      return
+    }
+
     if (!this.isVisible) {
       this.isVisible = true
       this._processCachedLogs()

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1493,9 +1493,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     ) {
       const canStartSelection = Boolean(
         maybeRenderable &&
-        maybeRenderable.selectable &&
-        !maybeRenderable.isDestroyed &&
-        maybeRenderable.shouldStartSelection(mouseEvent.x, mouseEvent.y),
+          maybeRenderable.selectable &&
+          !maybeRenderable.isDestroyed &&
+          maybeRenderable.shouldStartSelection(mouseEvent.x, mouseEvent.y),
       )
 
       if (canStartSelection && maybeRenderable) {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -161,6 +161,9 @@ function createNullStdin(): NodeJS.ReadStream {
 /**
  * Creates a no-op WriteStream used for stream mode when stdout is omitted.
  * Carries terminal dimensions while all actual output flows through onOutput.
+ * Sets isTTY=true so existing renderer internals work without null checks.
+ * Debug features like dumpOutputCache() write to this no-op stream and are
+ * intentionally discarded in stream mode.
  */
 function createNullStdout(width: number, height: number): NodeJS.WriteStream {
   const stdout = new Writable({
@@ -337,14 +340,20 @@ export enum MouseButton {
 
 const rendererTracker = singleton("RendererTracker", () => {
   const renderers = new Set<CliRenderer>()
+  let processStdinUsers = 0
   return {
     addRenderer: (renderer: CliRenderer) => {
       renderers.add(renderer)
+      if (renderer.stdin === process.stdin) processStdinUsers++
     },
     removeRenderer: (renderer: CliRenderer) => {
       renderers.delete(renderer)
+      if (renderer.stdin === process.stdin) processStdinUsers = Math.max(0, processStdinUsers - 1)
       if (renderers.size === 0) {
-        process.stdin.pause()
+        // Only pause process.stdin if a renderer was actually using it
+        if (processStdinUsers === 0) {
+          process.stdin.pause()
+        }
 
         if (hasSingleton("tree-sitter-client")) {
           getTreeSitterClient().destroy()
@@ -367,6 +376,16 @@ export async function createCliRenderer(config: CliRendererConfig = {}): Promise
   let feed: NativeSpanFeed | null
 
   if (config.outputMode === "stream") {
+    if (typeof config.onOutput !== "function") {
+      throw new Error('outputMode "stream" requires onOutput')
+    }
+    if (!Number.isInteger(config.width) || config.width < 1) {
+      throw new Error('outputMode "stream" requires width to be a positive integer')
+    }
+    if (!Number.isInteger(config.height) || config.height < 1) {
+      throw new Error('outputMode "stream" requires height to be a positive integer')
+    }
+
     // Stream mode has no process-backed tty, so width/height come from config.
     // Null-object streams let existing renderer internals run without null checks.
     width = config.width
@@ -633,8 +652,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   constructor(rendererInit: CliRendererInit, config: CliRendererConfig = {}) {
     super()
 
-    rendererTracker.addRenderer(this)
-
     this.stdin = rendererInit.stdin
     this.stdout = rendererInit.stdout
     this.realStdoutWrite = rendererInit.stdout.write
@@ -662,18 +679,26 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.lib.setTerminalEnvVar(this.rendererPtr, key, value)
     }
 
-    this.exitOnCtrlC = config.exitOnCtrlC === undefined ? true : config.exitOnCtrlC
-    this.exitSignals = config.exitSignals || [
-      "SIGINT", // Ctrl+C
-      "SIGTERM", // Termination signal
-      "SIGQUIT", // Ctrl+\
-      "SIGABRT", // Abort signal
-      "SIGHUP", // Hangup (terminal closed)
-      "SIGBREAK", // Ctrl+Break on Windows
-      "SIGPIPE", // Broken pipe
-      "SIGBUS", // Bus error
-      "SIGFPE", // Floating point exception
-    ]
+    // Stream mode defaults: no process-level signal handlers, no console error overlay.
+    // These are designed for multi-session SSH servers where process signals should not
+    // tear down individual sessions. Callers can still override explicitly.
+    const isStreamMode = config.outputMode === "stream"
+    this.exitOnCtrlC = config.exitOnCtrlC ?? !isStreamMode
+    this.exitSignals =
+      config.exitSignals ??
+      (isStreamMode
+        ? []
+        : [
+            "SIGINT", // Ctrl+C
+            "SIGTERM", // Termination signal
+            "SIGQUIT", // Ctrl+\
+            "SIGABRT", // Abort signal
+            "SIGHUP", // Hangup (terminal closed)
+            "SIGBREAK", // Ctrl+Break on Windows
+            "SIGPIPE", // Broken pipe
+            "SIGBUS", // Bus error
+            "SIGFPE", // Floating point exception
+          ])
 
     this.clipboard = new Clipboard(this.lib, this.rendererPtr)
     this.resizeDebounceDelay = config.debounceDelay || 100
@@ -718,6 +743,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       throw new Error('outputMode "stream" requires NativeSpanFeed (enforced by type, this should not happen)')
     }
 
+    // Register with tracker after validation succeeds to avoid leaking entries on throw
+    rendererTracker.addRenderer(this)
+
     // Handle terminal resize (skip in stream mode - resize comes via handleResize())
     if (this._outputMode === "stdout") {
       process.on("SIGWINCH", this.sigwinchHandler)
@@ -747,7 +775,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this._console = new TerminalConsole(this, config.consoleOptions)
     this.useConsole = config.useConsole ?? true
-    this._openConsoleOnError = config.openConsoleOnError ?? process.env.NODE_ENV !== "production"
+    this._openConsoleOnError =
+      config.openConsoleOnError ?? (isStreamMode ? false : process.env.NODE_ENV !== "production")
     this._onDestroy = config.onDestroy
 
     // Initialize stream mode if enabled (variables set earlier before SIGWINCH)
@@ -1372,15 +1401,16 @@ export class CliRenderer extends EventEmitter implements RenderContext {
    * Write input data to the renderer as if it came from stdin.
    * Use this in stream mode to provide input from SSH or other streams.
    */
-  public input(data: Buffer | Uint8Array): void {
+  public input(data: Buffer): void {
     if (this._outputMode !== "stream") {
       throw new Error("input() is only available in stream output mode")
     }
+    if (this._isDestroyed) return
 
-    if (this._useMouse && this.handleMouseData(data as Buffer)) {
+    if (this._useMouse && this.handleMouseData(data)) {
       return
     }
-    this._stdinBuffer.process(data as Buffer)
+    this._stdinBuffer.process(data)
   }
 
   /**
@@ -1737,6 +1767,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
    * For terminal-driven resize, the renderer handles SIGWINCH automatically.
    */
   public resize(width: number, height: number): void {
+    if (this._isDestroyed) return
     this.processResize(width, height)
   }
 
@@ -1918,30 +1949,33 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.disableMouse()
     this.removeExitListeners()
     this._stdinBuffer.clear()
-    this.stdin.removeListener("data", this.stdinListener)
     this.lib.suspendRenderer(this.rendererPtr)
 
-    if (this.stdin.setRawMode) {
-      this.stdin.setRawMode(false)
+    // Skip stdin teardown in stream mode — input comes via renderer.input()
+    if (this._outputMode === "stdout") {
+      this.stdin.removeListener("data", this.stdinListener)
+      if (this.stdin.setRawMode) {
+        this.stdin.setRawMode(false)
+      }
+      this.stdin.pause()
     }
-
-    this.stdin.pause()
   }
 
   public resume(): void {
-    if (this.stdin.setRawMode) {
-      this.stdin.setRawMode(true)
+    // Skip stdin setup in stream mode — input comes via renderer.input()
+    if (this._outputMode === "stdout") {
+      if (this.stdin.setRawMode) {
+        this.stdin.setRawMode(true)
+      }
+      this.stdin.resume()
+      setImmediate(() => {
+        // Consume any existing stdin data to avoid processing stale input
+        while (this.stdin.read() !== null) {}
+        this.stdin.on("data", this.stdinListener)
+      })
     }
 
-    this.stdin.resume()
     this.addExitListeners()
-
-    setImmediate(() => {
-      // Consume any existing stdin data to avoid processing stale input
-      while (this.stdin.read() !== null) {}
-      this.stdin.on("data", this.stdinListener)
-    })
-
     this.lib.resumeRenderer(this.rendererPtr)
 
     if (this._suspendedMouseEnabled) {
@@ -2077,12 +2111,22 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.flushStdoutCache(this._splitHeight, true)
     }
 
-    if (this.stdin.setRawMode) {
-      this.stdin.setRawMode(false)
+    // Only restore stdin in stdout mode — stream mode uses null stdin
+    if (this._outputMode === "stdout") {
+      if (this.stdin.setRawMode) {
+        this.stdin.setRawMode(false)
+      }
+      this.stdin.removeListener("data", this.stdinListener)
     }
-    this.stdin.removeListener("data", this.stdinListener)
 
-    // Tear down stream feed callbacks before destroying native renderer
+    // Tear down stream feed callbacks before destroying native renderer.
+    //
+    // Memory ownership: the renderer's native struct (buffers, hit grids) is
+    // freed by destroyRenderer(). The feed's chunk memory is owned independently
+    // by NativeSpanFeed and freed in its own finalizeDestroy(), which defers
+    // until all pending async onOutput handlers have settled. This means
+    // destroyRenderer() does not free the memory that onOutput views
+    // reference — those views point into feed-owned chunks, not renderer memory.
     if (this._outputMode === "stream" && this._feed) {
       // Flush any committed spans (including shutdown sequences) before detaching handlers.
       try {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -350,8 +350,8 @@ const rendererTracker = singleton("RendererTracker", () => {
       renderers.delete(renderer)
       if (renderer.stdin === process.stdin) processStdinUsers = Math.max(0, processStdinUsers - 1)
       if (renderers.size === 0) {
-        // Only pause process.stdin if a renderer was actually using it
-        if (processStdinUsers === 0) {
+        // Only pause process.stdin when the final renderer was also a process.stdin user.
+        if (renderer.stdin === process.stdin && processStdinUsers === 0) {
           process.stdin.pause()
         }
 
@@ -2140,6 +2140,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this._detachFeedErrorHandler?.()
       this._detachFeedErrorHandler = null
 
+      // NOTE: close() is asynchronous when onOutput handlers are pending;
+      // renderer teardown does not currently wait for that completion.
       this._feed.close()
       this._feed = null
     }

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -10,9 +10,13 @@ import {
   type WidthMethod,
 } from "./types"
 import { RGBA, parseColor, type ColorInput } from "./lib/RGBA"
-import type { Pointer } from "bun:ffi"
+import { type Pointer } from "bun:ffi"
+import { Readable, Writable } from "stream"
 import { OptimizedBuffer } from "./buffer"
 import { resolveRenderLib, type RenderLib } from "./zig"
+import type { NativeSpanFeedOptions } from "./zig-structs"
+import { NativeSpanFeed, type DataHandler } from "./NativeSpanFeed"
+
 import { TerminalConsole, type ConsoleOptions, capture } from "./console"
 import { MouseParser, type MouseEventType, type RawMouseEvent, type ScrollInfo } from "./lib/parse.mouse"
 import { Selection } from "./lib/selection"
@@ -78,7 +82,7 @@ registerEnvVar({
   default: false,
 })
 
-export interface CliRendererConfig {
+interface BaseCliRendererConfig {
   stdin?: NodeJS.ReadStream
   stdout?: NodeJS.WriteStream
   remote?: boolean
@@ -106,6 +110,83 @@ export interface CliRendererConfig {
   openConsoleOnError?: boolean
   prependInputHandlers?: ((sequence: string) => boolean)[]
   onDestroy?: () => void
+}
+
+/**
+ * Output mode for the renderer.
+ * - "stdout": Write directly to process.stdout (default)
+ * - "stream": Deliver output via onOutput handler
+ */
+export type OutputMode = "stdout" | "stream"
+
+type OutputConfig =
+  | {
+      /**
+       * Default mode: renderer writes directly to stdout.
+       */
+      outputMode?: "stdout"
+    }
+  | {
+      /**
+       * Stream mode sends ANSI output through `onOutput` instead of writing to stdout.
+       * Width/height are required in this mode because there is no process-backed tty.
+       */
+      outputMode: "stream"
+      /**
+       * Called with zero-copy Uint8Array views into native output memory.
+       * Return a Promise to apply async backpressure.
+       */
+      onOutput: DataHandler
+      /** Initial terminal width for stream mode sessions. */
+      width: number
+      /** Initial terminal height for stream mode sessions. */
+      height: number
+      /** Optional NativeSpanFeed tuning knobs. */
+      feedOptions?: NativeSpanFeedOptions
+    }
+
+export type CliRendererConfig = BaseCliRendererConfig & OutputConfig
+
+/**
+ * Creates a no-op ReadStream used for stream mode when stdin is omitted.
+ */
+function createNullStdin(): NodeJS.ReadStream {
+  const stdin = new Readable({
+    read() {},
+  }) as NodeJS.ReadStream
+  Object.assign(stdin, { isTTY: true, setRawMode: () => stdin })
+  return stdin
+}
+
+/**
+ * Creates a no-op WriteStream used for stream mode when stdout is omitted.
+ * Carries terminal dimensions while all actual output flows through onOutput.
+ */
+function createNullStdout(width: number, height: number): NodeJS.WriteStream {
+  const stdout = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback()
+    },
+  }) as NodeJS.WriteStream
+  Object.assign(stdout, {
+    isTTY: true,
+    columns: width,
+    rows: height,
+  })
+  return stdout
+}
+
+/**
+ * Resolved constructor values computed by createCliRenderer.
+ */
+type CliRendererInit = {
+  lib: RenderLib
+  rendererPtr: Pointer
+  stdin: NodeJS.ReadStream
+  stdout: NodeJS.WriteStream
+  width: number
+  height: number
+  feed: NativeSpanFeed | null
 }
 
 export type PixelResolution = {
@@ -278,20 +359,41 @@ export async function createCliRenderer(config: CliRendererConfig = {}): Promise
   if (process.argv.includes("--delay-start")) {
     await new Promise((resolve) => setTimeout(resolve, 5000))
   }
-  const stdin = config.stdin || process.stdin
-  const stdout = config.stdout || process.stdout
+  const isStreamMode = config.outputMode === "stream"
+  let stdin: NodeJS.ReadStream
+  let stdout: NodeJS.WriteStream
+  let width: number
+  let height: number
+  let feed: NativeSpanFeed | null
 
-  const width = stdout.columns || 80
-  const height = stdout.rows || 24
+  if (config.outputMode === "stream") {
+    // Stream mode has no process-backed tty, so width/height come from config.
+    // Null-object streams let existing renderer internals run without null checks.
+    width = config.width
+    height = config.height
+    stdin = config.stdin ?? createNullStdin()
+    stdout = config.stdout ?? createNullStdout(width, height)
+    feed = NativeSpanFeed.create(config.feedOptions ?? {})
+  } else {
+    stdin = config.stdin || process.stdin
+    stdout = config.stdout || process.stdout
+    width = stdout.columns || 80
+    height = stdout.rows || 24
+    feed = null
+  }
+
   const renderHeight =
     config.experimental_splitHeight && config.experimental_splitHeight > 0 ? config.experimental_splitHeight : height
 
   const ziglib = resolveRenderLib()
   const rendererPtr = ziglib.createRenderer(width, renderHeight, {
-    remote: config.remote ?? false,
     testing: config.testing ?? false,
+    outputStrategy: isStreamMode ? 1 : 0,
+    remote: config.remote ?? false,
+    feedPtr: feed?.streamPtr ?? null,
   })
   if (!rendererPtr) {
+    feed?.close()
     throw new Error("Failed to create renderer")
   }
   if (config.useThread === undefined) {
@@ -310,11 +412,17 @@ export async function createCliRenderer(config: CliRendererConfig = {}): Promise
 
   ziglib.setKittyKeyboardFlags(rendererPtr, kittyFlags)
 
-  const renderer = new CliRenderer(ziglib, rendererPtr, stdin, stdout, width, height, config)
-  if (!config.testing) {
-    await renderer.setupTerminal()
+  try {
+    const rendererInit: CliRendererInit = { lib: ziglib, rendererPtr, stdin, stdout, width, height, feed }
+    const renderer = new CliRenderer(rendererInit, config)
+    if (!config.testing) {
+      await renderer.setupTerminal()
+    }
+    return renderer
+  } catch (error) {
+    feed?.close()
+    throw error
   }
-  return renderer
 }
 
 export enum CliRenderEvents {
@@ -469,6 +577,13 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private _debugInputs: Array<{ timestamp: string; sequence: string }> = []
   private _debugModeEnabled: boolean = env.OTUI_DEBUG
 
+  // Output mode fields
+  private _outputMode: OutputMode = "stdout"
+  private _onOutput?: DataHandler
+  private _feed: NativeSpanFeed | null = null
+  private _detachFeedDataHandler: (() => void) | null = null
+  private _detachFeedErrorHandler: (() => void) | null = null
+
   private handleError: (error: Error) => void = ((error: Error) => {
     console.error(error)
 
@@ -515,38 +630,30 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     return this._controlState
   }
 
-  constructor(
-    lib: RenderLib,
-    rendererPtr: Pointer,
-    stdin: NodeJS.ReadStream,
-    stdout: NodeJS.WriteStream,
-    width: number,
-    height: number,
-    config: CliRendererConfig = {},
-  ) {
+  constructor(rendererInit: CliRendererInit, config: CliRendererConfig = {}) {
     super()
 
     rendererTracker.addRenderer(this)
 
-    this.stdin = stdin
-    this.stdout = stdout
-    this.realStdoutWrite = stdout.write
-    this.lib = lib
-    this._terminalWidth = stdout.columns ?? width
-    this._terminalHeight = stdout.rows ?? height
-    this.width = width
-    this.height = height
+    this.stdin = rendererInit.stdin
+    this.stdout = rendererInit.stdout
+    this.realStdoutWrite = rendererInit.stdout.write
+    this.lib = rendererInit.lib
+    this._terminalWidth = rendererInit.stdout.columns ?? rendererInit.width
+    this._terminalHeight = rendererInit.stdout.rows ?? rendererInit.height
+    this.width = rendererInit.width
+    this.height = rendererInit.height
     this._useThread = config.useThread === undefined ? false : config.useThread
     this._splitHeight = config.experimental_splitHeight || 0
 
     if (this._splitHeight > 0) {
       capture.on("write", this.captureCallback)
-      this.renderOffset = height - this._splitHeight
+      this.renderOffset = rendererInit.height - this._splitHeight
       this.height = this._splitHeight
-      lib.setRenderOffset(rendererPtr, this.renderOffset)
+      rendererInit.lib.setRenderOffset(rendererInit.rendererPtr, this.renderOffset)
     }
 
-    this.rendererPtr = rendererPtr
+    this.rendererPtr = rendererInit.rendererPtr
 
     const forwardEnvKeys = config.forwardEnvKeys ?? [...DEFAULT_FORWARDED_ENV_KEYS]
     for (const key of forwardEnvKeys) {
@@ -596,8 +703,25 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.stdout.write = this.interceptStdoutWrite.bind(this)
     }
 
-    // Handle terminal resize
-    process.on("SIGWINCH", this.sigwinchHandler)
+    // Output mode setup (must be before SIGWINCH binding)
+    this._outputMode = config.outputMode ?? "stdout"
+    this._onOutput = config.outputMode === "stream" ? config.onOutput : undefined
+    this._feed = rendererInit.feed
+
+    if (this._outputMode === "stream" && !this._onOutput) {
+      this.lib.destroyRenderer(this.rendererPtr)
+      throw new Error('outputMode "stream" requires onOutput (enforced by type, this should not happen)')
+    }
+
+    if (this._outputMode === "stream" && !this._feed) {
+      this.lib.destroyRenderer(this.rendererPtr)
+      throw new Error('outputMode "stream" requires NativeSpanFeed (enforced by type, this should not happen)')
+    }
+
+    // Handle terminal resize (skip in stream mode - resize comes via handleResize())
+    if (this._outputMode === "stdout") {
+      process.on("SIGWINCH", this.sigwinchHandler)
+    }
 
     process.on("warning", this.warningHandler)
 
@@ -625,6 +749,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.useConsole = config.useConsole ?? true
     this._openConsoleOnError = config.openConsoleOnError ?? process.env.NODE_ENV !== "production"
     this._onDestroy = config.onDestroy
+
+    // Initialize stream mode if enabled (variables set earlier before SIGWINCH)
+    if (this._outputMode === "stream") {
+      this.initStreamMode()
+    }
 
     global.requestAnimationFrame = (callback: FrameRequestCallback) => {
       const id = CliRenderer.animationFrameId++
@@ -1153,6 +1282,28 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       return this._keyHandler.processInput(sequence)
     })
 
+    // Skip stdin setup in stream mode
+    if (this._outputMode === "stream") {
+      this._stdinBuffer.on("data", (sequence: string) => {
+        if (this._debugModeEnabled) {
+          this._debugInputs.push({
+            timestamp: new Date().toISOString(),
+            sequence,
+          })
+        }
+
+        for (const handler of this.inputHandlers) {
+          if (handler(sequence)) {
+            return
+          }
+        }
+      })
+      this._stdinBuffer.on("paste", (data: string) => {
+        this._keyHandler.processPaste(data)
+      })
+      return
+    }
+
     if (this.stdin.setRawMode) {
       this.stdin.setRawMode(true)
     }
@@ -1199,6 +1350,44 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     return event
+  }
+
+  private initStreamMode(): void {
+    if (!this._feed || !this._onOutput) {
+      return
+    }
+
+    // If onOutput returns a Promise, NativeSpanFeed keeps the chunk pinned
+    // until that Promise resolves, which provides natural async backpressure.
+    this._detachFeedDataHandler = this._feed.onData((data: Uint8Array) => {
+      return this._onOutput?.(data)
+    })
+
+    this._detachFeedErrorHandler = this._feed.onError((code: number) => {
+      console.error(`[CliRenderer] NativeSpanFeed error: code=${code}`)
+    })
+  }
+
+  /**
+   * Write input data to the renderer as if it came from stdin.
+   * Use this in stream mode to provide input from SSH or other streams.
+   */
+  public input(data: Buffer | Uint8Array): void {
+    if (this._outputMode !== "stream") {
+      throw new Error("input() is only available in stream output mode")
+    }
+
+    if (this._useMouse && this.handleMouseData(data as Buffer)) {
+      return
+    }
+    this._stdinBuffer.process(data as Buffer)
+  }
+
+  /**
+   * Get the current output mode.
+   */
+  public get outputMode(): OutputMode {
+    return this._outputMode
   }
 
   private handleMouseData(data: Buffer): boolean {
@@ -1274,9 +1463,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     ) {
       const canStartSelection = Boolean(
         maybeRenderable &&
-          maybeRenderable.selectable &&
-          !maybeRenderable.isDestroyed &&
-          maybeRenderable.shouldStartSelection(mouseEvent.x, mouseEvent.y),
+        maybeRenderable.selectable &&
+        !maybeRenderable.isDestroyed &&
+        maybeRenderable.shouldStartSelection(mouseEvent.x, mouseEvent.y),
       )
 
       if (canStartSelection && maybeRenderable) {
@@ -1540,6 +1729,15 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.root.resize(this.width, this.height)
     this.emit("resize", this.width, this.height)
     this.requestRender()
+  }
+
+  /**
+   * Programmatically resize the renderer to new dimensions.
+   * Use this for external resize events (e.g., SSH window-change).
+   * For terminal-driven resize, the renderer handles SIGWINCH automatically.
+   */
+  public resize(width: number, height: number): void {
+    this.processResize(width, height)
   }
 
   public setBackgroundColor(color: ColorInput): void {
@@ -1821,7 +2019,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this._destroyFinalized = true
     this._destroyPending = false
 
-    process.removeListener("SIGWINCH", this.sigwinchHandler)
+    // Only remove SIGWINCH if we registered it (not in stream mode)
+    if (this._outputMode === "stdout") {
+      process.removeListener("SIGWINCH", this.sigwinchHandler)
+    }
     process.removeListener("uncaughtException", this.handleError)
     process.removeListener("unhandledRejection", this.handleError)
     process.removeListener("warning", this.warningHandler)
@@ -1880,6 +2081,24 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.stdin.setRawMode(false)
     }
     this.stdin.removeListener("data", this.stdinListener)
+
+    // Tear down stream feed callbacks before destroying native renderer
+    if (this._outputMode === "stream" && this._feed) {
+      // Flush any committed spans (including shutdown sequences) before detaching handlers.
+      try {
+        this._feed.drainAll()
+      } catch (error) {
+        console.error("Error draining NativeSpanFeed during destroy:", error)
+      }
+
+      this._detachFeedDataHandler?.()
+      this._detachFeedDataHandler = null
+      this._detachFeedErrorHandler?.()
+      this._detachFeedErrorHandler = null
+
+      this._feed.close()
+      this._feed = null
+    }
 
     this.lib.destroyRenderer(this.rendererPtr)
     rendererTracker.removeRenderer(this)

--- a/packages/core/src/testing/test-renderer.ts
+++ b/packages/core/src/testing/test-renderer.ts
@@ -1,11 +1,12 @@
 import { Readable } from "stream"
 import { CliRenderer, type CliRendererConfig } from "../renderer"
 import { resolveRenderLib } from "../zig"
+import { NativeSpanFeed } from "../NativeSpanFeed"
 import { createMockKeys } from "./mock-keys"
 import { createMockMouse } from "./mock-mouse"
 import type { CapturedFrame } from "../types"
 
-export interface TestRendererOptions extends CliRendererConfig {
+export type TestRendererOptions = CliRendererConfig & {
   width?: number
   height?: number
   kittyKeyboard?: boolean
@@ -73,8 +74,7 @@ export async function createTestRenderer(options: TestRendererOptions): Promise<
       }
     },
     resize: (width: number, height: number) => {
-      //@ts-expect-error - this is a test renderer
-      renderer.processResize(width, height)
+      renderer.resize(width, height)
     },
   }
 }
@@ -89,11 +89,16 @@ async function setupTestRenderer(config: TestRendererOptions) {
     config.experimental_splitHeight && config.experimental_splitHeight > 0 ? config.experimental_splitHeight : height
 
   const ziglib = resolveRenderLib()
+  const feed = config.outputMode === "stream" ? NativeSpanFeed.create(config.feedOptions ?? {}) : null
+
   const rendererPtr = ziglib.createRenderer(width, renderHeight, {
     testing: true,
+    outputStrategy: config.outputMode === "stream" ? 1 : 0,
     remote: config.remote ?? false,
+    feedPtr: feed?.streamPtr ?? null,
   })
   if (!rendererPtr) {
+    feed?.close()
     throw new Error("Failed to create test renderer")
   }
   if (config.useThread === undefined) {
@@ -105,7 +110,13 @@ async function setupTestRenderer(config: TestRendererOptions) {
   }
   ziglib.setUseThread(rendererPtr, config.useThread)
 
-  const renderer = new CliRenderer(ziglib, rendererPtr, stdin, stdout, width, height, config)
+  let renderer: CliRenderer
+  try {
+    renderer = new CliRenderer({ lib: ziglib, rendererPtr, stdin, stdout, width, height, feed }, config)
+  } catch (error) {
+    feed?.close()
+    throw error
+  }
 
   process.off("SIGWINCH", renderer["sigwinchHandler"])
 

--- a/packages/core/src/tests/renderer.callback-mode.test.ts
+++ b/packages/core/src/tests/renderer.callback-mode.test.ts
@@ -1,6 +1,0 @@
-import { test, expect } from "bun:test"
-import { createTestRenderer } from "../testing/test-renderer"
-
-test("stream output mode requires onOutput", async () => {
-  await expect(createTestRenderer({ outputMode: "stream" })).rejects.toThrow('outputMode "stream" requires onOutput')
-})

--- a/packages/core/src/tests/renderer.callback-mode.test.ts
+++ b/packages/core/src/tests/renderer.callback-mode.test.ts
@@ -1,0 +1,6 @@
+import { test, expect } from "bun:test"
+import { createTestRenderer } from "../testing/test-renderer"
+
+test("stream output mode requires onOutput", async () => {
+  await expect(createTestRenderer({ outputMode: "stream" })).rejects.toThrow('outputMode "stream" requires onOutput')
+})

--- a/packages/core/src/tests/renderer.stream-mode.test.ts
+++ b/packages/core/src/tests/renderer.stream-mode.test.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "bun:test"
+import { createCliRenderer } from "../renderer"
+
+test("stream mode emits setup output through onOutput", async () => {
+  const chunks: Uint8Array[] = []
+
+  const renderer = await createCliRenderer({
+    outputMode: "stream",
+    width: 80,
+    height: 24,
+    onOutput: (data) => {
+      chunks.push(new Uint8Array(data))
+    },
+    useAlternateScreen: false,
+    useConsole: false,
+    openConsoleOnError: false,
+    exitOnCtrlC: false,
+    exitSignals: [],
+  })
+
+  const deadline = Date.now() + 250
+  while (chunks.length === 0 && Date.now() < deadline) {
+    await Bun.sleep(5)
+  }
+
+  expect(chunks.length).toBeGreaterThan(0)
+
+  renderer.destroy()
+  await renderer.idle()
+})
+
+test("stream mode destroy finalizes after pending async onOutput", async () => {
+  let chunkCount = 0
+  let resolvePending!: () => void
+  let resolveDestroyed!: () => void
+  let onDestroyCalled = false
+  const pending = new Promise<void>((resolve) => {
+    resolvePending = resolve
+  })
+  const destroyed = new Promise<void>((resolve) => {
+    resolveDestroyed = resolve
+  })
+
+  const renderer = await createCliRenderer({
+    outputMode: "stream",
+    width: 80,
+    height: 24,
+    onOutput: () => {
+      chunkCount += 1
+      if (chunkCount === 1) {
+        return pending
+      }
+    },
+    onDestroy: () => {
+      onDestroyCalled = true
+      resolveDestroyed()
+    },
+    useAlternateScreen: false,
+    useConsole: false,
+    openConsoleOnError: false,
+    exitOnCtrlC: false,
+    exitSignals: [],
+  })
+
+  const startDeadline = Date.now() + 250
+  while (chunkCount === 0 && Date.now() < startDeadline) {
+    await Bun.sleep(5)
+  }
+
+  expect(chunkCount).toBeGreaterThan(0)
+
+  renderer.destroy()
+  await destroyed
+
+  resolvePending()
+  await Bun.sleep(0)
+
+  expect(onDestroyCalled).toBe(true)
+  expect(renderer.isDestroyed).toBe(true)
+})

--- a/packages/core/src/tests/renderer.stream-mode.test.ts
+++ b/packages/core/src/tests/renderer.stream-mode.test.ts
@@ -1,5 +1,16 @@
 import { test, expect } from "bun:test"
-import { createCliRenderer } from "../renderer"
+import { createCliRenderer, RendererControlState } from "../renderer"
+
+const streamDefaults = {
+  outputMode: "stream" as const,
+  width: 80,
+  height: 24,
+  useAlternateScreen: false,
+  useConsole: false,
+  openConsoleOnError: false,
+  exitOnCtrlC: false,
+  exitSignals: [] as NodeJS.Signals[],
+}
 
 test("stream mode emits setup output through onOutput", async () => {
   const chunks: Uint8Array[] = []
@@ -77,4 +88,157 @@ test("stream mode destroy finalizes after pending async onOutput", async () => {
 
   expect(onDestroyCalled).toBe(true)
   expect(renderer.isDestroyed).toBe(true)
+})
+
+test("stream mode input() processes data through key handlers", async () => {
+  let keypressReceived = false
+
+  const renderer = await createCliRenderer({
+    ...streamDefaults,
+    onOutput: () => {},
+  })
+
+  renderer.keyInput.on("keypress", (event: any) => {
+    if (event.name === "a") {
+      keypressReceived = true
+    }
+  })
+
+  // Send the letter "a" as raw input
+  renderer.input(Buffer.from("a"))
+  await Bun.sleep(10)
+
+  expect(keypressReceived).toBe(true)
+
+  renderer.destroy()
+  await renderer.idle()
+})
+
+test("stream mode resize() updates renderer dimensions", async () => {
+  const renderer = await createCliRenderer({
+    ...streamDefaults,
+    onOutput: () => {},
+  })
+
+  expect(renderer.width).toBe(80)
+  expect(renderer.height).toBe(24)
+
+  renderer.resize(120, 40)
+
+  const deadline = Date.now() + 300
+  while ((renderer.width !== 120 || renderer.height !== 40) && Date.now() < deadline) {
+    await Bun.sleep(10)
+  }
+
+  expect(renderer.width).toBe(120)
+  expect(renderer.height).toBe(40)
+
+  renderer.destroy()
+  await renderer.idle()
+})
+
+test("stream mode handles mouse input through input()", async () => {
+  let keypressCount = 0
+  const renderer = await createCliRenderer({
+    ...streamDefaults,
+    onOutput: () => {},
+  })
+
+  renderer.keyInput.on("keypress", () => {
+    keypressCount += 1
+  })
+
+  // SGR mouse down event: ESC [ < 0 ; 10 ; 10 M
+  renderer.input(Buffer.from("\x1b[<0;10;10M"))
+  await Bun.sleep(20)
+
+  expect(keypressCount).toBe(0)
+
+  renderer.destroy()
+  await renderer.idle()
+})
+
+test("stream mode resize during active render loop remains stable", async () => {
+  const renderer = await createCliRenderer({
+    ...streamDefaults,
+    onOutput: () => {},
+  })
+
+  renderer.start()
+
+  renderer.resize(100, 30)
+  renderer.resize(110, 35)
+  renderer.resize(120, 40)
+
+  const deadline = Date.now() + 500
+  while ((renderer.width !== 120 || renderer.height !== 40) && Date.now() < deadline) {
+    await Bun.sleep(10)
+  }
+
+  expect(renderer.width).toBe(120)
+  expect(renderer.height).toBe(40)
+
+  renderer.destroy()
+  await renderer.idle()
+})
+
+test("stream mode double destroy is safe", async () => {
+  const renderer = await createCliRenderer({
+    ...streamDefaults,
+    onOutput: () => {},
+  })
+
+  renderer.destroy()
+  // Second destroy should be a no-op, not throw
+  renderer.destroy()
+  await renderer.idle()
+
+  expect(renderer.isDestroyed).toBe(true)
+})
+
+test("stream mode input() after destroy is ignored", async () => {
+  const renderer = await createCliRenderer({
+    ...streamDefaults,
+    onOutput: () => {},
+  })
+
+  renderer.destroy()
+  renderer.input(Buffer.from("a"))
+  await renderer.idle()
+
+  expect(renderer.isDestroyed).toBe(true)
+})
+
+test("stream mode suspend/resume preserves control state", async () => {
+  const renderer = await createCliRenderer({
+    ...streamDefaults,
+    onOutput: () => {},
+  })
+
+  renderer.start()
+  expect(renderer.controlState).toBe(RendererControlState.EXPLICIT_STARTED)
+
+  renderer.suspend()
+  expect(renderer.controlState).toBe(RendererControlState.EXPLICIT_SUSPENDED)
+
+  renderer.resume()
+  expect(renderer.controlState).toBe(RendererControlState.EXPLICIT_STARTED)
+
+  renderer.destroy()
+  await renderer.idle()
+})
+
+test("stream mode input() throws in stdout mode", async () => {
+  const renderer = await createCliRenderer({
+    useAlternateScreen: false,
+    useConsole: false,
+    openConsoleOnError: false,
+    exitOnCtrlC: false,
+    exitSignals: [],
+  })
+
+  expect(() => renderer.input(Buffer.from("a"))).toThrow("input() is only available in stream output mode")
+
+  renderer.destroy()
+  await renderer.idle()
 })

--- a/packages/core/src/tests/renderer.stream-mode.test.ts
+++ b/packages/core/src/tests/renderer.stream-mode.test.ts
@@ -90,6 +90,31 @@ test("stream mode destroy finalizes after pending async onOutput", async () => {
   expect(renderer.isDestroyed).toBe(true)
 })
 
+test("stream mode destroy does not pause process.stdin", async () => {
+  const originalPause = process.stdin.pause
+  const stdinAny = process.stdin as any
+  let pauseCalls = 0
+
+  stdinAny.pause = function patchedPause() {
+    pauseCalls += 1
+    return process.stdin
+  }
+
+  try {
+    const renderer = await createCliRenderer({
+      ...streamDefaults,
+      onOutput: () => {},
+    })
+
+    renderer.destroy()
+    await renderer.idle()
+
+    expect(pauseCalls).toBe(0)
+  } finally {
+    stdinAny.pause = originalPause
+  }
+})
+
 test("stream mode input() processes data through key handlers", async () => {
   let keypressReceived = false
 

--- a/packages/core/src/tests/renderer.stream-validation.test.ts
+++ b/packages/core/src/tests/renderer.stream-validation.test.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "bun:test"
+import { createCliRenderer } from "../renderer"
+
+test("stream output mode requires onOutput", async () => {
+  await expect(createCliRenderer({ outputMode: "stream" } as any)).rejects.toThrow(
+    'outputMode "stream" requires onOutput',
+  )
+})
+
+test("stream output mode requires width", async () => {
+  await expect(
+    createCliRenderer({
+      outputMode: "stream",
+      height: 24,
+      onOutput: () => {},
+    } as any),
+  ).rejects.toThrow('outputMode "stream" requires width to be a positive integer')
+})
+
+test("stream output mode requires height", async () => {
+  await expect(
+    createCliRenderer({
+      outputMode: "stream",
+      width: 80,
+      onOutput: () => {},
+    } as any),
+  ).rejects.toThrow('outputMode "stream" requires height to be a positive integer')
+})
+
+test("stream output mode requires integer dimensions", async () => {
+  await expect(
+    createCliRenderer({
+      outputMode: "stream",
+      width: 80.5,
+      height: 24,
+      onOutput: () => {},
+    }),
+  ).rejects.toThrow('outputMode "stream" requires width to be a positive integer')
+
+  await expect(
+    createCliRenderer({
+      outputMode: "stream",
+      width: 80,
+      height: 0,
+      onOutput: () => {},
+    }),
+  ).rejects.toThrow('outputMode "stream" requires height to be a positive integer')
+})

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -134,7 +134,7 @@ function getOpenTUILib(libPath?: string) {
     },
     // Renderer management
     createRenderer: {
-      args: ["u32", "u32", "bool", "bool"],
+      args: ["u32", "u32", "bool", "u8", "bool", "ptr"],
       returns: "ptr",
     },
     setTerminalEnvVar: {
@@ -1381,7 +1381,11 @@ export interface CursorState {
 export type NativeSpanFeedEventHandler = (eventId: number, arg0: Pointer, arg1: number | bigint) => void
 
 export interface RenderLib {
-  createRenderer: (width: number, height: number, options?: { testing?: boolean; remote?: boolean }) => Pointer | null
+  createRenderer: (
+    width: number,
+    height: number,
+    options?: { testing?: boolean; outputStrategy?: number; remote?: boolean; feedPtr?: Pointer | null },
+  ) => Pointer | null
   setTerminalEnvVar: (renderer: Pointer, key: string, value: string) => boolean
   destroyRenderer: (renderer: Pointer) => void
   setUseThread: (renderer: Pointer, useThread: boolean) => void
@@ -1992,10 +1996,18 @@ class FFIRenderLib implements RenderLib {
     this.opentui.symbols.setEventCallback(callbackPtr)
   }
 
-  public createRenderer(width: number, height: number, options: { testing?: boolean; remote?: boolean } = {}) {
+  public createRenderer(
+    width: number,
+    height: number,
+    options: { testing?: boolean; outputStrategy?: number; remote?: boolean; feedPtr?: Pointer | null } = {},
+  ) {
     const testing = options.testing ?? false
+    // Keep numeric strategy mapping aligned with Zig createRenderer ABI.
+    const strategy = options.outputStrategy ?? 0 // 0 = stdout (default), 1 = span_feed
     const remote = options.remote ?? false
-    return this.opentui.symbols.createRenderer(width, height, testing, remote)
+    // feedPtr is an internal wiring detail for stream mode; public callers use outputMode/onOutput.
+    const feedPtr = options.feedPtr ?? null
+    return this.opentui.symbols.createRenderer(width, height, testing, strategy, remote, feedPtr)
   }
 
   public setTerminalEnvVar(renderer: Pointer, key: string, value: string): boolean {

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -184,15 +184,35 @@ export fn getAllocatorStats(out_ptr: *ExternalAllocatorStats) void {
     };
 }
 
-export fn createRenderer(width: u32, height: u32, testing: bool, remote: bool) ?*renderer.CliRenderer {
+// Positional args rather than an extern struct: only 2 TS call sites and 6 params.
+// A struct-by-pointer approach would add a TS/Zig definition sync burden with no
+// compile-time guard against field drift. Reconsider if this grows past ~6 params.
+// outputStrategy is an ABI contract shared with TS: 0 = stdout, 1 = span_feed.
+// feedPtr is required for span_feed and ignored for stdout.
+export fn createRenderer(width: u32, height: u32, testing: bool, outputStrategy: u8, remote: bool, feedPtr: ?*native_span_feed.Stream) ?*renderer.CliRenderer {
     if (width == 0 or height == 0) {
         logger.warn("Invalid renderer dimensions: {}x{}", .{ width, height });
         return null;
     }
 
+    if (outputStrategy == 1 and feedPtr == null) {
+        logger.warn("span_feed strategy requires a non-null feed pointer", .{});
+        return null;
+    }
+
+    if (outputStrategy > 1) {
+        logger.warn("Invalid output strategy: {}", .{outputStrategy});
+        return null;
+    }
+
     const pool = gp.initGlobalPool(globalArena);
     _ = link.initGlobalLinkPool(globalArena);
-    return renderer.CliRenderer.createWithOptions(globalAllocator, width, height, pool, testing, remote) catch |err| {
+    return renderer.CliRenderer.create(globalAllocator, width, height, pool, .{
+        .testing = testing,
+        .output_strategy = outputStrategy,
+        .remote = remote,
+        .feed_ptr = feedPtr,
+    }) catch |err| {
         logger.err("Failed to create renderer: {}", .{err});
         return null;
     };

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -195,13 +195,13 @@ export fn createRenderer(width: u32, height: u32, testing: bool, outputStrategy:
         return null;
     }
 
-    if (outputStrategy == 1 and feedPtr == null) {
-        logger.warn("span_feed strategy requires a non-null feed pointer", .{});
-        return null;
-    }
-
-    if (outputStrategy > 1) {
+    const strategyTag = renderer.CliRenderer.OutputStrategyTag.fromU8(outputStrategy) orelse {
         logger.warn("Invalid output strategy: {}", .{outputStrategy});
+        return null;
+    };
+
+    if (strategyTag == .span_feed and feedPtr == null) {
+        logger.warn("span_feed strategy requires a non-null feed pointer", .{});
         return null;
     }
 
@@ -209,7 +209,7 @@ export fn createRenderer(width: u32, height: u32, testing: bool, outputStrategy:
     _ = link.initGlobalLinkPool(globalArena);
     return renderer.CliRenderer.create(globalAllocator, width, height, pool, .{
         .testing = testing,
-        .output_strategy = outputStrategy,
+        .output_strategy = strategyTag,
         .remote = remote,
         .feed_ptr = feedPtr,
     }) catch |err| {

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -184,6 +184,11 @@ pub const CliRenderer = struct {
         feed: *NativeSpanFeed.Stream,
     };
 
+    /// Writes data to the NativeSpanFeed stream.
+    /// All StreamError variants (NoSpace, MaxBytes, Invalid, OutOfMemory, Busy)
+    /// are collapsed into FeedWriteError because prepareRenderFrameWithWriter
+    /// catches all write errors uniformly — there is no recovery path that
+    /// differs by error kind. Revisit if richer observability is needed.
     fn feedWrite(ctx: FeedWriterContext, data: []const u8) error{FeedWriteError}!usize {
         ctx.feed.write(data) catch return error.FeedWriteError;
         return data.len;
@@ -196,23 +201,37 @@ pub const CliRenderer = struct {
         };
     }
 
+    /// ABI tag mapping from the u8 passed by TS FFI to a type-safe enum.
+    /// Convert at the lib.zig boundary via `fromU8`, then use the enum internally.
+    pub const OutputStrategyTag = enum(u8) {
+        stdout = 0,
+        span_feed = 1,
+
+        pub fn fromU8(value: u8) ?OutputStrategyTag {
+            return switch (value) {
+                0 => .stdout,
+                1 => .span_feed,
+                else => null,
+            };
+        }
+    };
+
     pub const CreateOptions = struct {
         testing: bool = false,
-        output_strategy: u8 = 0, // 0 = stdout, 1 = span_feed
+        output_strategy: OutputStrategyTag = .stdout,
         remote: bool = false,
         feed_ptr: ?*NativeSpanFeed.Stream = null,
     };
 
     pub fn create(allocator: Allocator, width: u32, height: u32, pool: *gp.GraphemePool, opts: CreateOptions) !*CliRenderer {
         // Non-stdout strategies imply remote output behavior.
-        const remote = opts.remote or (opts.output_strategy != 0);
+        const remote = opts.remote or (opts.output_strategy != .stdout);
         const outputStrategy: OutputStrategy = switch (opts.output_strategy) {
-            0 => .{ .stdout = {} },
-            1 => blk: {
+            .stdout => .{ .stdout = {} },
+            .span_feed => blk: {
                 const feed_ptr = opts.feed_ptr orelse return error.InvalidOutputStrategy;
                 break :blk .{ .span_feed = .{ .feed = feed_ptr } };
             },
-            else => return error.InvalidOutputStrategy,
         };
         const self = try allocator.create(CliRenderer);
         errdefer allocator.destroy(self);
@@ -256,7 +275,7 @@ pub const CliRenderer = struct {
         const hitScissorStack: std.ArrayListUnmanaged(buf.ClipRect) = .{};
 
         // Allocate instance output buffers only for strategies that use them.
-        const uses_instance_buffers = opts.output_strategy == 0;
+        const uses_instance_buffers = opts.output_strategy == .stdout;
         const instanceOutputA = if (uses_instance_buffers)
             try allocator.alloc(u8, OUTPUT_BUFFER_SIZE)
         else
@@ -367,14 +386,11 @@ pub const CliRenderer = struct {
         self.allocator.destroy(self);
     }
 
-    /// Free instance output buffers (called in destroy)
+    /// Free instance output buffers (called in destroy).
+    /// Always free unconditionally — Zig allocators handle zero-length slices safely.
     fn freeInstanceBuffers(self: *CliRenderer) void {
-        if (self.instanceOutputA.len > 0) {
-            self.allocator.free(self.instanceOutputA);
-        }
-        if (self.instanceOutputB.len > 0) {
-            self.allocator.free(self.instanceOutputB);
-        }
+        self.allocator.free(self.instanceOutputA);
+        self.allocator.free(self.instanceOutputB);
     }
 
     pub fn setupTerminal(self: *CliRenderer, useAlternateScreen: bool) void {
@@ -450,10 +466,17 @@ pub const CliRenderer = struct {
         // Write first batch
         self.writeOut(stream.getWritten());
 
-        // Sleep and write showCursor again (Ghostty workaround)
-        std.Thread.sleep(10 * std.time.ns_per_ms);
-        self.writeOut(ansi.ANSI.showCursor);
-        std.Thread.sleep(10 * std.time.ns_per_ms);
+        // Sleep + resend showCursor as a terminal compatibility workaround.
+        // Only needed for stdout (local terminal); span_feed delegates
+        // cursor visibility to the remote client.
+        switch (self.outputStrategy) {
+            .stdout => {
+                std.Thread.sleep(10 * std.time.ns_per_ms);
+                self.writeOut(ansi.ANSI.showCursor);
+                std.Thread.sleep(10 * std.time.ns_per_ms);
+            },
+            .span_feed => {},
+        }
     }
 
     fn addStatSample(self: *CliRenderer, comptime T: type, samples: *std.ArrayListUnmanaged(T), value: T) void {
@@ -613,6 +636,8 @@ pub const CliRenderer = struct {
     // Render once with current state
     pub fn render(self: *CliRenderer, force: bool) void {
         // Backpressure check for span_feed strategy.
+        // When skipping, lastRenderTime is intentionally NOT updated (catch-up
+        // semantics): the next successful render sees the full elapsed delta
         switch (self.outputStrategy) {
             .stdout => {},
             .span_feed => |sf| {
@@ -1021,10 +1046,21 @@ pub const CliRenderer = struct {
                 w.flush() catch {};
             },
             .span_feed => |sf| {
+                var wrote_any = false;
                 for (data_slices) |slice| {
-                    sf.feed.write(slice) catch break;
+                    sf.feed.write(slice) catch {
+                        // Flush anything already written in this batch to avoid
+                        // carrying orphaned bytes into a later commit.
+                        if (wrote_any) {
+                            sf.feed.commit() catch {};
+                        }
+                        return;
+                    };
+                    wrote_any = true;
                 }
-                sf.feed.commit() catch {};
+                if (wrote_any) {
+                    sf.feed.commit() catch {};
+                }
             },
         }
     }
@@ -1261,6 +1297,10 @@ pub const CliRenderer = struct {
         writer.flush() catch {};
     }
 
+    /// Return the last rendered output from instance buffers.
+    /// NOTE: Only meaningful for stdout strategy — span_feed renderers use
+    /// zero-length instance buffers and output goes through the feed instead.
+    /// Use drainFeedBytes() in tests for span_feed renderers.
     pub fn getLastOutputForTest(self: *CliRenderer) []const u8 {
         // Return the current active instance buffer contents
         const buffer = if (self.instanceActiveBuffer == .A) self.instanceOutputA else self.instanceOutputB;

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -6,6 +6,7 @@ const gp = @import("grapheme.zig");
 const link = @import("link.zig");
 const Terminal = @import("terminal.zig");
 const logger = @import("logger.zig");
+const NativeSpanFeed = @import("native-span-feed.zig");
 
 pub const RGBA = ansi.RGBA;
 pub const OptimizedBuffer = buf.OptimizedBuffer;
@@ -17,11 +18,23 @@ const MAX_STAT_SAMPLES = 30;
 const STAT_SAMPLE_CAPACITY = 30;
 
 const COLOR_EPSILON_DEFAULT: f32 = 0.00001;
-const OUTPUT_BUFFER_SIZE = 1024 * 1024 * 2; // 2MB
+pub const OUTPUT_BUFFER_SIZE = 1024 * 1024 * 2; // 2MB
+
+/// Output strategy for the renderer.
+/// Strategy is immutable after renderer creation.
+pub const OutputStrategy = union(enum) {
+    /// Write directly to stdout (default)
+    stdout: void,
+    /// Write output into NativeSpanFeed stream memory.
+    span_feed: struct {
+        feed: *NativeSpanFeed.Stream,
+    },
+};
 
 pub const RendererError = error{
     OutOfMemory,
     InvalidDimensions,
+    InvalidOutputStrategy,
     ThreadingFailed,
     WriteFailed,
 };
@@ -129,48 +142,78 @@ pub const CliRenderer = struct {
     lastCursorColorRGB: ?[3]u8 = null,
     lastMousePointerStyle: Terminal.MousePointerStyle = .default,
 
-    // Preallocated output buffer
-    var outputBuffer: [OUTPUT_BUFFER_SIZE]u8 = undefined;
-    var outputBufferLen: usize = 0;
-    var outputBufferB: [OUTPUT_BUFFER_SIZE]u8 = undefined;
-    var outputBufferBLen: usize = 0;
-    var activeBuffer: enum { A, B } = .A;
+    // Stream-agnostic output support
+    outputStrategy: OutputStrategy = .{ .stdout = {} },
 
-    const OutputBufferWriter = struct {
-        pub fn write(_: void, data: []const u8) !usize {
-            const bufferLen = if (activeBuffer == .A) &outputBufferLen else &outputBufferBLen;
-            const buffer = if (activeBuffer == .A) &outputBuffer else &outputBufferB;
+    // Per-renderer output buffers (unified architecture)
+    // These instance buffers replace the shared static buffers (removed in T9).
+    // Allocated unconditionally in create(), freed in destroy().
+    instanceOutputA: []u8,
+    instanceOutputB: []u8,
+    instanceOutputLenA: usize = 0,
+    instanceOutputLenB: usize = 0,
+    instanceActiveBuffer: enum { A, B } = .A,
 
-            if (bufferLen.* + data.len > buffer.len) {
-                // TODO: Resize buffer when necessary
-                return error.BufferFull;
-            }
-
-            @memcpy(buffer.*[bufferLen.*..][0..data.len], data);
-            bufferLen.* += data.len;
-
-            return data.len;
-        }
-
-        // TODO: std.io.GenericWriter is deprecated, however the "correct" option seems to be much more involved
-        // So I have simply used GenericWriter here, and then the proper migration can be done later
-        pub fn writer() std.io.GenericWriter(void, error{BufferFull}, write) {
-            return .{ .context = {} };
-        }
+    /// Writer context for unified buffer writer (uses instance buffers)
+    const BufferWriterContext = struct {
+        renderer: *CliRenderer,
     };
 
-    pub fn create(allocator: Allocator, width: u32, height: u32, pool: *gp.GraphemePool, testing: bool) !*CliRenderer {
-        return createWithOptions(allocator, width, height, pool, testing, false);
+    fn bufferWrite(ctx: BufferWriterContext, data: []const u8) !usize {
+        const self = ctx.renderer;
+        const bufferLen = if (self.instanceActiveBuffer == .A) &self.instanceOutputLenA else &self.instanceOutputLenB;
+        const buffer = if (self.instanceActiveBuffer == .A) self.instanceOutputA else self.instanceOutputB;
+
+        if (bufferLen.* + data.len > buffer.len) {
+            return error.BufferFull;
+        }
+
+        @memcpy(buffer[bufferLen.*..][0..data.len], data);
+        bufferLen.* += data.len;
+
+        return data.len;
     }
 
-    pub fn createWithOptions(
-        allocator: Allocator,
-        width: u32,
-        height: u32,
-        pool: *gp.GraphemePool,
-        testing: bool,
-        remote: bool,
-    ) !*CliRenderer {
+    /// Unified buffer writer for instance buffers.
+    fn bufferWriter(self: *CliRenderer) std.io.GenericWriter(BufferWriterContext, error{BufferFull}, bufferWrite) {
+        return .{ .context = .{ .renderer = self } };
+    }
+
+    /// Writer context for NativeSpanFeed stream output.
+    const FeedWriterContext = struct {
+        feed: *NativeSpanFeed.Stream,
+    };
+
+    fn feedWrite(ctx: FeedWriterContext, data: []const u8) error{FeedWriteError}!usize {
+        ctx.feed.write(data) catch return error.FeedWriteError;
+        return data.len;
+    }
+
+    fn feedWriter(self: *CliRenderer) ?std.io.GenericWriter(FeedWriterContext, error{FeedWriteError}, feedWrite) {
+        return switch (self.outputStrategy) {
+            .span_feed => |sf| .{ .context = .{ .feed = sf.feed } },
+            .stdout => null,
+        };
+    }
+
+    pub const CreateOptions = struct {
+        testing: bool = false,
+        output_strategy: u8 = 0, // 0 = stdout, 1 = span_feed
+        remote: bool = false,
+        feed_ptr: ?*NativeSpanFeed.Stream = null,
+    };
+
+    pub fn create(allocator: Allocator, width: u32, height: u32, pool: *gp.GraphemePool, opts: CreateOptions) !*CliRenderer {
+        // Non-stdout strategies imply remote output behavior.
+        const remote = opts.remote or (opts.output_strategy != 0);
+        const outputStrategy: OutputStrategy = switch (opts.output_strategy) {
+            0 => .{ .stdout = {} },
+            1 => blk: {
+                const feed_ptr = opts.feed_ptr orelse return error.InvalidOutputStrategy;
+                break :blk .{ .span_feed = .{ .feed = feed_ptr } };
+            },
+            else => return error.InvalidOutputStrategy,
+        };
         const self = try allocator.create(CliRenderer);
         errdefer allocator.destroy(self);
 
@@ -212,6 +255,19 @@ pub const CliRenderer = struct {
         @memset(nextHitGrid, 0);
         const hitScissorStack: std.ArrayListUnmanaged(buf.ClipRect) = .{};
 
+        // Allocate instance output buffers only for strategies that use them.
+        const uses_instance_buffers = opts.output_strategy == 0;
+        const instanceOutputA = if (uses_instance_buffers)
+            try allocator.alloc(u8, OUTPUT_BUFFER_SIZE)
+        else
+            try allocator.alloc(u8, 0);
+        errdefer allocator.free(instanceOutputA);
+        const instanceOutputB = if (uses_instance_buffers)
+            try allocator.alloc(u8, OUTPUT_BUFFER_SIZE)
+        else
+            try allocator.alloc(u8, 0);
+        errdefer allocator.free(instanceOutputB);
+
         self.* = .{
             .width = width,
             .height = height,
@@ -221,7 +277,7 @@ pub const CliRenderer = struct {
             .backgroundColor = .{ 0.0, 0.0, 0.0, 0.0 },
             .renderOffset = 0,
             .terminal = Terminal.init(.{ .remote = remote }),
-            .testing = testing,
+            .testing = opts.testing,
             .lastCursorStyleTag = null,
             .lastCursorBlinking = null,
             .lastCursorColorRGB = null,
@@ -258,6 +314,11 @@ pub const CliRenderer = struct {
             .hitGridWidth = width,
             .hitGridHeight = height,
             .hitScissorStack = hitScissorStack,
+            // Instance output buffers (allocated only for stdout)
+            .instanceOutputA = instanceOutputA,
+            .instanceOutputB = instanceOutputB,
+            // Output strategy (immutable after creation)
+            .outputStrategy = outputStrategy,
         };
 
         try currentBuffer.clear(.{ self.backgroundColor[0], self.backgroundColor[1], self.backgroundColor[2], self.backgroundColor[3] }, CLEAR_CHAR);
@@ -300,27 +361,41 @@ pub const CliRenderer = struct {
         self.allocator.free(self.nextHitGrid);
         self.hitScissorStack.deinit(self.allocator);
 
+        // Free instance output buffers if allocated
+        self.freeInstanceBuffers();
+
         self.allocator.destroy(self);
+    }
+
+    /// Free instance output buffers (called in destroy)
+    fn freeInstanceBuffers(self: *CliRenderer) void {
+        if (self.instanceOutputA.len > 0) {
+            self.allocator.free(self.instanceOutputA);
+        }
+        if (self.instanceOutputB.len > 0) {
+            self.allocator.free(self.instanceOutputB);
+        }
     }
 
     pub fn setupTerminal(self: *CliRenderer, useAlternateScreen: bool) void {
         self.useAlternateScreen = useAlternateScreen;
         self.terminalSetup = true;
 
-        var stdoutWriter = std.fs.File.stdout().writer(&self.stdoutBuffer);
-        const writer = &stdoutWriter.interface;
-
-        self.terminal.queryTerminalSend(writer) catch {
+        // Query terminal capabilities - write to appropriate output
+        var queryBuf: [256]u8 = undefined;
+        var queryStream = std.io.fixedBufferStream(&queryBuf);
+        self.terminal.queryTerminalSend(queryStream.writer()) catch {
             logger.warn("Failed to query terminal capabilities", .{});
         };
-        writer.flush() catch {};
+        self.writeOut(queryStream.getWritten());
 
         self.setupTerminalWithoutDetection(useAlternateScreen);
     }
 
     fn setupTerminalWithoutDetection(self: *CliRenderer, useAlternateScreen: bool) void {
-        var stdoutWriter = std.fs.File.stdout().writer(&self.stdoutBuffer);
-        const writer = &stdoutWriter.interface;
+        var setupBuf: [1024]u8 = undefined;
+        var stream = std.io.fixedBufferStream(&setupBuf);
+        const writer = stream.writer();
 
         writer.writeAll(ansi.ANSI.saveCursorState) catch {};
 
@@ -334,7 +409,7 @@ pub const CliRenderer = struct {
         const useKitty = self.terminal.opts.kitty_keyboard_flags > 0;
         self.terminal.enableDetectedFeatures(writer, useKitty) catch {};
 
-        writer.flush() catch {};
+        self.writeOut(stream.getWritten());
     }
 
     pub fn suspendRenderer(self: *CliRenderer) void {
@@ -350,35 +425,34 @@ pub const CliRenderer = struct {
     pub fn performShutdownSequence(self: *CliRenderer) void {
         if (!self.terminalSetup) return;
 
-        var stdoutWriter = std.fs.File.stdout().writer(&self.stdoutBuffer);
-        const direct = &stdoutWriter.interface;
-        self.terminal.resetState(direct) catch {
+        // Build shutdown sequence in buffer
+        var shutdownBuf: [1024]u8 = undefined;
+        var stream = std.io.fixedBufferStream(&shutdownBuf);
+        const writer = stream.writer();
+
+        self.terminal.resetState(writer) catch {
             logger.warn("Failed to reset terminal state", .{});
         };
 
-        if (self.useAlternateScreen) {
-            direct.flush() catch {};
-        } else if (self.renderOffset == 0) {
-            direct.writeAll("\x1b[H\x1b[J") catch {};
-            direct.flush() catch {};
-        } else if (self.renderOffset > 0) {
-            // Currently still handled in typescript
-            // const consoleEndLine = self.height - self.renderOffset;
-            // ansi.ANSI.moveToOutput(direct, 1, consoleEndLine) catch {};
+        if (!self.useAlternateScreen and self.renderOffset == 0) {
+            writer.writeAll("\x1b[H\x1b[J") catch {};
         }
 
         // NOTE: This messes up state after shutdown, but might be necessary for windows?
-        // direct.writeAll(ansi.ANSI.restoreCursorState) catch {};
+        // writer.writeAll(ansi.ANSI.restoreCursorState) catch {};
 
-        direct.writeAll(ansi.ANSI.resetCursorColorFallback) catch {};
-        direct.writeAll(ansi.ANSI.resetCursorColor) catch {};
-        direct.writeAll(ansi.ANSI.defaultCursorStyle) catch {};
+        writer.writeAll(ansi.ANSI.resetCursorColorFallback) catch {};
+        writer.writeAll(ansi.ANSI.resetCursorColor) catch {};
+        writer.writeAll(ansi.ANSI.defaultCursorStyle) catch {};
         // Workaround for Ghostty not showing the cursor after shutdown for some reason
-        direct.writeAll(ansi.ANSI.showCursor) catch {};
-        direct.flush() catch {};
+        writer.writeAll(ansi.ANSI.showCursor) catch {};
+
+        // Write first batch
+        self.writeOut(stream.getWritten());
+
+        // Sleep and write showCursor again (Ghostty workaround)
         std.Thread.sleep(10 * std.time.ns_per_ms);
-        direct.writeAll(ansi.ANSI.showCursor) catch {};
-        direct.flush() catch {};
+        self.writeOut(ansi.ANSI.showCursor);
         std.Thread.sleep(10 * std.time.ns_per_ms);
     }
 
@@ -410,7 +484,12 @@ pub const CliRenderer = struct {
     pub fn setUseThread(self: *CliRenderer, useThread: bool) void {
         if (self.useThread == useThread) return;
 
+        // Non-stdout strategies are kept single-threaded.
         if (useThread) {
+            switch (self.outputStrategy) {
+                .stdout => {},
+                .span_feed => return, // Keep non-stdout strategies single-threaded
+            }
             if (self.renderThread == null) {
                 self.renderThread = std.Thread.spawn(.{}, renderThreadFn, .{self}) catch |err| {
                     std.log.warn("Failed to spawn render thread: {}, falling back to non-threaded mode", .{err});
@@ -533,6 +612,16 @@ pub const CliRenderer = struct {
 
     // Render once with current state
     pub fn render(self: *CliRenderer, force: bool) void {
+        // Backpressure check for span_feed strategy.
+        switch (self.outputStrategy) {
+            .stdout => {},
+            .span_feed => |sf| {
+                const pending_spans = sf.feed.getStats().pending_spans;
+                const span_capacity = sf.feed.options.span_queue_capacity;
+                if (span_capacity > 0 and pending_spans >= span_capacity) return;
+            },
+        }
+
         const now = std.time.microTimestamp();
         const deltaTimeMs = @as(f64, @floatFromInt(now - self.lastRenderTime));
         const deltaTime = deltaTimeMs / 1000.0; // Convert to seconds
@@ -540,37 +629,56 @@ pub const CliRenderer = struct {
         self.lastRenderTime = now;
         self.renderDebugOverlay();
 
-        self.prepareRenderFrame(force);
+        switch (self.outputStrategy) {
+            .span_feed => |sf| {
+                var writer = self.feedWriter() orelse return;
+                self.prepareRenderFrameWithWriter(&writer, force);
+                if (!self.testing) {
+                    sf.feed.commit() catch {};
+                }
+            },
+            .stdout => self.prepareRenderFrame(force),
+        }
 
-        if (self.useThread) {
-            self.renderMutex.lock();
-            while (self.renderInProgress) {
-                self.renderCondition.wait(&self.renderMutex);
-            }
+        // Output dispatch based on strategy
+        switch (self.outputStrategy) {
+            .stdout => {
+                if (self.useThread) {
+                    self.renderMutex.lock();
+                    while (self.renderInProgress) {
+                        self.renderCondition.wait(&self.renderMutex);
+                    }
 
-            if (activeBuffer == .A) {
-                activeBuffer = .B;
-                self.currentOutputBuffer = &outputBuffer;
-                self.currentOutputLen = outputBufferLen;
-            } else {
-                activeBuffer = .A;
-                self.currentOutputBuffer = &outputBufferB;
-                self.currentOutputLen = outputBufferBLen;
-            }
+                    // Hand off instance buffer to render thread
+                    if (self.instanceActiveBuffer == .A) {
+                        self.currentOutputBuffer = self.instanceOutputA;
+                        self.currentOutputLen = self.instanceOutputLenA;
+                        self.instanceActiveBuffer = .B;
+                    } else {
+                        self.currentOutputBuffer = self.instanceOutputB;
+                        self.currentOutputLen = self.instanceOutputLenB;
+                        self.instanceActiveBuffer = .A;
+                    }
 
-            self.renderRequested = true;
-            self.renderInProgress = true;
-            self.renderCondition.signal();
-            self.renderMutex.unlock();
-        } else {
-            const writeStart = std.time.microTimestamp();
-            if (!self.testing) {
-                var stdoutWriter = std.fs.File.stdout().writer(&self.stdoutBuffer);
-                const w = &stdoutWriter.interface;
-                w.writeAll(outputBuffer[0..outputBufferLen]) catch {};
-                w.flush() catch {};
-            }
-            self.renderStats.stdoutWriteTime = @as(f64, @floatFromInt(std.time.microTimestamp() - writeStart));
+                    self.renderRequested = true;
+                    self.renderInProgress = true;
+                    self.renderCondition.signal();
+                    self.renderMutex.unlock();
+                } else {
+                    const writeStart = std.time.microTimestamp();
+                    if (!self.testing) {
+                        var stdoutWriter = std.fs.File.stdout().writer(&self.stdoutBuffer);
+                        const w = &stdoutWriter.interface;
+                        // Use instance buffer
+                        const buffer = if (self.instanceActiveBuffer == .A) self.instanceOutputA else self.instanceOutputB;
+                        const len = if (self.instanceActiveBuffer == .A) self.instanceOutputLenA else self.instanceOutputLenB;
+                        w.writeAll(buffer[0..len]) catch {};
+                        w.flush() catch {};
+                    }
+                    self.renderStats.stdoutWriteTime = @as(f64, @floatFromInt(std.time.microTimestamp() - writeStart));
+                }
+            },
+            .span_feed => {},
         }
 
         self.renderStats.lastFrameTime = deltaTime * 1000.0;
@@ -597,17 +705,24 @@ pub const CliRenderer = struct {
         return self.currentRenderBuffer;
     }
 
+    /// Prepare render frame using unified instance buffers.
     fn prepareRenderFrame(self: *CliRenderer, force: bool) void {
-        const renderStartTime = std.time.microTimestamp();
-        var cellsUpdated: u32 = 0;
-
-        if (activeBuffer == .A) {
-            outputBufferLen = 0;
+        // Reset the active instance buffer
+        if (self.instanceActiveBuffer == .A) {
+            self.instanceOutputLenA = 0;
         } else {
-            outputBufferBLen = 0;
+            self.instanceOutputLenB = 0;
         }
 
-        var writer = OutputBufferWriter.writer();
+        // Use unified instance buffer writer
+        var writer = self.bufferWriter();
+        self.prepareRenderFrameWithWriter(&writer, force);
+    }
+
+    /// Core render frame preparation logic, parameterized by writer type
+    fn prepareRenderFrameWithWriter(self: *CliRenderer, writer: anytype, force: bool) void {
+        const renderStartTime = std.time.microTimestamp();
+        var cellsUpdated: u32 = 0;
 
         writer.writeAll(ansi.ANSI.syncSet) catch {};
         writer.writeAll(ansi.ANSI.hideCursor) catch {};
@@ -850,34 +965,36 @@ pub const CliRenderer = struct {
         self.writeOut(ansi.ANSI.clearAndHome);
     }
 
+    /// Write data to output.
     pub fn writeOut(self: *CliRenderer, data: []const u8) void {
         if (data.len == 0) return;
         if (self.testing) return;
 
-        if (self.useThread) {
-            self.renderMutex.lock();
-            while (self.renderInProgress) {
-                self.renderCondition.wait(&self.renderMutex);
-            }
-            self.renderMutex.unlock();
-        }
+        switch (self.outputStrategy) {
+            .stdout => {
+                if (self.useThread) {
+                    self.renderMutex.lock();
+                    while (self.renderInProgress) {
+                        self.renderCondition.wait(&self.renderMutex);
+                    }
+                    self.renderMutex.unlock();
+                }
 
-        var stdoutWriter = std.fs.File.stdout().writer(&self.stdoutBuffer);
-        const w = &stdoutWriter.interface;
-        w.writeAll(data) catch {};
-        w.flush() catch {};
+                var stdoutWriter = std.fs.File.stdout().writer(&self.stdoutBuffer);
+                const w = &stdoutWriter.interface;
+                w.writeAll(data) catch {};
+                w.flush() catch {};
+            },
+            .span_feed => |sf| {
+                sf.feed.write(data) catch return;
+                sf.feed.commit() catch {};
+            },
+        }
     }
 
+    /// Write multiple data slices to output.
     pub fn writeOutMultiple(self: *CliRenderer, data_slices: []const []const u8) void {
         if (self.testing) return;
-
-        if (self.useThread) {
-            self.renderMutex.lock();
-            while (self.renderInProgress) {
-                self.renderCondition.wait(&self.renderMutex);
-            }
-            self.renderMutex.unlock();
-        }
 
         var totalLen: usize = 0;
         for (data_slices) |slice| {
@@ -886,12 +1003,30 @@ pub const CliRenderer = struct {
 
         if (totalLen == 0) return;
 
-        var stdoutWriter = std.fs.File.stdout().writer(&self.stdoutBuffer);
-        const w = &stdoutWriter.interface;
-        for (data_slices) |slice| {
-            w.writeAll(slice) catch {};
+        switch (self.outputStrategy) {
+            .stdout => {
+                if (self.useThread) {
+                    self.renderMutex.lock();
+                    while (self.renderInProgress) {
+                        self.renderCondition.wait(&self.renderMutex);
+                    }
+                    self.renderMutex.unlock();
+                }
+
+                var stdoutWriter = std.fs.File.stdout().writer(&self.stdoutBuffer);
+                const w = &stdoutWriter.interface;
+                for (data_slices) |slice| {
+                    w.writeAll(slice) catch {};
+                }
+                w.flush() catch {};
+            },
+            .span_feed => |sf| {
+                for (data_slices) |slice| {
+                    sf.feed.write(slice) catch break;
+                }
+                sf.feed.commit() catch {};
+            },
         }
-        w.flush() catch {};
     }
 
     /// Write a renderable's bounds to nextHitGrid for the upcoming frame.
@@ -1126,16 +1261,14 @@ pub const CliRenderer = struct {
         writer.flush() catch {};
     }
 
-    pub fn getLastOutputForTest(_: *CliRenderer) []const u8 {
-        // In non-threaded mode, we want the current active buffer
-        // In threaded mode, we want the previously rendered buffer
-        const currentBuffer = if (activeBuffer == .A) &outputBuffer else &outputBufferB;
-        const currentLen = if (activeBuffer == .A) outputBufferLen else outputBufferBLen;
-        return currentBuffer.*[0..currentLen];
+    pub fn getLastOutputForTest(self: *CliRenderer) []const u8 {
+        // Return the current active instance buffer contents
+        const buffer = if (self.instanceActiveBuffer == .A) self.instanceOutputA else self.instanceOutputB;
+        const len = if (self.instanceActiveBuffer == .A) self.instanceOutputLenA else self.instanceOutputLenB;
+        return buffer[0..len];
     }
 
     pub fn dumpStdoutBuffer(self: *CliRenderer, timestamp: i64) void {
-        _ = self;
         std.fs.cwd().makeDir("buffer_dump") catch |err| switch (err) {
             error.PathAlreadyExists => {},
             else => return,
@@ -1151,22 +1284,23 @@ pub const CliRenderer = struct {
         var fileWriter = file.writer(&fileBuffer);
         const writer = &fileWriter.interface;
 
-        writer.print("Stdout Buffer Output (timestamp: {d}):\n", .{timestamp}) catch return;
+        writer.print("Instance Buffer Output (timestamp: {d}):\n", .{timestamp}) catch return;
         writer.writeAll("Last Rendered ANSI Output:\n") catch return;
         writer.writeAll("================\n") catch return;
 
-        const lastBuffer = if (activeBuffer == .A) &outputBufferB else &outputBuffer;
-        const lastLen = if (activeBuffer == .A) outputBufferBLen else outputBufferLen;
+        // Use instance buffers (the non-active buffer contains last rendered output)
+        const lastBuffer = if (self.instanceActiveBuffer == .A) self.instanceOutputB else self.instanceOutputA;
+        const lastLen = if (self.instanceActiveBuffer == .A) self.instanceOutputLenB else self.instanceOutputLenA;
 
         if (lastLen > 0) {
-            writer.writeAll(lastBuffer.*[0..lastLen]) catch return;
+            writer.writeAll(lastBuffer[0..lastLen]) catch return;
         } else {
             writer.writeAll("(no output rendered yet)\n") catch return;
         }
 
         writer.writeAll("\n================\n") catch return;
         writer.print("Buffer size: {d} bytes\n", .{lastLen}) catch return;
-        writer.print("Active buffer: {s}\n", .{if (activeBuffer == .A) "A" else "B"}) catch return;
+        writer.print("Active buffer: {s}\n", .{if (self.instanceActiveBuffer == .A) "A" else "B"}) catch return;
         writer.flush() catch {};
     }
 

--- a/packages/core/src/zig/tests/buffer_test.zig
+++ b/packages/core/src/zig/tests/buffer_test.zig
@@ -2462,7 +2462,7 @@ test "renderer - CJK graphemes shifting left must preserve continuation cells (#
         20,
         1,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 

--- a/packages/core/src/zig/tests/buffer_test.zig
+++ b/packages/core/src/zig/tests/buffer_test.zig
@@ -2387,7 +2387,7 @@ test "renderer - grapheme WrongGeneration repro with pool slot reuse" {
         40,
         5,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -796,7 +796,7 @@ test "renderer - hyperlink spanning multiple rows uses same id" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -1053,7 +1053,10 @@ test "renderer - span_feed mode writes rendered frame to feed" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-    var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, &local_link_pool, .unicode);
     defer tb.deinit();
     try tb.setText("Span feed output");
 
@@ -1147,14 +1150,17 @@ test "renderer - multiple span_feed renderers use independent feeds" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-    var tb1 = try TextBuffer.init(std.testing.allocator, pool, .unicode);
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var tb1 = try TextBuffer.init(std.testing.allocator, pool, &local_link_pool, .unicode);
     defer tb1.deinit();
     try tb1.setText("Renderer 1");
 
     var view1 = try TextBufferView.init(std.testing.allocator, tb1);
     defer view1.deinit();
 
-    var tb2 = try TextBuffer.init(std.testing.allocator, pool, .unicode);
+    var tb2 = try TextBuffer.init(std.testing.allocator, pool, &local_link_pool, .unicode);
     defer tb2.deinit();
     try tb2.setText("Renderer 2");
 

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -1041,7 +1041,7 @@ test "renderer - instance buffers allocated by strategy" {
         80,
         24,
         pool,
-        .{ .testing = true, .output_strategy = 1, .feed_ptr = feed },
+        .{ .testing = true, .output_strategy = .span_feed, .feed_ptr = feed },
     );
     defer renderer_stream.destroy();
 
@@ -1068,7 +1068,7 @@ test "renderer - span_feed mode writes rendered frame to feed" {
         80,
         24,
         pool,
-        .{ .testing = false, .output_strategy = 1, .feed_ptr = feed },
+        .{ .testing = false, .output_strategy = .span_feed, .feed_ptr = feed },
     );
     defer cli_renderer.destroy();
 
@@ -1097,7 +1097,7 @@ test "renderer - span_feed backpressure skips render when queue is full" {
         80,
         24,
         pool,
-        .{ .testing = false, .output_strategy = 1, .feed_ptr = feed },
+        .{ .testing = false, .output_strategy = .span_feed, .feed_ptr = feed },
     );
     defer cli_renderer.destroy();
 
@@ -1133,7 +1133,7 @@ test "renderer - span_feed strategy prevents threading" {
         80,
         24,
         pool,
-        .{ .testing = true, .output_strategy = 1, .feed_ptr = feed },
+        .{ .testing = true, .output_strategy = .span_feed, .feed_ptr = feed },
     );
     defer cli_renderer.destroy();
 
@@ -1169,7 +1169,7 @@ test "renderer - multiple span_feed renderers use independent feeds" {
         80,
         24,
         pool,
-        .{ .testing = false, .output_strategy = 1, .feed_ptr = feed1 },
+        .{ .testing = false, .output_strategy = .span_feed, .feed_ptr = feed1 },
     );
     defer renderer1.destroy();
 
@@ -1181,7 +1181,7 @@ test "renderer - multiple span_feed renderers use independent feeds" {
         80,
         24,
         pool,
-        .{ .testing = false, .output_strategy = 1, .feed_ptr = feed2 },
+        .{ .testing = false, .output_strategy = .span_feed, .feed_ptr = feed2 },
     );
     defer renderer2.destroy();
 
@@ -1208,4 +1208,38 @@ test "renderer - multiple span_feed renderers use independent feeds" {
 
     try std.testing.expect(std.mem.indexOf(u8, bytes1, "Renderer 1") != null);
     try std.testing.expect(std.mem.indexOf(u8, bytes2, "Renderer 2") != null);
+}
+
+test "renderer - span_feed writeOutMultiple flushes partial batch on write failure" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+
+    var feed_options = native_span_feed.defaultOptions();
+    feed_options.chunk_size = 16;
+    feed_options.initial_chunks = 1;
+    feed_options.max_bytes = 16;
+    feed_options.growth_policy = @intFromEnum(native_span_feed.GrowthPolicy.block);
+    feed_options.auto_commit_on_full = 0;
+    feed_options.span_queue_capacity = 16;
+
+    const feed = try createAttachedFeed(std.testing.allocator, feed_options);
+    defer feed.destroy();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        80,
+        24,
+        pool,
+        .{ .testing = false, .output_strategy = .span_feed, .feed_ptr = feed },
+    );
+    defer cli_renderer.destroy();
+
+    const slices = [_][]const u8{ "12345678", "ABCDEFGHIJ" };
+    cli_renderer.writeOutMultiple(slices[0..]);
+
+    const bytes = try drainFeedBytes(std.testing.allocator, feed);
+    defer std.testing.allocator.free(bytes);
+
+    try std.testing.expect(std.mem.indexOf(u8, bytes, "12345678") != null);
+    try std.testing.expect(std.mem.indexOf(u8, bytes, "ABCDEFGHIJ") == null);
 }

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -7,6 +7,7 @@ const gp = @import("../grapheme.zig");
 const ss = @import("../syntax-style.zig");
 const link = @import("../link.zig");
 const ansi = @import("../ansi.zig");
+const native_span_feed = @import("../native-span-feed.zig");
 
 const CliRenderer = renderer.CliRenderer;
 const TextBuffer = text_buffer.TextBuffer;
@@ -19,7 +20,7 @@ fn createWithOptionsOnce(allocator: std.mem.Allocator, width: u32, height: u32) 
     defer gp.deinitGlobalPool();
     defer link.deinitGlobalLinkPool();
 
-    var cli_renderer = try CliRenderer.createWithOptions(allocator, width, height, pool, true, false);
+    var cli_renderer = try CliRenderer.create(allocator, width, height, pool, .{ .testing = true });
     cli_renderer.destroy();
 }
 
@@ -52,7 +53,7 @@ test "renderer - create and destroy" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -80,7 +81,7 @@ test "renderer - simple text rendering to currentRenderBuffer" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -123,7 +124,7 @@ test "renderer - multi-line text rendering" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -165,7 +166,7 @@ test "renderer - emoji (wide grapheme) rendering" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -223,7 +224,7 @@ test "renderer - CJK characters rendering" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -277,7 +278,7 @@ test "renderer - mixed ASCII, emoji, and CJK" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -327,7 +328,7 @@ test "renderer - resize updates dimensions" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -351,7 +352,7 @@ test "renderer - background color setting" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -380,7 +381,7 @@ test "renderer - empty text buffer renders correctly" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -406,7 +407,7 @@ test "renderer - multiple renders update currentRenderBuffer" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -452,7 +453,7 @@ test "renderer - 1000 frame render loop with setStyledText" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -536,7 +537,7 @@ test "renderer - grapheme pool refcounting with frame buffer fast path" {
         80,
         24,
         limited_pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -604,7 +605,7 @@ test "renderer - unchanged grapheme should not churn IDs across frames" {
         4,
         1,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -653,7 +654,7 @@ test "renderer - hyperlinks enabled with OSC 8 output" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -701,7 +702,7 @@ test "renderer - hyperlinks disabled no OSC 8 output" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -738,7 +739,7 @@ test "renderer - link transition mid-line" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -857,7 +858,7 @@ test "renderer - explicit_cursor_positioning emits cursor move after wide graphe
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -892,7 +893,7 @@ test "renderer - explicit_cursor_positioning produces more cursor moves" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer1.destroy();
 
@@ -909,7 +910,7 @@ test "renderer - explicit_cursor_positioning produces more cursor moves" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer2.destroy();
 
@@ -968,7 +969,7 @@ test "renderer - explicit_cursor_positioning with CJK characters" {
         80,
         24,
         pool,
-        true,
+        .{ .testing = true },
     );
     defer cli_renderer.destroy();
 
@@ -983,4 +984,228 @@ test "renderer - explicit_cursor_positioning with CJK characters" {
     const output = cli_renderer.getLastOutputForTest();
 
     try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[1;3H") != null);
+}
+
+fn createAttachedFeed(allocator: std.mem.Allocator, options: ?native_span_feed.Options) !*native_span_feed.Stream {
+    const opts = if (options) |custom| custom else native_span_feed.defaultOptions();
+    const feed = try native_span_feed.Stream.create(allocator, opts);
+    try feed.attach();
+    return feed;
+}
+
+fn drainFeedBytes(allocator: std.mem.Allocator, feed: *native_span_feed.Stream) ![]u8 {
+    var spans: [256]native_span_feed.SpanInfo = undefined;
+    var out: std.ArrayListUnmanaged(u8) = .{};
+    errdefer out.deinit(allocator);
+
+    while (true) {
+        const count = feed.drainSpans(spans[0..]);
+        if (count == 0) break;
+
+        var i: u32 = 0;
+        while (i < count) : (i += 1) {
+            const span = spans[i];
+            try out.appendSlice(allocator, span.slice());
+            feed.markSpanConsumed(span);
+        }
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+// ============================================================================
+// STREAM MODE TESTS
+// ============================================================================
+
+test "renderer - instance buffers allocated by strategy" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+
+    var renderer_stdout = try CliRenderer.create(
+        std.testing.allocator,
+        80,
+        24,
+        pool,
+        .{ .testing = true },
+    );
+    defer renderer_stdout.destroy();
+
+    try std.testing.expect(renderer_stdout.instanceOutputA.len == renderer.OUTPUT_BUFFER_SIZE);
+    try std.testing.expect(renderer_stdout.instanceOutputB.len == renderer.OUTPUT_BUFFER_SIZE);
+
+    const feed = try createAttachedFeed(std.testing.allocator, null);
+    defer feed.destroy();
+
+    var renderer_stream = try CliRenderer.create(
+        std.testing.allocator,
+        80,
+        24,
+        pool,
+        .{ .testing = true, .output_strategy = 1, .feed_ptr = feed },
+    );
+    defer renderer_stream.destroy();
+
+    try std.testing.expectEqual(@as(usize, 0), renderer_stream.instanceOutputA.len);
+    try std.testing.expectEqual(@as(usize, 0), renderer_stream.instanceOutputB.len);
+}
+
+test "renderer - span_feed mode writes rendered frame to feed" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
+    defer tb.deinit();
+    try tb.setText("Span feed output");
+
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    const feed = try createAttachedFeed(std.testing.allocator, null);
+    defer feed.destroy();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        80,
+        24,
+        pool,
+        .{ .testing = false, .output_strategy = 1, .feed_ptr = feed },
+    );
+    defer cli_renderer.destroy();
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    try next_buffer.drawTextBuffer(view, 0, 0);
+
+    cli_renderer.render(false);
+
+    const bytes = try drainFeedBytes(std.testing.allocator, feed);
+    defer std.testing.allocator.free(bytes);
+
+    try std.testing.expect(std.mem.indexOf(u8, bytes, "Span feed output") != null);
+}
+
+test "renderer - span_feed backpressure skips render when queue is full" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+
+    var feed_options = native_span_feed.defaultOptions();
+    feed_options.span_queue_capacity = 1;
+    const feed = try createAttachedFeed(std.testing.allocator, feed_options);
+    defer feed.destroy();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        80,
+        24,
+        pool,
+        .{ .testing = false, .output_strategy = 1, .feed_ptr = feed },
+    );
+    defer cli_renderer.destroy();
+
+    try feed.write("prefill");
+    try feed.commit();
+
+    const frame_before_skip = cli_renderer.renderStats.frameCount;
+    cli_renderer.render(false);
+    try std.testing.expectEqual(frame_before_skip, cli_renderer.renderStats.frameCount);
+
+    var spans: [4]native_span_feed.SpanInfo = undefined;
+    const drained = feed.drainSpans(spans[0..]);
+    try std.testing.expect(drained > 0);
+
+    var i: u32 = 0;
+    while (i < drained) : (i += 1) {
+        feed.markSpanConsumed(spans[i]);
+    }
+
+    cli_renderer.render(false);
+    try std.testing.expectEqual(frame_before_skip + 1, cli_renderer.renderStats.frameCount);
+}
+
+test "renderer - span_feed strategy prevents threading" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+
+    const feed = try createAttachedFeed(std.testing.allocator, null);
+    defer feed.destroy();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        80,
+        24,
+        pool,
+        .{ .testing = true, .output_strategy = 1, .feed_ptr = feed },
+    );
+    defer cli_renderer.destroy();
+
+    try std.testing.expect(!cli_renderer.useThread);
+
+    cli_renderer.setUseThread(true);
+    try std.testing.expect(!cli_renderer.useThread);
+}
+
+test "renderer - multiple span_feed renderers use independent feeds" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+
+    var tb1 = try TextBuffer.init(std.testing.allocator, pool, .unicode);
+    defer tb1.deinit();
+    try tb1.setText("Renderer 1");
+
+    var view1 = try TextBufferView.init(std.testing.allocator, tb1);
+    defer view1.deinit();
+
+    var tb2 = try TextBuffer.init(std.testing.allocator, pool, .unicode);
+    defer tb2.deinit();
+    try tb2.setText("Renderer 2");
+
+    var view2 = try TextBufferView.init(std.testing.allocator, tb2);
+    defer view2.deinit();
+
+    const feed1 = try createAttachedFeed(std.testing.allocator, null);
+    defer feed1.destroy();
+
+    var renderer1 = try CliRenderer.create(
+        std.testing.allocator,
+        80,
+        24,
+        pool,
+        .{ .testing = false, .output_strategy = 1, .feed_ptr = feed1 },
+    );
+    defer renderer1.destroy();
+
+    const feed2 = try createAttachedFeed(std.testing.allocator, null);
+    defer feed2.destroy();
+
+    var renderer2 = try CliRenderer.create(
+        std.testing.allocator,
+        80,
+        24,
+        pool,
+        .{ .testing = false, .output_strategy = 1, .feed_ptr = feed2 },
+    );
+    defer renderer2.destroy();
+
+    // Draw different content to each
+    const buf1 = renderer1.getNextBuffer();
+    try buf1.drawTextBuffer(view1, 0, 0);
+
+    const buf2 = renderer2.getNextBuffer();
+    try buf2.drawTextBuffer(view2, 0, 0);
+
+    // Render both
+    renderer1.render(false);
+    renderer2.render(false);
+
+    // Verify both rendered (frame count incremented)
+    try std.testing.expectEqual(@as(u64, 1), renderer1.renderStats.frameCount);
+    try std.testing.expectEqual(@as(u64, 1), renderer2.renderStats.frameCount);
+
+    const bytes1 = try drainFeedBytes(std.testing.allocator, feed1);
+    defer std.testing.allocator.free(bytes1);
+
+    const bytes2 = try drainFeedBytes(std.testing.allocator, feed2);
+    defer std.testing.allocator.free(bytes2);
+
+    try std.testing.expect(std.mem.indexOf(u8, bytes1, "Renderer 1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, bytes2, "Renderer 2") != null);
 }

--- a/packages/ssh/README.md
+++ b/packages/ssh/README.md
@@ -1,0 +1,279 @@
+# @opentui/ssh
+
+SSH server for hosting OpenTUI terminal applications over SSH connections.
+
+## Installation
+
+```bash
+bun add @opentui/ssh
+```
+
+## Quick Start
+
+```typescript
+import { createSSHServer, logging, devMode } from "@opentui/ssh"
+import { TextRenderable, BoxRenderable, RGBA } from "@opentui/core"
+
+const server = createSSHServer({
+  port: 2222,
+  hostKeyPath: "./.ssh/host_key",
+  middleware: [
+    logging(),
+    devMode(), // Accept all connections (for development only!)
+  ],
+})
+
+server.on("session", (session) => {
+  const { renderer } = session
+
+  // Create your UI using OpenTUI renderables
+  const text = new TextRenderable(renderer, {
+    id: "hello",
+    content: `Hello, ${session.user.username}!`,
+    fg: RGBA.fromInts(255, 255, 255, 255),
+  })
+  renderer.root.add(text)
+
+  // Handle keyboard input
+  renderer.keyInput.on("keypress", (key) => {
+    if (key.name === "q") {
+      session.close()
+    }
+  })
+
+  // Start rendering
+  renderer.start()
+})
+
+server.on("listening", () => {
+  console.log(`SSH server running on port ${server.port}`)
+})
+
+await server.listen()
+```
+
+## API
+
+### `createSSHServer(config: SSHServerConfig): SSHServer`
+
+Creates a new SSH server instance.
+
+#### Config Options
+
+- `port` (required): Port to listen on
+- `host`: Host to bind to (default: `"0.0.0.0"`)
+- `hostKeyPath` (required): Path to host key file (auto-generated if missing)
+- `middleware`: Array of middleware functions for auth/session handling
+- `requirePty`: Require PTY allocation (default: `true`)
+- `rendererOptions`: Options passed to `createCliRenderer`
+
+`SSHSession` always uses renderer `outputMode: "stream"` internally and manages `onOutput` for channel writes.
+`rendererOptions` intentionally excludes transport-owned fields (`stdin`, `stdout`, `outputMode`, `onOutput`, `width`, `height`).
+
+### `SSHServer`
+
+#### Events
+
+- `listening`: Emitted when server starts listening
+- `session(session: SSHSession)`: Emitted when a new session is established
+- `error(error: Error)`: Emitted on server errors
+- `close`: Emitted when server closes
+
+#### Methods
+
+- `listen(): Promise<void>`: Start listening for connections
+- `close(): void`: Stop the server
+
+### `SSHSession`
+
+#### Properties
+
+- `renderer`: The `CliRenderer` instance for this session
+- `user`: User info (`{ username, publicKey? }`)
+  - `publicKey` currently stores the key algorithm (e.g. `ssh-ed25519`).
+    Planned: expose a stable key fingerprint for auditing and logging.
+- `remoteAddress`: Client IP address
+- `pty`: PTY info (`{ term, width, height }`)
+
+#### Events
+
+- `resize(width, height)`: Emitted when terminal is resized
+- `close`: Emitted when session ends
+
+#### Methods
+
+- `close(exitCode?: number)`: Close the session
+- `handleResize(width, height)`: Manually trigger resize
+
+## Middleware
+
+Middleware uses a Koa-style onion model with `compose()`. Each middleware receives a context and a `next` function to call the next middleware in the chain.
+
+### Middleware Phases
+
+Middleware runs in two phases:
+
+- **`auth`**: Called for each authentication attempt. Use `ctx.accept()` or `ctx.reject()` to make a decision.
+- **`session`**: Called once after authentication succeeds, when the shell session starts.
+
+### Middleware Context
+
+```typescript
+interface MiddlewareContext {
+  phase: "auth" | "session"
+  connection: Connection // SSH2 connection object
+  username: string // Attempting username
+  clientKey?: PublicKey // Client's public key (if publickey auth)
+  remoteAddress: string // Client IP address
+  state: Record<string, unknown> // Shared state between middleware
+  accept?: () => void // Accept auth (auth phase only)
+  reject?: (methods?: string[]) => void // Reject auth (auth phase only)
+  log: (message: string) => void // Log helper
+}
+```
+
+### Middleware Order
+
+Middleware executes in array order using the onion model:
+
+```typescript
+middleware: [
+  logging(), // 1. Runs first, wraps accept/reject, calls next()
+  publicKey(), // 2. Makes auth decision, calls next()
+] //    Control returns to logging for post-processing
+```
+
+**Important**: Place `logging()` first so it can observe auth decisions made by subsequent middleware.
+
+### Built-in Middleware
+
+#### `logging(options?)`
+
+Logs authentication attempts and connections. Should be placed **first** in the middleware array.
+
+```typescript
+logging({
+  onAuthAttempt: (ctx, accepted) => console.log(`Auth: ${ctx.username} - ${accepted}`),
+  onConnect: (ctx) => console.log(`Connected: ${ctx.username}`),
+  onDisconnect: (ctx) => console.log(`Disconnected: ${ctx.username}`),
+})
+```
+
+#### `publicKey(options)`
+
+Public key authentication using OpenSSH authorized_keys format.
+
+```typescript
+publicKey({
+  authorizedKeysPath: "~/.ssh/authorized_keys",
+  // OR provide keys directly
+  authorizedKeys: ["ssh-ed25519 AAAA... user@host"],
+})
+```
+
+#### `devMode()`
+
+Accepts all authentication attempts. **For development only!** Prints a security warning on startup.
+
+```typescript
+devMode()
+```
+
+### Custom Middleware
+
+#### Auth Middleware Pattern
+
+```typescript
+const myAuth: Middleware = async (ctx, next) => {
+  if (ctx.phase !== "auth") {
+    await next()
+    return
+  }
+
+  // Make your auth decision
+  if (isValid(ctx.username)) {
+    ctx.accept?.()
+  } else {
+    ctx.reject?.(["publickey", "password"]) // Allowed methods for retry
+  }
+
+  // ALWAYS call next() after auth decision
+  // This allows outer middleware (like logging) to complete
+  await next()
+}
+```
+
+#### Session Middleware Pattern
+
+```typescript
+const sessionSetup: Middleware = async (ctx, next) => {
+  if (ctx.phase === "session") {
+    // Set up session-specific state
+    ctx.state.startTime = Date.now()
+
+    // Listen for disconnect
+    ctx.connection.on("close", () => {
+      console.log(`Session lasted ${Date.now() - ctx.state.startTime}ms`)
+    })
+  }
+
+  await next()
+}
+```
+
+#### Combining Multiple Auth Methods
+
+```typescript
+middleware: [
+  logging(),
+  publicKey({ authorizedKeysPath: "~/.ssh/authorized_keys" }),
+  passwordAuth({ users: { admin: "secret" } }), // hypothetical
+]
+```
+
+If `publicKey` doesn't handle the attempt (no client key provided), it calls `next()` to let `passwordAuth` try. If no middleware accepts, the server rejects by default.
+
+### Default Behavior
+
+If no middleware calls `accept()` or `reject()`, the server automatically rejects the authentication attempt. This ensures connections are never left in a pending state.
+
+## Compatibility
+
+### Ghostty Terminal
+
+[Ghostty](https://ghostty.org) includes an `ssh-terminfo` shell integration feature that attempts to install its terminfo entry on remote hosts before starting an interactive session. This runs an `exec` command via SSH before requesting a shell.
+
+**Server-side handling**: This package accepts `exec` requests and immediately returns exit code 1, allowing Ghostty's preflight to complete quickly without hanging.
+
+**Client-side alternative**: If you prefer to disable this on the client, add to your Ghostty config:
+
+```ini
+# ~/.config/ghostty/config
+shell-integration-features = no-ssh-terminfo
+```
+
+This disables automatic terminfo installation while keeping other shell integration features.
+
+### Terminal Compatibility
+
+The server advertises `xterm-256color` compatibility by default. For best results:
+
+- Clients should use `TERM=xterm-256color` or similar
+- The renderer supports truecolor (24-bit) output
+
+## Examples
+
+See [`examples/counter.ts`](./examples/counter.ts) for a complete interactive example.
+
+```bash
+# Run the example
+cd packages/ssh
+bun examples/counter.ts
+
+# Connect from another terminal
+ssh -p 2222 localhost
+```
+
+## License
+
+MIT

--- a/packages/ssh/README.md
+++ b/packages/ssh/README.md
@@ -171,6 +171,9 @@ publicKey({
 })
 ```
 
+Note: `authorized_keys` option prefixes (for example `from=`, `command=`, `no-pty`) are not supported yet.
+Entries containing options are ignored to avoid silently weakening intended key restrictions.
+
 #### `devMode()`
 
 Accepts all authentication attempts. **For development only!** Prints a security warning on startup.

--- a/packages/ssh/README.md
+++ b/packages/ssh/README.md
@@ -82,7 +82,7 @@ Creates a new SSH server instance.
 #### Methods
 
 - `listen(): Promise<void>`: Start listening for connections
-- `close(): void`: Stop the server
+- `close(): Promise<void>`: Stop the server and wait for active sessions to finish teardown
 
 ### `SSHSession`
 
@@ -102,7 +102,7 @@ Creates a new SSH server instance.
 
 #### Methods
 
-- `close(exitCode?: number)`: Close the session
+- `close(exitCode?: number): Promise<void>`: Close the session and wait for renderer teardown
 - `handleResize(width, height)`: Manually trigger resize
 
 ## Middleware
@@ -139,7 +139,7 @@ Middleware executes in array order using the onion model:
 ```typescript
 middleware: [
   logging(), // 1. Runs first, wraps accept/reject, calls next()
-  publicKey(), // 2. Makes auth decision, calls next()
+  publicKey(), // 2. Makes auth decision and returns
 ] //    Control returns to logging for post-processing
 ```
 
@@ -197,9 +197,10 @@ const myAuth: Middleware = async (ctx, next) => {
     ctx.reject?.(["publickey", "password"]) // Allowed methods for retry
   }
 
-  // ALWAYS call next() after auth decision
-  // This allows outer middleware (like logging) to complete
-  await next()
+  // Return immediately after making an auth decision.
+  // Calling next() is optional and only needed if you intentionally want
+  // downstream auth middleware to continue running.
+  return
 }
 ```
 

--- a/packages/ssh/README.md
+++ b/packages/ssh/README.md
@@ -174,9 +174,17 @@ publicKey({
 Note: `authorized_keys` option prefixes (for example `from=`, `command=`, `no-pty`) are not supported yet.
 Entries containing options are ignored to avoid silently weakening intended key restrictions.
 
+#### `allowAll()`
+
+Accepts all authentication attempts silently. Use for intentionally open servers (public demos, LAN apps, etc.).
+
+```typescript
+allowAll()
+```
+
 #### `devMode()`
 
-Accepts all authentication attempts. **For development only!** Prints a security warning on startup.
+Accepts all authentication attempts and prints a security warning on startup. Use only during local development.
 
 ```typescript
 devMode()

--- a/packages/ssh/examples/counter.ts
+++ b/packages/ssh/examples/counter.ts
@@ -1,0 +1,109 @@
+// packages/ssh/examples/counter.ts
+import { createSSHServer, logging, devMode } from "../src"
+import { TextRenderable, BoxRenderable, RGBA, type KeyEvent } from "@opentui/core"
+
+const server = createSSHServer({
+  port: 2222,
+  hostKeyPath: "./.ssh/host_key",
+  rendererOptions: {
+    useAlternateScreen: true,
+  },
+  middleware: [
+    logging({
+      onAuthAttempt: (ctx, accepted) => ctx.log(`[Auth] ${ctx.username}: ${accepted ? "accepted" : "rejected"}`),
+      onConnect: (ctx) => ctx.log(`[Connect] ${ctx.username} from ${ctx.remoteAddress}`),
+      onDisconnect: (ctx) => ctx.log(`[Disconnect] ${ctx.username}`),
+    }),
+    devMode(), // Accept all for testing
+  ],
+})
+
+server.on("session", (session) => {
+  let count = 0
+  const { renderer } = session
+
+  // Set background color
+  renderer.setBackgroundColor(RGBA.fromInts(0, 0, 0, 255))
+
+  // Create a container box
+  const container = new BoxRenderable(renderer, {
+    id: "container",
+    width: "100%",
+    height: "100%",
+    padding: 2,
+  })
+  renderer.root.add(container)
+
+  // Counter display
+  const counterText = new TextRenderable(renderer, {
+    id: "counter",
+    content: `Counter: ${count}`,
+    fg: RGBA.fromInts(255, 255, 255, 255),
+  })
+  container.add(counterText)
+
+  // Instructions
+  const instructions = new TextRenderable(renderer, {
+    id: "instructions",
+    content: "\nPress +/- to change counter, q to quit",
+    fg: RGBA.fromInts(128, 128, 128, 255),
+  })
+  container.add(instructions)
+
+  // Terminal info
+  const terminalInfo = new TextRenderable(renderer, {
+    id: "terminal-info",
+    content: `\n\nTerminal: ${session.pty.width}x${session.pty.height} (${session.pty.term})`,
+    fg: RGBA.fromInts(80, 80, 80, 255),
+  })
+  container.add(terminalInfo)
+
+  // User info
+  const userInfo = new TextRenderable(renderer, {
+    id: "user-info",
+    content: `User: ${session.user.username} from ${session.remoteAddress}`,
+    fg: RGBA.fromInts(80, 80, 80, 255),
+  })
+  container.add(userInfo)
+
+  function updateDisplay() {
+    counterText.content = `Counter: ${count}`
+    terminalInfo.content = `\n\nTerminal: ${session.pty.width}x${session.pty.height} (${session.pty.term})`
+  }
+
+  // Handle keyboard input
+  renderer.keyInput.on("keypress", (key: KeyEvent) => {
+    if (key.name === "+" || key.name === "=") {
+      count++
+      updateDisplay()
+    } else if (key.name === "-" || key.name === "_") {
+      count--
+      updateDisplay()
+    } else if (key.name === "q") {
+      // Only quit on 'q' - removed ctrl+c to avoid accidental close from control sequences
+      session.close()
+    }
+  })
+
+  // Handle resize
+  session.on("resize", () => updateDisplay())
+
+  // Handle disconnect
+  session.on("close", () => {
+    console.log(`Session closed: ${session.user.username}`)
+  })
+
+  // Start the renderer
+  renderer.start()
+})
+
+server.on("listening", () => {
+  console.log(`SSH Counter running on port ${server.port}`)
+  console.log(`Connect with: ssh -p ${server.port} localhost`)
+})
+
+server.on("error", (err) => {
+  console.error(`[SSH Server Error] ${err.message}`)
+})
+
+await server.listen()

--- a/packages/ssh/package.json
+++ b/packages/ssh/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@opentui/ssh",
+  "version": "0.1.0",
+  "description": "SSH server for hosting OpenTUI terminal applications",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/anomalyco/opentui",
+    "directory": "packages/ssh"
+  },
+  "module": "src/index.ts",
+  "type": "module",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "bun run scripts/build.ts",
+    "test": "bun test",
+    "example": "bun run examples/counter.ts"
+  },
+  "dependencies": {
+    "@opentui/core": "workspace:*",
+    "ssh2": "^1.16.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/node": "^24.0.0",
+    "@types/ssh2": "^1.15.1",
+    "typescript": "^5"
+  },
+  "peerDependencies": {
+    "bun": ">=1.2.0"
+  }
+}

--- a/packages/ssh/src/index.ts
+++ b/packages/ssh/src/index.ts
@@ -1,0 +1,24 @@
+// Core exports
+export { SSHServer, createSSHServer } from "./server.ts"
+export { SSHSession } from "./session.ts"
+
+// Middleware
+export { compose, logging, publicKey, devMode } from "./middleware/index.ts"
+
+// Utilities
+export { ensureHostKey } from "./utils/host-key.ts"
+export { parseAuthorizedKeys, matchesKey } from "./utils/authorized-keys.ts"
+
+// Types
+export type {
+  SSHServerConfig,
+  MiddlewareContext,
+  MiddlewarePhase,
+  Middleware,
+  NextFn,
+  PtyInfo,
+  UserInfo,
+  PublicKeyOptions,
+  LoggingOptions,
+  AuthorizedKey,
+} from "./types.ts"

--- a/packages/ssh/src/index.ts
+++ b/packages/ssh/src/index.ts
@@ -3,7 +3,7 @@ export { SSHServer, createSSHServer } from "./server.ts"
 export { SSHSession } from "./session.ts"
 
 // Middleware
-export { compose, logging, publicKey, devMode } from "./middleware/index.ts"
+export { compose, logging, publicKey, allowAll, devMode } from "./middleware/index.ts"
 
 // Utilities
 export { ensureHostKey } from "./utils/host-key.ts"

--- a/packages/ssh/src/middleware/index.ts
+++ b/packages/ssh/src/middleware/index.ts
@@ -1,0 +1,148 @@
+import { readFileSync, existsSync } from "fs"
+import { homedir } from "os"
+import { join } from "path"
+import type { Middleware, LoggingOptions, PublicKeyOptions } from "../types.ts"
+import { parseAuthorizedKeys, matchesKey } from "../utils/authorized-keys.ts"
+
+export function compose(...middlewares: Middleware[]): Middleware {
+  return async (ctx, next) => {
+    let index = -1
+
+    async function dispatch(i: number): Promise<void> {
+      if (i <= index) throw new Error("next() called multiple times")
+      index = i
+
+      const fn = middlewares[i]
+      if (!fn) {
+        await next()
+        return
+      }
+
+      await fn(ctx, () => dispatch(i + 1))
+    }
+
+    await dispatch(0)
+  }
+}
+
+export function logging(options: LoggingOptions = {}): Middleware {
+  const { onAuthAttempt, onConnect, onDisconnect } = options
+
+  return async (ctx, next) => {
+    if (ctx.phase === "auth") {
+      // Wrap accept/reject to track auth result
+      const originalAccept = ctx.accept
+      const originalReject = ctx.reject
+      let authResult: boolean | null = null
+
+      if (originalAccept) {
+        ctx.accept = () => {
+          authResult = true
+          originalAccept()
+        }
+      }
+
+      if (originalReject) {
+        ctx.reject = (allowedMethods) => {
+          authResult = false
+          originalReject(allowedMethods)
+        }
+      }
+
+      await next()
+
+      // Log auth attempt after middleware chain completes
+      if (authResult !== null && onAuthAttempt) {
+        onAuthAttempt(ctx, authResult)
+      }
+    } else if (ctx.phase === "session") {
+      // Log connection
+      if (onConnect) {
+        onConnect(ctx)
+      }
+
+      // Set up disconnect listener
+      if (onDisconnect) {
+        ctx.connection.on("close", () => {
+          onDisconnect(ctx)
+        })
+      }
+
+      await next()
+    } else {
+      await next()
+    }
+  }
+}
+
+export function publicKey(options: PublicKeyOptions): Middleware {
+  // Load authorized keys
+  let authorizedKeys = options.authorizedKeys ?? []
+
+  // Load from file if path provided
+  if (options.authorizedKeysPath) {
+    const keyPath = options.authorizedKeysPath.replace(/^~/, homedir())
+    if (existsSync(keyPath)) {
+      const content = readFileSync(keyPath, "utf-8")
+      const parsedKeys = parseAuthorizedKeys(content)
+      authorizedKeys = [...authorizedKeys, ...parsedKeys.map((k) => `${k.type} ${k.key}`)]
+    }
+  }
+
+  // Parse all keys once
+  const parsedAuthorizedKeys = authorizedKeys
+    .map((keyStr) => {
+      const parts = keyStr.split(" ")
+      if (parts.length >= 2) {
+        return { type: parts[0], key: parts[1], comment: parts.slice(2).join(" ") || undefined }
+      }
+      return null
+    })
+    .filter((k): k is NonNullable<typeof k> => k !== null)
+
+  return async (ctx, next) => {
+    if (ctx.phase !== "auth") {
+      await next()
+      return
+    }
+
+    // Only handle publickey auth
+    if (!ctx.clientKey) {
+      // Not a publickey auth attempt, let other middleware handle it
+      await next()
+      return
+    }
+
+    // Get client key info
+    const clientKeyType = ctx.clientKey.algo
+    const clientKeyData = ctx.clientKey.data.toString("base64")
+
+    // Check if key is authorized
+    const isAuthorized = matchesKey(clientKeyType, clientKeyData, parsedAuthorizedKeys)
+
+    if (isAuthorized) {
+      ctx.accept?.()
+    } else {
+      ctx.reject?.(["publickey"])
+    }
+
+    // Always call next() to allow outer middleware (like logging) to complete
+    // and let the default handler run (which is a no-op if we already decided)
+    await next()
+  }
+}
+
+export function devMode(): Middleware {
+  // Security warning - this middleware accepts ALL authentication attempts
+  console.warn(
+    "\x1b[33m[SSH WARNING]\x1b[0m devMode() middleware is enabled - ALL authentication attempts will be accepted!\n" +
+      "             DO NOT use this in production.",
+  )
+
+  return async (ctx, next) => {
+    if (ctx.phase === "auth" && ctx.accept) {
+      ctx.accept()
+    }
+    await next()
+  }
+}

--- a/packages/ssh/src/middleware/index.ts
+++ b/packages/ssh/src/middleware/index.ts
@@ -61,9 +61,9 @@ export function logging(options: LoggingOptions = {}): Middleware {
         onConnect(ctx)
       }
 
-      // Set up disconnect listener
+      // Set up disconnect listener (once — connection only closes once)
       if (onDisconnect) {
-        ctx.connection.on("close", () => {
+        ctx.connection.once("close", () => {
           onDisconnect(ctx)
         })
       }
@@ -76,29 +76,36 @@ export function logging(options: LoggingOptions = {}): Middleware {
 }
 
 export function publicKey(options: PublicKeyOptions): Middleware {
-  // Load authorized keys
-  let authorizedKeys = options.authorizedKeys ?? []
+  const parsedAuthorizedKeys = new Map<string, { type: string; key: string; comment?: string }>()
+
+  const addParsedKeys = (rawKeys: string[]) => {
+    if (rawKeys.length === 0) return
+
+    const parsed = parseAuthorizedKeys(rawKeys.join("\n"))
+    for (const key of parsed) {
+      parsedAuthorizedKeys.set(`${key.type}:${key.key}`, key)
+    }
+  }
+
+  addParsedKeys(options.authorizedKeys ?? [])
 
   // Load from file if path provided
   if (options.authorizedKeysPath) {
     const keyPath = options.authorizedKeysPath.replace(/^~/, homedir())
     if (existsSync(keyPath)) {
       const content = readFileSync(keyPath, "utf-8")
-      const parsedKeys = parseAuthorizedKeys(content)
-      authorizedKeys = [...authorizedKeys, ...parsedKeys.map((k) => `${k.type} ${k.key}`)]
+      addParsedKeys(content.split("\n"))
+    } else if (parsedAuthorizedKeys.size === 0) {
+      console.warn(
+        `[SSH] authorizedKeysPath "${keyPath}" not found and no authorizedKeys provided` +
+          " \u2014 all public key auth will be rejected",
+      )
+    } else {
+      console.warn(`[SSH] authorizedKeysPath "${keyPath}" not found, using inline keys only`)
     }
   }
 
-  // Parse all keys once
-  const parsedAuthorizedKeys = authorizedKeys
-    .map((keyStr) => {
-      const parts = keyStr.split(" ")
-      if (parts.length >= 2) {
-        return { type: parts[0], key: parts[1], comment: parts.slice(2).join(" ") || undefined }
-      }
-      return null
-    })
-    .filter((k): k is NonNullable<typeof k> => k !== null)
+  const keys = Array.from(parsedAuthorizedKeys.values())
 
   return async (ctx, next) => {
     if (ctx.phase !== "auth") {
@@ -118,7 +125,7 @@ export function publicKey(options: PublicKeyOptions): Middleware {
     const clientKeyData = ctx.clientKey.data.toString("base64")
 
     // Check if key is authorized
-    const isAuthorized = matchesKey(clientKeyType, clientKeyData, parsedAuthorizedKeys)
+    const isAuthorized = matchesKey(clientKeyType, clientKeyData, keys)
 
     if (isAuthorized) {
       ctx.accept?.()
@@ -126,9 +133,9 @@ export function publicKey(options: PublicKeyOptions): Middleware {
       ctx.reject?.(["publickey"])
     }
 
-    // Always call next() to allow outer middleware (like logging) to complete
-    // and let the default handler run (which is a no-op if we already decided)
-    await next()
+    // Do NOT call next() after accept/reject — downstream middleware could
+    // override the auth decision. Outer middleware (like logging) completes
+    // when control returns up the Koa onion stack, not via next() here.
   }
 }
 

--- a/packages/ssh/src/middleware/index.ts
+++ b/packages/ssh/src/middleware/index.ts
@@ -145,17 +145,28 @@ export function publicKey(options: PublicKeyOptions): Middleware {
   }
 }
 
-export function devMode(): Middleware {
-  // Security warning - this middleware accepts ALL authentication attempts
-  console.warn(
-    "\x1b[33m[SSH WARNING]\x1b[0m devMode() middleware is enabled - ALL authentication attempts will be accepted!\n" +
-      "             DO NOT use this in production.",
-  )
-
+/**
+ * Accepts all authentication attempts without warnings.
+ * Use for intentionally open servers (public demos, LAN apps, etc.).
+ */
+export function allowAll(): Middleware {
   return async (ctx, next) => {
     if (ctx.phase === "auth" && ctx.accept) {
       ctx.accept()
     }
     await next()
   }
+}
+
+/**
+ * Accepts all authentication attempts with a security warning.
+ * Use only during local development — prints a warning on startup.
+ */
+export function devMode(): Middleware {
+  console.warn(
+    "\x1b[33m[SSH WARNING]\x1b[0m devMode() middleware is enabled - ALL authentication attempts will be accepted!\n" +
+      "             DO NOT use this in production.",
+  )
+
+  return allowAll()
 }

--- a/packages/ssh/src/middleware/index.ts
+++ b/packages/ssh/src/middleware/index.ts
@@ -1,7 +1,7 @@
 import { readFileSync, existsSync } from "fs"
 import { homedir } from "os"
 import { join } from "path"
-import type { Middleware, LoggingOptions, PublicKeyOptions } from "../types.ts"
+import type { Middleware, LoggingOptions, PublicKeyOptions, AuthorizedKey } from "../types.ts"
 import { parseAuthorizedKeys, matchesKey } from "../utils/authorized-keys.ts"
 
 export function compose(...middlewares: Middleware[]): Middleware {
@@ -76,13 +76,19 @@ export function logging(options: LoggingOptions = {}): Middleware {
 }
 
 export function publicKey(options: PublicKeyOptions): Middleware {
-  const parsedAuthorizedKeys = new Map<string, { type: string; key: string; comment?: string }>()
+  const parsedAuthorizedKeys = new Map<string, AuthorizedKey>()
 
   const addParsedKeys = (rawKeys: string[]) => {
     if (rawKeys.length === 0) return
 
     const parsed = parseAuthorizedKeys(rawKeys.join("\n"))
     for (const key of parsed) {
+      if (key.options) {
+        console.warn(
+          `[SSH] Ignoring authorized_keys entry with unsupported options (${key.options}) for key type ${key.type}`,
+        )
+        continue
+      }
       parsedAuthorizedKeys.set(`${key.type}:${key.key}`, key)
     }
   }

--- a/packages/ssh/src/server.ts
+++ b/packages/ssh/src/server.ts
@@ -1,0 +1,233 @@
+import { EventEmitter } from "events"
+import {
+  Server as SSH2Server,
+  type Connection,
+  type AuthContext,
+  type Session,
+  type ClientInfo,
+  type AuthenticationType,
+} from "ssh2"
+import type { SSHServerConfig, MiddlewareContext, Middleware, PtyInfo, UserInfo } from "./types.ts"
+import { SSHSession } from "./session.ts"
+import { ensureHostKey } from "./utils/host-key.ts"
+import { compose } from "./middleware/index.ts"
+
+export interface SSHServerEvents {
+  session: (session: SSHSession) => void
+  listening: () => void
+  error: (error: Error) => void
+  close: () => void
+}
+
+// Declaration merging for typed events
+export interface SSHServer {
+  on<K extends keyof SSHServerEvents>(event: K, listener: SSHServerEvents[K]): this
+  once<K extends keyof SSHServerEvents>(event: K, listener: SSHServerEvents[K]): this
+  off<K extends keyof SSHServerEvents>(event: K, listener: SSHServerEvents[K]): this
+  emit<K extends keyof SSHServerEvents>(event: K, ...args: Parameters<SSHServerEvents[K]>): boolean
+}
+
+export class SSHServer extends EventEmitter {
+  public readonly port: number
+  private readonly host: string
+  private readonly requirePty: boolean
+  private readonly middleware: Middleware
+  private readonly hostKey: Buffer
+  private readonly rendererOptions: SSHServerConfig["rendererOptions"]
+  private server: SSH2Server | null = null
+  private _listening = false
+
+  constructor(private config: SSHServerConfig) {
+    super()
+    this.port = config.port
+    this.host = config.host ?? "0.0.0.0"
+    this.requirePty = config.requirePty ?? true
+    this.rendererOptions = config.rendererOptions
+    this.hostKey = ensureHostKey(config.hostKeyPath)
+    this.middleware = config.middleware?.length ? compose(...config.middleware) : async (_, next) => next()
+  }
+
+  public async listen(): Promise<void> {
+    if (this._listening) return
+
+    return new Promise((resolve, reject) => {
+      this.server = new SSH2Server({ hostKeys: [this.hostKey] }, (client, info) => this.handleConnection(client, info))
+
+      this.server.on("error", (err: Error) => {
+        this.emit("error", err)
+        if (!this._listening) reject(err)
+      })
+
+      this.server.listen(this.port, this.host, () => {
+        this._listening = true
+        this.emit("listening")
+        resolve()
+      })
+    })
+  }
+
+  public close(): void {
+    if (this.server) {
+      this.server.close()
+      this.server = null
+      this._listening = false
+      this.emit("close")
+    }
+  }
+
+  private handleConnection(client: Connection, info: ClientInfo): void {
+    const remoteAddress = info.ip
+    let authenticatedUser: UserInfo | null = null
+
+    client.on("authentication", (ctx: AuthContext) => {
+      // ssh2 can emit "ready"/"session" synchronously after accept; set user before calling accept.
+      const originalAccept = ctx.accept.bind(ctx)
+      ctx.accept = () => {
+        authenticatedUser = {
+          username: ctx.username,
+          publicKey: ctx.method === "publickey" && ctx.key ? ctx.key.algo : undefined,
+        }
+        originalAccept()
+      }
+
+      this.handleAuth(ctx, remoteAddress, client).catch((err) => {
+        this.emit("error", err)
+        ctx.reject()
+      })
+    })
+
+    client.on("ready", () => {
+      client.on("session", (accept, _reject) => {
+        const sshSession = accept()
+        this.handleSession(sshSession, authenticatedUser!, remoteAddress, client)
+      })
+    })
+
+    client.on("error", (err: Error) => {
+      this.emit("error", err)
+    })
+  }
+
+  private async handleAuth(ctx: AuthContext, remoteAddress: string, connection: Connection): Promise<UserInfo | null> {
+    const middlewareCtx: MiddlewareContext = {
+      phase: "auth",
+      connection,
+      username: ctx.username,
+      clientKey: ctx.method === "publickey" ? ctx.key : undefined,
+      remoteAddress,
+      state: {},
+      log: (message: string) => process.stdout.write(message + "\n"),
+    }
+
+    let accepted = false
+    let rejected = false
+
+    middlewareCtx.accept = () => {
+      accepted = true
+      ctx.accept()
+    }
+
+    middlewareCtx.reject = (allowedMethods?: string[]) => {
+      rejected = true
+      ctx.reject(allowedMethods as AuthenticationType[] | undefined)
+    }
+
+    await this.middleware(middlewareCtx, () => {
+      // Default: reject if no middleware accepted
+      if (!accepted && !rejected) {
+        ctx.reject(["publickey"] as AuthenticationType[])
+      }
+    })
+
+    if (accepted) {
+      return {
+        username: ctx.username,
+        publicKey: ctx.method === "publickey" && ctx.key ? ctx.key.algo : undefined,
+      }
+    }
+
+    return null
+  }
+
+  private handleSession(sshSession: Session, user: UserInfo, remoteAddress: string, connection: Connection): void {
+    let ptyInfo: PtyInfo | null = null
+
+    sshSession.on("pty", (accept, _reject, info) => {
+      // PseudoTtyInfo has cols, rows, width, height, modes
+      // term type comes from the info object at runtime (ssh2 types may be incomplete)
+      const termInfo = info as { term?: string; cols: number; rows: number }
+      ptyInfo = {
+        term: termInfo.term ?? "xterm",
+        width: info.cols,
+        height: info.rows,
+      }
+      accept?.()
+    })
+
+    sshSession.on("shell", (accept, reject) => {
+      if (this.requirePty && !ptyInfo) {
+        reject?.()
+        return
+      }
+
+      const stream = accept()
+      if (!stream) return
+
+      // Run middleware for session phase (enables onConnect/onDisconnect logging)
+      const middlewareCtx: MiddlewareContext = {
+        phase: "session",
+        connection,
+        username: user.username,
+        remoteAddress,
+        state: {},
+        log: (message: string) => process.stdout.write(message + "\n"),
+      }
+      // Start middleware with error handling (non-blocking)
+      Promise.resolve(this.middleware(middlewareCtx, () => Promise.resolve())).catch((err: Error) => {
+        this.emit("error", err)
+      })
+
+      // Use PTY dimensions or default to 80x24
+      const finalPty = ptyInfo ?? { term: "xterm", width: 80, height: 24 }
+
+      // Create session asynchronously
+      SSHSession.create(stream, finalPty, user, remoteAddress, this.rendererOptions)
+        .then((session) => {
+          // Handle window-change on the ssh session (not stream)
+          sshSession.on("window-change", (accept, _reject, info) => {
+            session.handleResize(info.cols, info.rows)
+            accept?.()
+          })
+
+          this.emit("session", session)
+        })
+        .catch((err) => {
+          this.emit("error", err as Error)
+          stream.exit(1)
+          stream.end()
+        })
+    })
+
+    // Handle exec requests (e.g., Ghostty terminfo setup)
+    // Accept and immediately exit to prevent client hang
+    // Some clients (like Ghostty with ssh-terminfo) run preflight exec commands
+    // Rejecting can leave them waiting; accepting + exiting completes quickly
+    sshSession.on("exec", (accept, _reject, info) => {
+      const stream = accept()
+      if (stream) {
+        // Log the exec attempt for debugging (note: we accept then exit, not reject)
+        const command = (info as { command?: string }).command ?? "<unknown>"
+        console.log(
+          `[SSH] exec request not supported (command: ${command.substring(0, 50)}${command.length > 50 ? "..." : ""})`,
+        )
+        // Exit with non-zero status to indicate exec is not supported
+        stream.exit(1)
+        stream.end()
+      }
+    })
+  }
+}
+
+export function createSSHServer(config: SSHServerConfig): SSHServer {
+  return new SSHServer(config)
+}

--- a/packages/ssh/src/server.ts
+++ b/packages/ssh/src/server.ts
@@ -37,7 +37,49 @@ export class SSHServer extends EventEmitter {
   private readonly rendererOptions: SSHServerConfig["rendererOptions"]
   private server: SSH2Server | null = null
   private _listening = false
+  private _closing = false
   private sessions = new Set<SSHSession>()
+  private pendingSessions = 0
+
+  private static readonly DEFAULT_PTY_WIDTH = 80
+  private static readonly DEFAULT_PTY_HEIGHT = 24
+
+  private normalizePtyInfo(pty: PtyInfo | null): PtyInfo {
+    const width = pty && Number.isInteger(pty.width) && pty.width > 0 ? pty.width : SSHServer.DEFAULT_PTY_WIDTH
+    const height = pty && Number.isInteger(pty.height) && pty.height > 0 ? pty.height : SSHServer.DEFAULT_PTY_HEIGHT
+
+    return {
+      term: pty?.term || "xterm",
+      width,
+      height,
+    }
+  }
+
+  private createAuthDecision(
+    ctx: AuthContext,
+    onAccept?: () => void,
+  ): {
+    accept: () => void
+    reject: (allowedMethods?: AuthenticationType[]) => void
+    isResolved: () => boolean
+  } {
+    let resolved = false
+
+    return {
+      accept: () => {
+        if (resolved) return
+        resolved = true
+        onAccept?.()
+        ctx.accept()
+      },
+      reject: (allowedMethods?: AuthenticationType[]) => {
+        if (resolved) return
+        resolved = true
+        ctx.reject(allowedMethods)
+      },
+      isResolved: () => resolved,
+    }
+  }
 
   /** Returns the actual bound port (resolves port 0 after listen). */
   public get port(): number {
@@ -60,6 +102,7 @@ export class SSHServer extends EventEmitter {
     if (this._listening) return
 
     return new Promise((resolve, reject) => {
+      this._closing = false
       this.server = new SSH2Server({ hostKeys: [this.hostKey] }, (client, info) => this.handleConnection(client, info))
 
       this.server.on("error", (err: Error) => {
@@ -79,6 +122,8 @@ export class SSHServer extends EventEmitter {
     if (!this.server) {
       return
     }
+
+    this._closing = true
 
     const server = this.server
     this.server = null
@@ -117,18 +162,16 @@ export class SSHServer extends EventEmitter {
 
     client.on("authentication", (ctx: AuthContext) => {
       // ssh2 can emit "ready"/"session" synchronously after accept; set user before calling accept.
-      const originalAccept = ctx.accept.bind(ctx)
-      ctx.accept = () => {
+      const authDecision = this.createAuthDecision(ctx, () => {
         authenticatedUser = {
           username: ctx.username,
           publicKey: ctx.method === "publickey" && ctx.key ? ctx.key.algo : undefined,
         }
-        originalAccept()
-      }
+      })
 
-      this.handleAuth(ctx, remoteAddress, client, connectionState).catch((err) => {
+      this.handleAuth(ctx, remoteAddress, client, connectionState, authDecision).catch((err) => {
         this.emit("error", err)
-        ctx.reject()
+        authDecision.reject(["publickey"])
       })
     })
 
@@ -154,6 +197,11 @@ export class SSHServer extends EventEmitter {
     remoteAddress: string,
     connection: Connection,
     connectionState: Record<string, unknown>,
+    authDecision: {
+      accept: () => void
+      reject: (allowedMethods?: AuthenticationType[]) => void
+      isResolved: () => boolean
+    } = this.createAuthDecision(ctx),
   ): Promise<void> {
     const middlewareCtx: MiddlewareContext = {
       phase: "auth",
@@ -165,25 +213,18 @@ export class SSHServer extends EventEmitter {
       log: (message: string) => process.stdout.write(message + "\n"),
     }
 
-    let accepted = false
-    let rejected = false
-
     middlewareCtx.accept = () => {
-      if (accepted || rejected) return
-      accepted = true
-      ctx.accept()
+      authDecision.accept()
     }
 
     middlewareCtx.reject = (allowedMethods?: string[]) => {
-      if (accepted || rejected) return
-      rejected = true
-      ctx.reject(allowedMethods as AuthenticationType[] | undefined)
+      authDecision.reject(allowedMethods as AuthenticationType[] | undefined)
     }
 
     await this.middleware(middlewareCtx, () => {
       // Default: reject if no middleware accepted
-      if (!accepted && !rejected) {
-        ctx.reject(["publickey"] as AuthenticationType[])
+      if (!authDecision.isResolved()) {
+        authDecision.reject(["publickey"])
       }
     })
   }
@@ -210,19 +251,30 @@ export class SSHServer extends EventEmitter {
     })
 
     sshSession.on("shell", (accept, reject) => {
+      if (this._closing) {
+        reject?.()
+        return
+      }
+
       if (this.requirePty && !ptyInfo) {
         reject?.()
         return
       }
 
       // Enforce maxSessions limit (0 = unlimited)
-      if (this.maxSessions > 0 && this.sessions.size >= this.maxSessions) {
+      if (this.maxSessions > 0 && this.sessions.size + this.pendingSessions >= this.maxSessions) {
         reject?.()
         return
       }
 
       const stream = accept()
       if (!stream) return
+
+      this.pendingSessions += 1
+
+      const releasePendingSession = () => {
+        this.pendingSessions = Math.max(0, this.pendingSessions - 1)
+      }
 
       // Run middleware for session phase (enables onConnect/onDisconnect logging)
       const middlewareCtx: MiddlewareContext = {
@@ -238,12 +290,21 @@ export class SSHServer extends EventEmitter {
         this.emit("error", err)
       })
 
-      // Use PTY dimensions or default to 80x24
-      const finalPty = ptyInfo ?? { term: "xterm", width: 80, height: 24 }
+      // Use PTY dimensions when valid; fallback to safe defaults for buggy clients.
+      const finalPty = this.normalizePtyInfo(ptyInfo)
 
       // Create session asynchronously
       SSHSession.create(stream, finalPty, user, remoteAddress, this.rendererOptions)
         .then((session) => {
+          releasePendingSession()
+
+          if (this._closing) {
+            void session.close().catch((err) => {
+              this.emit("error", err as Error)
+            })
+            return
+          }
+
           this.trackSession(session)
 
           // Handle window-change on the ssh session (not stream)
@@ -261,6 +322,7 @@ export class SSHServer extends EventEmitter {
           this.emit("session", session)
         })
         .catch((err) => {
+          releasePendingSession()
           this.emit("error", err as Error)
           stream.exit(1)
           stream.end()

--- a/packages/ssh/src/server.ts
+++ b/packages/ssh/src/server.ts
@@ -28,20 +28,29 @@ export interface SSHServer {
 }
 
 export class SSHServer extends EventEmitter {
-  public readonly port: number
+  private readonly _configPort: number
   private readonly host: string
   private readonly requirePty: boolean
+  private readonly maxSessions: number
   private readonly middleware: Middleware
   private readonly hostKey: Buffer
   private readonly rendererOptions: SSHServerConfig["rendererOptions"]
   private server: SSH2Server | null = null
   private _listening = false
+  private sessions = new Set<SSHSession>()
+
+  /** Returns the actual bound port (resolves port 0 after listen). */
+  public get port(): number {
+    const addr = this.server?.address()
+    return typeof addr === "object" && addr?.port ? addr.port : this._configPort
+  }
 
   constructor(private config: SSHServerConfig) {
     super()
-    this.port = config.port
+    this._configPort = config.port
     this.host = config.host ?? "0.0.0.0"
     this.requirePty = config.requirePty ?? true
+    this.maxSessions = config.maxSessions ?? 0
     this.rendererOptions = config.rendererOptions
     this.hostKey = ensureHostKey(config.hostKeyPath)
     this.middleware = config.middleware?.length ? compose(...config.middleware) : async (_, next) => next()
@@ -66,18 +75,45 @@ export class SSHServer extends EventEmitter {
     })
   }
 
-  public close(): void {
-    if (this.server) {
-      this.server.close()
-      this.server = null
-      this._listening = false
-      this.emit("close")
+  public async close(): Promise<void> {
+    if (!this.server) {
+      return
     }
+
+    const server = this.server
+    this.server = null
+    this._listening = false
+
+    const sessions = Array.from(this.sessions)
+    this.sessions.clear()
+
+    await Promise.allSettled(sessions.map((session) => session.close()))
+
+    await new Promise<void>((resolve) => {
+      try {
+        server.close(() => resolve())
+      } catch {
+        resolve()
+      }
+    })
+
+    this.emit("close")
+  }
+
+  private trackSession(session: SSHSession): void {
+    this.sessions.add(session)
+    session.once("close", () => this.sessions.delete(session))
+  }
+
+  public get activeSessions(): number {
+    return this.sessions.size
   }
 
   private handleConnection(client: Connection, info: ClientInfo): void {
     const remoteAddress = info.ip
     let authenticatedUser: UserInfo | null = null
+    // Per-connection state shared across auth and session middleware phases
+    const connectionState: Record<string, unknown> = {}
 
     client.on("authentication", (ctx: AuthContext) => {
       // ssh2 can emit "ready"/"session" synchronously after accept; set user before calling accept.
@@ -90,16 +126,21 @@ export class SSHServer extends EventEmitter {
         originalAccept()
       }
 
-      this.handleAuth(ctx, remoteAddress, client).catch((err) => {
+      this.handleAuth(ctx, remoteAddress, client, connectionState).catch((err) => {
         this.emit("error", err)
         ctx.reject()
       })
     })
 
     client.on("ready", () => {
-      client.on("session", (accept, _reject) => {
+      client.on("session", (accept, reject) => {
+        if (!authenticatedUser) {
+          reject?.()
+          return
+        }
+
         const sshSession = accept()
-        this.handleSession(sshSession, authenticatedUser!, remoteAddress, client)
+        this.handleSession(sshSession, authenticatedUser, remoteAddress, client, connectionState)
       })
     })
 
@@ -108,14 +149,19 @@ export class SSHServer extends EventEmitter {
     })
   }
 
-  private async handleAuth(ctx: AuthContext, remoteAddress: string, connection: Connection): Promise<UserInfo | null> {
+  private async handleAuth(
+    ctx: AuthContext,
+    remoteAddress: string,
+    connection: Connection,
+    connectionState: Record<string, unknown>,
+  ): Promise<void> {
     const middlewareCtx: MiddlewareContext = {
       phase: "auth",
       connection,
       username: ctx.username,
       clientKey: ctx.method === "publickey" ? ctx.key : undefined,
       remoteAddress,
-      state: {},
+      state: connectionState,
       log: (message: string) => process.stdout.write(message + "\n"),
     }
 
@@ -123,11 +169,13 @@ export class SSHServer extends EventEmitter {
     let rejected = false
 
     middlewareCtx.accept = () => {
+      if (accepted || rejected) return
       accepted = true
       ctx.accept()
     }
 
     middlewareCtx.reject = (allowedMethods?: string[]) => {
+      if (accepted || rejected) return
       rejected = true
       ctx.reject(allowedMethods as AuthenticationType[] | undefined)
     }
@@ -138,18 +186,15 @@ export class SSHServer extends EventEmitter {
         ctx.reject(["publickey"] as AuthenticationType[])
       }
     })
-
-    if (accepted) {
-      return {
-        username: ctx.username,
-        publicKey: ctx.method === "publickey" && ctx.key ? ctx.key.algo : undefined,
-      }
-    }
-
-    return null
   }
 
-  private handleSession(sshSession: Session, user: UserInfo, remoteAddress: string, connection: Connection): void {
+  private handleSession(
+    sshSession: Session,
+    user: UserInfo,
+    remoteAddress: string,
+    connection: Connection,
+    connectionState: Record<string, unknown>,
+  ): void {
     let ptyInfo: PtyInfo | null = null
 
     sshSession.on("pty", (accept, _reject, info) => {
@@ -170,6 +215,12 @@ export class SSHServer extends EventEmitter {
         return
       }
 
+      // Enforce maxSessions limit (0 = unlimited)
+      if (this.maxSessions > 0 && this.sessions.size >= this.maxSessions) {
+        reject?.()
+        return
+      }
+
       const stream = accept()
       if (!stream) return
 
@@ -179,7 +230,7 @@ export class SSHServer extends EventEmitter {
         connection,
         username: user.username,
         remoteAddress,
-        state: {},
+        state: connectionState,
         log: (message: string) => process.stdout.write(message + "\n"),
       }
       // Start middleware with error handling (non-blocking)
@@ -193,10 +244,18 @@ export class SSHServer extends EventEmitter {
       // Create session asynchronously
       SSHSession.create(stream, finalPty, user, remoteAddress, this.rendererOptions)
         .then((session) => {
+          this.trackSession(session)
+
           // Handle window-change on the ssh session (not stream)
-          sshSession.on("window-change", (accept, _reject, info) => {
+          const windowChangeHandler = (accept: (() => void) | undefined, _reject: any, info: any) => {
             session.handleResize(info.cols, info.rows)
             accept?.()
+          }
+          sshSession.on("window-change", windowChangeHandler)
+
+          // Remove window-change listener when session closes to avoid reference leak
+          session.once("close", () => {
+            sshSession.removeListener("window-change", windowChangeHandler)
           })
 
           this.emit("session", session)
@@ -217,7 +276,7 @@ export class SSHServer extends EventEmitter {
       if (stream) {
         // Log the exec attempt for debugging (note: we accept then exit, not reject)
         const command = (info as { command?: string }).command ?? "<unknown>"
-        console.log(
+        console.error(
           `[SSH] exec request not supported (command: ${command.substring(0, 50)}${command.length > 50 ? "..." : ""})`,
         )
         // Exit with non-zero status to indicate exec is not supported

--- a/packages/ssh/src/session.ts
+++ b/packages/ssh/src/session.ts
@@ -24,6 +24,11 @@ export class SSHSession extends EventEmitter {
   private _pty: PtyInfo
   private _stream: ServerChannel
   private _closed = false
+  private _closePromise: Promise<void> | null = null
+
+  private static readonly MAX_WIDTH = 500
+  private static readonly MAX_HEIGHT = 200
+  private static readonly IDLE_TIMEOUT_MS = 5000
 
   public get pty(): Readonly<PtyInfo> {
     return this._pty
@@ -53,7 +58,11 @@ export class SSHSession extends EventEmitter {
       Omit<CliRendererConfig, "stdin" | "stdout" | "outputMode" | "onOutput" | "width" | "height" | "feedOptions">
     > = {},
   ): Promise<SSHSession> {
-    // Create placeholder for the session so we can reference it in onOutput
+    // Create placeholder for the session so we can reference it in onOutput.
+    // Note: `session` is null during createCliRenderer(). The optional chaining
+    // (`session?.`) evaluates to undefined (falsy), allowing initial setup output
+    // to flow through to the stream. This is intentional — the SSH stream is
+    // writable before the SSHSession wrapper is constructed.
     let session: SSHSession | null = null
 
     const renderer = await createCliRenderer({
@@ -120,27 +129,70 @@ export class SSHSession extends EventEmitter {
 
   /** Internal cleanup when stream closes/errors - idempotent */
   private _cleanup(): void {
-    if (this._closed) return
+    void this.beginClose({ closeStream: false })
+  }
+
+  private async waitForRendererIdleWithTimeout(): Promise<void> {
+    await Promise.race([
+      this.renderer.idle(),
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, SSHSession.IDLE_TIMEOUT_MS)
+      }),
+    ])
+  }
+
+  private beginClose(options: { closeStream: boolean; exitCode?: number }): Promise<void> {
+    if (this._closePromise) {
+      return this._closePromise
+    }
+
     this._closed = true
 
-    // Stop renderer and clean up asynchronously
-    this.renderer.stop()
-    this.renderer
-      .idle()
-      .then(() => {
-        this.renderer.destroy()
+    this._closePromise = (async () => {
+      try {
+        if (options.closeStream) {
+          try {
+            this._stream.exit(options.exitCode ?? 0)
+            this._stream.end()
+          } catch (err) {
+            console.error(`[SSH] Error while closing stream: ${err instanceof Error ? err.message : String(err)}`)
+          }
+        }
+
+        this.renderer.stop()
+
+        try {
+          await this.waitForRendererIdleWithTimeout()
+        } catch (err) {
+          console.error(
+            `[SSH] Error while waiting for renderer idle: ${err instanceof Error ? err.message : String(err)}`,
+          )
+        }
+
+        try {
+          this.renderer.destroy()
+        } catch (err) {
+          console.error(`[SSH] Error during renderer destroy: ${err instanceof Error ? err.message : String(err)}`)
+        }
+      } finally {
         this.emit("close")
-      })
-      .catch((err) => {
-        console.error(`[SSH] Error during session cleanup: ${err instanceof Error ? err.message : String(err)}`)
-        // Still emit close event so listeners know the session is done
-        this.emit("close")
-      })
+      }
+    })()
+
+    return this._closePromise
   }
 
   public handleResize(width: number, height: number): void {
+    if (this._closed) return
     // Validate dimensions - reject invalid values from malicious/buggy clients
-    if (width < 1 || height < 1 || width > 10000 || height > 10000) {
+    if (
+      !Number.isInteger(width) ||
+      !Number.isInteger(height) ||
+      width < 1 ||
+      height < 1 ||
+      width > SSHSession.MAX_WIDTH ||
+      height > SSHSession.MAX_HEIGHT
+    ) {
       return
     }
     this._pty.width = width
@@ -149,27 +201,7 @@ export class SSHSession extends EventEmitter {
     this.emit("resize", width, height)
   }
 
-  public close(exitCode: number = 0): void {
-    if (this._closed) return
-    this._closed = true
-
-    // Close the SSH stream FIRST (immediately) so the client sees the disconnect
-    // This allows new connections to work without waiting for renderer cleanup
-    this._stream.exit(exitCode)
-    this._stream.end()
-
-    // Then clean up the renderer asynchronously
-    this.renderer.stop()
-    this.renderer
-      .idle()
-      .then(() => {
-        this.renderer.destroy()
-        this.emit("close")
-      })
-      .catch((err) => {
-        console.error(`[SSH] Error during session close: ${err instanceof Error ? err.message : String(err)}`)
-        // Still emit close event so listeners know the session is done
-        this.emit("close")
-      })
+  public close(exitCode: number = 0): Promise<void> {
+    return this.beginClose({ closeStream: true, exitCode })
   }
 }

--- a/packages/ssh/src/session.ts
+++ b/packages/ssh/src/session.ts
@@ -1,0 +1,175 @@
+import { EventEmitter } from "events"
+import { createCliRenderer, type CliRenderer, type CliRendererConfig } from "@opentui/core"
+import type { ServerChannel } from "ssh2"
+import type { PtyInfo, UserInfo } from "./types.ts"
+
+export interface SSHSessionEvents {
+  close: () => void
+  resize: (width: number, height: number) => void
+}
+
+// Declaration merging for typed events
+export interface SSHSession {
+  on<K extends keyof SSHSessionEvents>(event: K, listener: SSHSessionEvents[K]): this
+  once<K extends keyof SSHSessionEvents>(event: K, listener: SSHSessionEvents[K]): this
+  off<K extends keyof SSHSessionEvents>(event: K, listener: SSHSessionEvents[K]): this
+  emit<K extends keyof SSHSessionEvents>(event: K, ...args: Parameters<SSHSessionEvents[K]>): boolean
+}
+
+export class SSHSession extends EventEmitter {
+  public readonly renderer: CliRenderer
+  public readonly user: UserInfo
+  public readonly remoteAddress: string
+
+  private _pty: PtyInfo
+  private _stream: ServerChannel
+  private _closed = false
+
+  public get pty(): Readonly<PtyInfo> {
+    return this._pty
+  }
+
+  private constructor(
+    renderer: CliRenderer,
+    stream: ServerChannel,
+    ptyInfo: PtyInfo,
+    user: UserInfo,
+    remoteAddress: string,
+  ) {
+    super()
+    this.renderer = renderer
+    this._stream = stream
+    this._pty = { ...ptyInfo }
+    this.user = user
+    this.remoteAddress = remoteAddress
+  }
+
+  static async create(
+    stream: ServerChannel,
+    ptyInfo: PtyInfo,
+    user: UserInfo,
+    remoteAddress: string,
+    rendererOptions: Partial<
+      Omit<CliRendererConfig, "stdin" | "stdout" | "outputMode" | "onOutput" | "width" | "height" | "feedOptions">
+    > = {},
+  ): Promise<SSHSession> {
+    // Create placeholder for the session so we can reference it in onOutput
+    let session: SSHSession | null = null
+
+    const renderer = await createCliRenderer({
+      ...rendererOptions,
+      outputMode: "stream",
+      width: ptyInfo.width,
+      height: ptyInfo.height,
+      useAlternateScreen: rendererOptions.useAlternateScreen ?? true,
+      openConsoleOnError: false,
+      useConsole: false,
+      exitOnCtrlC: false,
+      exitSignals: [],
+      onOutput: (buffer: Uint8Array) => {
+        // Guard: skip write if session is closed or stream is not writable
+        if (session?._closed || !stream.writable) {
+          return
+        }
+        // Zero-copy write to SSH stream:
+        // Buffer.from(arrayBuffer, offset, length) creates a VIEW over the same memory,
+        // NOT a copy. This was validated in Bun runtime - modifications to either the
+        // original Uint8Array or the Buffer reflect in both.
+        // The native buffer stays pinned until the returned Promise resolves.
+        const out = Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+        return new Promise<void>((resolve) => {
+          // Wrap stream.write in try/catch to guarantee resolution even on error
+          try {
+            stream.write(out, (err) => {
+              if (err) {
+                console.error(`[SSH] Stream write error: ${err.message}`)
+              }
+              resolve()
+            })
+          } catch (err) {
+            // stream.write can throw synchronously if stream is destroyed
+            console.error(`[SSH] Stream write threw: ${err instanceof Error ? err.message : String(err)}`)
+            resolve()
+          }
+        })
+      },
+    })
+
+    session = new SSHSession(renderer, stream, ptyInfo, user, remoteAddress)
+
+    // Wire SSH input -> renderer
+    stream.on("data", (data: Buffer) => {
+      if (!session!._closed) {
+        renderer.input(data)
+      }
+    })
+
+    // Handle stream errors
+    stream.on("error", (err: Error) => {
+      console.error(`[SSH] Stream error: ${err.message}`)
+      session!._cleanup()
+    })
+
+    // Wire cleanup on stream close
+    stream.once("close", () => {
+      session!._cleanup()
+    })
+
+    return session
+  }
+
+  /** Internal cleanup when stream closes/errors - idempotent */
+  private _cleanup(): void {
+    if (this._closed) return
+    this._closed = true
+
+    // Stop renderer and clean up asynchronously
+    this.renderer.stop()
+    this.renderer
+      .idle()
+      .then(() => {
+        this.renderer.destroy()
+        this.emit("close")
+      })
+      .catch((err) => {
+        console.error(`[SSH] Error during session cleanup: ${err instanceof Error ? err.message : String(err)}`)
+        // Still emit close event so listeners know the session is done
+        this.emit("close")
+      })
+  }
+
+  public handleResize(width: number, height: number): void {
+    // Validate dimensions - reject invalid values from malicious/buggy clients
+    if (width < 1 || height < 1 || width > 10000 || height > 10000) {
+      return
+    }
+    this._pty.width = width
+    this._pty.height = height
+    this.renderer.resize(width, height)
+    this.emit("resize", width, height)
+  }
+
+  public close(exitCode: number = 0): void {
+    if (this._closed) return
+    this._closed = true
+
+    // Close the SSH stream FIRST (immediately) so the client sees the disconnect
+    // This allows new connections to work without waiting for renderer cleanup
+    this._stream.exit(exitCode)
+    this._stream.end()
+
+    // Then clean up the renderer asynchronously
+    this.renderer.stop()
+    this.renderer
+      .idle()
+      .then(() => {
+        this.renderer.destroy()
+        this.emit("close")
+      })
+      .catch((err) => {
+        console.error(`[SSH] Error during session close: ${err instanceof Error ? err.message : String(err)}`)
+        // Still emit close event so listeners know the session is done
+        this.emit("close")
+      })
+  }
+}

--- a/packages/ssh/src/types.ts
+++ b/packages/ssh/src/types.ts
@@ -1,0 +1,63 @@
+import type { CliRendererConfig } from "@opentui/core"
+import type { Connection, PublicKey } from "ssh2"
+
+export type MiddlewarePhase = "auth" | "session"
+
+export interface MiddlewareContext {
+  phase: MiddlewarePhase
+  connection: Connection
+  username: string
+  clientKey?: PublicKey
+  remoteAddress: string
+  state: Record<string, unknown>
+  accept?: () => void
+  reject?: (allowedMethods?: string[]) => void
+  /** Log helper that bypasses console capture - use in callbacks that run during renderer teardown */
+  log: (message: string) => void
+}
+
+export type NextFn = () => void | Promise<void>
+export type Middleware = (ctx: MiddlewareContext, next: NextFn) => void | Promise<void>
+
+export interface SSHServerConfig {
+  port: number
+  host?: string
+  hostKeyPath: string
+  requirePty?: boolean
+  // SSHSession owns stream-mode wiring (outputMode/onOutput/stdin/stdout/size).
+  // rendererOptions only exposes safe app-level renderer tuning.
+  rendererOptions?: Omit<
+    CliRendererConfig,
+    "stdin" | "stdout" | "outputMode" | "onOutput" | "width" | "height" | "feedOptions"
+  >
+  middleware?: Middleware[]
+}
+
+export interface PtyInfo {
+  term: string
+  width: number
+  height: number
+}
+
+export interface UserInfo {
+  username: string
+  publicKey?: string
+}
+
+export interface PublicKeyOptions {
+  authorizedKeysPath?: string
+  authorizedKeys?: string[]
+}
+
+export interface LoggingOptions {
+  onAuthAttempt?: (ctx: MiddlewareContext, success: boolean) => void
+  onConnect?: (ctx: MiddlewareContext) => void
+  onDisconnect?: (ctx: MiddlewareContext) => void
+}
+
+export interface AuthorizedKey {
+  type: string
+  key: string
+  comment?: string
+  options?: string
+}

--- a/packages/ssh/src/types.ts
+++ b/packages/ssh/src/types.ts
@@ -24,6 +24,8 @@ export interface SSHServerConfig {
   host?: string
   hostKeyPath: string
   requirePty?: boolean
+  /** Maximum concurrent sessions (0 = unlimited, default: 0). */
+  maxSessions?: number
   // SSHSession owns stream-mode wiring (outputMode/onOutput/stdin/stdout/size).
   // rendererOptions only exposes safe app-level renderer tuning.
   rendererOptions?: Omit<

--- a/packages/ssh/src/utils/authorized-keys.ts
+++ b/packages/ssh/src/utils/authorized-keys.ts
@@ -1,0 +1,36 @@
+import { utils } from "ssh2"
+import type { AuthorizedKey } from "../types.ts"
+
+export function parseAuthorizedKeys(content: string): AuthorizedKey[] {
+  return content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"))
+    .map(parseLine)
+    .filter((key): key is AuthorizedKey => key !== null)
+}
+
+function parseLine(line: string): AuthorizedKey | null {
+  // Handle options prefix: command="...",from="..." ssh-ed25519 AAAA...
+  // Key types start with "ssh-", "ecdsa-", or "sk-"
+  const keyTypeMatch = line.match(/(ssh-\S+|ecdsa-\S+|sk-\S+)\s+(\S+)(\s+(.*))?/)
+  if (!keyTypeMatch) return null
+
+  const [, type, key, , comment] = keyTypeMatch
+
+  // Validate key can be parsed by ssh2
+  try {
+    const parsed = utils.parseKey(`${type} ${key}`)
+    if (!parsed || parsed instanceof Error) {
+      return null
+    }
+  } catch {
+    return null // Invalid key format
+  }
+
+  return { type, key, comment }
+}
+
+export function matchesKey(clientKeyType: string, clientKeyData: string, authorizedKeys: AuthorizedKey[]): boolean {
+  return authorizedKeys.some((ak) => ak.type === clientKeyType && ak.key === clientKeyData)
+}

--- a/packages/ssh/src/utils/authorized-keys.ts
+++ b/packages/ssh/src/utils/authorized-keys.ts
@@ -11,12 +11,12 @@ export function parseAuthorizedKeys(content: string): AuthorizedKey[] {
 }
 
 function parseLine(line: string): AuthorizedKey | null {
-  // Handle options prefix: command="...",from="..." ssh-ed25519 AAAA...
-  // Key types start with "ssh-", "ecdsa-", or "sk-"
-  const keyTypeMatch = line.match(/(ssh-\S+|ecdsa-\S+|sk-\S+)\s+(\S+)(\s+(.*))?/)
+  // Handle optional options prefix: command="...",from="..." ssh-ed25519 AAAA...
+  // Key types start with "ssh-", "ecdsa-", or "sk-".
+  const keyTypeMatch = line.match(/^(?:(.*?)\s+)?(ssh-\S+|ecdsa-\S+|sk-\S+)\s+(\S+)(?:\s+(.*))?$/)
   if (!keyTypeMatch) return null
 
-  const [, type, key, , comment] = keyTypeMatch
+  const [, options, type, key, comment] = keyTypeMatch
 
   // Validate key can be parsed by ssh2
   try {
@@ -28,7 +28,7 @@ function parseLine(line: string): AuthorizedKey | null {
     return null // Invalid key format
   }
 
-  return { type, key, comment }
+  return { type, key, comment, options: options?.trim() || undefined }
 }
 
 export function matchesKey(clientKeyType: string, clientKeyData: string, authorizedKeys: AuthorizedKey[]): boolean {

--- a/packages/ssh/src/utils/host-key.ts
+++ b/packages/ssh/src/utils/host-key.ts
@@ -1,0 +1,22 @@
+import { utils } from "ssh2"
+import { writeFileSync, mkdirSync, existsSync, readFileSync, chmodSync } from "fs"
+import { dirname } from "path"
+
+export function ensureHostKey(keyPath: string): Buffer {
+  if (existsSync(keyPath)) {
+    return readFileSync(keyPath)
+  }
+
+  const dir = dirname(keyPath)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+  }
+
+  // Use ssh2's key generation to ensure OpenSSH format compatibility
+  const keypair = utils.generateKeyPairSync("ed25519")
+
+  writeFileSync(keyPath, keypair.private, { mode: 0o600 })
+  chmodSync(keyPath, 0o600)
+
+  return Buffer.from(keypair.private, "utf-8")
+}

--- a/packages/ssh/src/utils/host-key.ts
+++ b/packages/ssh/src/utils/host-key.ts
@@ -1,9 +1,13 @@
 import { utils } from "ssh2"
-import { writeFileSync, mkdirSync, existsSync, readFileSync, chmodSync } from "fs"
+import { writeFileSync, mkdirSync, existsSync, readFileSync, chmodSync, statSync } from "fs"
 import { dirname } from "path"
 
 export function ensureHostKey(keyPath: string): Buffer {
   if (existsSync(keyPath)) {
+    const mode = statSync(keyPath).mode & 0o777
+    if ((mode & 0o077) !== 0) {
+      chmodSync(keyPath, 0o600)
+    }
     return readFileSync(keyPath)
   }
 

--- a/packages/ssh/tests/authorized-keys.test.ts
+++ b/packages/ssh/tests/authorized-keys.test.ts
@@ -1,0 +1,131 @@
+import { test, expect, describe } from "bun:test"
+import { parseAuthorizedKeys, matchesKey } from "../src/utils/authorized-keys.ts"
+
+describe("parseAuthorizedKeys", () => {
+  test("parses valid ssh-ed25519 key", () => {
+    const content = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host"
+    const keys = parseAuthorizedKeys(content)
+
+    expect(keys).toHaveLength(1)
+    expect(keys[0].type).toBe("ssh-ed25519")
+    expect(keys[0].key).toBe("AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl")
+    expect(keys[0].comment).toBe("user@host")
+  })
+
+  test("parses multiple keys", () => {
+    const content = `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user1@host
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user2@host`
+
+    const keys = parseAuthorizedKeys(content)
+    expect(keys).toHaveLength(2)
+  })
+
+  test("skips comment lines", () => {
+    const content = `# This is a comment
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host
+# Another comment`
+
+    const keys = parseAuthorizedKeys(content)
+    expect(keys).toHaveLength(1)
+  })
+
+  test("skips empty lines", () => {
+    const content = `
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host
+
+`
+    const keys = parseAuthorizedKeys(content)
+    expect(keys).toHaveLength(1)
+  })
+
+  test("handles key without comment", () => {
+    const content = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+    const keys = parseAuthorizedKeys(content)
+
+    expect(keys).toHaveLength(1)
+    expect(keys[0].comment).toBeUndefined()
+  })
+
+  test("handles options prefix", () => {
+    const content = `command="/bin/echo" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl restricted`
+    const keys = parseAuthorizedKeys(content)
+
+    expect(keys).toHaveLength(1)
+    expect(keys[0].type).toBe("ssh-ed25519")
+    expect(keys[0].comment).toBe("restricted")
+  })
+
+  test("rejects invalid key format", () => {
+    const content = "invalid-key-type AAAA123 badkey"
+    const keys = parseAuthorizedKeys(content)
+
+    expect(keys).toHaveLength(0)
+  })
+
+  test("handles mixed valid and invalid keys", () => {
+    const content = `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl valid
+invalid-type BADKEY invalid
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl another-valid`
+
+    const keys = parseAuthorizedKeys(content)
+    expect(keys).toHaveLength(2)
+  })
+})
+
+describe("matchesKey", () => {
+  test("returns true for matching key", () => {
+    const keys = parseAuthorizedKeys(
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host",
+    )
+
+    const result = matchesKey(
+      "ssh-ed25519",
+      "AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl",
+      keys,
+    )
+
+    expect(result).toBe(true)
+  })
+
+  test("returns false for non-matching key type", () => {
+    const keys = parseAuthorizedKeys(
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host",
+    )
+
+    const result = matchesKey("ssh-rsa", "AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl", keys)
+
+    expect(result).toBe(false)
+  })
+
+  test("returns false for non-matching key data", () => {
+    const keys = parseAuthorizedKeys(
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host",
+    )
+
+    const result = matchesKey("ssh-ed25519", "DIFFERENT_KEY_DATA", keys)
+
+    expect(result).toBe(false)
+  })
+
+  test("returns false for empty authorized keys list", () => {
+    const result = matchesKey("ssh-ed25519", "AAAA", [])
+    expect(result).toBe(false)
+  })
+
+  test("finds match among multiple keys", () => {
+    // Use the same valid key twice with different comments to test matching
+    const content = `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl key1
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl key2`
+
+    const keys = parseAuthorizedKeys(content)
+
+    // Should match both (they're the same key)
+    const result = matchesKey(
+      "ssh-ed25519",
+      "AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl",
+      keys,
+    )
+
+    expect(result).toBe(true)
+  })
+})

--- a/packages/ssh/tests/authorized-keys.test.ts
+++ b/packages/ssh/tests/authorized-keys.test.ts
@@ -53,6 +53,7 @@ ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
     expect(keys).toHaveLength(1)
     expect(keys[0].type).toBe("ssh-ed25519")
     expect(keys[0].comment).toBe("restricted")
+    expect(keys[0].options).toBe('command="/bin/echo"')
   })
 
   test("rejects invalid key format", () => {

--- a/packages/ssh/tests/host-key.test.ts
+++ b/packages/ssh/tests/host-key.test.ts
@@ -1,0 +1,108 @@
+import { test, expect, describe, afterEach } from "bun:test"
+import { ensureHostKey } from "../src/utils/host-key.ts"
+import { unlinkSync, existsSync, statSync, mkdirSync, writeFileSync, rmdirSync } from "fs"
+import { tmpdir } from "os"
+import { join, dirname } from "path"
+
+describe("ensureHostKey", () => {
+  const testDir = join(tmpdir(), "opentui-ssh-test-" + Date.now())
+  const cleanupPaths: string[] = []
+
+  afterEach(() => {
+    // Cleanup test files
+    for (const path of cleanupPaths) {
+      try {
+        if (existsSync(path)) {
+          unlinkSync(path)
+        }
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+    cleanupPaths.length = 0
+
+    // Cleanup test directory
+    try {
+      if (existsSync(testDir)) {
+        rmdirSync(testDir, { recursive: true })
+      }
+    } catch {
+      // Ignore
+    }
+  })
+
+  test("generates new Ed25519 key if file does not exist", () => {
+    const keyPath = join(testDir, "new-host-key")
+    cleanupPaths.push(keyPath)
+
+    const key = ensureHostKey(keyPath)
+
+    expect(existsSync(keyPath)).toBe(true)
+    expect(key).toBeInstanceOf(Buffer)
+    // ssh2 generates OpenSSH format keys
+    expect(key.toString()).toContain("-----BEGIN OPENSSH PRIVATE KEY-----")
+    expect(key.toString()).toContain("-----END OPENSSH PRIVATE KEY-----")
+  })
+
+  test("loads existing key if file exists", () => {
+    const keyPath = join(testDir, "existing-key")
+    cleanupPaths.push(keyPath)
+
+    // Create directory and write a dummy key
+    mkdirSync(dirname(keyPath), { recursive: true })
+    const dummyKey = "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"
+    writeFileSync(keyPath, dummyKey, { mode: 0o600 })
+
+    const key = ensureHostKey(keyPath)
+
+    expect(key.toString()).toBe(dummyKey)
+  })
+
+  test("creates parent directory if it does not exist", () => {
+    const keyPath = join(testDir, "nested", "deep", "host-key")
+    cleanupPaths.push(keyPath)
+
+    ensureHostKey(keyPath)
+
+    expect(existsSync(keyPath)).toBe(true)
+    expect(existsSync(dirname(keyPath))).toBe(true)
+  })
+
+  test("sets correct file permissions (0o600)", () => {
+    const keyPath = join(testDir, "perms-test-key")
+    cleanupPaths.push(keyPath)
+
+    ensureHostKey(keyPath)
+
+    const stat = statSync(keyPath)
+    const mode = stat.mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  test("returns same content when called twice for same path", () => {
+    const keyPath = join(testDir, "idempotent-key")
+    cleanupPaths.push(keyPath)
+
+    const key1 = ensureHostKey(keyPath)
+    const key2 = ensureHostKey(keyPath)
+
+    expect(key1.equals(key2)).toBe(true)
+  })
+
+  test("generates valid OpenSSH format key", () => {
+    const keyPath = join(testDir, "openssh-format-key")
+    cleanupPaths.push(keyPath)
+
+    const key = ensureHostKey(keyPath)
+    const keyStr = key.toString().trim()
+
+    // Check OpenSSH format (ssh2 generates this format)
+    const lines = keyStr.split("\n")
+    expect(lines[0]).toBe("-----BEGIN OPENSSH PRIVATE KEY-----")
+    expect(lines[lines.length - 1]).toBe("-----END OPENSSH PRIVATE KEY-----")
+
+    // Check base64 content exists
+    const base64Content = lines.slice(1, -1).join("")
+    expect(base64Content.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/ssh/tests/host-key.test.ts
+++ b/packages/ssh/tests/host-key.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe, afterEach } from "bun:test"
 import { ensureHostKey } from "../src/utils/host-key.ts"
-import { unlinkSync, existsSync, statSync, mkdirSync, writeFileSync, rmdirSync } from "fs"
+import { unlinkSync, existsSync, statSync, mkdirSync, writeFileSync, rmSync } from "fs"
 import { tmpdir } from "os"
 import { join, dirname } from "path"
 
@@ -24,7 +24,7 @@ describe("ensureHostKey", () => {
     // Cleanup test directory
     try {
       if (existsSync(testDir)) {
-        rmdirSync(testDir, { recursive: true })
+        rmSync(testDir, { recursive: true, force: true })
       }
     } catch {
       // Ignore
@@ -87,6 +87,21 @@ describe("ensureHostKey", () => {
     const key2 = ensureHostKey(keyPath)
 
     expect(key1.equals(key2)).toBe(true)
+  })
+
+  test("tightens permissions on existing key", () => {
+    const keyPath = join(testDir, "insecure-key")
+    cleanupPaths.push(keyPath)
+
+    mkdirSync(dirname(keyPath), { recursive: true })
+    const dummyKey = "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"
+    writeFileSync(keyPath, dummyKey, { mode: 0o644 })
+
+    ensureHostKey(keyPath)
+
+    const stat = statSync(keyPath)
+    const mode = stat.mode & 0o777
+    expect(mode).toBe(0o600)
   })
 
   test("generates valid OpenSSH format key", () => {

--- a/packages/ssh/tests/integration.test.ts
+++ b/packages/ssh/tests/integration.test.ts
@@ -1,0 +1,100 @@
+import { test, expect, describe } from "bun:test"
+import { EventEmitter } from "events"
+import type { ServerChannel } from "ssh2"
+import { TextRenderable, RGBA } from "@opentui/core"
+import { SSHSession } from "../src/session.ts"
+
+function createMockStream() {
+  const emitter = new EventEmitter()
+  const writes: Buffer[] = []
+
+  const stream = Object.assign(emitter, {
+    writable: true,
+    write: (chunk: Buffer, callback?: (err?: Error | null) => void) => {
+      writes.push(Buffer.from(chunk))
+      callback?.(null)
+      return true
+    },
+    end: () => {
+      stream.writable = false
+    },
+    exit: (_code?: number) => {},
+  })
+
+  return { stream: stream as unknown as ServerChannel, writes }
+}
+
+async function createSession() {
+  const { stream, writes } = createMockStream()
+  const session = await SSHSession.create(
+    stream,
+    { term: "xterm", width: 80, height: 24 },
+    { username: "test" },
+    "127.0.0.1",
+  )
+  return { session, stream, writes }
+}
+
+describe("SSH integration", () => {
+  test("forwards stream input to renderer key handlers", async () => {
+    const { session, stream } = await createSession()
+    let keypressReceived = false
+
+    session.renderer.keyInput.on("keypress", (key: any) => {
+      if (key.name === "a") {
+        keypressReceived = true
+      }
+    })
+
+    stream.emit("data", Buffer.from("a"))
+    await Bun.sleep(20)
+
+    expect(keypressReceived).toBe(true)
+    await session.close()
+  })
+
+  test("propagates renderer output to stream writes", async () => {
+    const { session, writes } = await createSession()
+
+    const initialWrites = writes.length
+    const text = new TextRenderable(session.renderer, {
+      id: "integration-text",
+      content: "hello over ssh",
+      fg: RGBA.fromInts(255, 255, 255, 255),
+    })
+    session.renderer.root.add(text)
+
+    session.renderer.requestRender()
+
+    const deadline = Date.now() + 300
+    while (writes.length <= initialWrites && Date.now() < deadline) {
+      await Bun.sleep(10)
+    }
+
+    expect(writes.length).toBeGreaterThan(initialWrites)
+    await session.close()
+  })
+
+  test("propagates resize to renderer dimensions", async () => {
+    const { session } = await createSession()
+
+    session.handleResize(100, 30)
+
+    const deadline = Date.now() + 300
+    while ((session.renderer.width !== 100 || session.renderer.height !== 30) && Date.now() < deadline) {
+      await Bun.sleep(10)
+    }
+
+    expect(session.renderer.width).toBe(100)
+    expect(session.renderer.height).toBe(30)
+    await session.close()
+  })
+
+  test("close() tears down renderer lifecycle", async () => {
+    const { session } = await createSession()
+
+    await session.close()
+
+    expect(session.renderer.isDestroyed).toBe(true)
+  })
+})

--- a/packages/ssh/tests/middleware.test.ts
+++ b/packages/ssh/tests/middleware.test.ts
@@ -1,0 +1,393 @@
+import { test, expect, describe } from "bun:test"
+import { EventEmitter } from "events"
+import { compose, devMode, logging, publicKey } from "../src/middleware/index.ts"
+import type { MiddlewareContext, Middleware } from "../src/types.ts"
+import type { PublicKey } from "ssh2"
+
+function createMockContext(overrides: Partial<MiddlewareContext> = {}): MiddlewareContext {
+  return {
+    phase: "auth",
+    connection: {} as any,
+    username: "testuser",
+    remoteAddress: "127.0.0.1",
+    state: {},
+    ...overrides,
+  }
+}
+
+describe("compose", () => {
+  test("executes middlewares in order (before next)", async () => {
+    const order: string[] = []
+
+    const mw1: Middleware = async (_ctx, next) => {
+      order.push("mw1-before")
+      await next()
+      order.push("mw1-after")
+    }
+
+    const mw2: Middleware = async (_ctx, next) => {
+      order.push("mw2-before")
+      await next()
+      order.push("mw2-after")
+    }
+
+    const mw3: Middleware = async (_ctx, next) => {
+      order.push("mw3-before")
+      await next()
+      order.push("mw3-after")
+    }
+
+    const composed = compose(mw1, mw2, mw3)
+    const ctx = createMockContext()
+
+    await composed(ctx, () => {
+      order.push("final")
+    })
+
+    expect(order).toEqual(["mw1-before", "mw2-before", "mw3-before", "final", "mw3-after", "mw2-after", "mw1-after"])
+  })
+
+  test("passes context through middleware chain", async () => {
+    const mw1: Middleware = async (ctx, next) => {
+      ctx.state.mw1 = true
+      await next()
+    }
+
+    const mw2: Middleware = async (ctx, next) => {
+      ctx.state.mw2 = ctx.state.mw1 ? "saw-mw1" : "no-mw1"
+      await next()
+    }
+
+    const composed = compose(mw1, mw2)
+    const ctx = createMockContext()
+
+    await composed(ctx, () => {})
+
+    expect(ctx.state.mw1).toBe(true)
+    expect(ctx.state.mw2).toBe("saw-mw1")
+  })
+
+  test("throws error when next() called multiple times", async () => {
+    const badMw: Middleware = async (_ctx, next) => {
+      await next()
+      await next()
+    }
+
+    const composed = compose(badMw)
+    const ctx = createMockContext()
+
+    await expect(composed(ctx, () => {})).rejects.toThrow("next() called multiple times")
+  })
+
+  test("works with empty middleware array", async () => {
+    const composed = compose()
+    const ctx = createMockContext()
+    let finalCalled = false
+
+    await composed(ctx, () => {
+      finalCalled = true
+    })
+
+    expect(finalCalled).toBe(true)
+  })
+
+  test("middleware can short-circuit by not calling next", async () => {
+    const order: string[] = []
+
+    const mw1: Middleware = async (_ctx, next) => {
+      order.push("mw1-before")
+      await next()
+      order.push("mw1-after")
+    }
+
+    const shortCircuit: Middleware = async (_ctx, _next) => {
+      order.push("short-circuit")
+      // Don't call next()
+    }
+
+    const mw3: Middleware = async (_ctx, next) => {
+      order.push("mw3-before")
+      await next()
+      order.push("mw3-after")
+    }
+
+    const composed = compose(mw1, shortCircuit, mw3)
+    const ctx = createMockContext()
+
+    await composed(ctx, () => {
+      order.push("final")
+    })
+
+    expect(order).toEqual(["mw1-before", "short-circuit", "mw1-after"])
+  })
+})
+
+describe("devMode", () => {
+  test("accepts auth requests", async () => {
+    const mw = devMode()
+    let accepted = false
+
+    const ctx = createMockContext({
+      phase: "auth",
+      accept: () => {
+        accepted = true
+      },
+    })
+
+    await mw(ctx, () => {})
+
+    expect(accepted).toBe(true)
+  })
+
+  test("does not accept on session phase", async () => {
+    const mw = devMode()
+    let accepted = false
+
+    const ctx = createMockContext({
+      phase: "session",
+      accept: () => {
+        accepted = true
+      },
+    })
+
+    await mw(ctx, () => {})
+
+    expect(accepted).toBe(false)
+  })
+
+  test("calls next after accepting", async () => {
+    const mw = devMode()
+    let nextCalled = false
+
+    const ctx = createMockContext({
+      phase: "auth",
+      accept: () => {},
+    })
+
+    await mw(ctx, () => {
+      nextCalled = true
+    })
+
+    expect(nextCalled).toBe(true)
+  })
+})
+
+describe("logging", () => {
+  test("calls onAuthAttempt with success on accept", async () => {
+    let authResult: boolean | undefined
+    const mw = logging({
+      onAuthAttempt: (_ctx, success) => {
+        authResult = success
+      },
+    })
+
+    const ctx = createMockContext({
+      phase: "auth",
+      accept: () => {},
+    })
+
+    // Simulate acceptance by another middleware
+    const composed = compose(mw, devMode())
+    await composed(ctx, () => {})
+
+    expect(authResult).toBe(true)
+  })
+
+  test("calls onAuthAttempt with failure on reject", async () => {
+    let authResult: boolean | undefined
+    const mw = logging({
+      onAuthAttempt: (_ctx, success) => {
+        authResult = success
+      },
+    })
+
+    const ctx = createMockContext({
+      phase: "auth",
+      accept: () => {},
+      reject: () => {},
+    })
+
+    // Simulate rejection
+    const rejectMw: Middleware = async (ctx, next) => {
+      ctx.reject?.()
+      await next()
+    }
+
+    const composed = compose(mw, rejectMw)
+    await composed(ctx, () => {})
+
+    expect(authResult).toBe(false)
+  })
+
+  test("calls onConnect on session phase", async () => {
+    let connectCalled = false
+    const mw = logging({
+      onConnect: () => {
+        connectCalled = true
+      },
+    })
+
+    const mockConnection = new EventEmitter()
+    const ctx = createMockContext({
+      phase: "session",
+      connection: mockConnection as any,
+    })
+
+    await mw(ctx, () => {})
+
+    expect(connectCalled).toBe(true)
+  })
+
+  test("sets up onDisconnect listener", async () => {
+    let disconnectCalled = false
+    const mw = logging({
+      onDisconnect: () => {
+        disconnectCalled = true
+      },
+    })
+
+    const mockConnection = new EventEmitter()
+    const ctx = createMockContext({
+      phase: "session",
+      connection: mockConnection as any,
+    })
+
+    await mw(ctx, () => {})
+
+    // Trigger close event
+    mockConnection.emit("close")
+
+    expect(disconnectCalled).toBe(true)
+  })
+})
+
+describe("publicKey", () => {
+  // Valid Ed25519 key for testing
+  const validKeyType = "ssh-ed25519"
+  const validKeyData = "AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+  const validKeyString = `${validKeyType} ${validKeyData} test@host`
+
+  function createClientKey(algo: string, dataBase64: string): PublicKey {
+    return {
+      algo,
+      data: Buffer.from(dataBase64, "base64"),
+    }
+  }
+
+  test("accepts authorized key", async () => {
+    const mw = publicKey({
+      authorizedKeys: [validKeyString],
+    })
+
+    let accepted = false
+    const ctx = createMockContext({
+      phase: "auth",
+      clientKey: createClientKey(validKeyType, validKeyData),
+      accept: () => {
+        accepted = true
+      },
+      reject: () => {},
+    })
+
+    await mw(ctx, () => {})
+
+    expect(accepted).toBe(true)
+  })
+
+  test("rejects unauthorized key", async () => {
+    const mw = publicKey({
+      authorizedKeys: [validKeyString],
+    })
+
+    let rejected = false
+    const ctx = createMockContext({
+      phase: "auth",
+      clientKey: createClientKey("ssh-ed25519", "DIFFERENT_KEY_DATA"),
+      accept: () => {},
+      reject: () => {
+        rejected = true
+      },
+    })
+
+    await mw(ctx, () => {})
+
+    expect(rejected).toBe(true)
+  })
+
+  test("rejects when no keys authorized", async () => {
+    const mw = publicKey({
+      authorizedKeys: [],
+    })
+
+    let rejected = false
+    const ctx = createMockContext({
+      phase: "auth",
+      clientKey: createClientKey(validKeyType, validKeyData),
+      accept: () => {},
+      reject: () => {
+        rejected = true
+      },
+    })
+
+    await mw(ctx, () => {})
+
+    expect(rejected).toBe(true)
+  })
+
+  test("passes through non-auth phases", async () => {
+    const mw = publicKey({
+      authorizedKeys: [],
+    })
+
+    let nextCalled = false
+    let accepted = false
+    let rejected = false
+
+    const ctx = createMockContext({
+      phase: "session",
+      accept: () => {
+        accepted = true
+      },
+      reject: () => {
+        rejected = true
+      },
+    })
+
+    await mw(ctx, () => {
+      nextCalled = true
+    })
+
+    expect(nextCalled).toBe(true)
+    expect(accepted).toBe(false)
+    expect(rejected).toBe(false)
+  })
+
+  test("passes through non-publickey auth", async () => {
+    const mw = publicKey({
+      authorizedKeys: [validKeyString],
+    })
+
+    let nextCalled = false
+    let accepted = false
+    let rejected = false
+
+    const ctx = createMockContext({
+      phase: "auth",
+      clientKey: undefined, // No client key = not publickey auth
+      accept: () => {
+        accepted = true
+      },
+      reject: () => {
+        rejected = true
+      },
+    })
+
+    await mw(ctx, () => {
+      nextCalled = true
+    })
+
+    expect(nextCalled).toBe(true)
+    expect(accepted).toBe(false)
+    expect(rejected).toBe(false)
+  })
+})

--- a/packages/ssh/tests/middleware.test.ts
+++ b/packages/ssh/tests/middleware.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe } from "bun:test"
 import { EventEmitter } from "events"
-import { compose, devMode, logging, publicKey } from "../src/middleware/index.ts"
+import { compose, devMode, allowAll, logging, publicKey } from "../src/middleware/index.ts"
 import type { MiddlewareContext, Middleware } from "../src/types.ts"
 import type { PublicKey } from "ssh2"
 import { mkdtempSync, rmSync, writeFileSync } from "fs"
@@ -126,9 +126,9 @@ describe("compose", () => {
   })
 })
 
-describe("devMode", () => {
+describe("allowAll", () => {
   test("accepts auth requests", async () => {
-    const mw = devMode()
+    const mw = allowAll()
     let accepted = false
 
     const ctx = createMockContext({
@@ -144,7 +144,7 @@ describe("devMode", () => {
   })
 
   test("does not accept on session phase", async () => {
-    const mw = devMode()
+    const mw = allowAll()
     let accepted = false
 
     const ctx = createMockContext({
@@ -160,7 +160,7 @@ describe("devMode", () => {
   })
 
   test("calls next after accepting", async () => {
-    const mw = devMode()
+    const mw = allowAll()
     let nextCalled = false
 
     const ctx = createMockContext({
@@ -173,6 +173,24 @@ describe("devMode", () => {
     })
 
     expect(nextCalled).toBe(true)
+  })
+})
+
+describe("devMode", () => {
+  test("accepts auth requests (delegates to allowAll)", async () => {
+    const mw = devMode()
+    let accepted = false
+
+    const ctx = createMockContext({
+      phase: "auth",
+      accept: () => {
+        accepted = true
+      },
+    })
+
+    await mw(ctx, () => {})
+
+    expect(accepted).toBe(true)
   })
 })
 

--- a/packages/ssh/tests/middleware.test.ts
+++ b/packages/ssh/tests/middleware.test.ts
@@ -461,4 +461,29 @@ describe("publicKey", () => {
       rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  test("rejects keys with authorized_keys options to avoid unsupported restriction bypass", async () => {
+    const mw = publicKey({
+      authorizedKeys: [`from="127.0.0.1" ${validKeyString}`],
+    })
+
+    let accepted = false
+    let rejected = false
+
+    const ctx = createMockContext({
+      phase: "auth",
+      clientKey: createClientKey(validKeyType, validKeyData),
+      accept: () => {
+        accepted = true
+      },
+      reject: () => {
+        rejected = true
+      },
+    })
+
+    await mw(ctx, () => {})
+
+    expect(accepted).toBe(false)
+    expect(rejected).toBe(true)
+  })
 })

--- a/packages/ssh/tests/middleware.test.ts
+++ b/packages/ssh/tests/middleware.test.ts
@@ -3,6 +3,9 @@ import { EventEmitter } from "events"
 import { compose, devMode, logging, publicKey } from "../src/middleware/index.ts"
 import type { MiddlewareContext, Middleware } from "../src/types.ts"
 import type { PublicKey } from "ssh2"
+import { mkdtempSync, rmSync, writeFileSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
 
 function createMockContext(overrides: Partial<MiddlewareContext> = {}): MiddlewareContext {
   return {
@@ -11,6 +14,7 @@ function createMockContext(overrides: Partial<MiddlewareContext> = {}): Middlewa
     username: "testuser",
     remoteAddress: "127.0.0.1",
     state: {},
+    log: () => {},
     ...overrides,
   }
 }
@@ -362,6 +366,46 @@ describe("publicKey", () => {
     expect(rejected).toBe(false)
   })
 
+  test("does not call next() after accept to prevent downstream override", async () => {
+    const mw = publicKey({
+      authorizedKeys: [validKeyString],
+    })
+
+    let nextCalled = false
+    const ctx = createMockContext({
+      phase: "auth",
+      clientKey: createClientKey(validKeyType, validKeyData),
+      accept: () => {},
+      reject: () => {},
+    })
+
+    await mw(ctx, () => {
+      nextCalled = true
+    })
+
+    expect(nextCalled).toBe(false)
+  })
+
+  test("does not call next() after reject to prevent downstream override", async () => {
+    const mw = publicKey({
+      authorizedKeys: [validKeyString],
+    })
+
+    let nextCalled = false
+    const ctx = createMockContext({
+      phase: "auth",
+      clientKey: createClientKey("ssh-ed25519", "DIFFERENT_KEY_DATA"),
+      accept: () => {},
+      reject: () => {},
+    })
+
+    await mw(ctx, () => {
+      nextCalled = true
+    })
+
+    expect(nextCalled).toBe(false)
+  })
+
   test("passes through non-publickey auth", async () => {
     const mw = publicKey({
       authorizedKeys: [validKeyString],
@@ -389,5 +433,32 @@ describe("publicKey", () => {
     expect(nextCalled).toBe(true)
     expect(accepted).toBe(false)
     expect(rejected).toBe(false)
+  })
+
+  test("loads authorized keys from authorizedKeysPath", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "opentui-ssh-authkeys-"))
+    const keyPath = join(dir, "authorized_keys")
+    writeFileSync(keyPath, validKeyString + "\n", "utf-8")
+
+    try {
+      const mw = publicKey({
+        authorizedKeysPath: keyPath,
+      })
+
+      let accepted = false
+      const ctx = createMockContext({
+        phase: "auth",
+        clientKey: createClientKey(validKeyType, validKeyData),
+        accept: () => {
+          accepted = true
+        },
+        reject: () => {},
+      })
+
+      await mw(ctx, () => {})
+      expect(accepted).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/ssh/tests/server.test.ts
+++ b/packages/ssh/tests/server.test.ts
@@ -1,0 +1,164 @@
+import { test, expect, describe, afterEach } from "bun:test"
+import { EventEmitter } from "events"
+import { createSSHServer, devMode } from "../src/index.ts"
+import type { UserInfo } from "../src/types.ts"
+import { tmpdir } from "os"
+import { join } from "path"
+import { unlinkSync, existsSync, rmdirSync } from "fs"
+
+describe("SSHServer", () => {
+  const testDir = join(tmpdir(), "opentui-ssh-server-test-" + Date.now())
+  let serverCleanup: (() => void) | null = null
+
+  afterEach(() => {
+    // Cleanup server
+    if (serverCleanup) {
+      serverCleanup()
+      serverCleanup = null
+    }
+
+    // Cleanup test directory
+    try {
+      if (existsSync(testDir)) {
+        rmdirSync(testDir, { recursive: true })
+      }
+    } catch {
+      // Ignore
+    }
+  })
+
+  test("creates server with config", () => {
+    const server = createSSHServer({
+      port: 0,
+      hostKeyPath: join(testDir, "host-key"),
+      middleware: [devMode()],
+    })
+
+    expect(server).toBeDefined()
+    expect(server.port).toBe(0)
+    serverCleanup = () => server.close()
+  })
+
+  test("emits listening event on start", async () => {
+    const server = createSSHServer({
+      port: 0, // Random port
+      hostKeyPath: join(testDir, "host-key-listening"),
+      middleware: [devMode()],
+    })
+    serverCleanup = () => server.close()
+
+    let listeningEmitted = false
+    server.on("listening", () => {
+      listeningEmitted = true
+    })
+
+    await server.listen()
+
+    expect(listeningEmitted).toBe(true)
+  })
+
+  test("emits close event on stop", async () => {
+    const server = createSSHServer({
+      port: 0,
+      hostKeyPath: join(testDir, "host-key-close"),
+      middleware: [devMode()],
+    })
+
+    await server.listen()
+
+    let closeEmitted = false
+    server.on("close", () => {
+      closeEmitted = true
+    })
+
+    server.close()
+    serverCleanup = null // Already closed
+
+    expect(closeEmitted).toBe(true)
+  })
+
+  test("generates host key if missing", async () => {
+    const keyPath = join(testDir, "generated-host-key")
+
+    expect(existsSync(keyPath)).toBe(false)
+
+    const server = createSSHServer({
+      port: 0,
+      hostKeyPath: keyPath,
+      middleware: [devMode()],
+    })
+    serverCleanup = () => server.close()
+
+    await server.listen()
+
+    expect(existsSync(keyPath)).toBe(true)
+  })
+
+  test("uses default host (0.0.0.0) when not specified", () => {
+    const server = createSSHServer({
+      port: 2222,
+      hostKeyPath: join(testDir, "host-key-default"),
+      middleware: [devMode()],
+    })
+    serverCleanup = () => server.close()
+
+    // Just verify it creates without error
+    expect(server).toBeDefined()
+  })
+
+  test("requirePty defaults to true", () => {
+    const server = createSSHServer({
+      port: 2222,
+      hostKeyPath: join(testDir, "host-key-pty"),
+      middleware: [devMode()],
+    })
+    serverCleanup = () => server.close()
+
+    // Server should be created with requirePty default
+    expect(server).toBeDefined()
+  })
+
+  test("sets authenticated user before session start", async () => {
+    const server = createSSHServer({
+      port: 0,
+      hostKeyPath: join(testDir, "host-key-auth-order"),
+      middleware: [devMode()],
+    })
+    serverCleanup = () => server.close()
+
+    const client = new EventEmitter()
+    let capturedUser: UserInfo | null = null
+
+    ;(server as any).handleSession = (_sshSession: unknown, user: UserInfo) => {
+      capturedUser = user
+    }
+    ;(server as any).handleConnection(client as any, { ip: "127.0.0.1" } as any)
+
+    const ctx = {
+      username: "testuser",
+      method: "publickey",
+      key: { algo: "ssh-ed25519", data: Buffer.from("AAAA", "base64") },
+      accept: () => {
+        client.emit("ready")
+        client.emit(
+          "session",
+          () => ({}),
+          () => {},
+        )
+      },
+      reject: () => {},
+    } as any
+
+    client.emit("authentication", ctx)
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    if (!capturedUser) {
+      throw new Error("Expected authenticated user")
+    }
+
+    const resolvedUser = capturedUser as unknown as { username: string; publicKey?: string }
+    expect(resolvedUser.username).toBe("testuser")
+    expect(resolvedUser.publicKey).toBe("ssh-ed25519")
+  })
+})

--- a/packages/ssh/tests/server.test.ts
+++ b/packages/ssh/tests/server.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe, afterEach } from "bun:test"
 import { EventEmitter } from "events"
 import { createSSHServer, devMode } from "../src/index.ts"
+import { SSHSession } from "../src/session.ts"
 import type { UserInfo } from "../src/types.ts"
 import { tmpdir } from "os"
 import { join } from "path"
@@ -208,6 +209,213 @@ describe("SSHServer", () => {
     expect(resolvedUser.publicKey).toBe("ssh-ed25519")
   })
 
+  test("falls back to default PTY size when client sends invalid dimensions", async () => {
+    const server = createSSHServer({
+      port: 0,
+      hostKeyPath: join(testDir, "host-key-invalid-pty"),
+      middleware: [devMode()],
+      requirePty: false,
+    })
+
+    const originalCreate = SSHSession.create
+    let capturedPty: { term: string; width: number; height: number } | null = null
+
+    ;(SSHSession as any).create = (
+      _stream: unknown,
+      pty: { term: string; width: number; height: number },
+      _user: unknown,
+      _remoteAddress: unknown,
+      _rendererOptions: unknown,
+    ) => {
+      capturedPty = pty
+      const session = new EventEmitter() as any
+      session.handleResize = () => {}
+      session.close = async () => {
+        session.emit("close")
+      }
+      return Promise.resolve(session)
+    }
+
+    try {
+      const sshSession = new EventEmitter()
+      ;(server as any).handleSession(
+        sshSession as any,
+        { username: "testuser" },
+        "127.0.0.1",
+        new EventEmitter() as any,
+        {},
+      )
+
+      sshSession.emit(
+        "pty",
+        () => {},
+        () => {},
+        { term: "xterm-256color", cols: 0, rows: 0 },
+      )
+
+      const stream = new EventEmitter() as any
+      stream.writable = true
+      stream.exit = () => {}
+      stream.end = () => {}
+
+      sshSession.emit(
+        "shell",
+        () => stream,
+        () => {
+          throw new Error("shell should not be rejected")
+        },
+      )
+
+      await Bun.sleep(0)
+
+      if (!capturedPty) {
+        throw new Error("Expected SSHSession.create to be called")
+      }
+      const resolvedPty = capturedPty as { term: string; width: number; height: number }
+      expect(resolvedPty.term).toBe("xterm-256color")
+      expect(resolvedPty.width).toBe(80)
+      expect(resolvedPty.height).toBe(24)
+    } finally {
+      ;(SSHSession as any).create = originalCreate
+      ;(server as any).sessions.clear()
+      ;(server as any).pendingSessions = 0
+    }
+  })
+
+  test("enforces maxSessions while session creation is pending", async () => {
+    const server = createSSHServer({
+      port: 0,
+      hostKeyPath: join(testDir, "host-key-max-sessions-pending"),
+      middleware: [devMode()],
+      requirePty: false,
+      maxSessions: 1,
+    })
+
+    const originalCreate = SSHSession.create
+    let resolveCreate!: (session: SSHSession) => void
+    const createPromise = new Promise<SSHSession>((resolve) => {
+      resolveCreate = resolve
+    })
+    ;(SSHSession as any).create = () => createPromise
+
+    try {
+      const sshSession = new EventEmitter()
+      ;(server as any).handleSession(
+        sshSession as any,
+        { username: "testuser" },
+        "127.0.0.1",
+        new EventEmitter() as any,
+        {},
+      )
+
+      const stream1 = new EventEmitter() as any
+      stream1.writable = true
+      stream1.exit = () => {}
+      stream1.end = () => {}
+
+      let rejectedSecond = false
+
+      sshSession.emit(
+        "shell",
+        () => stream1,
+        () => {
+          throw new Error("first shell should not be rejected")
+        },
+      )
+
+      sshSession.emit(
+        "shell",
+        () => {
+          throw new Error("second shell should be rejected before accept")
+        },
+        () => {
+          rejectedSecond = true
+        },
+      )
+
+      expect(rejectedSecond).toBe(true)
+      expect((server as any).pendingSessions).toBe(1)
+
+      const createdSession = new EventEmitter() as any
+      createdSession.handleResize = () => {}
+      createdSession.close = async () => {
+        createdSession.emit("close")
+      }
+      resolveCreate(createdSession)
+      await Bun.sleep(0)
+    } finally {
+      ;(SSHSession as any).create = originalCreate
+      ;(server as any).sessions.clear()
+      ;(server as any).pendingSessions = 0
+    }
+  })
+
+  test("closes session created after close() begins", async () => {
+    const server = createSSHServer({
+      port: 0,
+      hostKeyPath: join(testDir, "host-key-close-race"),
+      middleware: [devMode()],
+      requirePty: false,
+    })
+
+    ;(server as any).server = {
+      close: (cb: () => void) => cb(),
+      address: () => ({ port: 0 }),
+    }
+
+    const originalCreate = SSHSession.create
+    let resolveCreate!: (session: SSHSession) => void
+    const createPromise = new Promise<SSHSession>((resolve) => {
+      resolveCreate = resolve
+    })
+    ;(SSHSession as any).create = () => createPromise
+
+    try {
+      const sshSession = new EventEmitter()
+      ;(server as any).handleSession(
+        sshSession as any,
+        { username: "testuser" },
+        "127.0.0.1",
+        new EventEmitter() as any,
+        {},
+      )
+
+      const stream = new EventEmitter() as any
+      stream.writable = true
+      stream.exit = () => {}
+      stream.end = () => {}
+
+      sshSession.emit(
+        "shell",
+        () => stream,
+        () => {
+          throw new Error("shell should not be rejected before close starts")
+        },
+      )
+
+      const closePromise = server.close()
+
+      let closeCalls = 0
+      const createdSession = new EventEmitter() as any
+      createdSession.handleResize = () => {}
+      createdSession.close = async () => {
+        closeCalls += 1
+        createdSession.emit("close")
+      }
+      resolveCreate(createdSession)
+
+      await closePromise
+      await Bun.sleep(0)
+
+      expect(closeCalls).toBe(1)
+      expect(server.activeSessions).toBe(0)
+    } finally {
+      ;(SSHSession as any).create = originalCreate
+      ;(server as any).sessions.clear()
+      ;(server as any).pendingSessions = 0
+    }
+  })
+
   test("ignores second auth decision after accept", async () => {
     const server = createSSHServer({
       port: 0,
@@ -250,5 +458,48 @@ describe("SSHServer", () => {
 
     expect(acceptCount).toBe(1)
     expect(rejectCount).toBe(0)
+  })
+
+  test("does not reject after accept when auth middleware throws", async () => {
+    const server = createSSHServer({
+      port: 0,
+      hostKeyPath: join(testDir, "host-key-auth-accept-throw"),
+      middleware: [
+        async (ctx, _next) => {
+          if (ctx.phase === "auth") {
+            ctx.accept?.()
+            throw new Error("auth middleware error after accept")
+          }
+        },
+      ],
+    })
+
+    const client = new EventEmitter()
+    ;(server as any).handleConnection(client as any, { ip: "127.0.0.1" } as any)
+
+    let acceptCount = 0
+    let rejectCount = 0
+    let errorCount = 0
+    server.on("error", () => {
+      errorCount += 1
+    })
+
+    client.emit("authentication", {
+      username: "testuser",
+      method: "publickey",
+      key: { algo: "ssh-ed25519", data: Buffer.from("AAAA", "base64") },
+      accept: () => {
+        acceptCount += 1
+      },
+      reject: () => {
+        rejectCount += 1
+      },
+    } as any)
+
+    await Bun.sleep(0)
+
+    expect(acceptCount).toBe(1)
+    expect(rejectCount).toBe(0)
+    expect(errorCount).toBe(1)
   })
 })

--- a/packages/ssh/tests/server.test.ts
+++ b/packages/ssh/tests/server.test.ts
@@ -4,23 +4,23 @@ import { createSSHServer, devMode } from "../src/index.ts"
 import type { UserInfo } from "../src/types.ts"
 import { tmpdir } from "os"
 import { join } from "path"
-import { unlinkSync, existsSync, rmdirSync } from "fs"
+import { existsSync, rmSync } from "fs"
 
 describe("SSHServer", () => {
   const testDir = join(tmpdir(), "opentui-ssh-server-test-" + Date.now())
-  let serverCleanup: (() => void) | null = null
+  let serverCleanup: (() => Promise<void>) | null = null
 
-  afterEach(() => {
+  afterEach(async () => {
     // Cleanup server
     if (serverCleanup) {
-      serverCleanup()
+      await serverCleanup()
       serverCleanup = null
     }
 
     // Cleanup test directory
     try {
       if (existsSync(testDir)) {
-        rmdirSync(testDir, { recursive: true })
+        rmSync(testDir, { recursive: true, force: true })
       }
     } catch {
       // Ignore
@@ -36,7 +36,9 @@ describe("SSHServer", () => {
 
     expect(server).toBeDefined()
     expect(server.port).toBe(0)
-    serverCleanup = () => server.close()
+    serverCleanup = async () => {
+      await server.close()
+    }
   })
 
   test("emits listening event on start", async () => {
@@ -45,7 +47,9 @@ describe("SSHServer", () => {
       hostKeyPath: join(testDir, "host-key-listening"),
       middleware: [devMode()],
     })
-    serverCleanup = () => server.close()
+    serverCleanup = async () => {
+      await server.close()
+    }
 
     let listeningEmitted = false
     server.on("listening", () => {
@@ -71,7 +75,7 @@ describe("SSHServer", () => {
       closeEmitted = true
     })
 
-    server.close()
+    await server.close()
     serverCleanup = null // Already closed
 
     expect(closeEmitted).toBe(true)
@@ -87,7 +91,9 @@ describe("SSHServer", () => {
       hostKeyPath: keyPath,
       middleware: [devMode()],
     })
-    serverCleanup = () => server.close()
+    serverCleanup = async () => {
+      await server.close()
+    }
 
     await server.listen()
 
@@ -100,7 +106,9 @@ describe("SSHServer", () => {
       hostKeyPath: join(testDir, "host-key-default"),
       middleware: [devMode()],
     })
-    serverCleanup = () => server.close()
+    serverCleanup = async () => {
+      await server.close()
+    }
 
     // Just verify it creates without error
     expect(server).toBeDefined()
@@ -112,10 +120,46 @@ describe("SSHServer", () => {
       hostKeyPath: join(testDir, "host-key-pty"),
       middleware: [devMode()],
     })
-    serverCleanup = () => server.close()
+    serverCleanup = async () => {
+      await server.close()
+    }
 
     // Server should be created with requirePty default
     expect(server).toBeDefined()
+  })
+
+  test("rejects shell when maxSessions limit is reached", () => {
+    const server = createSSHServer({
+      port: 0,
+      hostKeyPath: join(testDir, "host-key-max-sessions"),
+      middleware: [devMode()],
+      requirePty: false,
+      maxSessions: 1,
+    })
+    serverCleanup = async () => {
+      await server.close()
+    }
+
+    const sshSession = new EventEmitter()
+    ;(server as any).sessions = new Set([{}])
+    ;(server as any).handleSession(
+      sshSession as any,
+      { username: "testuser" },
+      "127.0.0.1",
+      new EventEmitter() as any,
+      {},
+    )
+
+    let rejected = false
+    sshSession.emit(
+      "shell",
+      () => ({}),
+      () => {
+        rejected = true
+      },
+    )
+
+    expect(rejected).toBe(true)
   })
 
   test("sets authenticated user before session start", async () => {
@@ -124,7 +168,9 @@ describe("SSHServer", () => {
       hostKeyPath: join(testDir, "host-key-auth-order"),
       middleware: [devMode()],
     })
-    serverCleanup = () => server.close()
+    serverCleanup = async () => {
+      await server.close()
+    }
 
     const client = new EventEmitter()
     let capturedUser: UserInfo | null = null
@@ -160,5 +206,49 @@ describe("SSHServer", () => {
     const resolvedUser = capturedUser as unknown as { username: string; publicKey?: string }
     expect(resolvedUser.username).toBe("testuser")
     expect(resolvedUser.publicKey).toBe("ssh-ed25519")
+  })
+
+  test("ignores second auth decision after accept", async () => {
+    const server = createSSHServer({
+      port: 0,
+      hostKeyPath: join(testDir, "host-key-auth-guard"),
+      middleware: [
+        async (ctx, next) => {
+          if (ctx.phase === "auth") {
+            ctx.accept?.()
+            await next()
+            ctx.reject?.(["publickey"])
+            return
+          }
+          await next()
+        },
+      ],
+    })
+    serverCleanup = async () => {
+      await server.close()
+    }
+
+    let acceptCount = 0
+    let rejectCount = 0
+
+    await (server as any).handleAuth(
+      {
+        username: "testuser",
+        method: "publickey",
+        key: { algo: "ssh-ed25519", data: Buffer.from("AAAA", "base64") },
+        accept: () => {
+          acceptCount += 1
+        },
+        reject: () => {
+          rejectCount += 1
+        },
+      },
+      "127.0.0.1",
+      new EventEmitter() as any,
+      {},
+    )
+
+    expect(acceptCount).toBe(1)
+    expect(rejectCount).toBe(0)
   })
 })

--- a/packages/ssh/tests/session.test.ts
+++ b/packages/ssh/tests/session.test.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "bun:test"
+import { EventEmitter } from "events"
+import type { ServerChannel } from "ssh2"
+import { SSHSession } from "../src/session.ts"
+
+function createMockStream() {
+  const emitter = new EventEmitter()
+  const writes: Buffer[] = []
+
+  const stream = Object.assign(emitter, {
+    writable: true,
+    write: (chunk: Buffer, callback?: () => void) => {
+      writes.push(Buffer.from(chunk))
+      callback?.()
+      return true
+    },
+    end: () => {
+      stream.writable = false
+    },
+    exit: (_code?: number) => {},
+  })
+
+  return { stream: stream as unknown as ServerChannel, writes }
+}
+
+test("SSHSession writes terminal setup output during create", async () => {
+  const { stream, writes } = createMockStream()
+
+  const session = await SSHSession.create(
+    stream,
+    { term: "xterm", width: 80, height: 24 },
+    { username: "testuser" },
+    "127.0.0.1",
+  )
+
+  const deadline = Date.now() + 250
+  while (writes.length === 0 && Date.now() < deadline) {
+    await Bun.sleep(5)
+  }
+
+  expect(writes.length).toBeGreaterThan(0)
+
+  session.close()
+  await new Promise<void>((resolve) => session.once("close", () => resolve()))
+})

--- a/packages/ssh/tests/session.test.ts
+++ b/packages/ssh/tests/session.test.ts
@@ -1,17 +1,20 @@
-import { test, expect } from "bun:test"
+import { test, expect, describe } from "bun:test"
 import { EventEmitter } from "events"
 import type { ServerChannel } from "ssh2"
 import { SSHSession } from "../src/session.ts"
 
-function createMockStream() {
+function createMockStream(options: { throwOnWrite?: boolean; callbackError?: Error } = {}) {
   const emitter = new EventEmitter()
   const writes: Buffer[] = []
 
   const stream = Object.assign(emitter, {
     writable: true,
-    write: (chunk: Buffer, callback?: () => void) => {
+    write: (chunk: Buffer, callback?: (err?: Error | null) => void) => {
+      if (options.throwOnWrite) {
+        throw new Error("write failed")
+      }
       writes.push(Buffer.from(chunk))
-      callback?.()
+      callback?.(options.callbackError ?? null)
       return true
     },
     end: () => {
@@ -23,23 +26,131 @@ function createMockStream() {
   return { stream: stream as unknown as ServerChannel, writes }
 }
 
-test("SSHSession writes terminal setup output during create", async () => {
-  const { stream, writes } = createMockStream()
-
+async function createTestSession(streamOverride?: ReturnType<typeof createMockStream>) {
+  const { stream, writes } = streamOverride ?? createMockStream()
   const session = await SSHSession.create(
     stream,
     { term: "xterm", width: 80, height: 24 },
     { username: "testuser" },
     "127.0.0.1",
   )
+  return { session, stream, writes }
+}
 
-  const deadline = Date.now() + 250
-  while (writes.length === 0 && Date.now() < deadline) {
-    await Bun.sleep(5)
-  }
+function waitForClose(session: SSHSession): Promise<void> {
+  return new Promise<void>((resolve) => session.once("close", () => resolve()))
+}
 
-  expect(writes.length).toBeGreaterThan(0)
+describe("SSHSession", () => {
+  test("writes terminal setup output during create", async () => {
+    const { session, writes } = await createTestSession()
 
-  session.close()
-  await new Promise<void>((resolve) => session.once("close", () => resolve()))
+    const deadline = Date.now() + 250
+    while (writes.length === 0 && Date.now() < deadline) {
+      await Bun.sleep(5)
+    }
+
+    expect(writes.length).toBeGreaterThan(0)
+
+    session.close()
+    await waitForClose(session)
+  })
+
+  test("close() is idempotent", async () => {
+    const { session } = await createTestSession()
+
+    const closePromise = waitForClose(session)
+    await session.close()
+    await session.close() // second call should be a no-op
+    await closePromise
+
+    // Should not throw or double-emit
+    expect(session.pty).toBeDefined()
+  })
+
+  test("handleResize skips when session is closed", async () => {
+    const { session } = await createTestSession()
+
+    await session.close()
+
+    // Should not throw — the _closed guard skips the resize
+    session.handleResize(120, 40)
+    expect(session.pty.width).toBe(80) // unchanged from original
+  })
+
+  test("handleResize rejects invalid dimensions", async () => {
+    const { session } = await createTestSession()
+
+    session.handleResize(0, 24)
+    expect(session.pty.width).toBe(80) // unchanged
+
+    session.handleResize(80, -1)
+    expect(session.pty.height).toBe(24) // unchanged
+
+    session.handleResize(10001, 24)
+    expect(session.pty.width).toBe(80) // unchanged
+
+    session.handleResize(NaN, 24)
+    expect(session.pty.width).toBe(80) // unchanged
+
+    session.handleResize(80.5, 24)
+    expect(session.pty.width).toBe(80) // unchanged
+
+    await session.close()
+  })
+
+  test("handleResize updates dimensions when valid", async () => {
+    const { session } = await createTestSession()
+
+    session.handleResize(120, 40)
+    expect(session.pty.width).toBe(120)
+    expect(session.pty.height).toBe(40)
+
+    await session.close()
+  })
+
+  test("_cleanup from stream close is idempotent with close()", async () => {
+    const mock = createMockStream()
+    const { session, stream } = await createTestSession(mock)
+
+    const closePromise = waitForClose(session)
+
+    // Close from the SSH side (stream close event)
+    stream.emit("close")
+    await closePromise
+
+    // Calling close() after stream-driven cleanup should not throw
+    await session.close()
+  })
+
+  test("create succeeds when stream.write callback reports error", async () => {
+    const mock = createMockStream({ callbackError: new Error("callback failure") })
+    const { session, writes } = await createTestSession(mock)
+
+    const deadline = Date.now() + 250
+    while (writes.length === 0 && Date.now() < deadline) {
+      await Bun.sleep(5)
+    }
+
+    expect(writes.length).toBeGreaterThan(0)
+
+    await session.close()
+  })
+
+  test("create succeeds when stream.write throws synchronously", async () => {
+    const mock = createMockStream({ throwOnWrite: true })
+    const { session } = await createTestSession(mock)
+
+    expect(session).toBeDefined()
+
+    await session.close()
+  })
+
+  test("create rejects when renderer cannot be created", async () => {
+    const { stream } = createMockStream()
+
+    await expect(
+      SSHSession.create(stream, { term: "xterm", width: 0, height: 24 }, { username: "testuser" }, "127.0.0.1"),
+    ).rejects.toThrow("width to be a positive integer")
+  })
 })

--- a/packages/ssh/tsconfig.build.json
+++ b/packages/ssh/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "noEmit": false,
+    "rootDir": ".",
+    "types": ["bun", "node"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@opentui/core": ["../core/dist"],
+      "@opentui/core/*": ["../core/dist/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "examples/**/*", "scripts/**/*", "node_modules/**/*", "../core/**/*"]
+}

--- a/packages/ssh/tsconfig.json
+++ b/packages/ssh/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    // Enable latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}


### PR DESCRIPTION
# `@opentui/ssh` + stream-mode renderer migration

## Summary
- Adds a new `@opentui/ssh` package for running OpenTUI apps over SSH with per-session renderer isolation.
- Migrates core non-stdout transport from callback output to `outputMode: "stream"` backed by `NativeSpanFeed` in Zig.
- Applies follow-up hardening from review: auth decision guarding, session admission race fixes, authorized_keys option safety, PTY dimension normalization, and renderer stdin teardown correction.

## What This PR Includes

### 1) New package: `@opentui/ssh`
- `createSSHServer()` with lifecycle events (`listening`, `session`, `error`, `close`).
- `SSHSession` wrapper with stream output wiring, input forwarding, resize handling, and idempotent close.
- Built-in middleware:
  - `logging()`
  - `publicKey()` (OpenSSH `authorized_keys` parsing/matching)
  - `allowAll()` (production-ready open server, no warnings)
  - `devMode()` (development-only, prints security warning)
- Host key utilities and docs/examples/tests.

### 2) Core renderer stream architecture
- `outputMode: "stream"` in `@opentui/core` with required `onOutput`, `width`, and `height` validation.
- NativeSpanFeed/Zig integration for feed-backed output dispatch and backpressure-safe async delivery.
- Renderer and test utilities updated for stream-mode creation and validation.

### 3) Reviewer follow-up fixes
- Prevents auth double-decision races via guarded accept/reject flow in SSH auth handling.
- Enforces `maxSessions` against active + pending session creation to close async admission race.
- Normalizes invalid PTY dimensions (e.g. `0x0`) to safe defaults before renderer creation.
- Treats `authorized_keys` option-prefixed entries as unsupported and ignores them (with warning) to avoid silently weakening restrictions.
- Fixes global `process.stdin.pause()` behavior so stream-only renderer teardown does not pause stdin.

## Documentation and Testing
- Expanded `packages/ssh/README.md` with middleware phases/order, auth/session patterns, and compatibility notes.
- Added/expanded tests across:
  - `packages/ssh/tests/*` (server, middleware, authorized-keys, session, integration, host-key)
  - `packages/core/src/tests/renderer.stream-mode.test.ts`
  - `packages/core/src/tests/renderer.stream-validation.test.ts`

## Manual Verification (SSH Counter Example)
1. Start the example server:
   - `cd packages/ssh`
   - `bun run example`
2. In another terminal, connect with SSH:
   - `ssh -p 2222 localhost`
3. Validate behavior in one or more sessions:
   - `+` / `-` updates the counter
   - terminal resize updates displayed dimensions
   - `q` cleanly closes the session
4. (If host key changed) clear stale host key entry:
   - `ssh-keygen -R "[localhost]:2222"`

## Pilotty-Based Verification

### 1) Install Pilotty
```bash
npm install -g pilotty
```
Verify with `pilotty --version`.

### 2) Install the Pilotty OpenCode skill
```bash
npx skills add msmps/pilotty
```

### 3) AI-assisted review prompt
Use this in OpenCode to run the flow autonomously:

```text
use pilotty to test out the ssh impl with the ssh counter example;
spawn concurrent sessions and validate
```

Expected validation flow: start server, open concurrent SSH sessions, verify per-session counter isolation, test resize propagation, and quit sessions cleanly.

## Notes
- `publicKey()` currently supports key matching only; OpenSSH option prefixes (`from=`, `command=`, `no-pty`, etc.) are intentionally not enforced yet and are ignored.