### PR TITLE
fix(markdown): skip redundant href in conceal mode for autolinks

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -233,9 +233,14 @@ export class MarkdownRenderable extends Renderable {
           for (const child of token.tokens) {
             this.renderInlineTokenWithStyle(child as MarkedToken, chunks, "markup.link.label", linkHref)
           }
-          chunks.push(this.createChunk(" (", "markup.link", linkHref))
-          chunks.push(this.createChunk(token.href, "markup.link.url", linkHref))
-          chunks.push(this.createChunk(")", "markup.link", linkHref))
+          // Only show (href) suffix when label text differs from the URL itself
+          // (autolinks and bare URLs have label === href, so showing both is redundant)
+          const labelText = token.tokens.map((t: { raw: string }) => t.raw).join("")
+          if (labelText !== token.href) {
+            chunks.push(this.createChunk(" (", "markup.link", linkHref))
+            chunks.push(this.createChunk(token.href, "markup.link.url", linkHref))
+            chunks.push(this.createChunk(")", "markup.link", linkHref))
+          }
         } else {
           chunks.push(this.createChunk("[", "markup.link", linkHref))
           for (const child of token.tokens) {

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -984,8 +984,7 @@ test("incomplete link (no closing paren)", async () => {
 
   expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
     "
-    Check out [this link](https://example.com (https://example.
-    com)"
+    Check out [this link](https://example.com"
   `)
 })
 


### PR DESCRIPTION
When conceal mode renders a link where the label text equals the href (e.g. bare URLs and autolinks), the URL was displayed twice:

```
https://example.com (https://example.com)
```

This adds a check to skip the `(href)` suffix when the label matches the URL. Named links like `[docs](https://example.com)` still render as `docs (https://example.com)`.