### PR TITLE
fix crash on mouse hover of a destroyed renderable

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1311,7 +1311,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     if (!sameElement && (mouseEvent.type === "drag" || mouseEvent.type === "move")) {
-      if (this.lastOverRenderable && this.lastOverRenderable !== this.capturedRenderable) {
+      if (
+        this.lastOverRenderable &&
+        this.lastOverRenderable !== this.capturedRenderable &&
+        !this.lastOverRenderable.isDestroyed
+      ) {
         const event = new MouseEvent(this.lastOverRenderable, { ...mouseEvent, type: "out" })
         this.lastOverRenderable.processMouseEvent(event)
       }

--- a/packages/core/src/tests/renderer.mouse.test.ts
+++ b/packages/core/src/tests/renderer.mouse.test.ts
@@ -1162,6 +1162,42 @@ describe("renderer handleMouseData", () => {
       renderer.destroy()
     }
   })
+
+  test("mouse out is not fired on a destroyed renderable before render", async () => {
+    try {
+      const target = new TestRenderable(renderer, {
+        id: "destroyed-hover-before-render",
+        position: "absolute",
+        left: 1,
+        top: 1,
+        width: 4,
+        height: 4,
+      })
+      renderer.root.add(target)
+      await renderOnce()
+
+      let overCount = 0
+      let outCount = 0
+      target.onMouseOver = () => {
+        overCount++
+      }
+      target.onMouseOut = () => {
+        outCount++
+      }
+
+      await mockMouse.moveTo(target.x + 1, target.y + 1)
+      expect(overCount).toBe(1)
+
+      // Destroy without rendering — the hit grid still has the old state,
+      // so the next mouse move hits handleMouseData's "out" path directly
+      target.destroy()
+
+      await mockMouse.moveTo(renderer.width - 1, renderer.height - 1)
+      expect(outCount).toBe(0)
+    } finally {
+      renderer.destroy()
+    }
+  })
 })
 
 describe("renderer handleMouseData split height", () => {


### PR DESCRIPTION
Fixes #738 

Tested in my TUI, see the line with `// HACK:` where I added:
```typescript
if (this.isDestroyed) return;
```
Without this guard, we crash in the scenario described in #738 . With the guard, we don't.

```typescript
import { useTheme } from '../../theme/index.ts';
import { ICONS } from '../../utils/icons.ts';
import { openInBrowser } from '../../utils/shell.ts';

type Props = {
	text: string;
	url: string;
};

export function Link(props: Props) {
	const theme = useTheme();
	return (
		<text
			onMouseUp={() => openInBrowser(props.url)}
			onMouseDown={function () {
				this.fg = theme.text;
			}}
			onMouseOver={function () {
				this.fg = theme.accent;
			}}
			onMouseOut={function () {
				if (this.isDestroyed) return; // HACK:
				this.fg = theme.text;
			}}
			fg={theme.text}
			wrapMode='none'
		>
			<span>{props.text}</span>
			<span style={{ fg: theme.accent }}>{ICONS.urlHint}</span>
		</text>
	);
}
```