### PR TITLE
fix(markdown): only skip incomplete rows in streaming tables

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -427,7 +427,7 @@ export class MarkdownRenderable extends Renderable {
     const borderColor = this.getStyle("conceal")?.fg ?? "#888888"
     const headingStyle = this.getStyle("markup.heading") || this.getStyle("default")
 
-    const rowsToRender = this._streaming && table.rows.length > 0 ? table.rows.slice(0, -1) : table.rows
+    const rowsToRender = this.getTableRowsToRender(table)
     const colCount = table.header.length
 
     // Traverse existing table structure: tableBox -> columnBoxes -> cells
@@ -501,8 +501,7 @@ export class MarkdownRenderable extends Renderable {
   private createTableRenderable(table: Tokens.Table, id: string, marginBottom: number = 0): Renderable {
     const colCount = table.header.length
 
-    // During streaming, skip the last row (might be incomplete)
-    const rowsToRender = this._streaming && table.rows.length > 0 ? table.rows.slice(0, -1) : table.rows
+    const rowsToRender = this.getTableRowsToRender(table)
 
     if (colCount === 0 || rowsToRender.length === 0) {
       return this.createTextRenderable([this.createDefaultChunk(table.raw)], id, marginBottom)
@@ -614,6 +613,23 @@ export class MarkdownRenderable extends Renderable {
     return tableBox
   }
 
+  private getTableRowsToRender(table: Tokens.Table): Tokens.Table["rows"] {
+    if (!this._streaming) {
+      return table.rows
+    }
+    if (table.rows.length === 0) {
+      return table.rows
+    }
+    if (table.raw.endsWith("\n")) {
+      return table.rows
+    }
+    return table.rows.slice(0, -1)
+  }
+
+  private getTableRenderableRowCount(table: Tokens.Table): number {
+    return this.getTableRowsToRender(table).length
+  }
+
   private createDefaultRenderable(token: MarkedToken, index: number, hasNextToken: boolean = false): Renderable | null {
     const id = `${this.id}-block-${index}`
     const marginBottom = hasNextToken ? 1 : 0
@@ -658,8 +674,8 @@ export class MarkdownRenderable extends Renderable {
 
       // During streaming, only rebuild when complete row count changes (skip incomplete last row)
       if (this._streaming) {
-        const prevCompleteRows = Math.max(0, prevTable.rows.length - 1)
-        const newCompleteRows = Math.max(0, newTable.rows.length - 1)
+        const prevCompleteRows = this.getTableRenderableRowCount(prevTable)
+        const newCompleteRows = this.getTableRenderableRowCount(newTable)
 
         // Check if both previous and new are in raw fallback mode (no complete rows to render)
         const prevIsRawFallback = prevTable.header.length === 0 || prevCompleteRows === 0

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1522,6 +1522,34 @@ test("streaming table transitions cleanly from raw fallback to proper table", as
   expect(frame).not.toContain("| D")
 })
 
+test("streaming table renders with conceal=false when row is complete", async () => {
+  const md = new MarkdownRenderable(renderer, {
+    id: "markdown",
+    content: "| A | B |\n|---|---|\n| 1 | 2 |\n",
+    syntaxStyle,
+    conceal: false,
+    streaming: true,
+  })
+
+  renderer.root.add(md)
+  await renderOnce()
+
+  const frame = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trimEnd()
+
+  expect("\n" + frame).toMatchInlineSnapshot(`
+    "
+    ┌───┬───┐
+    │A  │B  │
+    │───│───│
+    │1  │2  │
+    └───┴───┘"
+  `)
+})
+
 test("streaming table can transition back to raw fallback when rows are removed", async () => {
   const md = new MarkdownRenderable(renderer, {
     id: "markdown",


### PR DESCRIPTION
Split from #597 to make review easier.

Previously the last table row was always skipped during streaming, even when complete. Now checks if `table.raw.endsWith("\n")` — if yes, the row is complete and shown. Extracts `getTableRowsToRender()` and `getTableRenderableRowCount()` helpers.