### PR TITLE
fix(renderer): add errdefer for hit grid

### DIFF
--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -458,6 +458,7 @@ pub const CliRenderer = struct {
         const currentHitGridSize = self.hitGridWidth * self.hitGridHeight;
         if (newHitGridSize > currentHitGridSize) {
             const newCurrentHitGrid = try self.allocator.alloc(u32, newHitGridSize);
+            errdefer self.allocator.free(newCurrentHitGrid);
             const newNextHitGrid = try self.allocator.alloc(u32, newHitGridSize);
             @memset(newCurrentHitGrid, 0);
             @memset(newNextHitGrid, 0);


### PR DESCRIPTION
If the second hit grid allocation fails, the first allocation is now properly freed via errdefer.

Similar to #640 and #641