### PR TITLE
test(text): add regression for UTF-8 word wrapping in word mode

### DIFF
--- a/packages/core/src/renderables/Text.test.ts
+++ b/packages/core/src/renderables/Text.test.ts
@@ -2301,6 +2301,27 @@ describe("TextRenderable Selection", () => {
       expect(frame).toMatchSnapshot()
     })
 
+    it("regression #651: should keep multi-byte UTF-8 words intact when wrapping in word mode", async () => {
+      resize(80, 24)
+
+      await createTextRenderable(currentRenderer, {
+        content: "gyorskiszolgáló éttermek közül. Azóta alapjaiban értelmeztük újra a vendéglátást",
+        wrapMode: "word",
+        width: 40,
+        left: 0,
+        top: 0,
+      })
+
+      const lines = captureFrame()
+        .split("\n")
+        .map((line) => line.trimEnd())
+        .filter((line) => line.length > 0)
+
+      const expectedLines = ["gyorskiszolgáló éttermek közül. Azóta", "alapjaiban értelmeztük újra a", "vendéglátást"]
+
+      expect(lines).toEqual(expectedLines)
+    })
+
     it("should dynamically change wrap mode", async () => {
       const { text } = await createTextRenderable(currentRenderer, {
         content: "The quick brown fox jumps",


### PR DESCRIPTION
Add a regression test for issue #651 to verify multi-byte UTF-8 words stay
intact when wrapping text by words.

Close #651
