### PR TITLE
fix(markdown): word-wrap table cells instead of truncating content

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -430,70 +430,55 @@ export class MarkdownRenderable extends Renderable {
 
     const rowsToRender = this._streaming && table.rows.length > 0 ? table.rows.slice(0, -1) : table.rows
     const colCount = table.header.length
+    const totalRows = 1 + rowsToRender.length // header + data rows
 
-    // Traverse existing table structure: tableBox -> columnBoxes -> cells
-    const columns = (tableBox as any)._childrenInLayoutOrder as Renderable[]
-    for (let col = 0; col < colCount; col++) {
-      const columnBox = columns[col]
-      if (!columnBox) continue
+    // Traverse row-major structure: tableBox -> rows -> cells
+    const rows = (tableBox as any)._childrenInLayoutOrder as Renderable[]
+    for (let row = 0; row < Math.min(totalRows, rows.length); row++) {
+      const isHeaderRow = row === 0
+      const dataRowIndex = row - 1
+      const rowBox = rows[row]
+      const cells = (rowBox as any)._childrenInLayoutOrder as Renderable[]
 
-      // Update column border colors
-      if (columnBox instanceof BoxRenderable) {
-        columnBox.borderColor = borderColor
-      }
+      for (let col = 0; col < Math.min(colCount, cells.length); col++) {
+        const cellBox = cells[col]
 
-      const columnChildren = (columnBox as any)._childrenInLayoutOrder as Renderable[]
-
-      // Update header (first child of column)
-      const headerBox = columnChildren[0]
-      if (headerBox instanceof BoxRenderable) {
-        headerBox.borderColor = borderColor
-        const headerChildren = (headerBox as any)._childrenInLayoutOrder as Renderable[]
-        const headerText = headerChildren[0]
-        if (headerText instanceof TextRenderable) {
-          const headerCell = table.header[col]
-          const headerChunks: TextChunk[] = []
-          this.renderInlineContent(headerCell.tokens, headerChunks)
-          const styledHeaderChunks = headerChunks.map((chunk) => ({
-            ...chunk,
-            fg: headingStyle?.fg ?? chunk.fg,
-            bg: headingStyle?.bg ?? chunk.bg,
-            attributes: headingStyle
-              ? createTextAttributes({
-                  bold: headingStyle.bold,
-                  italic: headingStyle.italic,
-                  underline: headingStyle.underline,
-                  dim: headingStyle.dim,
-                })
-              : chunk.attributes,
-          }))
-          headerText.content = new StyledText(styledHeaderChunks)
-        }
-      }
-
-      // Update data rows (remaining children)
-      for (let row = 0; row < rowsToRender.length; row++) {
-        const childIndex = row + 1 // +1 because header is first child
-        const cellContainer = columnChildren[childIndex]
-
-        let cellText: TextRenderable | undefined
-        if (cellContainer instanceof BoxRenderable) {
-          // Cell has a border box wrapper
-          cellContainer.borderColor = borderColor
-          const cellChildren = (cellContainer as any)._childrenInLayoutOrder as Renderable[]
-          cellText = cellChildren[0] as TextRenderable
-        } else if (cellContainer instanceof TextRenderable) {
-          // Last row, no border box
-          cellText = cellContainer
+        // Update border color
+        if (cellBox instanceof BoxRenderable) {
+          cellBox.borderColor = borderColor
         }
 
-        if (cellText) {
-          const cell = rowsToRender[row][col]
-          const cellChunks: TextChunk[] = []
-          if (cell) {
-            this.renderInlineContent(cell.tokens, cellChunks)
+        // Update text content (first child of cellBox)
+        const cellChildren = (cellBox as any)._childrenInLayoutOrder as Renderable[]
+        const cellText = cellChildren[0]
+
+        if (cellText instanceof TextRenderable) {
+          if (isHeaderRow) {
+            const headerCell = table.header[col]
+            const headerChunks: TextChunk[] = []
+            this.renderInlineContent(headerCell.tokens, headerChunks)
+            const styledHeaderChunks = headerChunks.map((chunk) => ({
+              ...chunk,
+              fg: headingStyle?.fg ?? chunk.fg,
+              bg: headingStyle?.bg ?? chunk.bg,
+              attributes: headingStyle
+                ? createTextAttributes({
+                    bold: headingStyle.bold,
+                    italic: headingStyle.italic,
+                    underline: headingStyle.underline,
+                    dim: headingStyle.dim,
+                  })
+                : chunk.attributes,
+            }))
+            cellText.content = new StyledText(styledHeaderChunks)
+          } else {
+            const cell = rowsToRender[dataRowIndex]?.[col]
+            const cellChunks: TextChunk[] = []
+            if (cell) {
+              this.renderInlineContent(cell.tokens, cellChunks)
+            }
+            cellText.content = new StyledText(cellChunks.length > 0 ? cellChunks : [this.createDefaultChunk(" ")])
           }
-          cellText.content = new StyledText(cellChunks.length > 0 ? cellChunks : [this.createDefaultChunk(" ")])
         }
       }
     }
@@ -509,107 +494,122 @@ export class MarkdownRenderable extends Renderable {
       return this.createTextRenderable([this.createDefaultChunk(table.raw)], id, marginBottom)
     }
 
+    const borderColor = this.getStyle("conceal")?.fg ?? "#888888"
+    const headingStyle = this.getStyle("markup.heading") || this.getStyle("default")
+    const totalRows = 1 + rowsToRender.length // header + data rows
+    const CELL_PADDING = 2 // paddingLeft: 1 + paddingRight: 1
+
+    // Pre-render all cell chunks and calculate natural column widths.
+    // This ensures columns are sized to their content (compact tables for short data)
+    // while allowing proportional shrinking with word-wrap for wide tables.
+    const allChunks: TextChunk[][][] = [] // allChunks[row][col] = chunks
+    const colNaturalWidths: number[] = new Array(colCount).fill(0)
+
+    for (let row = 0; row < totalRows; row++) {
+      allChunks[row] = []
+      for (let col = 0; col < colCount; col++) {
+        let chunks: TextChunk[]
+        if (row === 0) {
+          const headerCell = table.header[col]
+          const headerChunks: TextChunk[] = []
+          this.renderInlineContent(headerCell.tokens, headerChunks)
+          chunks = headerChunks.map((chunk) => ({
+            ...chunk,
+            fg: headingStyle?.fg ?? chunk.fg,
+            bg: headingStyle?.bg ?? chunk.bg,
+            attributes: headingStyle
+              ? createTextAttributes({
+                  bold: headingStyle.bold,
+                  italic: headingStyle.italic,
+                  underline: headingStyle.underline,
+                  dim: headingStyle.dim,
+                })
+              : chunk.attributes,
+          }))
+        } else {
+          const cell = rowsToRender[row - 1]?.[col]
+          chunks = []
+          if (cell) {
+            this.renderInlineContent(cell.tokens, chunks)
+          }
+          if (chunks.length === 0) {
+            chunks = [this.createDefaultChunk(" ")]
+          }
+        }
+        allChunks[row][col] = chunks
+
+        const contentWidth = chunks.reduce((sum, c) => sum + c.text.length, 0)
+        colNaturalWidths[col] = Math.max(colNaturalWidths[col], contentWidth + CELL_PADDING)
+      }
+    }
+
+    // Row-major table: vertical stack of rows, each row is a horizontal flex container.
+    // Cells in the same row auto-sync height via alignItems: stretch (Yoga default).
+    // flexBasis = natural width ensures compact tables; flexShrink = 1 enables
+    // proportional shrinking with word-wrap when the table is wider than the viewport.
     const tableBox = new BoxRenderable(this.ctx, {
       id,
-      flexDirection: "row",
+      flexDirection: "column",
       marginBottom,
     })
 
-    const borderColor = this.getStyle("conceal")?.fg ?? "#888888"
+    for (let row = 0; row < totalRows; row++) {
+      const isLastRow = row === totalRows - 1
 
-    for (let col = 0; col < colCount; col++) {
-      const isFirstCol = col === 0
-      const isLastCol = col === colCount - 1
-
-      const columnBox = new BoxRenderable(this.ctx, {
-        id: `${id}-col-${col}`,
-        flexDirection: "column",
-        border: isLastCol ? true : ["top", "bottom", "left"],
-        borderColor,
-        // Use T-joins for non-first columns to connect with previous column
-        customBorderChars: isFirstCol
-          ? undefined
-          : {
-              topLeft: "┬",
-              topRight: "┐",
-              bottomLeft: "┴",
-              bottomRight: "┘",
-              horizontal: "─",
-              vertical: "│",
-              topT: "┬",
-              bottomT: "┴",
-              leftT: "├",
-              rightT: "┤",
-              cross: "┼",
-            },
+      const rowBox = new BoxRenderable(this.ctx, {
+        id: `${id}-row-${row}`,
+        flexDirection: "row",
       })
 
-      const headerCell = table.header[col]
-      const headerChunks: TextChunk[] = []
-      this.renderInlineContent(headerCell.tokens, headerChunks)
-      const headingStyle = this.getStyle("markup.heading") || this.getStyle("default")
-      const styledHeaderChunks = headerChunks.map((chunk) => ({
-        ...chunk,
-        fg: headingStyle?.fg ?? chunk.fg,
-        bg: headingStyle?.bg ?? chunk.bg,
-        attributes: headingStyle
-          ? createTextAttributes({
-              bold: headingStyle.bold,
-              italic: headingStyle.italic,
-              underline: headingStyle.underline,
-              dim: headingStyle.dim,
-            })
-          : chunk.attributes,
-      }))
+      for (let col = 0; col < colCount; col++) {
+        const isLastCol = col === colCount - 1
 
-      const headerBox = new BoxRenderable(this.ctx, {
-        id: `${id}-col-${col}-header-box`,
-        border: ["bottom"],
-        borderColor,
-      })
-      headerBox.add(
-        new TextRenderable(this.ctx, {
-          id: `${id}-col-${col}-header`,
-          content: new StyledText(styledHeaderChunks),
-          height: 1,
-          overflow: "hidden",
-          paddingLeft: 1,
-          paddingRight: 1,
-        }),
-      )
-      columnBox.add(headerBox)
+        // Border sides: always top+left; last col adds right; last row adds bottom
+        const borderSides: ("top" | "right" | "bottom" | "left")[] = ["top", "left"]
+        if (isLastCol) borderSides.push("right")
+        if (isLastRow) borderSides.push("bottom")
 
-      for (let row = 0; row < rowsToRender.length; row++) {
-        const cell = rowsToRender[row][col]
-        const cellChunks: TextChunk[] = []
-        if (cell) {
-          this.renderInlineContent(cell.tokens, cellChunks)
+        // Custom border chars for proper T-junctions and crosses at cell intersections
+        const customBorderChars = {
+          topLeft: row === 0 && col === 0 ? "┌" : row === 0 ? "┬" : col === 0 ? "├" : "┼",
+          topRight: row === 0 ? "┐" : "┤",
+          bottomLeft: col === 0 ? "└" : "┴",
+          bottomRight: "┘",
+          horizontal: "─",
+          vertical: "│",
+          topT: "┬",
+          bottomT: "┴",
+          leftT: "├",
+          rightT: "┤",
+          cross: "┼",
         }
 
-        const isLastRow = row === rowsToRender.length - 1
-        const cellText = new TextRenderable(this.ctx, {
-          id: `${id}-col-${col}-row-${row}`,
-          content: new StyledText(cellChunks.length > 0 ? cellChunks : [this.createDefaultChunk(" ")]),
-          height: 1,
-          overflow: "hidden",
-          paddingLeft: 1,
-          paddingRight: 1,
+        // Yoga uses border-box sizing: flexBasis must include border widths
+        const borderLeftWidth = 1 // all cells have left border
+        const borderRightWidth = isLastCol ? 1 : 0
+
+        const cellBox = new BoxRenderable(this.ctx, {
+          id: `${id}-cell-${row}-${col}`,
+          flexBasis: colNaturalWidths[col] + borderLeftWidth + borderRightWidth,
+          flexShrink: 1,
+          border: borderSides,
+          borderColor,
+          customBorderChars,
         })
 
-        if (isLastRow) {
-          columnBox.add(cellText)
-        } else {
-          const cellBox = new BoxRenderable(this.ctx, {
-            id: `${id}-col-${col}-row-${row}-box`,
-            border: ["bottom"],
-            borderColor,
-          })
-          cellBox.add(cellText)
-          columnBox.add(cellBox)
-        }
+        const cellText = new TextRenderable(this.ctx, {
+          id: `${id}-text-${row}-${col}`,
+          content: new StyledText(allChunks[row][col]),
+          paddingLeft: 1,
+          paddingRight: 1,
+          // No explicit height or overflow: auto-size with word wrap
+        })
+
+        cellBox.add(cellText)
+        rowBox.add(cellBox)
       }
 
-      tableBox.add(columnBox)
+      tableBox.add(rowBox)
     }
 
     return tableBox

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -56,9 +56,9 @@ test("basic table alignment", async () => {
     "
     ┌───────┬─────┐
     │Name   │Age  │
-    │───────│─────│
+    ├───────┼─────┤
     │Alice  │30   │
-    │───────│─────│
+    ├───────┼─────┤
     │Bob    │5    │
     └───────┴─────┘"
   `)
@@ -75,11 +75,11 @@ test("table with inline code (backticks)", async () => {
     "
     ┌───────────────┬───────────────┐
     │Command        │Description    │
-    │───────────────│───────────────│
+    ├───────────────┼───────────────┤
     │npm install    │Install deps   │
-    │───────────────│───────────────│
+    ├───────────────┼───────────────┤
     │npm run build  │Build project  │
-    │───────────────│───────────────│
+    ├───────────────┼───────────────┤
     │npm test       │Run tests      │
     └───────────────┴───────────────┘"
   `)
@@ -95,9 +95,9 @@ test("table with bold text", async () => {
     "
     ┌────────────────┬────────┐
     │Feature         │Status  │
-    │────────────────│────────│
+    ├────────────────┼────────┤
     │Authentication  │Done    │
-    │────────────────│────────│
+    ├────────────────┼────────┤
     │API             │WIP     │
     └────────────────┴────────┘"
   `)
@@ -113,9 +113,9 @@ test("table with italic text", async () => {
     "
     ┌──────┬───────────┐
     │Item  │Note       │
-    │──────│───────────│
+    ├──────┼───────────┤
     │One   │important  │
-    │──────│───────────│
+    ├──────┼───────────┤
     │Two   │ok         │
     └──────┴───────────┘"
   `)
@@ -131,9 +131,9 @@ test("table with mixed formatting", async () => {
     "
     ┌───────┬────────┬────────┐
     │Type   │Value   │Notes   │
-    │───────│────────│────────│
+    ├───────┼────────┼────────┤
     │Bold   │code    │italic  │
-    │───────│────────│────────│
+    ├───────┼────────┼────────┤
     │Plain  │strong  │cmd     │
     └───────┴────────┴────────┘"
   `)
@@ -149,9 +149,9 @@ test("table with alignment markers (left, center, right)", async () => {
     "
     ┌───────────┬────────┬───────┐
     │Left       │Center  │Right  │
-    │───────────│────────│───────│
+    ├───────────┼────────┼───────┤
     │A          │B       │C      │
-    │───────────│────────│───────│
+    ├───────────┼────────┼───────┤
     │Long text  │X       │Y      │
     └───────────┴────────┴───────┘"
   `)
@@ -167,9 +167,9 @@ test("table with empty cells", async () => {
     "
     ┌───┬───┐
     │A  │B  │
-    │───│───│
+    ├───┼───┤
     │X  │   │
-    │───│───│
+    ├───┼───┤
     │   │Y  │
     └───┴───┘"
   `)
@@ -184,7 +184,7 @@ test("table with long header and short content", async () => {
     "
     ┌─────────────────────────┬───────┐
     │Very Long Column Header  │Short  │
-    │─────────────────────────│───────│
+    ├─────────────────────────┼───────┤
     │A                        │B      │
     └─────────────────────────┴───────┘"
   `)
@@ -199,7 +199,7 @@ test("table with short header and long content", async () => {
     "
     ┌───────────────────────────┬───────┐
     │X                          │Y      │
-    │───────────────────────────│───────│
+    ├───────────────────────────┼───────┤
     │This is very long content  │Short  │
     └───────────────────────────┴───────┘"
   `)
@@ -224,7 +224,7 @@ test("table inside code block should NOT be formatted", async () => {
 
     ┌──────┬───────────┐
     │Real  │Table      │
-    │──────│───────────│
+    ├──────┼───────────┤
     │Is    │Formatted  │
     └──────┴───────────┘"
   `)
@@ -245,7 +245,7 @@ Some text between.
     "
     ┌────────┬───┐
     │Table1  │A  │
-    │────────│───│
+    ├────────┼───┤
     │X       │Y  │
     └────────┴───┘
 
@@ -253,7 +253,7 @@ Some text between.
 
     ┌──────────────┬────┐
     │Table2        │BB  │
-    │──────────────│────│
+    ├──────────────┼────┤
     │Long content  │Z   │
     └──────────────┴────┘"
   `)
@@ -269,9 +269,9 @@ test("table with escaped pipe character", async () => {
     "
     ┌───────────┬──────────┐
     │Command    │Output    │
-    │───────────│──────────│
+    ├───────────┼──────────┤
     │echo       │Hello     │
-    │───────────│──────────│
+    ├───────────┼──────────┤
     │ls | grep  │Filtered  │
     └───────────┴──────────┘"
   `)
@@ -286,15 +286,16 @@ test("table with unicode characters", async () => {
 
   expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
     "
-    ┌────────┬──────────┐
-    │Emoji   │Name      │
-    │────────│──────────│
-    │🎉      │Party     │
-    │────────│──────────│
-    │🚀      │Rocket    │
-    │────────│──────────│
-    │日本語  │Japanese  │
-    └────────┴──────────┘"
+    ┌───────┬──────────┐
+    │Emoji  │Name      │
+    ├───────┼──────────┤
+    │🎉     │Party     │
+    ├───────┼──────────┤
+    │🚀     │Rocket    │
+    ├───────┼──────────┤
+    │日本語 │Japanese  │
+    │       │          │
+    └───────┴──────────┘"
   `)
 })
 
@@ -308,9 +309,9 @@ test("table with links", async () => {
     "
     ┌────────┬───────────────────────────┐
     │Name    │Link                       │
-    │────────│───────────────────────────│
+    ├────────┼───────────────────────────┤
     │Google  │link (https://google.com)  │
-    │────────│───────────────────────────│
+    ├────────┼───────────────────────────┤
     │GitHub  │gh (https://github.com)    │
     └────────┴───────────────────────────┘"
   `)
@@ -336,10 +337,43 @@ test("table with many columns", async () => {
     "
     ┌───┬───┬───┬───┬───┐
     │A  │B  │C  │D  │E  │
-    │───│───│───│───│───│
+    ├───┼───┼───┼───┼───┤
     │1  │2  │3  │4  │5  │
     └───┴───┴───┴───┴───┘"
   `)
+})
+
+test("table with wide content wraps instead of truncating", async () => {
+  // With 60 char width, 3 columns of long text should wrap within cells
+  const markdown = `| Header A | Header B | Header C |
+|---|---|---|
+| This is a long cell | Also quite long | Short |`
+
+  const result = await renderMarkdown(markdown)
+  // Columns should shrink proportionally; content should NOT be truncated
+  expect(result).toContain("This is a")
+  expect(result).toContain("long cell")
+  expect(result).toContain("Also quite")
+  expect(result).toContain("long")
+  expect(result).toContain("Short")
+  // Should have proper table borders
+  expect(result).toContain("┌")
+  expect(result).toContain("┘")
+  expect(result).toContain("├")
+})
+
+test("table cells in same row have equal height with word wrap", async () => {
+  // One cell wraps, other doesn't - they should still align
+  const markdown = `| Short | This is a very long text that will definitely need to wrap |
+|---|---|
+| A | B |`
+
+  const result = await renderMarkdown(markdown)
+  // Long header should wrap but still be fully visible
+  expect(result).toContain("This is a very")
+  expect(result).toContain("long text")
+  expect(result).toContain("wrap")
+  expect(result).toContain("Short")
 })
 
 test("no tables returns original content", async () => {
@@ -369,9 +403,9 @@ test("table with nested inline formatting", async () => {
     "
     ┌─────────────────────────────────┐
     │Description                      │
-    │─────────────────────────────────│
+    ├─────────────────────────────────┤
     │This has bold and code together  │
-    │─────────────────────────────────│
+    ├─────────────────────────────────┤
     │And italic with nested bold      │
     └─────────────────────────────────┘"
   `)
@@ -389,9 +423,9 @@ test("conceal=false: table with bold text", async () => {
     "
     ┌────────────────────┬────────┐
     │Feature             │Status  │
-    │────────────────────│────────│
+    ├────────────────────┼────────┤
     │**Authentication**  │Done    │
-    │────────────────────│────────│
+    ├────────────────────┼────────┤
     │**API**             │WIP     │
     └────────────────────┴────────┘"
   `)
@@ -407,9 +441,9 @@ test("conceal=false: table with inline code", async () => {
     "
     ┌─────────────────┬───────────────┐
     │Command          │Description    │
-    │─────────────────│───────────────│
+    ├─────────────────┼───────────────┤
     │\`npm install\`    │Install deps   │
-    │─────────────────│───────────────│
+    ├─────────────────┼───────────────┤
     │\`npm run build\`  │Build project  │
     └─────────────────┴───────────────┘"
   `)
@@ -425,9 +459,9 @@ test("conceal=false: table with italic text", async () => {
     "
     ┌──────┬─────────────┐
     │Item  │Note         │
-    │──────│─────────────│
+    ├──────┼─────────────┤
     │One   │*important*  │
-    │──────│─────────────│
+    ├──────┼─────────────┤
     │Two   │*ok*         │
     └──────┴─────────────┘"
   `)
@@ -443,9 +477,9 @@ test("conceal=false: table with mixed formatting", async () => {
     "
     ┌──────────┬────────────┬──────────┐
     │Type      │Value       │Notes     │
-    │──────────│────────────│──────────│
+    ├──────────┼────────────┼──────────┤
     │**Bold**  │\`code\`      │*italic*  │
-    │──────────│────────────│──────────│
+    ├──────────┼────────────┼──────────┤
     │Plain     │**strong**  │\`cmd\`     │
     └──────────┴────────────┴──────────┘"
   `)
@@ -460,15 +494,16 @@ test("conceal=false: table with unicode characters", async () => {
 
   expect(await renderMarkdown(markdown, false)).toMatchInlineSnapshot(`
     "
-    ┌────────┬──────────┐
-    │Emoji   │Name      │
-    │────────│──────────│
-    │🎉      │Party     │
-    │────────│──────────│
-    │🚀      │Rocket    │
-    │────────│──────────│
-    │日本語  │Japanese  │
-    └────────┴──────────┘"
+    ┌───────┬──────────┐
+    │Emoji  │Name      │
+    ├───────┼──────────┤
+    │🎉     │Party     │
+    ├───────┼──────────┤
+    │🚀     │Rocket    │
+    ├───────┼──────────┤
+    │日本語 │Japanese  │
+    │       │          │
+    └───────┴──────────┘"
   `)
 })
 
@@ -482,9 +517,9 @@ test("conceal=false: basic table alignment", async () => {
     "
     ┌───────┬─────┐
     │Name   │Age  │
-    │───────│─────│
+    ├───────┼─────┤
     │Alice  │30   │
-    │───────│─────│
+    ├───────┼─────┤
     │Bob    │5    │
     └───────┴─────┘"
   `)
@@ -505,7 +540,7 @@ This is a paragraph after the table.`
 
     ┌───────┬─────┐
     │Name   │Age  │
-    │───────│─────│
+    ├───────┼─────┤
     │Alice  │30   │
     └───────┴─────┘
 
@@ -1033,7 +1068,7 @@ test("malformed table with missing pipes", async () => {
     "
     ┌───┬───┐
     │A  │B  │
-    │───│───│
+    ├───┼───┤
     │1  │2  │
     └───┴───┘"
   `)
@@ -1118,7 +1153,7 @@ test("table at end with trailing blank lines", async () => {
     "
     ┌───┬───┐
     │A  │B  │
-    │───│───│
+    ├───┼───┤
     │1  │2  │
     └───┴───┘"
   `)


### PR DESCRIPTION
Fixes #711

## Summary

- Rewrites table layout from column-major to row-major so cells word-wrap instead of silently truncating content
- Fixes row separator characters: `│───│` → `├───┼───┤` (proper T-junctions)

## Problem

Table cells were created with `height: 1` and `overflow: "hidden"`, silently cutting off any content that didn't fit in a single line. The column-major layout (each column as a separate flex-column) made it impossible to synchronize row heights across columns.

## Solution

**Row-major layout:** each row is a flex-row container. Yoga's default `alignItems: stretch` automatically synchronizes cell heights within a row.

- No explicit `height` or `overflow` on `TextRenderable` — `measureFunc` auto-calculates height from wrapped content
- `flexBasis` set to natural column width (max content + padding + borders) for compact tables
- `flexShrink: 1` enables proportional shrinking with word-wrap when the table exceeds viewport width
- `customBorderChars` per cell position for correct T-junction/cross characters

## Testing

- All 84 existing tests pass (25 snapshot updates for improved separator chars)
- 2 new tests for word-wrap behavior