### PR TITLE
fix(palette): querySpecialColors resistent to term emulators with noi…

### DIFF
--- a/packages/core/src/lib/terminal-palette.ts
+++ b/packages/core/src/lib/terminal-palette.ts
@@ -230,7 +230,7 @@ export class TerminalPalette implements TerminalPaletteDetector {
 
       const onData = (chunk: string | Buffer) => {
         buffer += chunk.toString()
-        let updated = false;
+        let updated = false
 
         let m: RegExpExecArray | null
         OSC_SPECIAL_RESPONSE.lastIndex = 0
@@ -238,7 +238,7 @@ export class TerminalPalette implements TerminalPaletteDetector {
           const idx = parseInt(m[1], 10)
           if (idx in results) {
             results[idx] = toHex(m[2], m[3], m[4], m[5])
-            updated = true;
+            updated = true
           }
         }
 


### PR DESCRIPTION
### Issue for this PR

#705 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Opentuin getPallette function for querySpecialColors has an idleTimer meant to exit out before the explicit timeout if the terminal does not provide all of the color escape sequences 10-19. The idle timer resets if any escape sequence triggers the onData function again.

This is an issue for terminal emulators like ghostty which are very noisy with the escape sequences they send. Here we only allow the timeout to reset if a response conforming to `OSC_SPECIAL_RESPONSE` is read in the buffer. 

This is possibly overly conservative. If we were being more aggressive, we could only reset the idle timer when an entry in results gets updated from a null value. As it stands, this improves start time of getPallette in ghostty from the max timeout to almost negligable


### How did you verify your code works?
- I tested locally with the following simple script
```js
#!/usr/bin/env bun

import { createCliRenderer, TextRenderable } from "../index"
import { setupCommonDemoKeys } from "./lib/standalone-keys"

const startTime = Date.now()

// 1. Create renderer
const renderer = await createCliRenderer({
  exitOnCtrlC: true,
  targetFps: 60,
})

// 2. Start automatic render loop
renderer.auto()

// 3. Add trivial renderable
const text = new TextRenderable(renderer, {
  id: "placeholder",
  content: "Renderer active… (toggle stdout with `)",
  left: 0,
  top: 0,
})
renderer.root.add(text)

// 4. Hook up common demo keys (including stdout toggle)
setupCommonDemoKeys(renderer)

// 5. Request palette
const palette = await renderer.getPalette({ timeout: 5000, size: 16 })

console.log("time elapsed", Date.now() - startTime)
```
- Without fix: `[17:54:05] [LOG] 'time elapsed' 5014`
- With fix: `[17:54:28] [LOG] 'time elapsed' 220`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

