### PR TITLE
Add Renderable.scrollIntoView()

### DIFF
--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -429,6 +429,21 @@ export abstract class Renderable extends BaseRenderable {
     this.emit(RenderableEvents.BLURRED)
   }
 
+  /**
+   * Scroll the nearest ScrollBox ancestor so that this renderable is fully visible.
+   * No-op if no ScrollBox ancestor exists.
+   */
+  public scrollIntoView(): void {
+    let current: Renderable | null = this.parent
+    while (current) {
+      if ("scrollChildIntoView" in current) {
+        ;(current as Renderable & { scrollChildIntoView: (child: Renderable) => void }).scrollChildIntoView(this)
+        return
+      }
+      current = current.parent
+    }
+  }
+
   public get focused(): boolean {
     return this._focused
   }

--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -380,6 +380,24 @@ export class ScrollBoxRenderable extends BoxRenderable {
     // the scrollTop/scrollLeft setters handle it
   }
 
+  /**
+   * Scroll the minimum amount needed to make `child` fully visible in the viewport.
+   * If the child is already visible, does nothing. If the child is taller than the
+   * viewport, aligns to the top edge.
+   */
+  private scrollChildIntoView(child: Renderable): void {
+    const childTop = child.y - this.content.y
+    const childBottom = childTop + child.height
+    const viewTop = this.scrollTop
+    const viewBottom = viewTop + this.viewport.height
+
+    if (childTop < viewTop) {
+      this.scrollTop = childTop
+    } else if (childBottom > viewBottom) {
+      this.scrollTop = childBottom - this.viewport.height
+    }
+  }
+
   private isAtStickyPosition(): boolean {
     if (!this._stickyScroll || !this._stickyStart) {
       return false

--- a/packages/core/src/tests/scrollbox-scroll-into-view.test.ts
+++ b/packages/core/src/tests/scrollbox-scroll-into-view.test.ts
@@ -1,0 +1,123 @@
+import { test, expect, beforeEach, afterEach } from "bun:test"
+import { createTestRenderer, type TestRenderer } from "../testing"
+import { BoxRenderable } from "../renderables/Box"
+import { ScrollBoxRenderable } from "../renderables/ScrollBox"
+
+let testRenderer: TestRenderer
+let renderOnce: () => Promise<void>
+
+beforeEach(async () => {
+  ;({ renderer: testRenderer, renderOnce } = await createTestRenderer({ width: 80, height: 24 }))
+})
+
+afterEach(() => {
+  testRenderer.destroy()
+})
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Renderable.scrollIntoView()
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test("child below viewport scrolls down", async () => {
+  const scrollbox = new ScrollBoxRenderable(testRenderer, {
+    id: "sb",
+    width: 40,
+    height: 10,
+  })
+
+  // Create children taller than the viewport
+  const a = new BoxRenderable(testRenderer, { id: "a", width: 40, height: 5 })
+  const b = new BoxRenderable(testRenderer, { id: "b", width: 40, height: 5 })
+  const c = new BoxRenderable(testRenderer, { id: "c", width: 40, height: 5 })
+  scrollbox.add(a)
+  scrollbox.add(b)
+  scrollbox.add(c)
+  testRenderer.root.add(scrollbox)
+
+  await renderOnce()
+
+  expect(scrollbox.scrollTop).toBe(0)
+
+  c.scrollIntoView()
+  expect(scrollbox.scrollTop).toBeGreaterThan(0)
+})
+
+test("child above viewport scrolls up", async () => {
+  const scrollbox = new ScrollBoxRenderable(testRenderer, {
+    id: "sb",
+    width: 40,
+    height: 10,
+  })
+
+  const a = new BoxRenderable(testRenderer, { id: "a", width: 40, height: 5 })
+  const b = new BoxRenderable(testRenderer, { id: "b", width: 40, height: 5 })
+  const c = new BoxRenderable(testRenderer, { id: "c", width: 40, height: 5 })
+  scrollbox.add(a)
+  scrollbox.add(b)
+  scrollbox.add(c)
+  testRenderer.root.add(scrollbox)
+
+  await renderOnce()
+
+  // Scroll to bottom first
+  scrollbox.scrollTop = 99
+  await renderOnce()
+
+  const prevScroll = scrollbox.scrollTop
+
+  // Scroll first child into view — should scroll up
+  a.scrollIntoView()
+  expect(scrollbox.scrollTop).toBe(0)
+  expect(scrollbox.scrollTop).toBeLessThan(prevScroll)
+})
+
+test("child already visible - no scroll change", async () => {
+  const scrollbox = new ScrollBoxRenderable(testRenderer, {
+    id: "sb",
+    width: 40,
+    height: 20,
+  })
+
+  const a = new BoxRenderable(testRenderer, { id: "a", width: 40, height: 5 })
+  scrollbox.add(a)
+  testRenderer.root.add(scrollbox)
+
+  await renderOnce()
+
+  expect(scrollbox.scrollTop).toBe(0)
+  a.scrollIntoView()
+  expect(scrollbox.scrollTop).toBe(0)
+})
+
+test("no scrollbox ancestor - no crash", () => {
+  const box = new BoxRenderable(testRenderer, { id: "box", width: 40, height: 10 })
+  const child = new BoxRenderable(testRenderer, { id: "child", width: 10, height: 5 })
+  box.add(child)
+  testRenderer.root.add(box)
+
+  // Should not throw
+  expect(() => child.scrollIntoView()).not.toThrow()
+})
+
+test("nested containers - finds scrollbox through wrapper", async () => {
+  const scrollbox = new ScrollBoxRenderable(testRenderer, {
+    id: "sb",
+    width: 40,
+    height: 10,
+  })
+
+  const wrapper = new BoxRenderable(testRenderer, { id: "wrapper", width: 40, height: 15 })
+  const deep = new BoxRenderable(testRenderer, { id: "deep", width: 40, height: 5 })
+  wrapper.add(deep)
+
+  const spacer = new BoxRenderable(testRenderer, { id: "spacer", width: 40, height: 10 })
+  scrollbox.add(spacer)
+  scrollbox.add(wrapper)
+  testRenderer.root.add(scrollbox)
+
+  await renderOnce()
+
+  // deep is nested inside wrapper, which is inside scrollbox after a spacer
+  deep.scrollIntoView()
+  expect(scrollbox.scrollTop).toBeGreaterThan(0)
+})


### PR DESCRIPTION
## Problem / Intent

There's no way to scroll a renderable into view from a ref. Consumers (e.g. Solid/React) need to call `ref.scrollIntoView()` to reveal a focused or selected item inside a ScrollBox — mirroring the DOM API.

## Approach

`Renderable.scrollIntoView()` walks up the parent chain looking for a ScrollBox ancestor via duck typing (`'scrollChildIntoView' in current`), avoiding a circular dependency between Renderable and ScrollBox. The private `ScrollBox.scrollChildIntoView(child)` does the viewport math — scrolls the minimum amount to make the child fully visible, no-ops if already in view.