### PR TITLE
fix(solid): return empty string sentinel from cleanChildren when no replacement

### DIFF
--- a/packages/solid/src/renderer/universal.js
+++ b/packages/solid/src/renderer/universal.js
@@ -165,7 +165,7 @@ export function createRenderer({
       let removed
       while ((removed = getFirstChild(parent))) removeNode(parent, removed)
       replacement && insertNode(parent, replacement)
-      return replacement
+      return replacement ?? ""
     }
     const node = replacement || createSlotNode()
     if (current.length) {


### PR DESCRIPTION
## Summary

- Fix `cleanChildren` in the forked universal renderer to return `""` instead of `undefined` when called without a replacement, matching solid-js's upstream behavior

## Problem

When `cleanChildren` is called without a `marker` or `replacement` (e.g. when `Show`/`Switch` hides content), the no-marker early-return path returns `replacement` — which is `undefined`. The solid-js upstream returns `""`.

This `undefined` propagates as the `current` value through `insertExpression`'s reactive chain, eventually corrupting downstream memo reads and causing crashes like:

```
TypeError: undefined is not an object (evaluating 'grouped().length')
```

Introduced in #169 when the universal renderer was forked from solid-js.

## Fix

```diff
- return replacement
+ return replacement ?? ""
```