### PR TITLE
fix: stable grapheme across frames

### DIFF
--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -739,19 +739,9 @@ pub const CliRenderer = struct {
                 }
                 runLength += 1;
 
-                // Update the current buffer with the new cell
-                self.currentRenderBuffer.setRaw(x, y, nextCell.?);
-
-                // If this is a grapheme start, also update all continuation cells
-                if (gp.isGraphemeChar(nextCell.?.char)) {
-                    const rightExtent = gp.charRightExtent(nextCell.?.char);
-                    var k: u32 = 1;
-                    while (k <= rightExtent and x + k < self.width) : (k += 1) {
-                        if (self.nextRenderBuffer.get(x + k, y)) |contCell| {
-                            self.currentRenderBuffer.setRaw(x + k, y, contCell);
-                        }
-                    }
-                }
+                // Update grapheme/link trackers (and continuation cells), so current buffer
+                // retains grapheme ownership after next buffer clear and IDs remain stable.
+                self.currentRenderBuffer.set(x, y, nextCell.?);
 
                 cellsUpdated += 1;
             }


### PR DESCRIPTION
The renderer diff compares `Cell.char` values to decide what changed between frames. For grapheme cells, the char value embeds a pool ID. Without interning, drawing the same "👋" on two consecutive frames produces two different IDs, so the diff treats every grapheme cell as dirty every frame.

This adds content-addressed interning to GraphemePool: when bytes are already live in the pool, alloc() returns the existing ID instead of allocating a new slot. The intern map is maintained on refcount transitions (interned at 0->1, removed at 1->0), so it stays in sync with the pool's own lifetime tracking.

Maybe most important change is to switch from setRaw() to set(). set() is a bit more expensive, but transfers ownership through the tracker. Its also just called for changed cells, so the perf impact should be acceptable.

Fix #667 