### PR TITLE
chore(zig): run zig fmt

### DIFF
--- a/packages/core/src/zig/bench/rope-markers_bench.zig
+++ b/packages/core/src/zig/bench/rope-markers_bench.zig
@@ -87,15 +87,15 @@ fn benchRebuildMarkerIndex(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -114,15 +114,15 @@ fn benchRebuildMarkerIndex(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -141,15 +141,15 @@ fn benchRebuildMarkerIndex(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -168,15 +168,15 @@ fn benchRebuildMarkerIndex(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -195,15 +195,15 @@ fn benchRebuildMarkerIndex(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -222,15 +222,15 @@ fn benchRebuildMarkerIndex(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -264,15 +264,15 @@ fn benchMarkerLookup(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -295,15 +295,15 @@ fn benchMarkerLookup(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -331,15 +331,15 @@ fn benchMarkerLookup(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -363,15 +363,15 @@ fn benchMarkerLookup(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -405,15 +405,15 @@ fn benchMarkerCount(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -443,15 +443,15 @@ fn benchDepthVsPerformance(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -478,15 +478,15 @@ fn benchDepthVsPerformance(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -528,15 +528,15 @@ fn benchEditThenRebuild(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -559,15 +559,15 @@ fn benchEditThenRebuild(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -591,15 +591,15 @@ fn benchEditThenRebuild(
                 stats.record(timer.read());
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -631,15 +631,15 @@ fn benchMemoryUsage(
                 stats.record(elapsed);
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -658,15 +658,15 @@ fn benchMemoryUsage(
                 stats.record(elapsed);
             }
 
-        try results.append(allocator, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(allocator, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 

--- a/packages/core/src/zig/bench/utf8_bench.zig
+++ b/packages/core/src/zig/bench/utf8_bench.zig
@@ -73,15 +73,15 @@ fn benchIsAsciiOnly(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -100,15 +100,15 @@ fn benchIsAsciiOnly(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -127,15 +127,15 @@ fn benchIsAsciiOnly(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -154,15 +154,15 @@ fn benchIsAsciiOnly(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -202,15 +202,15 @@ fn benchFindLineBreaks(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -238,15 +238,15 @@ fn benchFindLineBreaks(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -274,15 +274,15 @@ fn benchFindLineBreaks(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -317,15 +317,15 @@ fn benchFindWrapBreaks(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -348,15 +348,15 @@ fn benchFindWrapBreaks(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -387,15 +387,15 @@ fn benchFindWrapPosByWidth(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -414,15 +414,15 @@ fn benchFindWrapPosByWidth(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -441,15 +441,15 @@ fn benchFindWrapPosByWidth(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -468,15 +468,15 @@ fn benchFindWrapPosByWidth(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -507,15 +507,15 @@ fn benchFindPosByWidth(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -534,15 +534,15 @@ fn benchFindPosByWidth(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -561,15 +561,15 @@ fn benchFindPosByWidth(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -600,15 +600,15 @@ fn benchCalculateTextWidth(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -627,15 +627,15 @@ fn benchCalculateTextWidth(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -654,15 +654,15 @@ fn benchCalculateTextWidth(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -690,15 +690,15 @@ fn benchCalculateTextWidth(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -717,15 +717,15 @@ fn benchCalculateTextWidth(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 
@@ -744,15 +744,15 @@ fn benchCalculateTextWidth(
                 stats.record(timer.read());
             }
 
-        try results.append(results_alloc, BenchResult{
-            .name = name,
-            .min_ns = stats.min_ns,
-            .avg_ns = stats.avg(),
-            .max_ns = stats.max_ns,
-            .total_ns = stats.total_ns,
-            .iterations = iterations,
-            .mem_stats = null,
-        });
+            try results.append(results_alloc, BenchResult{
+                .name = name,
+                .min_ns = stats.min_ns,
+                .avg_ns = stats.avg(),
+                .max_ns = stats.max_ns,
+                .total_ns = stats.total_ns,
+                .iterations = iterations,
+                .mem_stats = null,
+            });
         }
     }
 

--- a/packages/core/src/zig/tests/edit-buffer-history_test.zig
+++ b/packages/core/src/zig/tests/edit-buffer-history_test.zig
@@ -8,7 +8,6 @@ test "EditBuffer - basic undo/redo with insertText" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
 
@@ -33,7 +32,6 @@ test "EditBuffer - basic undo/redo with insertText" {
 test "EditBuffer - canUndo/canRedo" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
@@ -61,7 +59,6 @@ test "EditBuffer - undo/redo with deleteRange" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
 
@@ -85,7 +82,6 @@ test "EditBuffer - undo/redo with backspace" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
 
@@ -104,7 +100,6 @@ test "EditBuffer - undo/redo with backspace" {
 test "EditBuffer - undo/redo with deleteForward" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
@@ -125,7 +120,6 @@ test "EditBuffer - undo/redo with deleteForward" {
 test "EditBuffer - cursor position after undo" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
@@ -151,7 +145,6 @@ test "EditBuffer - lineCount after undo/redo" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
 
@@ -172,7 +165,6 @@ test "EditBuffer - clearHistory" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
 
@@ -190,7 +182,6 @@ test "EditBuffer - clearHistory" {
 test "EditBuffer - undo history branching" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
@@ -226,7 +217,6 @@ test "EditBuffer - undo history branching" {
 test "EditBuffer - multiple undo/redo operations" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();

--- a/packages/core/src/zig/tests/grapheme_test.zig
+++ b/packages/core/src/zig/tests/grapheme_test.zig
@@ -873,7 +873,6 @@ test "GraphemePool - global pool reinitialization returns same instance" {
 
 test "GraphemePool - global unicode data init" {
 
-
     // Pointers should not be null (just verify they're returned)
     // We can't easily test their validity without using them
 }

--- a/packages/core/src/zig/tests/segment-merge.test.zig
+++ b/packages/core/src/zig/tests/segment-merge.test.zig
@@ -6,7 +6,6 @@ test "EditBuffer - sequential character insertion merges segments" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
 

--- a/packages/core/src/zig/tests/text-buffer-highlights_test.zig
+++ b/packages/core/src/zig/tests/text-buffer-highlights_test.zig
@@ -11,7 +11,6 @@ test "TextBuffer coords - addHighlightByCoords" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer tb.deinit();
 
@@ -28,7 +27,6 @@ test "TextBuffer coords - addHighlightByCoords" {
 test "TextBuffer coords - addHighlightByCoords multi-line" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer tb.deinit();
@@ -50,7 +48,6 @@ test "TextBuffer highlights - add single highlight to line" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -68,7 +65,6 @@ test "TextBuffer highlights - add single highlight to line" {
 test "TextBuffer highlights - add multiple highlights to same line" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -88,7 +84,6 @@ test "TextBuffer highlights - add highlights to multiple lines" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -106,7 +101,6 @@ test "TextBuffer highlights - add highlights to multiple lines" {
 test "TextBuffer highlights - remove highlights by reference" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -131,7 +125,6 @@ test "TextBuffer highlights - clear line highlights" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -149,7 +142,6 @@ test "TextBuffer highlights - clear line highlights" {
 test "TextBuffer highlights - clear all highlights" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -171,7 +163,6 @@ test "TextBuffer highlights - get highlights from non-existent line" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -185,7 +176,6 @@ test "TextBuffer highlights - get highlights from non-existent line" {
 test "TextBuffer highlights - overlapping highlights" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -203,7 +193,6 @@ test "TextBuffer highlights - reset clears highlights" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -219,7 +208,6 @@ test "TextBuffer highlights - reset clears highlights" {
 test "TextBuffer highlights - setSyntaxStyle and getSyntaxStyle" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -239,7 +227,6 @@ test "TextBuffer highlights - setSyntaxStyle and getSyntaxStyle" {
 test "TextBuffer highlights - integration with SyntaxStyle" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -271,7 +258,6 @@ test "TextBuffer highlights - style spans computed correctly" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -297,7 +283,6 @@ test "TextBuffer highlights - style spans computed correctly" {
 test "TextBuffer highlights - priority handling in spans" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -326,7 +311,6 @@ test "TextBuffer char range highlights - single line highlight" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -344,7 +328,6 @@ test "TextBuffer char range highlights - single line highlight" {
 test "TextBuffer char range highlights - multi-line highlight" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -377,7 +360,6 @@ test "TextBuffer char range highlights - spanning three lines" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -404,7 +386,6 @@ test "TextBuffer char range highlights - exact line boundaries" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -427,7 +408,6 @@ test "TextBuffer char range highlights - empty range" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -443,7 +423,6 @@ test "TextBuffer char range highlights - empty range" {
 test "TextBuffer char range highlights - invalid range" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -461,7 +440,6 @@ test "TextBuffer char range highlights - out of bounds range" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -478,7 +456,6 @@ test "TextBuffer char range highlights - out of bounds range" {
 test "TextBuffer char range highlights - multiple non-overlapping ranges" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -500,7 +477,6 @@ test "TextBuffer char range highlights - with reference ID for removal" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -520,7 +496,6 @@ test "TextBuffer char range highlights - with reference ID for removal" {
 test "TextBuffer char range highlights - priority handling" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -547,7 +522,6 @@ test "TextBuffer char range highlights - unicode text" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -563,7 +537,6 @@ test "TextBuffer char range highlights - unicode text" {
 test "TextBuffer char range highlights - preserved after setText" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -587,7 +560,6 @@ test "TextBuffer char range highlights - multi-width chars before highlight" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -604,7 +576,6 @@ test "TextBuffer char range highlights - multi-width chars between highlights" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -620,7 +591,6 @@ test "TextBuffer char range highlights - multi-width chars between highlights" {
 test "TextBuffer char range highlights - emoji grapheme clusters" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();

--- a/packages/core/src/zig/tests/text-buffer-iterators_test.zig
+++ b/packages/core/src/zig/tests/text-buffer-iterators_test.zig
@@ -356,7 +356,6 @@ test "getGraphemeWidthAt - ASCII text" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -375,7 +374,6 @@ test "getGraphemeWidthAt - emoji and wide characters" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -390,7 +388,6 @@ test "getGraphemeWidthAt - emoji and wide characters" {
 test "getGraphemeWidthAt - multiple chunks" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -409,7 +406,6 @@ test "getGraphemeWidthAt - empty line" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -422,7 +418,6 @@ test "getGraphemeWidthAt - at chunk boundary" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -434,7 +429,6 @@ test "getGraphemeWidthAt - at chunk boundary" {
 test "getGraphemeWidthAt - after break segment" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -449,7 +443,6 @@ test "getGraphemeWidthAt - after break segment" {
 test "getPrevGraphemeWidth - ASCII text" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -468,7 +461,6 @@ test "getPrevGraphemeWidth - emoji and wide characters" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -484,7 +476,6 @@ test "getPrevGraphemeWidth - at chunk boundary" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -499,7 +490,6 @@ test "getPrevGraphemeWidth - emoji at chunk boundary" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -511,7 +501,6 @@ test "getPrevGraphemeWidth - emoji at chunk boundary" {
 test "getPrevGraphemeWidth - multiple chunks" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -528,7 +517,6 @@ test "getPrevGraphemeWidth - empty line" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -541,7 +529,6 @@ test "getPrevGraphemeWidth - col beyond line width" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -553,7 +540,6 @@ test "getPrevGraphemeWidth - col beyond line width" {
 test "getPrevGraphemeWidth - multiline" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -571,7 +557,6 @@ test "getGraphemeWidthAt - CJK characters (Chinese)" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -588,7 +573,6 @@ test "getGraphemeWidthAt - various emoji including star" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -602,7 +586,6 @@ test "getGraphemeWidthAt - various emoji including star" {
 test "getGraphemeWidthAt - tab characters" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -622,7 +605,6 @@ test "getGraphemeWidthAt - tab with different tab_width" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -639,7 +621,6 @@ test "getGraphemeWidthAt - middle of wide character" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -654,7 +635,6 @@ test "getGraphemeWidthAt - invalid row" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -666,7 +646,6 @@ test "getGraphemeWidthAt - invalid row" {
 test "getPrevGraphemeWidth - CJK characters" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -684,7 +663,6 @@ test "getPrevGraphemeWidth - star emoji" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -698,7 +676,6 @@ test "getPrevGraphemeWidth - star emoji" {
 test "getPrevGraphemeWidth - tabs" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -715,7 +692,6 @@ test "getPrevGraphemeWidth - invalid row" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -727,7 +703,6 @@ test "getPrevGraphemeWidth - invalid row" {
 test "getGraphemeWidthAt and getPrevGraphemeWidth - mixed content" {
     const pool = gp.initGlobalPool(testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(testing.allocator, pool, .unicode);
     defer tb.deinit();

--- a/packages/core/src/zig/tests/text-buffer-selection_viewport_test.zig
+++ b/packages/core/src/zig/tests/text-buffer-selection_viewport_test.zig
@@ -13,7 +13,6 @@ test "Selection - vertical viewport selection without wrapping" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -40,7 +39,6 @@ test "Selection - horizontal viewport selection without wrapping" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -63,7 +61,6 @@ test "Selection - horizontal viewport selection without wrapping" {
 test "Selection - wrapping mode ignores horizontal viewport offset" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -90,7 +87,6 @@ test "Selection - wrapping mode ignores horizontal viewport offset" {
 test "Selection - vertical viewport with wrapping" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -121,7 +117,6 @@ test "Selection - across empty line with viewport offset" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -144,7 +139,6 @@ test "Selection - across empty line with viewport offset" {
 test "Selection - viewport offset with multi-line selection" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -169,7 +163,6 @@ test "Selection - combined horizontal and vertical viewport offsets" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -192,7 +185,6 @@ test "Selection - combined horizontal and vertical viewport offsets" {
 test "Selection - viewport without offsets behaves as before" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -217,7 +209,6 @@ test "Selection - no viewport behaves as before" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -238,7 +229,6 @@ test "Selection - no viewport behaves as before" {
 test "Selection - VALIDATION: verify selection range matches extracted text with viewport" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -271,7 +261,6 @@ test "Selection - VALIDATION: verify selection range matches extracted text with
 test "Selection - VALIDATION: multi-line selection range with viewport" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -307,7 +296,6 @@ test "Selection - RENDER TEST: selection highlights correct cells with viewport 
 
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();

--- a/packages/core/src/zig/tests/text-buffer_test.zig
+++ b/packages/core/src/zig/tests/text-buffer_test.zig
@@ -9,7 +9,6 @@ test "TextBuffer init - creates empty buffer" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -20,7 +19,6 @@ test "TextBuffer init - creates empty buffer" {
 test "TextBuffer line info - empty buffer" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -37,7 +35,6 @@ test "TextBuffer line info - empty buffer" {
 test "TextBuffer line info - simple text without newlines" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -61,7 +58,6 @@ test "TextBuffer line info - single newline" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -77,7 +73,6 @@ test "TextBuffer line info - single newline" {
 test "TextBuffer line info - multiple lines separated by newlines" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -106,7 +101,6 @@ test "TextBuffer line info - text ending with newline" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -128,7 +122,6 @@ test "TextBuffer line info - consecutive newlines" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -144,7 +137,6 @@ test "TextBuffer line info - text starting with newline" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -158,7 +150,6 @@ test "TextBuffer line info - text starting with newline" {
 test "TextBuffer line info - only newlines" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -180,7 +171,6 @@ test "TextBuffer line info - wide characters (Unicode)" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -200,7 +190,6 @@ test "TextBuffer line info - empty lines between content" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -215,7 +204,6 @@ test "TextBuffer line info - empty lines between content" {
 test "TextBuffer line info - very long lines" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -232,7 +220,6 @@ test "TextBuffer line info - very long lines" {
 test "TextBuffer line info - lines with different widths" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -255,7 +242,6 @@ test "TextBuffer line info - text without styling" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -270,7 +256,6 @@ test "TextBuffer line info - text without styling" {
 test "TextBuffer line info - buffer with only whitespace" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -291,7 +276,6 @@ test "TextBuffer line info - single character lines" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -310,7 +294,6 @@ test "TextBuffer line info - single character lines" {
 test "TextBuffer line info - mixed content with special characters" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -350,7 +333,6 @@ test "TextBuffer line info - thousands of lines" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -381,7 +363,6 @@ test "TextBuffer line info - alternating empty and content lines" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -400,7 +381,6 @@ test "TextBuffer line info - complex Unicode combining characters" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -415,7 +395,6 @@ test "TextBuffer line info - complex Unicode combining characters" {
 test "TextBuffer line info - simple multi-line text" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -433,7 +412,6 @@ test "TextBuffer line info - unicode width method" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -447,7 +425,6 @@ test "TextBuffer line info - unicode width method" {
 test "TextBuffer line info - unicode mixed content with special characters" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -466,7 +443,6 @@ test "TextBuffer line info - unicode text without styling" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -484,7 +460,6 @@ test "TextBuffer line info - extremely long single line" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -500,7 +475,6 @@ test "TextBuffer line info - extremely long single line" {
 test "TextBuffer unicode - multi-line with extraction" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -519,7 +493,6 @@ test "TextBuffer reset - clears all content" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -534,7 +507,6 @@ test "TextBuffer reset - clears all content" {
 test "TextBuffer line iteration - walkLines callback" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -572,7 +544,6 @@ test "TextBuffer line queries - comprehensive rope coordinate checks" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -598,7 +569,6 @@ test "TextBuffer view registration - multiple views can be created" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -618,7 +588,6 @@ test "TextBuffer view registration - multiple views can be created" {
 test "TextBuffer view registration - views marked dirty on setText" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -645,7 +614,6 @@ test "TextBuffer view registration - views marked dirty on reset" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -662,7 +630,6 @@ test "TextBuffer view registration - views marked dirty on reset" {
 test "TextBuffer view registration - ID reuse after unregister" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -681,7 +648,6 @@ test "TextBuffer view registration - ID reuse after unregister" {
 test "TextBuffer view registration - multiple views all marked dirty on setText" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -716,7 +682,6 @@ test "TextBuffer memory registry - register and get buffer" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -731,7 +696,6 @@ test "TextBuffer memory registry - register and get buffer" {
 test "TextBuffer memory registry - multiple buffers" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -757,7 +721,6 @@ test "TextBuffer memory registry - invalid ID returns null" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -769,7 +732,6 @@ test "TextBuffer memory registry - invalid ID returns null" {
 test "TextBuffer memory registry - addLine from single buffer" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -791,7 +753,6 @@ test "TextBuffer memory registry - addLine from single buffer" {
 test "TextBuffer memory registry - addLine from multiple buffers" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -819,7 +780,6 @@ test "TextBuffer memory registry - addLine with invalid mem_id" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -831,7 +791,6 @@ test "TextBuffer memory registry - addLine with invalid mem_id" {
 test "TextBuffer memory registry - mixed with setText" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -850,7 +809,6 @@ test "TextBuffer memory registry - reset clears memory buffers" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -868,7 +826,6 @@ test "TextBuffer memory registry - reset clears memory buffers" {
 test "TextBuffer clear - preserves memory buffers" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -905,7 +862,6 @@ test "TextBuffer setText - preserves previously registered memory buffers" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -936,7 +892,6 @@ test "TextBuffer setText - preserves previously registered memory buffers" {
 test "TextBuffer setStyledText - preserves previously registered memory buffers" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -987,7 +942,6 @@ test "TextBuffer clear vs reset - memory registry behavior" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1014,7 +968,6 @@ test "TextBuffer memory registry - partial buffer slices" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1035,7 +988,6 @@ test "TextBuffer memory registry - partial buffer slices" {
 test "TextBuffer memory registry - unicode text from buffers" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1061,7 +1013,6 @@ test "TextBuffer memory registry - getByteSize with multiple buffers" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1081,7 +1032,6 @@ test "TextBuffer memory registry - getByteSize with multiple buffers" {
 test "TextBuffer memory registry - views marked dirty on addLine" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1103,7 +1053,6 @@ test "TextBuffer memory registry - empty chunk handling" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1120,7 +1069,6 @@ test "TextBuffer memory registry - empty chunk handling" {
 test "TextBuffer memory registry - buffer limit of 255" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1141,7 +1089,6 @@ test "TextBuffer memory registry - owned buffer memory management" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1161,7 +1108,6 @@ test "TextBuffer memory registry - byte range out of bounds" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1180,7 +1126,6 @@ test "TextBuffer memory registry - byte range out of bounds" {
 test "TextBuffer memory registry - character range highlights across buffers" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1208,7 +1153,6 @@ test "TextBuffer memory registry - empty buffer registration" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1223,7 +1167,6 @@ test "TextBuffer memory registry - empty buffer registration" {
 test "TextBuffer memory registry - same buffer registered multiple times" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1257,7 +1200,6 @@ test "TextBuffer setText - CRLF line endings (Windows)" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1277,7 +1219,6 @@ test "TextBuffer setText - mixed line endings (LF, CRLF, CR)" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1294,7 +1235,6 @@ test "TextBuffer setText - text ending with CRLF" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1310,7 +1250,6 @@ test "TextBuffer setText - consecutive CRLF sequences" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1325,7 +1264,6 @@ test "TextBuffer setText - consecutive CRLF sequences" {
 test "TextBuffer setText - only CRLF sequences" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1344,7 +1282,6 @@ test "TextBuffer setText - text starting with CRLF" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1358,7 +1295,6 @@ test "TextBuffer setText - text starting with CRLF" {
 test "TextBuffer setText - CR without LF" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1375,7 +1311,6 @@ test "TextBuffer setText - CR without LF" {
 test "TextBuffer setText - very long line with SIMD processing" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1402,7 +1337,6 @@ test "TextBuffer setText - unicode content with various line endings" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1419,7 +1353,6 @@ test "TextBuffer setText - multiple consecutive different line endings" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1433,7 +1366,6 @@ test "TextBuffer setText - multiple consecutive different line endings" {
 test "TextBuffer setText - SIMD boundary conditions" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1462,7 +1394,6 @@ test "TextBuffer setText - SIMD boundary conditions" {
 test "TextBuffer setText - CRLF at SIMD boundary" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1495,7 +1426,6 @@ test "TextBuffer setText - validate rope structure is correct" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try text_buffer.UnifiedTextBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer tb.deinit();
 
@@ -1522,7 +1452,6 @@ test "TextBuffer setText - then deleteRange via EditBuffer - validate markers" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     const edit_buffer = @import("../edit-buffer.zig");
     var eb = try edit_buffer.EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
@@ -1539,7 +1468,6 @@ test "TextBuffer setText - then deleteRange via EditBuffer - validate markers" {
 test "TextBuffer setStyledText - repeated calls with SyntaxStyle (crash reproduction)" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1604,7 +1532,6 @@ test "addHighlightByCharRange - single line highlight should not extend to EOL" 
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1625,7 +1552,6 @@ test "addHighlightByCharRange - single line highlight should not extend to EOL" 
 test "addHighlightByCharRange - multiple highlights on same line should have correct bounds" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1649,7 +1575,6 @@ test "addHighlightByCharRange - multiple highlights on same line should have cor
 test "addHighlightByCharRange - highlight after newline should not span to EOL" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1679,7 +1604,6 @@ test "addHighlightByCharRange - highlight after newline should not span to EOL" 
 test "addHighlightByCharRange - extmarks demo scenario reproduction" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1716,7 +1640,6 @@ test "TextBuffer append - to empty buffer" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1733,7 +1656,6 @@ test "TextBuffer append - to empty buffer" {
 test "TextBuffer append - to non-empty buffer, no newline" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1753,7 +1675,6 @@ test "TextBuffer append - creating new line with LF" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1770,7 +1691,6 @@ test "TextBuffer append - creating new line with LF" {
 test "TextBuffer append - multiple lines with various endings" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1791,7 +1711,6 @@ test "TextBuffer append - CRLF line endings" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1808,7 +1727,6 @@ test "TextBuffer append - CRLF line endings" {
 test "TextBuffer append - mixed line endings" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1827,7 +1745,6 @@ test "TextBuffer append - empty string is no-op" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1845,7 +1762,6 @@ test "TextBuffer append - unicode content" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1862,7 +1778,6 @@ test "TextBuffer append - unicode content" {
 test "TextBuffer append - streaming/chunked append vs ground truth" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1894,7 +1809,6 @@ test "TextBuffer append - large streaming append" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1917,7 +1831,6 @@ test "TextBuffer appendFromMemId - basic functionality" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1936,7 +1849,6 @@ test "TextBuffer appendFromMemId - basic functionality" {
 test "TextBuffer appendFromMemId - append to existing content" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1960,7 +1872,6 @@ test "TextBuffer appendFromMemId - invalid mem_id" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -1971,7 +1882,6 @@ test "TextBuffer appendFromMemId - invalid mem_id" {
 test "TextBuffer append - marker invariants maintained" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -1995,7 +1905,6 @@ test "TextBuffer append - memory registry preserved" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -2016,7 +1925,6 @@ test "TextBuffer append - views marked dirty" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -2034,7 +1942,6 @@ test "TextBuffer append - views marked dirty" {
 test "TextBuffer append - append after clear" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
@@ -2055,7 +1962,6 @@ test "TextBuffer append - consecutive empty line handling" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();
 
@@ -2073,7 +1979,6 @@ test "TextBuffer append - consecutive empty line handling" {
 test "TextBuffer append - mixed append and setText" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var tb = try TextBuffer.init(std.testing.allocator, pool, .unicode);
     defer tb.deinit();

--- a/packages/core/src/zig/tests/word-wrap-editing_test.zig
+++ b/packages/core/src/zig/tests/word-wrap-editing_test.zig
@@ -10,7 +10,6 @@ test "Word wrap - editing around wrap boundary creates correct wrap" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
 
@@ -38,7 +37,6 @@ test "Word wrap - editing around wrap boundary creates correct wrap" {
 test "Word wrap - backspace and retype near boundary" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
@@ -75,7 +73,6 @@ test "Word wrap - backspace and retype near boundary" {
 test "Word wrap - type character by character near boundary" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
@@ -129,7 +126,6 @@ test "Word wrap - insert word in middle causes rewrap" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
 
@@ -154,7 +150,6 @@ test "Word wrap - insert word in middle causes rewrap" {
 test "Word wrap - delete word causes rewrap" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
@@ -183,7 +178,6 @@ test "Word wrap - delete word causes rewrap" {
 test "Word wrap - rapid edits maintain correct wrapping" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
@@ -219,7 +213,6 @@ test "Word wrap - fragmented at exact word boundary" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
 
@@ -244,7 +237,6 @@ test "Word wrap - fragmented at exact word boundary" {
 test "Word wrap - chunk boundary at start of word" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
@@ -273,7 +265,6 @@ test "Word wrap - chunk boundary at start of word" {
 test "Word wrap - multiple edits create complex fragmentation" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
@@ -317,7 +308,6 @@ test "Word wrap - insert at wrap boundary with existing wrap" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
 
@@ -348,7 +338,6 @@ test "Word wrap - word at exact wrap width" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
 
@@ -376,7 +365,6 @@ test "Word wrap - debug virtual line contents" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
-
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();
 
@@ -400,7 +388,6 @@ test "Word wrap - debug virtual line contents" {
 test "Word wrap - incremental character edits near boundary" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
-
 
     var eb = try EditBuffer.init(std.testing.allocator, pool, .wcwidth);
     defer eb.deinit();


### PR DESCRIPTION
Fixed some inconsistencies in formatting (indentation and extra lines) by
running zig fmt.
