### PR TITLE
fix(core): prevent mouse escape sequences from leaking into keyboard input

### DIFF
--- a/packages/core/src/lib/parse.mouse.test.ts
+++ b/packages/core/src/lib/parse.mouse.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from "bun:test"
-import { MouseParser, type RawMouseEvent } from "./parse.mouse"
+import { MouseParser, type RawMouseEvent, type MouseParseResult } from "./parse.mouse"
 
 // Encode a basic/X10 mouse event: ESC [ M Cb Cx Cy
 // buttonByte is the logical value (before the +32 wire offset), x/y are 0-based.
@@ -516,6 +516,114 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
     expect(events).toHaveLength(2)
     expect(events[0]).toMatchObject({ type: "down" })
     expect(events[1]).toMatchObject({ type: "drag" })
+  })
+})
+
+describe("MouseParser parseAllMouseEventsWithOffset (split sequences & mixed data)", () => {
+  let parser: MouseParser
+
+  beforeEach(() => {
+    parser = new MouseParser()
+  })
+
+  test("pure mouse data: consumed equals total length, partial is false", () => {
+    const buf = Buffer.concat([encodeSGR(0, 10, 5, true), encodeSGR(0, 10, 5, false)])
+    const result = parser.parseAllMouseEventsWithOffset(buf)
+    expect(result.events).toHaveLength(2)
+    expect(result.consumed).toBe(buf.length)
+    expect(result.partial).toBe(false)
+  })
+
+  test("mouse followed by non-mouse data: consumed < length, partial is false", () => {
+    const mouseData = encodeSGR(0, 10, 5, true)
+    const keyData = Buffer.from("hello")
+    const buf = Buffer.concat([mouseData, keyData])
+    const result = parser.parseAllMouseEventsWithOffset(buf)
+    expect(result.events).toHaveLength(1)
+    expect(result.consumed).toBe(mouseData.length)
+    expect(result.partial).toBe(false)
+  })
+
+  test("mouse followed by partial mouse sequence: partial is true", () => {
+    const completeEvent = encodeSGR(0, 10, 5, true)
+    const partialEvent = Buffer.from("\x1b[<35;20")
+    const buf = Buffer.concat([completeEvent, partialEvent])
+    const result = parser.parseAllMouseEventsWithOffset(buf)
+    expect(result.events).toHaveLength(1)
+    expect(result.consumed).toBe(completeEvent.length)
+    expect(result.partial).toBe(true)
+  })
+
+  test("only partial SGR mouse sequence: 0 events, partial is true", () => {
+    const buf = Buffer.from("\x1b[<35;20;5")
+    const result = parser.parseAllMouseEventsWithOffset(buf)
+    expect(result.events).toHaveLength(0)
+    expect(result.consumed).toBe(0)
+    expect(result.partial).toBe(true)
+  })
+
+  test("bare ESC-[ < without digits is partial", () => {
+    const buf = Buffer.from("\x1b[<")
+    const result = parser.parseAllMouseEventsWithOffset(buf)
+    expect(result.events).toHaveLength(0)
+    expect(result.consumed).toBe(0)
+    expect(result.partial).toBe(true)
+  })
+
+  test("partial basic mouse: ESC[M + 1 byte (needs 3)", () => {
+    const buf = Buffer.from("\x1b[M\x20")
+    const result = parser.parseAllMouseEventsWithOffset(buf)
+    expect(result.events).toHaveLength(0)
+    expect(result.consumed).toBe(0)
+    expect(result.partial).toBe(true)
+  })
+
+  test("non-mouse data followed by mouse: consumed is 0, partial is false", () => {
+    const keyData = Buffer.from("abc")
+    const mouseData = encodeSGR(0, 10, 5, true)
+    const buf = Buffer.concat([keyData, mouseData])
+    const result = parser.parseAllMouseEventsWithOffset(buf)
+    // Parser starts at offset 0, 'a' is not a mouse introducer — breaks immediately
+    expect(result.events).toHaveLength(0)
+    expect(result.consumed).toBe(0)
+    expect(result.partial).toBe(false)
+  })
+
+  test("empty buffer: 0 events, consumed 0, partial false", () => {
+    const result = parser.parseAllMouseEventsWithOffset(Buffer.from(""))
+    expect(result.events).toHaveLength(0)
+    expect(result.consumed).toBe(0)
+    expect(result.partial).toBe(false)
+  })
+
+  test("non-mouse CSI sequence is not detected as partial", () => {
+    // ESC[A (Cursor Up) — valid CSI but not a mouse sequence
+    const buf = Buffer.from("\x1b[A")
+    const result = parser.parseAllMouseEventsWithOffset(buf)
+    expect(result.events).toHaveLength(0)
+    expect(result.consumed).toBe(0)
+    expect(result.partial).toBe(false)
+  })
+
+  test("simulated split: chunk 1 with partial, chunk 2 completes it", () => {
+    // Chunk 1: complete event + beginning of a second one
+    const complete = encodeSGR(35, 20, 10, true)  // move event
+    const partial = "\x1b[<35;21"
+    const chunk1 = Buffer.concat([complete, Buffer.from(partial)])
+
+    const result1 = parser.parseAllMouseEventsWithOffset(chunk1)
+    expect(result1.events).toHaveLength(1)
+    expect(result1.consumed).toBe(complete.length)
+    expect(result1.partial).toBe(true)
+
+    // Chunk 2: remainder of the partial sequence
+    const remainder = chunk1.toString().slice(result1.consumed)
+    const chunk2str = remainder + ";11M"  // completes \x1b[<35;21;11M
+    const result2 = parser.parseAllMouseEventsWithOffset(Buffer.from(chunk2str))
+    expect(result2.events).toHaveLength(1)
+    expect(result2.events[0]).toMatchObject({ type: "move", x: 20, y: 10 })
+    expect(result2.consumed).toBe(chunk2str.length)
+    expect(result2.partial).toBe(false)
   })
 })
 

--- a/packages/core/src/lib/parse.mouse.ts
+++ b/packages/core/src/lib/parse.mouse.ts
@@ -14,9 +14,19 @@ export type RawMouseEvent = {
   scroll?: ScrollInfo
 }
 
+/** Result of parsing a single mouse event, including how many bytes it consumed. */
 type ParsedMouseSequence = {
   event: RawMouseEvent
   consumed: number
+}
+
+/** Result of parseAllMouseEventsWithOffset — contains parsed events, consumed byte count, and partial-sequence detection. */
+export type MouseParseResult = {
+  events: RawMouseEvent[]
+  /** Number of bytes successfully parsed as mouse events. */
+  consumed: number
+  /** True if the buffer ends with an incomplete mouse sequence that needs more data. */
+  partial: boolean
 }
 
 export class MouseParser {
@@ -48,23 +58,77 @@ export class MouseParser {
   }
 
   public parseAllMouseEvents(data: Buffer): RawMouseEvent[] {
+    return this.parseAllMouseEventsWithOffset(data).events
+  }
+
+  /**
+   * Parse all mouse events from the buffer, returning how many bytes were
+   * consumed and whether the buffer ends with an incomplete mouse sequence.
+   * This allows callers to forward unconsumed data to keyboard handlers
+   * and buffer partial sequences for the next stdin chunk.
+   */
+  public parseAllMouseEventsWithOffset(data: Buffer): MouseParseResult {
     const str = this.decodeInput(data)
     const events: RawMouseEvent[] = []
     let offset = 0
+    let partial = false
 
     while (offset < str.length) {
       const parsed = this.parseMouseSequenceAt(str, offset)
-      if (!parsed) {
-        // Stop at the first non-mouse sequence. Callers can decide whether to
-        // route any remaining data through keyboard/terminal input handling.
+      if (parsed) {
+        events.push(parsed.event)
+        offset += parsed.consumed
+        continue
+      }
+
+      // No complete mouse event at this position.
+      // Check if there is a partial (truncated) mouse sequence starting here.
+      if (this.isPartialMouseSequence(str, offset)) {
+        partial = true
         break
       }
 
-      events.push(parsed.event)
-      offset += parsed.consumed
+      // Not a mouse sequence at all — stop. Caller routes the remainder
+      // through keyboard/terminal input handling.
+      break
     }
 
-    return events
+    return { events, consumed: offset, partial }
+  }
+
+  /**
+   * Check whether an incomplete mouse sequence starts at the given offset.
+   * For example, "\x1b[<35;20" is a truncated SGR sequence (missing the
+   * terminating "M" or "m").
+   */
+  private isPartialMouseSequence(str: string, offset: number): boolean {
+    if (!str.startsWith("\x1b[", offset)) return false
+    const remaining = str.slice(offset)
+
+    // Partial SGR mouse: \x1b[< followed by digits/semicolons but no M/m terminator
+    if (remaining.startsWith("\x1b[<")) {
+      // Just "\x1b[" or "\x1b[<" — clearly incomplete
+      if (remaining.length <= 3) return true
+      // Verify the rest consists only of valid SGR mouse characters (digits, semicolons)
+      for (let i = 3; i < remaining.length; i++) {
+        const ch = remaining.charCodeAt(i)
+        if (ch >= 48 && ch <= 57) continue  // digit
+        if (ch === 59) continue               // semicolon
+        // M or m means the sequence is actually complete (should have been parsed above)
+        if (ch === 77 || ch === 109) return false
+        // Any other character — not a valid mouse sequence
+        return false
+      }
+      // Only digits/semicolons without a terminator — partial
+      return true
+    }
+
+    // Partial basic (X10) mouse: \x1b[M needs 3 payload bytes (6 total)
+    if (remaining.startsWith("\x1b[M")) {
+      return remaining.length < 6
+    }
+
+    return false
   }
 
   private parseMouseSequenceAt(str: string, offset: number): ParsedMouseSequence | null {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1013,6 +1013,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this._useMouse = false
     this.setCapturedRenderable(undefined)
     this.mouseParser.reset()
+    this._mousePartialBuffer = ""
     this.lib.disableMouse(this.rendererPtr)
   }
 
@@ -1059,13 +1060,40 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.queryPixelResolution()
   }
 
+  /** Buffers partial mouse sequences that span across stdin chunk boundaries. */
+  private _mousePartialBuffer: string = ""
+
   private stdinListener: (data: Buffer) => void = ((data: Buffer) => {
-    // Mouse first (consume and stop if handled)
-    if (this._useMouse && this.handleMouseData(data)) {
+    if (this._useMouse) {
+      // Prepend any leftover partial mouse data from the previous chunk
+      let str = data.toString()
+      if (this._mousePartialBuffer.length > 0) {
+        str = this._mousePartialBuffer + str
+        this._mousePartialBuffer = ""
+      }
+
+      const result = this.mouseParser.parseAllMouseEventsWithOffset(Buffer.from(str))
+
+      // Dispatch parsed mouse events
+      for (const mouseEvent of result.events) {
+        this.processSingleMouseEvent(mouseEvent)
+      }
+
+      // Buffer any trailing partial sequence for the next chunk
+      if (result.partial) {
+        this._mousePartialBuffer = str.slice(result.consumed)
+        return
+      }
+
+      // Forward non-mouse remainder to the keyboard input pipeline
+      const remainder = str.slice(result.consumed)
+      if (remainder.length > 0) {
+        this._stdinBuffer.process(remainder)
+      }
       return
     }
 
-    // Everything else goes through the sequence buffer
+    // Mouse disabled — send everything to the keyboard input pipeline
     this._stdinBuffer.process(data)
   }).bind(this)
 
@@ -1201,13 +1229,17 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     return event
   }
 
+  /**
+   * @deprecated No longer called by stdinListener directly.
+   * Kept for potential external callers.
+   */
   private handleMouseData(data: Buffer): boolean {
-    const mouseEvents = this.mouseParser.parseAllMouseEvents(data)
+    const result = this.mouseParser.parseAllMouseEventsWithOffset(data)
 
-    if (mouseEvents.length === 0) return false
+    if (result.events.length === 0) return false
 
     let anyHandled = false
-    for (const mouseEvent of mouseEvents) {
+    for (const mouseEvent of result.events) {
       if (this.processSingleMouseEvent(mouseEvent)) {
         anyHandled = true
       }
@@ -1515,6 +1547,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this.setCapturedRenderable(undefined)
     this.mouseParser.reset()
+    this._mousePartialBuffer = ""
 
     if (this._splitHeight > 0) {
       // TODO: Handle resizing split mode properly

--- a/packages/core/src/tests/renderer.mouse.test.ts
+++ b/packages/core/src/tests/renderer.mouse.test.ts
@@ -1246,7 +1246,7 @@ describe("renderer handleMouseData split height", () => {
     }
   })
 
-  test("split height returns false for input above render area", async () => {
+  test("split height ignores mouse input above render area without leaking to keyboard", async () => {
     try {
       const sequences: string[] = []
       renderer.addInputHandler((sequence) => {
@@ -1261,7 +1261,10 @@ describe("renderer handleMouseData split height", () => {
       await mockMouse.click(1, Math.max(0, renderOffset - 1))
       await Bun.sleep(10)
 
-      expect(sequences.length).toBeGreaterThan(beforeSequences)
+      // Mouse events above the render area are silently ignored.
+      // They must NOT leak through as keyboard sequences to input handlers,
+      // which would cause raw escape codes to appear as typed text.
+      expect(sequences.length).toBe(beforeSequences)
     } finally {
       renderer.destroy()
     }


### PR DESCRIPTION
## Summary

Fixes the root cause of mouse escape sequences (e.g. `[555;129;29M`) appearing as typed text in input fields during normal use. This happens when stdin delivers mouse data split across chunk boundaries, which occurs regularly under high mouse activity.

- Add `parseAllMouseEventsWithOffset()` to `MouseParser` — returns consumed byte count and partial-sequence detection so callers know exactly what was parsed and what remains
- Add `isPartialMouseSequence()` to detect truncated SGR/Basic mouse sequences at chunk boundaries (e.g. `\x1b[<35;20` missing the terminating `M`)
- Add `_mousePartialBuffer` to `CliRenderer` that preserves incomplete mouse sequences between stdin chunks
- Rewrite `stdinListener` to properly route unconsumed non-mouse data to `StdinBuffer` instead of silently dropping it
- Update split-height test: mouse events above the render area are now correctly ignored instead of leaking to input handlers

## Root cause

The old `stdinListener` had an all-or-nothing design:

```typescript
// OLD (buggy)
if (this._useMouse && this.handleMouseData(data)) {
  return  // entire chunk treated as mouse — any non-mouse remainder is lost
}
this._stdinBuffer.process(data)  // entire chunk treated as keyboard
```

When a mouse sequence was split across two stdin chunks (e.g. `\x1b[<35;20;5M\x1b[<35` followed by `;21;5M`), the partial tail was dropped and its completion in the next chunk leaked into the keyboard handler as literal text.

## Three scenarios this fixes

| Scenario | Before (bug) | After (fix) |
|----------|-------------|-------------|
| Split: `\x1b[<35;20;5M\x1b[<35` + `;21;5M` | `;21;5M` appears as typed text | Buffered and correctly parsed |
| Mixed: `\x1b[<35;20;5Mhello` | `hello` silently lost | Mouse → handler, `hello` → keyboard |
| Rapid: 10 events + partial | Last event lost | All 11 events parsed correctly |

## Test plan

- [x] All 81 existing mouse parser tests pass
- [x] 10 new tests for `parseAllMouseEventsWithOffset` covering split sequences, partial detection, mixed data, and chunk reassembly
- [x] All 35 renderer mouse tests pass (1 test updated to match corrected behavior)
- [x] All 180 keyboard/keypress tests pass (no regressions)

Fixes https://github.com/anomalyco/opencode/issues/8614
Related: https://github.com/anomalyco/opencode/issues/7316, https://github.com/anomalyco/opencode/issues/11636