### PR TITLE
feat(markdown): render list items as nested containers

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -339,37 +339,6 @@ export class MarkdownRenderable extends Renderable {
     return chunks
   }
 
-  private renderListChunks(token: Tokens.List): TextChunk[] {
-    const chunks: TextChunk[] = []
-    let index = typeof token.start === "number" ? token.start : 1
-
-    for (const item of token.items) {
-      if (token.ordered) {
-        chunks.push(this.createChunk(`${index}. `, "markup.list"))
-        index++
-      } else {
-        chunks.push(this.createChunk("- ", "markup.list"))
-      }
-
-      for (let i = 0; i < item.tokens.length; i++) {
-        const child = item.tokens[i]
-        if (child.type === "text" && i === 0 && "tokens" in child && child.tokens) {
-          this.renderInlineContent(child.tokens, chunks)
-          chunks.push(this.createDefaultChunk("\n"))
-        } else if (child.type === "paragraph" && i === 0) {
-          this.renderInlineContent((child as Tokens.Paragraph).tokens, chunks)
-          chunks.push(this.createDefaultChunk("\n"))
-        } else {
-          const childChunks = this.renderTokenToChunks(child as MarkedToken)
-          chunks.push(...childChunks)
-          chunks.push(this.createDefaultChunk("\n"))
-        }
-      }
-    }
-
-    return chunks
-  }
-
   private renderThematicBreakChunks(): TextChunk[] {
     return [this.createChunk("---", "punctuation.special")]
   }
@@ -382,8 +351,6 @@ export class MarkdownRenderable extends Renderable {
         return this.renderParagraphChunks(token)
       case "blockquote":
         return this.renderBlockquoteChunks(token)
-      case "list":
-        return this.renderListChunks(token)
       case "hr":
         return this.renderThematicBreakChunks()
       case "space":
@@ -418,6 +385,85 @@ export class MarkdownRenderable extends Renderable {
     })
   }
 
+  private createListRenderable(token: Tokens.List, id: string, marginBottom: number = 0): Renderable {
+    const listBox = new BoxRenderable(this.ctx, {
+      id,
+      width: "100%",
+      flexDirection: "column",
+      marginBottom,
+    })
+
+    let index = typeof token.start === "number" ? token.start : 1
+    const nestedIndent = 2
+
+    for (let itemIndex = 0; itemIndex < token.items.length; itemIndex++) {
+      const item = token.items[itemIndex]
+      const itemId = `${id}-item-${itemIndex}`
+      const itemBox = new BoxRenderable(this.ctx, {
+        id: `${itemId}-box`,
+        width: "100%",
+        flexDirection: "column",
+      })
+
+      const markerText = token.ordered ? `${index++}. ` : "- "
+      const lineChunks: TextChunk[] = [this.createChunk(markerText, "markup.list")]
+
+      if (item.task) {
+        const checked = "checked" in item ? Boolean(item.checked) : false
+        lineChunks.push(this.createChunk(`${checked ? "[x]" : "[ ]"} `, "markup.list"))
+      }
+
+      let inlineRendered = false
+      const remainingTokens: MarkedToken[] = []
+
+      for (const child of item.tokens) {
+        if (child.type === "checkbox") {
+          continue
+        }
+
+        if (child.type === "space") {
+          continue
+        }
+
+        if (!inlineRendered && child.type === "text" && "tokens" in child && child.tokens) {
+          this.renderInlineContent(child.tokens, lineChunks)
+          inlineRendered = true
+          continue
+        }
+
+        if (!inlineRendered && child.type === "paragraph") {
+          this.renderInlineContent((child as Tokens.Paragraph).tokens, lineChunks)
+          inlineRendered = true
+          continue
+        }
+
+        remainingTokens.push(child as MarkedToken)
+      }
+
+      const lineRenderable = new TextRenderable(this.ctx, {
+        id: `${itemId}-line`,
+        content: new StyledText(lineChunks),
+        width: "100%",
+      })
+      itemBox.add(lineRenderable)
+
+      let childIndex = 0
+      for (const child of remainingTokens) {
+        const childId = `${itemId}-child-${childIndex}`
+        childIndex++
+        const childRenderable = this.createBlockRenderable(child as MarkedToken, childId, 0)
+        if (childRenderable) {
+          childRenderable.marginLeft = nestedIndent
+          itemBox.add(childRenderable)
+        }
+      }
+
+      listBox.add(itemBox)
+    }
+
+    return listBox
+  }
+
   private createBlockRenderable(token: MarkedToken, id: string, marginBottom: number): Renderable | null {
     if (token.type === "code") {
       return this.createCodeRenderable(token as Tokens.Code, id, marginBottom)
@@ -425,6 +471,10 @@ export class MarkdownRenderable extends Renderable {
 
     if (token.type === "table") {
       return this.createTableRenderable(token as Tokens.Table, id, marginBottom)
+    }
+
+    if (token.type === "list") {
+      return this.createListRenderable(token as Tokens.List, id, marginBottom)
     }
 
     if (token.type === "space") {
@@ -696,7 +746,20 @@ export class MarkdownRenderable extends Renderable {
       return
     }
 
-    // Text-based renderables (paragraph, heading, list, blockquote, hr)
+    if (token.type === "list") {
+      const nextRenderable = this._blockStates[index + 1]?.renderable
+      this.remove(state.renderable.id)
+      const newRenderable = this.createListRenderable(token as Tokens.List, `${this.id}-block-${index}`, marginBottom)
+      if (nextRenderable) {
+        this.insertBefore(newRenderable, nextRenderable)
+      } else {
+        this.add(newRenderable)
+      }
+      state.renderable = newRenderable
+      return
+    }
+
+    // Text-based renderables (paragraph, heading, blockquote, hr)
     const textRenderable = state.renderable as TextRenderable
     const chunks = this.renderTokenToChunks(token)
     textRenderable.content = new StyledText(chunks)
@@ -841,6 +904,20 @@ export class MarkdownRenderable extends Renderable {
         // Tables - update in place for better performance
         const marginBottom = hasNextToken ? 1 : 0
         this.updateTableRenderable(state.renderable, state.token as Tokens.Table, marginBottom)
+      } else if (state.token.type === "list") {
+        const nextRenderable = this._blockStates[i + 1]?.renderable
+        this.remove(state.renderable.id)
+        const newRenderable = this.createListRenderable(
+          state.token as Tokens.List,
+          `${this.id}-block-${i}`,
+          this.getBlockMarginBottom(hasNextToken),
+        )
+        if (nextRenderable) {
+          this.insertBefore(newRenderable, nextRenderable)
+        } else {
+          this.add(newRenderable)
+        }
+        state.renderable = newRenderable
       } else {
         // TextRenderable blocks - regenerate chunks with new style/conceal
         const textRenderable = state.renderable as TextRenderable

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -428,7 +428,7 @@ export class MarkdownRenderable extends Renderable {
     }
 
     if (token.type === "space") {
-      return null
+      return this.createTextRenderable([this.createDefaultChunk(" ")], id, marginBottom)
     }
 
     const chunks = this.renderTokenToChunks(token)

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -759,7 +759,7 @@ export class MarkdownRenderable extends Renderable {
       return
     }
 
-    // Text-based renderables (paragraph, heading, blockquote, hr)
+    // Text-based renderables (paragraph, heading, list, hr)
     const textRenderable = state.renderable as TextRenderable
     const chunks = this.renderTokenToChunks(token)
     textRenderable.content = new StyledText(chunks)

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -418,6 +418,27 @@ export class MarkdownRenderable extends Renderable {
     })
   }
 
+  private createBlockRenderable(token: MarkedToken, id: string, marginBottom: number): Renderable | null {
+    if (token.type === "code") {
+      return this.createCodeRenderable(token as Tokens.Code, id, marginBottom)
+    }
+
+    if (token.type === "table") {
+      return this.createTableRenderable(token as Tokens.Table, id, marginBottom)
+    }
+
+    if (token.type === "space") {
+      return null
+    }
+
+    const chunks = this.renderTokenToChunks(token)
+    if (chunks.length === 0) {
+      return null
+    }
+
+    return this.createTextRenderable(chunks, id, marginBottom)
+  }
+
   /**
    * Update an existing table renderable in-place for style/conceal changes.
    * Much faster than rebuilding the entire table structure.
@@ -614,32 +635,24 @@ export class MarkdownRenderable extends Renderable {
     return tableBox
   }
 
+  private getBlockMarginBottom(hasNextToken: boolean): number {
+    return hasNextToken ? 1 : 0
+  }
+
   private createDefaultRenderable(token: MarkedToken, index: number, hasNextToken: boolean = false): Renderable | null {
     const id = `${this.id}-block-${index}`
-    const marginBottom = hasNextToken ? 1 : 0
+    const marginBottom = this.getBlockMarginBottom(hasNextToken)
 
-    if (token.type === "code") {
-      return this.createCodeRenderable(token, id, marginBottom)
-    }
-
-    if (token.type === "table") {
-      return this.createTableRenderable(token, id, marginBottom)
-    }
-
-    if (token.type === "space") {
+    const renderable = this.createBlockRenderable(token, id, marginBottom)
+    if (!renderable || token.type === "space") {
       return null
     }
 
-    const chunks = this.renderTokenToChunks(token)
-    if (chunks.length === 0) {
-      return null
-    }
-
-    return this.createTextRenderable(chunks, id, marginBottom)
+    return renderable
   }
 
   private updateBlockRenderable(state: BlockState, token: MarkedToken, index: number, hasNextToken: boolean): void {
-    const marginBottom = hasNextToken ? 1 : 0
+    const marginBottom = this.getBlockMarginBottom(hasNextToken)
 
     if (token.type === "code") {
       const codeRenderable = state.renderable as CodeRenderable
@@ -736,9 +749,11 @@ export class MarkdownRenderable extends Renderable {
       const { token } = blockTokens[i]
       const hasNextToken = i < lastBlockIndex
       const existing = this._blockStates[blockIndex]
+      const marginBottom = this.getBlockMarginBottom(hasNextToken)
 
       // Same token object reference means unchanged
       if (existing && existing.token === token) {
+        existing.renderable.marginBottom = marginBottom
         blockIndex++
         continue
       }
@@ -746,6 +761,7 @@ export class MarkdownRenderable extends Renderable {
       // Same content, update reference
       if (existing && existing.tokenRaw === token.raw && existing.token.type === token.type) {
         existing.token = token
+        existing.renderable.marginBottom = marginBottom
         blockIndex++
         continue
       }

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -847,7 +847,6 @@ Visit [GitHub](https://github.com) for more.
     - inline code support
     - Italic and bold text
 
-
     Code Example
 
     const md = new MarkdownRenderable(ctx, {
@@ -862,6 +861,203 @@ Visit [GitHub](https://github.com) for more.
 
     Press ? for help"
   `)
+})
+
+test("llm-style response with quotes, nested lists, hr, and paragraphs", async () => {
+  const markdown = `Here is the plan:
+
+> We will ship in two phases.
+> Phase one focuses on stability.
+
+- Top item
+  - Nested one
+  - Nested two
+- Second item
+
+---
+
+Final paragraph with closing remarks.`
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    Here is the plan:
+
+    > We will ship in two phases.
+    > Phase one focuses on stability.
+
+    - Top item
+      - Nested one
+      - Nested two
+    - Second item
+
+    ---
+
+    Final paragraph with closing remarks."
+  `)
+})
+
+test("complex markdown with mixed nodes and nesting", async () => {
+  const markdown = `# Weekly Update
+
+Quick summary for the team with **bold**, *italic*, \`code\`, and ~~strikethrough~~.
+
+## People
+
+- Alice
+  - Role: Tech Lead
+  - Profile: https://example.com/alice
+  - Notes: [handoff doc](https://example.com/alice/handoff)
+- Bob
+  - Role: Infra
+  - Profile: https://example.com/bob
+  - Notes: [runbook](https://example.com/runbook)
+
+> Status call highlights:
+> - On-call load is high
+>   - Add more automation
+>   - Improve alert routing
+> - Task list:
+>   - [ ] Triage paging rules
+>   - [x] Reduce noisy alerts
+>
+> 1. Investigate spikes
+>    1. Check dashboard
+>    2. Review traces
+> 2. Apply fixes
+>
+> Final note with **bold** and \`code\`.
+
+## Metrics
+
+Table below:
+| Metric | Value |
+|---|---|
+| Coverage | 92% |
+| Latency | 120ms |
+
+Links right after table:
+- Dashboard: https://example.com/metrics
+- Incident history: https://example.com/incidents
+
+\`\`\`ts
+export const flag = true
+\`\`\`
+
+---
+
+### Risks
+
+Paragraph close to the table and hr with a link to [docs](https://example.com/docs).
+
+> Second quote block
+> with multiple lines
+> and a list:
+> - Q item 1
+> - Q item 2
+>   - Q nested 1
+>   - Q nested 2
+>
+> Final quoted line.
+
+Final paragraph with an image ![alt](https://example.com/img.png).`
+
+  const {
+    renderer: localRenderer,
+    renderOnce: localRenderOnce,
+    captureCharFrame,
+  } = await createTestRenderer({
+    width: 90,
+    height: 120,
+  })
+
+  try {
+    const md = new MarkdownRenderable(localRenderer, {
+      id: "markdown",
+      content: markdown,
+      syntaxStyle,
+    })
+
+    localRenderer.root.add(md)
+    await localRenderOnce()
+
+    const lines = captureCharFrame()
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .join("\n")
+      .trimEnd()
+
+    expect("\n" + lines).toMatchInlineSnapshot(`
+      "
+      Weekly Update
+
+      Quick summary for the team with bold, italic, code, and strikethrough.
+
+      People
+
+      - Alice
+        - Role: Tech Lead
+        - Profile: https://example.com/alice (https://example.com/alice)
+        - Notes: handoff doc (https://example.com/alice/handoff)
+      - Bob
+        - Role: Infra
+        - Profile: https://example.com/bob (https://example.com/bob)
+        - Notes: runbook (https://example.com/runbook)
+
+      > Status call highlights:
+      > - On-call load is high
+      >   - Add more automation
+      >   - Improve alert routing
+      > - Task list:
+      >   - [ ] Triage paging rules
+      >   - [x] Reduce noisy alerts
+      >
+      > 1. Investigate spikes
+      >   1. Check dashboard
+      >   2. Review traces
+      > 2. Apply fixes
+      >
+      > Final note with bold and code.
+
+      Metrics
+
+      Table below:
+
+      ┌──────────┬───────┐
+      │Metric    │Value  │
+      │──────────│───────│
+      │Coverage  │92%    │
+      │──────────│───────│
+      │Latency   │120ms  │
+      └──────────┴───────┘
+
+      Links right after table:
+
+      - Dashboard: https://example.com/metrics (https://example.com/metrics)
+      - Incident history: https://example.com/incidents (https://example.com/incidents)
+
+      export const flag = true
+
+      ---
+
+      Risks
+
+      Paragraph close to the table and hr with a link to docs (https://example.com/docs).
+
+      > Second quote block
+      > with multiple lines
+      > and a list:
+      > - Q item 1
+      > - Q item 2
+      >   - Q nested 1
+      >   - Q nested 2
+      >
+      > Final quoted line.
+
+      Final paragraph with an image alt."
+    `)
+  } finally {
+    localRenderer.destroy()
+  }
 })
 
 // Custom renderNode tests
@@ -1765,7 +1961,6 @@ The table alignment uses:
   // Switch theme
   md.syntaxStyle = theme2
   await renderOnce()
-
   const frame2 = captureSpans()
   const headingSpan2 = findSpanContaining(frame2, "OpenTUI Markdown Demo")
   expect(headingSpan2).toBeDefined()

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -673,6 +673,39 @@ test("list with inline formatting", async () => {
   `)
 })
 
+test("nested unordered list", async () => {
+  const markdown = `- Item 1
+  - Nested A
+  - Nested B
+- Item 2`
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    - Item 1
+      - Nested A
+      - Nested B
+    - Item 2"
+  `)
+})
+
+test("list item with fenced code block", async () => {
+  const markdown = `- Item with code:
+
+  \`\`\`ts
+  const value = 1
+  console.log(value)
+  \`\`\`
+- Next item`
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    - Item with code:
+      const value = 1
+      console.log(value)
+    - Next item"
+  `)
+})
+
 // Blockquote tests
 
 test("simple blockquote", async () => {
@@ -1176,6 +1209,32 @@ test("streaming mode keeps trailing tokens unstable", async () => {
     .join("\n")
     .trimEnd()
   expect(frame2).toContain("Hello World")
+})
+
+test("streaming task list keeps checkbox and text on same line", async () => {
+  const md = new MarkdownRenderable(renderer, {
+    id: "markdown",
+    content: "- [ ]",
+    syntaxStyle,
+    streaming: true,
+  })
+
+  renderer.root.add(md)
+  await renderOnce()
+
+  md.content = "- [ ] todo"
+  await renderOnce()
+
+  const frame = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trimEnd()
+
+  expect("\n" + frame).toMatchInlineSnapshot(`
+    "
+    - [ ] todo"
+  `)
 })
 
 test("non-streaming mode parses all tokens as stable", async () => {


### PR DESCRIPTION
Split from #597 to make review easier. Depends on #692.

Replaces flat text chunk list rendering with BoxRenderable containers. Each list item gets its own box, with the first inline text on the marker line and remaining child tokens (nested lists, code blocks) as indented children. Supports nested lists, task checkboxes, and code blocks inside list items.