### PR TITLE
scrollbox: add scrollChildIntoView method

### DIFF
--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -425,6 +425,55 @@ export class ScrollBoxRenderable extends BoxRenderable {
     // change will trigger the scrollTop setter which handles it
   }
 
+  public scrollChildIntoView(childId: string): void {
+    const child = this.content.findDescendantById(childId)
+    if (!child) return
+
+    const getNearestDelta = (
+      elementStart: number,
+      elementEnd: number,
+      viewportStart: number,
+      viewportEnd: number,
+    ): number => {
+      const elementSize = elementEnd - elementStart
+      const viewportSize = viewportEnd - viewportStart
+      const elementStartOutside = elementStart < viewportStart
+      const elementEndOutside = elementEnd > viewportEnd
+
+      if (elementStartOutside && elementEndOutside) {
+        return 0
+      }
+
+      if ((elementStartOutside && elementSize < viewportSize) || (elementEndOutside && elementSize > viewportSize)) {
+        return elementStart - viewportStart
+      }
+
+      if ((elementStartOutside && elementSize > viewportSize) || (elementEndOutside && elementSize < viewportSize)) {
+        return elementEnd - viewportEnd
+      }
+
+      return 0
+    }
+
+    const childTop = child.y
+    const childBottom = child.y + child.height
+    const viewportTop = this.viewport.y
+    const viewportBottom = this.viewport.y + this.viewport.height
+
+    const dy = getNearestDelta(childTop, childBottom, viewportTop, viewportBottom)
+
+    const childLeft = child.x
+    const childRight = child.x + child.width
+    const viewportLeft = this.viewport.x
+    const viewportRight = this.viewport.x + this.viewport.width
+
+    const dx = getNearestDelta(childLeft, childRight, viewportLeft, viewportRight)
+
+    if (dx !== 0 || dy !== 0) {
+      this.scrollBy({ x: dx, y: dy })
+    }
+  }
+
   public scrollTo(position: number | { x: number; y: number }): void {
     if (typeof position === "number") {
       this.scrollTop = position

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -1337,6 +1337,157 @@ console.log(processor.reduce((acc, val) => acc + val, 0))`
     expect(scrollBox.scrollTop).toBe(0)
   })
 
+  test("scrollChildIntoView does nothing when child is already visible", async () => {
+    const scrollBox = new ScrollBoxRenderable(testRenderer, {
+      width: 40,
+      height: 10,
+    })
+
+    for (let i = 0; i < 10; i++) {
+      scrollBox.add(new BoxRenderable(testRenderer, { id: `child-${i}`, height: 1 }))
+    }
+    testRenderer.root.add(scrollBox)
+    await renderOnce()
+
+    expect(scrollBox.scrollTop).toBe(0)
+
+    scrollBox.scrollChildIntoView("child-2")
+    expect(scrollBox.scrollTop).toBe(0)
+  })
+
+  test("scrollChildIntoView scrolls down to reveal child below viewport", async () => {
+    const scrollBox = new ScrollBoxRenderable(testRenderer, {
+      width: 40,
+      height: 10,
+    })
+
+    for (let i = 0; i < 30; i++) {
+      scrollBox.add(new BoxRenderable(testRenderer, { id: `child-${i}`, height: 1 }))
+    }
+    testRenderer.root.add(scrollBox)
+    await renderOnce()
+
+    scrollBox.scrollChildIntoView("child-25")
+    await renderOnce()
+
+    const child = scrollBox.content.findDescendantById("child-25")!
+    expect(child.y).toBeGreaterThanOrEqual(scrollBox.viewport.y)
+    expect(child.y + child.height).toBe(scrollBox.viewport.y + scrollBox.viewport.height)
+  })
+
+  test("scrollChildIntoView scrolls up to reveal child above viewport", async () => {
+    const scrollBox = new ScrollBoxRenderable(testRenderer, {
+      width: 40,
+      height: 10,
+    })
+
+    for (let i = 0; i < 30; i++) {
+      scrollBox.add(new BoxRenderable(testRenderer, { id: `child-${i}`, height: 1 }))
+    }
+    testRenderer.root.add(scrollBox)
+    await renderOnce()
+
+    scrollBox.scrollTo(20)
+    await renderOnce()
+
+    scrollBox.scrollChildIntoView("child-15")
+    await renderOnce()
+
+    const child = scrollBox.content.findDescendantById("child-15")!
+    expect(child.y).toBe(scrollBox.viewport.y)
+    expect(child.y + child.height).toBeLessThanOrEqual(scrollBox.viewport.y + scrollBox.viewport.height)
+  })
+
+  test("scrollChildIntoView finds nested descendants by id", async () => {
+    const scrollBox = new ScrollBoxRenderable(testRenderer, {
+      width: 40,
+      height: 10,
+    })
+
+    for (let i = 0; i < 30; i++) {
+      const wrapper = new BoxRenderable(testRenderer, { id: `wrapper-${i}`, height: 1 })
+      wrapper.add(new BoxRenderable(testRenderer, { id: `nested-${i}`, height: 1 }))
+      scrollBox.add(wrapper)
+    }
+    testRenderer.root.add(scrollBox)
+    await renderOnce()
+
+    scrollBox.scrollChildIntoView("nested-25")
+    await renderOnce()
+
+    const child = scrollBox.content.findDescendantById("nested-25")!
+    expect(child.y).toBeGreaterThanOrEqual(scrollBox.viewport.y)
+    expect(child.y + child.height).toBeLessThanOrEqual(scrollBox.viewport.y + scrollBox.viewport.height)
+  })
+
+  test("scrollChildIntoView does nothing for nonexistent child", async () => {
+    const scrollBox = new ScrollBoxRenderable(testRenderer, {
+      width: 40,
+      height: 10,
+    })
+
+    for (let i = 0; i < 20; i++) {
+      scrollBox.add(new BoxRenderable(testRenderer, { id: `child-${i}`, height: 1 }))
+    }
+    testRenderer.root.add(scrollBox)
+    await renderOnce()
+
+    scrollBox.scrollTo(5)
+    await renderOnce()
+
+    const scrollTopBefore = scrollBox.scrollTop
+    scrollBox.scrollChildIntoView("does-not-exist")
+    expect(scrollBox.scrollTop).toBe(scrollTopBefore)
+  })
+
+  test("scrollChildIntoView handles horizontal scrolling", async () => {
+    const scrollBox = new ScrollBoxRenderable(testRenderer, {
+      width: 20,
+      height: 10,
+      scrollX: true,
+      contentOptions: {
+        flexDirection: "row",
+      },
+    })
+
+    for (let i = 0; i < 6; i++) {
+      scrollBox.add(new BoxRenderable(testRenderer, { id: `child-${i}`, width: 10, height: 2 }))
+    }
+
+    testRenderer.root.add(scrollBox)
+    await renderOnce()
+
+    scrollBox.scrollLeft = 30
+    await renderOnce()
+
+    scrollBox.scrollChildIntoView("child-0")
+    await renderOnce()
+
+    const child = scrollBox.content.findDescendantById("child-0")!
+    expect(child.x).toBe(scrollBox.viewport.x)
+    expect(child.x + child.width).toBeLessThanOrEqual(scrollBox.viewport.x + scrollBox.viewport.width)
+  })
+
+  test("scrollChildIntoView follows nearest behavior for oversized children", async () => {
+    const scrollBox = new ScrollBoxRenderable(testRenderer, {
+      width: 40,
+      height: 10,
+    })
+
+    scrollBox.add(new BoxRenderable(testRenderer, { id: "oversized", height: 30 }))
+    testRenderer.root.add(scrollBox)
+    await renderOnce()
+
+    scrollBox.scrollChildIntoView("oversized")
+    expect(scrollBox.scrollTop).toBe(0)
+
+    scrollBox.scrollTo(10)
+    await renderOnce()
+
+    scrollBox.scrollChildIntoView("oversized")
+    expect(scrollBox.scrollTop).toBe(10)
+  })
+
   // Regression test for issue #530: edge case when content fits in viewport
   test("resets _hasManualScroll for stickyStart=bottom when content fits in viewport (issue #530)", async () => {
     const scrollBox = new ScrollBoxRenderable(testRenderer, {


### PR DESCRIPTION
Add a convenience API to keep a descendant visible without repeated
call-site math around viewport bounds and scroll deltas.

Use nearest alignment on both axes instead of DOM's default
block:start so keyboard navigation moves as little as possible.
Mirror CSSOM View nearest behavior for oversized children, including
no-op when an oversized child already intersects the viewport, to
avoid jumpy scrolling.

See https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview

Fixes #716