### PR TITLE
fix(input): handle surrogate pairs in stdin buffer

### DIFF
--- a/packages/core/src/lib/stdin-buffer.test.ts
+++ b/packages/core/src/lib/stdin-buffer.test.ts
@@ -50,6 +50,25 @@ describe("StdinBuffer", () => {
       processInput("hi👍bye")
       expect(emittedSequences).toEqual(["h", "i", "👍", "b", "y", "e"])
     })
+
+    it("should handle emoji split across chunks", () => {
+      processInput("\uD83D")
+      expect(emittedSequences).toEqual([])
+      expect(buffer.getBuffer()).toBe("\uD83D")
+
+      processInput("\uDC4D")
+      expect(emittedSequences).toEqual(["👍"])
+      expect(buffer.getBuffer()).toBe("")
+    })
+
+    it("should handle split emoji mixed with ascii", () => {
+      processInput("a\uD83D")
+      expect(emittedSequences).toEqual(["a"])
+      expect(buffer.getBuffer()).toBe("\uD83D")
+
+      processInput("\uDC4Db")
+      expect(emittedSequences).toEqual(["a", "👍", "b"])
+    })
   })
 
   describe("Complete Escape Sequences", () => {

--- a/packages/core/src/lib/stdin-buffer.ts
+++ b/packages/core/src/lib/stdin-buffer.ts
@@ -236,7 +236,11 @@ function extractCompleteSequences(buffer: string): { sequences: string[]; remain
     } else {
       // Not an escape sequence - take a single character, keeping surrogate pairs together
       const code = remaining.charCodeAt(0)
-      if (code >= 0xd800 && code <= 0xdbff && remaining.length > 1) {
+      if (code >= 0xd800 && code <= 0xdbff) {
+        if (remaining.length === 1) {
+          return { sequences, remainder: remaining }
+        }
+
         const next = remaining.charCodeAt(1)
         if (next >= 0xdc00 && next <= 0xdfff) {
           sequences.push(remaining.slice(0, 2))


### PR DESCRIPTION
### Bug

`extractCompleteSequences` in `stdin-buffer.ts` iterates the buffer using `remaining[0]` and `pos++`, which operate on UTF-16 code units. But characters above U+FFFF (emoji, CJK Extension B, etc.) are stored as surrogate pairs, two code units.

Existing code splits these into two lone surrogates, which `TextEncoder.encode()` will then convert to U+FFFD (replacement character) downstream.

For example, typing 👍 (U+1F44D) in the input field produces `��` instead.

Note that this doesn't seem to happen with pasted characters, since they probably go through a different code path. It does happen when I type an emoji using compose key in linux. I suppose it could also happen for other characters like CJK etc...

### Fix

Check whether the code unit is a high surrogate (0xD800–0xDBFF) followed by a low surrogate (0xDC00–0xDFFF), and if so keep both as a single sequence entry.

Two regression tests added:
- emoji as sole input
- emoji mixed with ASCII