### PR TITLE
test(core): add linux threaded renderer lifecycle regressions

### DIFF
--- a/packages/core/src/tests/renderer.linux-threading-ffi.test.ts
+++ b/packages/core/src/tests/renderer.linux-threading-ffi.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+
+// Regression test for Linux threaded renderer startup through Bun FFI.
+// We run this in a child process because historical failures were process-level
+// crashes/hangs when enabling `setUseThread(true)` in a dlopened native lib.
+// The test verifies the full lifecycle (create -> enable threads -> render -> destroy)
+// and fails if Bun exits non-zero or times out.
+test("linux ffi renderer can enable threading and shut down", () => {
+  if (process.platform !== "linux") {
+    return
+  }
+
+  if (process.arch !== "x64" && process.arch !== "arm64") {
+    return
+  }
+
+  const script = `
+const nativeModule = await import("@opentui/core-${process.platform}-${process.arch}/index.ts")
+const { dlopen } = await import("bun:ffi")
+
+const lib = dlopen(nativeModule.default, {
+  createRenderer: { args: ["u32", "u32", "bool", "bool"], returns: "ptr" },
+  setUseThread: { args: ["ptr", "bool"], returns: "void" },
+  render: { args: ["ptr", "bool"], returns: "void" },
+  destroyRenderer: { args: ["ptr"], returns: "void" },
+})
+
+const renderer = lib.symbols.createRenderer(20, 8, true, true)
+if (!renderer) {
+  throw new Error("createRenderer returned null")
+}
+
+lib.symbols.setUseThread(renderer, true)
+
+for (let i = 0; i < 20; i++) {
+  lib.symbols.render(renderer, false)
+}
+
+lib.symbols.destroyRenderer(renderer)
+`
+
+  const result = spawnSync(process.execPath, ["-e", script], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    timeout: 15_000,
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0) {
+    throw new Error(
+      `threading child process failed (status=${result.status}, signal=${result.signal})\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    )
+  }
+
+  expect(result.status).toBe(0)
+})

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -59,6 +59,22 @@ test "renderer - create and destroy" {
     try std.testing.expect(cli_renderer.testing == true);
 }
 
+test "renderer - enable threaded mode and destroy" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        80,
+        24,
+        pool,
+        true,
+    );
+
+    cli_renderer.setUseThread(true);
+    cli_renderer.destroy();
+}
+
 test "renderer - simple text rendering to currentRenderBuffer" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();


### PR DESCRIPTION
Add a Linux Bun FFI regression test that enables renderer threading in a child process and verifies create -> render -> destroy without hangs or crashes.

Since this currently fails it's mostly a placeholder to ensure we have a test in place to verify the fix once Bun thing are solved.