### PR TITLE
fix: forward unconsumed data after mouse sequence parsing

### DIFF
--- a/packages/core/src/lib/parse.mouse.test.ts
+++ b/packages/core/src/lib/parse.mouse.test.ts
@@ -428,15 +428,18 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
     parser = new MouseParser()
   })
 
+  // Helper: extract just the events array (most existing tests only care about events)
+  const parseAll = (data: Buffer) => parser.parseAllMouseEvents(data).events
+
   test("single event returns array of one", () => {
-    const events = parser.parseAllMouseEvents(encodeSGR(0, 10, 5, true))
+    const events = parseAll(encodeSGR(0, 10, 5, true))
     expect(events).toHaveLength(1)
     expect(events[0]).toMatchObject({ type: "down", button: 0, x: 10, y: 5 })
   })
 
   test("two SGR events concatenated are both parsed", () => {
     const buf = Buffer.concat([encodeSGR(32, 69, 49, true), encodeSGR(32, 68, 49, true)])
-    const events = parser.parseAllMouseEvents(buf)
+    const events = parseAll(buf)
     expect(events).toHaveLength(2)
     expect(events[0]).toMatchObject({ type: "move", x: 69, y: 49 })
     expect(events[1]).toMatchObject({ type: "move", x: 68, y: 49 })
@@ -449,7 +452,7 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
       encodeSGR(32, 68, 48, true),
       encodeSGR(32, 67, 48, true),
     ])
-    const events = parser.parseAllMouseEvents(buf)
+    const events = parseAll(buf)
     expect(events).toHaveLength(4)
     expect(events[0]).toMatchObject({ x: 69, y: 49 })
     expect(events[1]).toMatchObject({ x: 68, y: 49 })
@@ -463,7 +466,7 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
       encodeSGR(32, 12, 10, true), // motion (drag, since button is pressed)
       encodeSGR(0, 12, 10, false), // left up
     ])
-    const events = parser.parseAllMouseEvents(buf)
+    const events = parseAll(buf)
     expect(events).toHaveLength(3)
     expect(events[0]).toMatchObject({ type: "down", button: 0 })
     expect(events[1]).toMatchObject({ type: "drag" })
@@ -472,7 +475,7 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
 
   test("scroll events in a chunk", () => {
     const buf = Buffer.concat([encodeSGR(64, 82, 67, true), encodeSGR(64, 82, 67, true), encodeSGR(65, 82, 67, true)])
-    const events = parser.parseAllMouseEvents(buf)
+    const events = parseAll(buf)
     expect(events).toHaveLength(3)
     expect(events[0]).toMatchObject({ type: "scroll", scroll: { direction: "up" } })
     expect(events[1]).toMatchObject({ type: "scroll", scroll: { direction: "up" } })
@@ -481,7 +484,7 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
 
   test("chunk with scroll+motion codes (96/97) keeps scroll semantics", () => {
     const buf = Buffer.concat([encodeSGR(64, 82, 67, true), encodeSGR(96, 81, 67, true), encodeSGR(97, 80, 67, true)])
-    const events = parser.parseAllMouseEvents(buf)
+    const events = parseAll(buf)
     expect(events).toHaveLength(3)
     expect(events[0]).toMatchObject({ type: "scroll", scroll: { direction: "up" } })
     expect(events[1]).toMatchObject({ type: "scroll", scroll: { direction: "up" }, x: 81, y: 67 })
@@ -489,18 +492,18 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
   })
 
   test("returns empty array for non-mouse data", () => {
-    const events = parser.parseAllMouseEvents(Buffer.from("\x1b[A"))
+    const events = parseAll(Buffer.from("\x1b[A"))
     expect(events).toHaveLength(0)
   })
 
   test("returns empty array for empty buffer", () => {
-    const events = parser.parseAllMouseEvents(Buffer.from(""))
+    const events = parseAll(Buffer.from(""))
     expect(events).toHaveLength(0)
   })
 
   test("two X10 basic events concatenated", () => {
     const buf = Buffer.concat([encodeBasic(0, 10, 5), encodeBasic(3, 10, 5)])
-    const events = parser.parseAllMouseEvents(buf)
+    const events = parseAll(buf)
     expect(events).toHaveLength(2)
     expect(events[0]).toMatchObject({ type: "down", button: 0, x: 10, y: 5 })
     expect(events[1]).toMatchObject({ type: "up", x: 10, y: 5 })
@@ -512,10 +515,39 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
       encodeSGR(0, 5, 5, true), // press
       encodeSGR(32, 8, 5, true), // motion with button 0 bits → drag if button tracked
     ])
-    const events = parser.parseAllMouseEvents(buf)
+    const events = parseAll(buf)
     expect(events).toHaveLength(2)
     expect(events[0]).toMatchObject({ type: "down" })
     expect(events[1]).toMatchObject({ type: "drag" })
+  })
+
+  test("consumed equals total byte length when all data is mouse events", () => {
+    const buf = Buffer.concat([encodeSGR(0, 10, 5, true), encodeSGR(0, 10, 5, false)])
+    expect(parser.parseAllMouseEvents(buf).consumed).toBe(buf.length)
+  })
+
+  test("consumed stops at non-mouse trailing data", () => {
+    const mouse = encodeSGR(0, 10, 5, true)
+    const buf = Buffer.concat([mouse, Buffer.from("hello")])
+    const result = parser.parseAllMouseEvents(buf)
+    expect(result.events).toHaveLength(1)
+    expect(result.consumed).toBe(mouse.length)
+  })
+
+  test("consumed stops at partial SGR sequence", () => {
+    const complete = encodeSGR(0, 31, 16, true)
+    const buf = Buffer.concat([complete, Buffer.from("\x1b[<0;")])
+    const result = parser.parseAllMouseEvents(buf)
+    expect(result.events).toHaveLength(1)
+    expect(result.consumed).toBe(complete.length)
+  })
+
+  test("consumed is zero for non-mouse data", () => {
+    expect(parser.parseAllMouseEvents(Buffer.from("\x1b[A")).consumed).toBe(0)
+  })
+
+  test("consumed is zero for empty buffer", () => {
+    expect(parser.parseAllMouseEvents(Buffer.from("")).consumed).toBe(0)
   })
 })
 

--- a/packages/core/src/lib/parse.mouse.ts
+++ b/packages/core/src/lib/parse.mouse.ts
@@ -47,7 +47,7 @@ export class MouseParser {
     return parsed?.event ?? null
   }
 
-  public parseAllMouseEvents(data: Buffer): RawMouseEvent[] {
+  public parseAllMouseEvents(data: Buffer): { events: RawMouseEvent[]; consumed: number } {
     const str = this.decodeInput(data)
     const events: RawMouseEvent[] = []
     let offset = 0
@@ -64,7 +64,7 @@ export class MouseParser {
       offset += parsed.consumed
     }
 
-    return events
+    return { events, consumed: offset }
   }
 
   private parseMouseSequenceAt(str: string, offset: number): ParsedMouseSequence | null {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1197,18 +1197,21 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   private handleMouseData(data: Buffer): boolean {
-    const mouseEvents = this.mouseParser.parseAllMouseEvents(data)
+    const result = this.mouseParser.parseAllMouseEvents(data)
 
-    if (mouseEvents.length === 0) return false
+    if (result.events.length === 0) return false
 
-    let anyHandled = false
-    for (const mouseEvent of mouseEvents) {
-      if (this.processSingleMouseEvent(mouseEvent)) {
-        anyHandled = true
-      }
+    for (const mouseEvent of result.events) {
+      this.processSingleMouseEvent(mouseEvent)
     }
 
-    return anyHandled
+    // Forward any unconsumed remainder (partial sequences or non-mouse data)
+    // to the stdin buffer so it is not silently dropped.
+    if (result.consumed < data.length) {
+      this._stdinBuffer.process(data.subarray(result.consumed))
+    }
+
+    return true
   }
 
   private processSingleMouseEvent(mouseEvent: RawMouseEvent): boolean {

--- a/packages/core/src/testing/integration.test.ts
+++ b/packages/core/src/testing/integration.test.ts
@@ -21,7 +21,7 @@ class MockRenderer {
 
 // Helper function to parse all events from buffer
 function parseAllEvents(emittedData: Buffer, parser: MouseParser) {
-  return parser.parseAllMouseEvents(emittedData)
+  return parser.parseAllMouseEvents(emittedData).events
 }
 
 describe("mock-mouse + parser integration", () => {


### PR DESCRIPTION
## Summary

- `parseAllMouseEvents` now returns a `consumed` byte offset alongside parsed events, telling the caller exactly how many bytes were successfully parsed
- `handleMouseData` in the renderer forwards any unconsumed trailing data to `_stdinBuffer.process()` instead of silently dropping it

## Problem

When a stdin chunk contains complete mouse escape sequences followed by a partial one (e.g. `\x1b[<0;31;16M\x1b[<0;`), `parseAllMouseEvents` parses the complete event but the partial trailing bytes are silently dropped. When the next stdin chunk arrives with the remainder (`31;16M`), it can't be parsed as a mouse event (no `\x1b[` prefix), so it falls through to keyboard input handling — causing characters like `31M;` to appear in the input box.

This is most commonly triggered by rapid mouse movement during terminal focus switches.

## Changes

**`parse.mouse.ts`**: Changed `parseAllMouseEvents` return type from `RawMouseEvent[]` to `{ events: RawMouseEvent[]; consumed: number }`.

**`renderer.ts`**: `handleMouseData` now checks if `consumed < data.length` and forwards the unconsumed remainder to `_stdinBuffer.process()`, which correctly handles partial CSI sequences with its existing buffering/timeout logic.

**`parse.mouse.test.ts`**: Updated all call sites for new return type. Added 5 new tests covering `consumed` offset behavior (full consumption, trailing non-mouse data, partial SGR sequences, empty/non-mouse input).

**`integration.test.ts`**: Updated helper to access `.events` from the new return type.