### PR TITLE
feat(tree-sitter): detect URL scopes and set link property on text chunks

### DIFF
--- a/packages/core/src/lib/tree-sitter-styled-text.test.ts
+++ b/packages/core/src/lib/tree-sitter-styled-text.test.ts
@@ -1250,4 +1250,124 @@ Normal paragraph with [link](https://example.com).`
       expect(chunk.attributes).toBe(expectedAttributes)
     })
   })
+
+  describe("Link detection", () => {
+    test("should set link property on markup.link.url chunks", () => {
+      const content = "[Click here](https://example.com)"
+      const mockHighlights: SimpleHighlight[] = [
+        [0, 1, "markup.link"], // [
+        [1, 11, "markup.link.label"], // Click here
+        [11, 13, "markup.link"], // ](
+        [13, 32, "markup.link.url"], // https://example.com
+        [32, 33, "markup.link"], // )
+      ]
+
+      const style = SyntaxStyle.fromStyles({
+        default: { fg: RGBA.fromInts(255, 255, 255, 255) },
+        "markup.link": { fg: RGBA.fromInts(100, 100, 255, 255) },
+        "markup.link.label": { fg: RGBA.fromInts(165, 214, 255, 255) },
+        "markup.link.url": { fg: RGBA.fromInts(88, 166, 255, 255) },
+      })
+
+      const chunks = treeSitterToTextChunks(content, mockHighlights, style)
+      style.destroy()
+
+      const urlChunk = chunks.find((c) => c.text === "https://example.com")
+      expect(urlChunk).toBeDefined()
+      expect(urlChunk!.link).toEqual({ url: "https://example.com" })
+    })
+
+    test("should set link property on markup.link.label chunks with associated URL", () => {
+      const content = "[Click here](https://example.com)"
+      const mockHighlights: SimpleHighlight[] = [
+        [0, 1, "markup.link"], // [
+        [1, 11, "markup.link.label"], // Click here
+        [11, 13, "markup.link"], // ](
+        [13, 32, "markup.link.url"], // https://example.com
+        [32, 33, "markup.link"], // )
+      ]
+
+      const style = SyntaxStyle.fromStyles({
+        default: { fg: RGBA.fromInts(255, 255, 255, 255) },
+        "markup.link": { fg: RGBA.fromInts(100, 100, 255, 255) },
+        "markup.link.label": { fg: RGBA.fromInts(165, 214, 255, 255) },
+        "markup.link.url": { fg: RGBA.fromInts(88, 166, 255, 255) },
+      })
+
+      const chunks = treeSitterToTextChunks(content, mockHighlights, style)
+      style.destroy()
+
+      const labelChunk = chunks.find((c) => c.text === "Click here")
+      expect(labelChunk).toBeDefined()
+      expect(labelChunk!.link).toEqual({ url: "https://example.com" })
+    })
+
+    test("should set link property on string.special.url chunks", () => {
+      const content = "// see https://example.com for details"
+      const mockHighlights: SimpleHighlight[] = [
+        [0, 38, "comment"],
+        [7, 26, "string.special.url"], // https://example.com
+      ]
+
+      const style = SyntaxStyle.fromStyles({
+        default: { fg: RGBA.fromInts(255, 255, 255, 255) },
+        comment: { fg: RGBA.fromInts(128, 128, 128, 255), italic: true },
+        string: { fg: RGBA.fromInts(100, 255, 100, 255) },
+      })
+
+      const chunks = treeSitterToTextChunks(content, mockHighlights, style)
+      style.destroy()
+
+      const urlChunk = chunks.find((c) => c.text === "https://example.com")
+      expect(urlChunk).toBeDefined()
+      expect(urlChunk!.link).toEqual({ url: "https://example.com" })
+    })
+
+    test("should not set link property on non-URL chunks", () => {
+      const content = "const x = 42"
+      const mockHighlights: SimpleHighlight[] = [
+        [0, 5, "keyword"],
+        [6, 7, "variable"],
+        [10, 12, "number"],
+      ]
+
+      const style = SyntaxStyle.fromStyles({
+        default: { fg: RGBA.fromInts(255, 255, 255, 255) },
+        keyword: { fg: RGBA.fromInts(255, 100, 100, 255), bold: true },
+        variable: { fg: RGBA.fromInts(200, 200, 255, 255) },
+        number: { fg: RGBA.fromInts(100, 100, 255, 255) },
+      })
+
+      const chunks = treeSitterToTextChunks(content, mockHighlights, style)
+      style.destroy()
+
+      for (const chunk of chunks) {
+        expect(chunk.link).toBeUndefined()
+      }
+    })
+
+    test("should detect links in real markdown", async () => {
+      const content = "[Example](https://example.com)"
+
+      const linkStyle = SyntaxStyle.fromStyles({
+        default: { fg: RGBA.fromInts(255, 255, 255, 255) },
+        "markup.link": { fg: RGBA.fromInts(100, 100, 255, 255), underline: true },
+        "markup.link.label": { fg: RGBA.fromInts(165, 214, 255, 255), underline: true },
+        "markup.link.url": { fg: RGBA.fromInts(88, 166, 255, 255), underline: true },
+      })
+
+      const styledText = await treeSitterToStyledText(content, "markdown", linkStyle, client, {
+        conceal: { enabled: false },
+      })
+
+      linkStyle.destroy()
+
+      const chunks = styledText.chunks
+      const hasLink = chunks.some((c) => c.link?.url === "https://example.com")
+      expect(hasLink).toBe(true)
+
+      const reconstructed = chunks.map((c) => c.text).join("")
+      expect(reconstructed).toBe(content)
+    })
+  })
 })

--- a/packages/core/src/lib/tree-sitter-styled-text.ts
+++ b/packages/core/src/lib/tree-sitter-styled-text.ts
@@ -48,6 +48,25 @@ export function treeSitterToTextChunks(
   const injectionContainerRanges: Array<{ start: number; end: number }> = []
   const boundaries: Boundary[] = []
 
+  // Build a map of highlight index -> URL for link detection
+  const urlMap = new Map<number, string>()
+  for (let i = 0; i < highlights.length; i++) {
+    const [start, end, group] = highlights[i]
+    if (group === "markup.link.url" || group === "string.special.url") {
+      const url = content.slice(start, end)
+      urlMap.set(i, url)
+      // Look backwards for a markup.link.label that belongs to the same link
+      for (let j = i - 1; j >= 0; j--) {
+        const [, , prev] = highlights[j]
+        if (prev === "markup.link.label") {
+          urlMap.set(j, url)
+          break
+        }
+        if (!prev.startsWith("markup.link")) break
+      }
+    }
+  }
+
   for (let i = 0; i < highlights.length; i++) {
     const [start, end, , meta] = highlights[i]
     if (start === end) continue // Skip zero-length ranges
@@ -182,6 +201,16 @@ export function treeSitterToTextChunks(
         // Use merged style, falling back to default if nothing was merged
         const finalStyle = Object.keys(mergedStyle).length > 0 ? mergedStyle : defaultStyle
 
+        // Detect URL from active highlights
+        let url: string | undefined
+        for (const { index } of sortedGroups) {
+          const mapped = urlMap.get(index)
+          if (mapped) {
+            url = mapped
+            break
+          }
+        }
+
         chunks.push({
           __isChunk: true,
           text: segmentText,
@@ -195,6 +224,7 @@ export function treeSitterToTextChunks(
                 dim: finalStyle.dim,
               })
             : 0,
+          ...(url ? { link: { url } } : {}),
         })
       }
     } else if (currentOffset < boundary.offset) {


### PR DESCRIPTION
## Summary

When tree-sitter highlights markdown content via the `<code filetype="markdown">` rendering path, URL-bearing text chunks never receive a `link` property, so OSC 8 hyperlink sequences are never emitted. This causes terminals to fall back on visual URL auto-detection, which breaks when URLs wrap across lines.

## Changes

**`packages/core/src/lib/tree-sitter-styled-text.ts`**

Added URL detection to `treeSitterToTextChunks()`:

1. **Pre-scan phase** (lines 51-68): Builds a `Map<number, string>` mapping highlight indices to URLs. Scans for `markup.link.url` and `string.special.url` scopes, extracts the URL text, and also maps associated `markup.link.label` highlights (found by walking backwards past `markup.link` bracket highlights) to the same URL.

2. **Chunk creation** (lines 204-227): After merging styles, checks if any active highlight has a URL mapping. If so, sets `link: { url }` on the chunk.

This enables:
- URL text (`https://example.com`) → clickable OSC 8 hyperlink
- Link labels (`Click here` in `[Click here](url)`) → also clickable, linking to the same URL
- URLs in code comments tagged with `string.special.url` → also clickable

**`packages/core/src/lib/tree-sitter-styled-text.test.ts`**

Added 5 new tests in a `"Link detection"` describe block:
- `markup.link.url` chunks get `link` property ✅
- `markup.link.label` chunks get associated URL ✅
- `string.special.url` chunks get `link` property ✅
- Non-URL chunks don't get `link` ✅
- Integration test with real tree-sitter parser ✅

## Test Results

All 49 tests pass (44 existing + 5 new).

## Related

- Fixes the default rendering path issue described in anomalyco/opentui#735
- Complements #736 (which fixes OSC 8 id parameter for the experimental markdown path)
- Related opencode issue: sst/opencode#(pending)