### PR TITLE
fix(react/examples): import createRoot from package

### DIFF
--- a/packages/react/examples/text.tsx
+++ b/packages/react/examples/text.tsx
@@ -1,5 +1,5 @@
 import { createCliRenderer } from "@opentui/core"
-import { createRoot } from "../src"
+import { createRoot } from "@opentui/react"
 
 function App() {
   return (


### PR DESCRIPTION
The `text.tsx` example for React imported `createRoot` from `"../src"` instead of referencing the `"@opentui/react"` package like in other examples.

---

## Other imports in the same directory

All other `.tsx` files under `packages/react/examples` import `createRoot` using the `@opentui/react` package name, instead of a relative path ([GitHub search](https://github.com/search?q=repo%3Aanomalyco%2Fopentui%20import%20createRoot%20path%3Apackages%2Freact%2Fexamples&type=code)).

## Reusing this example/demo script

This relative import worked if the example was used from within this repo, but it prevented this demo file from being used separately:
```shell
curl -s https://raw.githubusercontent.com/anomalyco/opentui/main/packages/react/examples/text.tsx > text.tsx
bun install @opentui/react @opentui/core react
bun run ./text.tsx
```

This fails with:
```none
error: Cannot find module '../src' from '/private/tmp/import-repro/text.tsx'

Bun v1.3.10 (macOS arm64)
```

## After this fix

```shell
curl -s https://raw.githubusercontent.com/nicolasff/opentui/text-example-import/packages/react/examples/text.tsx > text.tsx
bun install @opentui/react @opentui/core react
bun run ./text.tsx
```

(works as expected)