### PR TITLE
fix(markdown): prevent MarkdownRenderable from shrinking

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -67,6 +67,7 @@ export class MarkdownRenderable extends Renderable {
     super(ctx, {
       ...options,
       flexDirection: "column",
+      flexShrink: options.flexShrink ?? 0,
     })
 
     this._syntaxStyle = options.syntaxStyle


### PR DESCRIPTION
Split from #597 to make review easier.

MarkdownRenderable inherits flexShrink: 1 by default, which causes it to collapse when placed next to large siblings in a flex layout. Setting `flexShrink: 0` as default prevents this while still allowing callers to override it.