### PR TITLE
fix(core): prevent input starvation from high-frequency mouse scroll events

### DIFF
--- a/packages/core/src/lib/parse.mouse.test.ts
+++ b/packages/core/src/lib/parse.mouse.test.ts
@@ -429,14 +429,14 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
   })
 
   test("single event returns array of one", () => {
-    const events = parser.parseAllMouseEvents(encodeSGR(0, 10, 5, true))
+    const { events } = parser.parseAllMouseEvents(encodeSGR(0, 10, 5, true))
     expect(events).toHaveLength(1)
     expect(events[0]).toMatchObject({ type: "down", button: 0, x: 10, y: 5 })
   })
 
   test("two SGR events concatenated are both parsed", () => {
     const buf = Buffer.concat([encodeSGR(32, 69, 49, true), encodeSGR(32, 68, 49, true)])
-    const events = parser.parseAllMouseEvents(buf)
+    const { events } = parser.parseAllMouseEvents(buf)
     expect(events).toHaveLength(2)
     expect(events[0]).toMatchObject({ type: "move", x: 69, y: 49 })
     expect(events[1]).toMatchObject({ type: "move", x: 68, y: 49 })
@@ -449,7 +449,7 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
       encodeSGR(32, 68, 48, true),
       encodeSGR(32, 67, 48, true),
     ])
-    const events = parser.parseAllMouseEvents(buf)
+    const { events } = parser.parseAllMouseEvents(buf)
     expect(events).toHaveLength(4)
     expect(events[0]).toMatchObject({ x: 69, y: 49 })
     expect(events[1]).toMatchObject({ x: 68, y: 49 })
@@ -463,7 +463,7 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
       encodeSGR(32, 12, 10, true), // motion (drag, since button is pressed)
       encodeSGR(0, 12, 10, false), // left up
     ])
-    const events = parser.parseAllMouseEvents(buf)
+    const { events } = parser.parseAllMouseEvents(buf)
     expect(events).toHaveLength(3)
     expect(events[0]).toMatchObject({ type: "down", button: 0 })
     expect(events[1]).toMatchObject({ type: "drag" })
@@ -472,7 +472,7 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
 
   test("scroll events in a chunk", () => {
     const buf = Buffer.concat([encodeSGR(64, 82, 67, true), encodeSGR(64, 82, 67, true), encodeSGR(65, 82, 67, true)])
-    const events = parser.parseAllMouseEvents(buf)
+    const { events } = parser.parseAllMouseEvents(buf)
     expect(events).toHaveLength(3)
     expect(events[0]).toMatchObject({ type: "scroll", scroll: { direction: "up" } })
     expect(events[1]).toMatchObject({ type: "scroll", scroll: { direction: "up" } })
@@ -481,41 +481,95 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
 
   test("chunk with scroll+motion codes (96/97) keeps scroll semantics", () => {
     const buf = Buffer.concat([encodeSGR(64, 82, 67, true), encodeSGR(96, 81, 67, true), encodeSGR(97, 80, 67, true)])
-    const events = parser.parseAllMouseEvents(buf)
+    const { events } = parser.parseAllMouseEvents(buf)
     expect(events).toHaveLength(3)
     expect(events[0]).toMatchObject({ type: "scroll", scroll: { direction: "up" } })
     expect(events[1]).toMatchObject({ type: "scroll", scroll: { direction: "up" }, x: 81, y: 67 })
     expect(events[2]).toMatchObject({ type: "scroll", scroll: { direction: "down" }, x: 80, y: 67 })
   })
 
-  test("returns empty array for non-mouse data", () => {
-    const events = parser.parseAllMouseEvents(Buffer.from("\x1b[A"))
+  test("returns empty for non-mouse data", () => {
+    const { events, consumed } = parser.parseAllMouseEvents(Buffer.from("\x1b[A"))
     expect(events).toHaveLength(0)
+    expect(consumed).toBe(0)
   })
 
-  test("returns empty array for empty buffer", () => {
-    const events = parser.parseAllMouseEvents(Buffer.from(""))
+  test("returns empty for empty buffer", () => {
+    const { events, consumed } = parser.parseAllMouseEvents(Buffer.from(""))
     expect(events).toHaveLength(0)
+    expect(consumed).toBe(0)
   })
 
   test("two X10 basic events concatenated", () => {
     const buf = Buffer.concat([encodeBasic(0, 10, 5), encodeBasic(3, 10, 5)])
-    const events = parser.parseAllMouseEvents(buf)
+    const { events } = parser.parseAllMouseEvents(buf)
     expect(events).toHaveLength(2)
     expect(events[0]).toMatchObject({ type: "down", button: 0, x: 10, y: 5 })
     expect(events[1]).toMatchObject({ type: "up", x: 10, y: 5 })
   })
 
   test("button tracking state is maintained across events in chunk", () => {
-    // down + motion in same chunk: second event should be classified as drag
     const buf = Buffer.concat([
       encodeSGR(0, 5, 5, true), // press
       encodeSGR(32, 8, 5, true), // motion with button 0 bits → drag if button tracked
     ])
-    const events = parser.parseAllMouseEvents(buf)
+    const { events } = parser.parseAllMouseEvents(buf)
     expect(events).toHaveLength(2)
     expect(events[0]).toMatchObject({ type: "down" })
     expect(events[1]).toMatchObject({ type: "drag" })
+  })
+})
+
+describe("MouseParser parseAllMouseEvents consumed bytes", () => {
+  let parser: MouseParser
+
+  beforeEach(() => {
+    parser = new MouseParser()
+  })
+
+  test("consumed equals total length when all data is mouse events", () => {
+    const a = encodeSGR(65, 10, 20, true)
+    const b = encodeSGR(65, 10, 21, true)
+    const buf = Buffer.concat([a, b])
+    const { consumed } = parser.parseAllMouseEvents(buf)
+    expect(consumed).toBe(buf.length)
+  })
+
+  test("consumed stops before non-mouse trailing data", () => {
+    const mouse = encodeSGR(0, 5, 5, true)
+    const focus = Buffer.from("\x1b[I")
+    const buf = Buffer.concat([mouse, focus])
+    const { events, consumed } = parser.parseAllMouseEvents(buf)
+    expect(events).toHaveLength(1)
+    expect(consumed).toBe(mouse.length)
+  })
+
+  test("consumed is zero when buffer starts with non-mouse data", () => {
+    const buf = Buffer.from("\x1b[Ahello")
+    const { events, consumed } = parser.parseAllMouseEvents(buf)
+    expect(events).toHaveLength(0)
+    expect(consumed).toBe(0)
+  })
+
+  test("multiple mouse events followed by keyboard data", () => {
+    const m1 = encodeSGR(65, 10, 20, true)
+    const m2 = encodeSGR(65, 10, 21, true)
+    const key = Buffer.from("a")
+    const buf = Buffer.concat([m1, m2, key])
+    const { events, consumed } = parser.parseAllMouseEvents(buf)
+    expect(events).toHaveLength(2)
+    expect(consumed).toBe(m1.length + m2.length)
+  })
+
+  test("mouse events followed by focus-in sequence are split correctly", () => {
+    const scroll1 = encodeSGR(65, 50, 30, true)
+    const scroll2 = encodeSGR(65, 50, 31, true)
+    const focusIn = Buffer.from("\x1b[I")
+    const buf = Buffer.concat([scroll1, scroll2, focusIn])
+    const { events, consumed } = parser.parseAllMouseEvents(buf)
+    expect(events).toHaveLength(2)
+    expect(consumed).toBe(scroll1.length + scroll2.length)
+    expect(buf.subarray(consumed).toString()).toBe("\x1b[I")
   })
 })
 

--- a/packages/core/src/lib/parse.mouse.ts
+++ b/packages/core/src/lib/parse.mouse.ts
@@ -14,6 +14,11 @@ export type RawMouseEvent = {
   scroll?: ScrollInfo
 }
 
+export type MouseParseResult = {
+  events: RawMouseEvent[]
+  consumed: number
+}
+
 type ParsedMouseSequence = {
   event: RawMouseEvent
   consumed: number
@@ -47,7 +52,7 @@ export class MouseParser {
     return parsed?.event ?? null
   }
 
-  public parseAllMouseEvents(data: Buffer): RawMouseEvent[] {
+  public parseAllMouseEvents(data: Buffer): MouseParseResult {
     const str = this.decodeInput(data)
     const events: RawMouseEvent[] = []
     let offset = 0
@@ -64,7 +69,7 @@ export class MouseParser {
       offset += parsed.consumed
     }
 
-    return events
+    return { events, consumed: offset }
   }
 
   private parseMouseSequenceAt(str: string, offset: number): ParsedMouseSequence | null {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -14,7 +14,13 @@ import type { Pointer } from "bun:ffi"
 import { OptimizedBuffer } from "./buffer"
 import { resolveRenderLib, type RenderLib } from "./zig"
 import { TerminalConsole, type ConsoleOptions, capture } from "./console"
-import { MouseParser, type MouseEventType, type RawMouseEvent, type ScrollInfo } from "./lib/parse.mouse"
+import {
+  MouseParser,
+  type MouseEventType,
+  type MouseParseResult,
+  type RawMouseEvent,
+  type ScrollInfo,
+} from "./lib/parse.mouse"
 import { Selection } from "./lib/selection"
 import { Clipboard, type ClipboardTarget } from "./lib/clipboard"
 import { EventEmitter } from "events"
@@ -198,6 +204,40 @@ export function buildKittyKeyboardFlags(config: KittyKeyboardOptions | null | un
   }
 
   return flags
+}
+
+function coalesceScrollEvents(events: RawMouseEvent[]): RawMouseEvent[] {
+  if (events.length <= 1) return events
+
+  const out: RawMouseEvent[] = []
+  let pending: RawMouseEvent | null = null
+
+  for (const evt of events) {
+    if (evt.type !== "scroll") {
+      if (pending) {
+        out.push(pending)
+        pending = null
+      }
+      out.push(evt)
+      continue
+    }
+
+    if (
+      pending &&
+      pending.scroll &&
+      evt.scroll &&
+      pending.scroll.direction === evt.scroll.direction &&
+      pending.x === evt.x &&
+      pending.y === evt.y
+    ) {
+      pending.scroll = { direction: pending.scroll.direction, delta: pending.scroll.delta + evt.scroll.delta }
+    } else {
+      if (pending) out.push(pending)
+      pending = evt
+    }
+  }
+  if (pending) out.push(pending)
+  return out
 }
 
 export class MouseEvent {
@@ -1059,9 +1099,16 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   private stdinListener: (data: Buffer) => void = ((data: Buffer) => {
-    // Mouse first (consume and stop if handled)
-    if (this._useMouse && this.handleMouseData(data)) {
-      return
+    if (this._useMouse) {
+      const consumed = this.handleMouseData(data)
+      if (consumed > 0) {
+        // Forward any remaining non-mouse data (keyboard input, focus sequences, etc.)
+        // to the sequence buffer so it isn't silently dropped.
+        if (consumed < data.length) {
+          this._stdinBuffer.process(data.subarray(consumed))
+        }
+        return
+      }
     }
 
     // Everything else goes through the sequence buffer
@@ -1196,19 +1243,17 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     return event
   }
 
-  private handleMouseData(data: Buffer): boolean {
-    const mouseEvents = this.mouseParser.parseAllMouseEvents(data)
+  private handleMouseData(data: Buffer): number {
+    const result = this.mouseParser.parseAllMouseEvents(data)
 
-    if (mouseEvents.length === 0) return false
+    if (result.events.length === 0) return 0
 
-    let anyHandled = false
-    for (const mouseEvent of mouseEvents) {
-      if (this.processSingleMouseEvent(mouseEvent)) {
-        anyHandled = true
-      }
+    const coalesced = coalesceScrollEvents(result.events)
+    for (const mouseEvent of coalesced) {
+      this.processSingleMouseEvent(mouseEvent)
     }
 
-    return anyHandled
+    return result.consumed
   }
 
   private processSingleMouseEvent(mouseEvent: RawMouseEvent): boolean {

--- a/packages/core/src/testing/integration.test.ts
+++ b/packages/core/src/testing/integration.test.ts
@@ -19,9 +19,8 @@ class MockRenderer {
   }
 }
 
-// Helper function to parse all events from buffer
 function parseAllEvents(emittedData: Buffer, parser: MouseParser) {
-  return parser.parseAllMouseEvents(emittedData)
+  return parser.parseAllMouseEvents(emittedData).events
 }
 
 describe("mock-mouse + parser integration", () => {


### PR DESCRIPTION
## Summary

Fixes #748 — high-frequency scroll wheels (Logitech MX Master 3 free-spin) cause keyboard input loss and event loop starvation.

## Changes

### 1. Forward remaining non-mouse data from mixed stdin chunks

`stdinListener` previously returned early after `handleMouseData` found any mouse events, silently dropping non-mouse data (keyboard input, focus-in/out sequences) that arrived in the same OS read. Now `handleMouseData` returns the consumed byte count and `stdinListener` forwards the remainder to `StdinBuffer`.

### 2. Coalesce consecutive scroll events within a chunk

Added `coalesceScrollEvents()` that merges adjacent same-direction scroll events at the same coordinates into a single event with accumulated `delta`. This reduces the number of hit tests, MouseEvent constructions, and renderable dispatches from O(n) to O(1) per direction per chunk.

### 3. Return consumed offset from `parseAllMouseEvents`

Changed `parseAllMouseEvents` return type from `RawMouseEvent[]` to `{ events: RawMouseEvent[], consumed: number }` so callers know exactly how many bytes were consumed and can handle the remainder appropriately.

## Testing

- Updated all existing `parseAllMouseEvents` tests for new return type
- Added 5 new tests for consumed byte tracking (trailing focus sequences, keyboard data, mixed buffers)
- Updated `integration.test.ts` for new return type
- All 196 tests pass (mouse parser + stdin buffer + integration)