### PR TITLE
Support 256-color fallback for terminals without truecolor

### DIFF
--- a/packages/core/src/zig/ansi.zig
+++ b/packages/core/src/zig/ansi.zig
@@ -32,6 +32,15 @@ pub const ANSI = struct {
         writer.print("\x1b[48;2;{d};{d};{d}m", .{ r, g, b }) catch return AnsiError.WriteFailed;
     }
 
+    // 256-color mode output functions (for terminals without truecolor support)
+    pub fn fgColor256Output(writer: anytype, index: u8) AnsiError!void {
+        std.fmt.format(writer, "\x1b[38;5;{d}m", .{index}) catch return AnsiError.WriteFailed;
+    }
+
+    pub fn bgColor256Output(writer: anytype, index: u8) AnsiError!void {
+        std.fmt.format(writer, "\x1b[48;5;{d}m", .{index}) catch return AnsiError.WriteFailed;
+    }
+
     // Text attribute constants
     pub const bold = "\x1b[1m";
     pub const dim = "\x1b[2m";
@@ -238,6 +247,88 @@ pub const TextAttributes = struct {
         if (base_attr & STRIKETHROUGH != 0) writer.writeAll(ANSI.strikethrough) catch return AnsiError.WriteFailed;
     }
 };
+
+// 256-color palette conversion
+// The 256-color palette is structured as:
+// - 0-15: Standard colors (system colors, not predictable)
+// - 16-231: 6x6x6 color cube (216 colors)
+// - 232-255: Grayscale ramp (24 shades)
+
+// The 6x6x6 color cube levels: 0, 95, 135, 175, 215, 255
+const color_cube_levels = [6]u8{ 0, 95, 135, 175, 215, 255 };
+
+/// Convert an 8-bit RGB component to the nearest 6x6x6 cube index (0-5)
+fn rgbTo6Level(value: u8) u8 {
+    // Find the nearest level in the color cube
+    if (value < 48) return 0; // 0
+    if (value < 115) return 1; // 95
+    if (value < 155) return 2; // 135
+    if (value < 195) return 3; // 175
+    if (value < 235) return 4; // 215
+    return 5; // 255
+}
+
+/// Convert an 8-bit grayscale value to the nearest grayscale index (232-255)
+fn grayTo24Level(value: u8) u8 {
+    // Grayscale ramp: 232-255 represents 24 shades
+    // Values are: 8, 18, 28, ..., 238 (step of 10)
+    // We map 0-255 to 0-23, then add 232
+    if (value < 4) return 232; // Closest to black
+    if (value > 243) return 255; // Closest to white
+    // Linear interpolation: (value - 8) / 10 + 232
+    return @as(u8, @intCast((@as(u16, value) - 8) / 10 + 232));
+}
+
+/// Calculate the squared distance between two RGB colors
+fn colorDistanceSquared(r1: u8, g1: u8, b1: u8, r2: u8, g2: u8, b2: u8) u32 {
+    const dr = @as(i32, r1) - @as(i32, r2);
+    const dg = @as(i32, g1) - @as(i32, g2);
+    const db = @as(i32, b1) - @as(i32, b2);
+    return @intCast(dr * dr + dg * dg + db * db);
+}
+
+/// Convert RGB (0-255) to the nearest 256-color palette index
+/// This chooses between the color cube (16-231) and grayscale ramp (232-255)
+pub fn rgbTo256Color(r: u8, g: u8, b: u8) u8 {
+    // Get the nearest color cube index
+    const cube_r = rgbTo6Level(r);
+    const cube_g = rgbTo6Level(g);
+    const cube_b = rgbTo6Level(b);
+    const cube_index = 16 + 36 * cube_r + 6 * cube_g + cube_b;
+
+    // Get the actual RGB values for this cube color
+    const cube_r_val = color_cube_levels[cube_r];
+    const cube_g_val = color_cube_levels[cube_g];
+    const cube_b_val = color_cube_levels[cube_b];
+
+    // Calculate distance to the cube color
+    const cube_dist = colorDistanceSquared(r, g, b, cube_r_val, cube_g_val, cube_b_val);
+
+    // Check if this might be better represented as grayscale
+    // Only consider grayscale if the color is relatively neutral
+    const max_component = @max(r, @max(g, b));
+    const min_component = @min(r, @min(g, b));
+
+    // If the color is fairly neutral (max - min < 32), try grayscale
+    if (max_component - min_component < 32) {
+        // Use average for grayscale
+        const gray = @as(u8, @intCast((@as(u16, r) + @as(u16, g) + @as(u16, b)) / 3));
+        const gray_index = grayTo24Level(gray);
+
+        // Calculate the actual grayscale value for this index
+        const gray_val: u8 = if (gray_index < 232) 0 else @as(u8, @intCast((gray_index - 232) * 10 + 8));
+
+        // Calculate distance to grayscale
+        const gray_dist = colorDistanceSquared(r, g, b, gray_val, gray_val, gray_val);
+
+        // Choose whichever is closer
+        if (gray_dist < cube_dist) {
+            return gray_index;
+        }
+    }
+
+    return cube_index;
+}
 
 const HSV_SECTOR_COUNT = 6;
 const HUE_SECTOR_DEGREES = 60.0;

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -698,7 +698,6 @@ pub const CliRenderer = struct {
                     const bgB = rgbaComponentToU8(cell.bg[2]);
                     const bgA = cell.bg[3];
 
-                    // Check if terminal supports truecolor (24-bit RGB)
                     const caps = self.terminal.getCapabilities();
                     if (caps.rgb) {
                         // Use truecolor (24-bit) output
@@ -829,7 +828,7 @@ pub const CliRenderer = struct {
             ansi.ANSI.setMousePointerOutput(writer, mousePointer.toName()) catch {};
             self.lastMousePointerStyle = mousePointer;
         }
-        
+
         writer.writeAll(ansi.ANSI.syncReset) catch {};
 
         const renderEndTime = std.time.microTimestamp();

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -698,13 +698,27 @@ pub const CliRenderer = struct {
                     const bgB = rgbaComponentToU8(cell.bg[2]);
                     const bgA = cell.bg[3];
 
-                    ansi.ANSI.fgColorOutput(writer, fgR, fgG, fgB) catch {};
+                    // Check if terminal supports truecolor (24-bit RGB)
+                    const caps = self.terminal.getCapabilities();
+                    if (caps.rgb) {
+                        // Use truecolor (24-bit) output
+                        ansi.ANSI.fgColorOutput(writer, fgR, fgG, fgB) catch {};
+                    } else {
+                        // Fall back to 256-color mode
+                        const fgIndex = ansi.rgbTo256Color(fgR, fgG, fgB);
+                        ansi.ANSI.fgColor256Output(writer, fgIndex) catch {};
+                    }
 
                     // If alpha is 0 (transparent), use terminal default background instead of black
                     if (bgA < 0.001) {
                         writer.writeAll("\x1b[49m") catch {};
                     } else {
-                        ansi.ANSI.bgColorOutput(writer, bgR, bgG, bgB) catch {};
+                        if (caps.rgb) {
+                            ansi.ANSI.bgColorOutput(writer, bgR, bgG, bgB) catch {};
+                        } else {
+                            const bgIndex = ansi.rgbTo256Color(bgR, bgG, bgB);
+                            ansi.ANSI.bgColor256Output(writer, bgIndex) catch {};
+                        }
                     }
 
                     ansi.TextAttributes.applyAttributesOutputWriter(writer, cell.attributes) catch {};

--- a/packages/core/src/zig/test.zig
+++ b/packages/core/src/zig/test.zig
@@ -31,6 +31,7 @@ const mem_registry_tests = @import("tests/mem-registry_test.zig");
 const memory_leak_regression_tests = @import("tests/memory_leak_regression_test.zig");
 const wrap_cache_perf_tests = @import("tests/wrap-cache-perf_test.zig");
 const native_span_feed_tests = @import("tests/native-span-feed_test.zig");
+const ansi_tests = @import("tests/ansi_test.zig");
 // const example_tests = @import("example_test.zig");
 
 // Re-export test declarations from individual test files
@@ -66,5 +67,6 @@ comptime {
     _ = memory_leak_regression_tests;
     _ = wrap_cache_perf_tests;
     _ = native_span_feed_tests;
+    _ = ansi_tests;
     // _ = example_tests;
 }

--- a/packages/core/src/zig/tests/ansi_test.zig
+++ b/packages/core/src/zig/tests/ansi_test.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const testing = std.testing;
+const ansi = @import("../ansi.zig");
+
+test "rgbTo256Color: pure red" {
+    const index = ansi.rgbTo256Color(255, 0, 0);
+    try testing.expectEqual(@as(u8, 196), index);
+}
+
+test "rgbTo256Color: pure green" {
+    const index = ansi.rgbTo256Color(0, 255, 0);
+    try testing.expectEqual(@as(u8, 46), index);
+}
+
+test "rgbTo256Color: pure blue" {
+    const index = ansi.rgbTo256Color(0, 0, 255);
+    try testing.expectEqual(@as(u8, 21), index);
+}
+
+test "rgbTo256Color: black" {
+    const index = ansi.rgbTo256Color(0, 0, 0);
+    try testing.expectEqual(@as(u8, 16), index);
+}
+
+test "rgbTo256Color: white" {
+    const index = ansi.rgbTo256Color(255, 255, 255);
+    try testing.expectEqual(@as(u8, 231), index);
+}
+
+test "rgbTo256Color: grayscale" {
+    const gray1 = ansi.rgbTo256Color(128, 128, 128);
+    try testing.expect(gray1 >= 232 and gray1 <= 255);
+
+    const gray2 = ansi.rgbTo256Color(64, 64, 64);
+    try testing.expect(gray2 >= 232 and gray2 <= 255);
+
+    const gray3 = ansi.rgbTo256Color(192, 192, 192);
+    try testing.expect(gray3 >= 232 and gray3 <= 255);
+}
+
+test "rgbTo256Color: color cube colors" {
+    const cyan = ansi.rgbTo256Color(0, 255, 255);
+    try testing.expectEqual(@as(u8, 51), cyan);
+
+    const magenta = ansi.rgbTo256Color(255, 0, 255);
+    try testing.expectEqual(@as(u8, 201), magenta);
+
+    const yellow = ansi.rgbTo256Color(255, 255, 0);
+    try testing.expectEqual(@as(u8, 226), yellow);
+}
+
+test "rgbTo256Color: near-black uses grayscale" {
+    const index = ansi.rgbTo256Color(10, 10, 10);
+    try testing.expect(index >= 232);
+}
+
+test "rgbTo256Color: near-white uses grayscale" {
+    const index = ansi.rgbTo256Color(245, 245, 245);
+    try testing.expect(index >= 232);
+}


### PR DESCRIPTION
## Problem

macOS Terminal.app does not support truecolor (24-bit RGB) by default, limiting colors to the standard 16 or 256 color palette. This makes it hard to see the full range of colors in opentui.

## Solution

This PR adds a 256-color fallback:
- Detects if the terminal supports truecolor via `$COLORTERM` environment variable
- When truecolor is not available, converts RGB colors to the nearest 256-color palette index
- Uses the 6x6x6 color cube (216 colors) and grayscale ramp (24 shades)

## Use case

Running opentui in macOS Terminal.app and seeing more than 16 colors.