### PR TITLE
fix(markdown): style code blocks and apply renderNode updates

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -15,6 +15,7 @@ import {
   type TextTableContent,
 } from "./TextTable"
 import type { TreeSitterClient } from "../lib/tree-sitter"
+import { extToFiletype } from "../lib/tree-sitter/resolve-ft"
 import { parseMarkdownIncremental, type ParseState } from "./markdown-parser"
 import type { OptimizedBuffer } from "../buffer"
 import { detectLinks } from "../lib/detect-links"
@@ -452,6 +453,11 @@ export class MarkdownRenderable extends Renderable {
     })
   }
 
+  private resolveCodeFiletype(lang: string | undefined): string | undefined {
+    if (!lang) return undefined
+    return extToFiletype(lang) ?? lang
+  }
+
   private getCodeBlockStyle(): StyleDefinition | undefined {
     const base = this.getStyle("default")
     const raw = this.getStyle("markup.raw.block") ?? this.getStyle("markup.raw")
@@ -466,11 +472,20 @@ export class MarkdownRenderable extends Renderable {
     }
   }
 
-  private applyCodeBlockStyle(renderable: CodeRenderable): void {
+  private applyCodeBlockStyle(renderable: CodeRenderable, token: Tokens.Code): void {
     const style = this.getCodeBlockStyle()
-    if (!style) return
-    if (style.fg) renderable.fg = style.fg
-    if (style.bg) renderable.bg = style.bg
+    if (!style) {
+      renderable.fg = undefined
+      renderable.bg = undefined
+      renderable.attributes = 0
+      return
+    }
+    renderable.fg = token.lang ? undefined : style.fg
+    renderable.bg = style.bg
+    if (token.lang) {
+      renderable.attributes = 0
+      return
+    }
     renderable.attributes = createTextAttributes({
       bold: style.bold,
       italic: style.italic,
@@ -481,23 +496,27 @@ export class MarkdownRenderable extends Renderable {
 
   private createCodeRenderable(token: Tokens.Code, id: string, marginBottom: number = 0): Renderable {
     const style = this.getCodeBlockStyle()
+    const filetype = this.resolveCodeFiletype(token.lang)
+    const attrs = token.lang
+      ? 0
+      : createTextAttributes({
+          bold: style?.bold,
+          italic: style?.italic,
+          underline: style?.underline,
+          dim: style?.dim,
+        })
     return new CodeRenderable(this.ctx, {
       id,
       content: token.text,
-      filetype: token.lang || undefined,
+      filetype,
       syntaxStyle: this._syntaxStyle,
       conceal: this._concealCode,
       drawUnstyledText: !(this._streaming && this._concealCode),
       streaming: this._streaming,
       treeSitterClient: this._treeSitterClient,
-      fg: style?.fg,
+      fg: token.lang ? undefined : style?.fg,
       bg: style?.bg,
-      attributes: createTextAttributes({
-        bold: style?.bold,
-        italic: style?.italic,
-        underline: style?.underline,
-        dim: style?.dim,
-      }),
+      attributes: attrs,
       width: "100%",
       marginBottom,
     })
@@ -515,13 +534,13 @@ export class MarkdownRenderable extends Renderable {
 
   private applyCodeBlockRenderable(renderable: CodeRenderable, token: Tokens.Code, marginBottom: number): void {
     renderable.content = token.text
-    renderable.filetype = token.lang || undefined
+    renderable.filetype = this.resolveCodeFiletype(token.lang)
     renderable.syntaxStyle = this._syntaxStyle
     renderable.conceal = this._concealCode
     renderable.drawUnstyledText = !(this._streaming && this._concealCode)
     renderable.streaming = this._streaming
     renderable.marginBottom = marginBottom
-    this.applyCodeBlockStyle(renderable)
+    this.applyCodeBlockStyle(renderable, token)
   }
 
   private shouldRenderSeparately(token: MarkedToken): boolean {

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -683,6 +683,47 @@ console.log(x);
   `)
 })
 
+test("code block language alias keeps syntax highlighting", async () => {
+  const style = SyntaxStyle.fromStyles({
+    default: { fg: RGBA.fromHex("#111111") },
+    keyword: { fg: RGBA.fromHex("#ff0000") },
+    variable: { fg: RGBA.fromHex("#00ffff") },
+    number: { fg: RGBA.fromHex("#ff00ff") },
+    "markup.raw.block": {
+      fg: RGBA.fromHex("#00aa00"),
+      bg: RGBA.fromHex("#220000"),
+    },
+  })
+
+  const md = createMarkdownRenderable({
+    id: "styled-code-block-with-alias",
+    content: `\`\`\`ts
+const x = 1
+\`\`\``,
+    syntaxStyle: style,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const startedAt = Date.now()
+  while (
+    md
+      .getChildren()
+      .some((child) => child instanceof CodeRenderable && child.filetype === "typescript" && child.isHighlighting)
+  ) {
+    if (Date.now() - startedAt > 2000) {
+      throw new Error("Timed out waiting for typescript highlights")
+    }
+    await Bun.sleep(10)
+    await renderOnce()
+  }
+
+  const spans = captureSpans().lines[0]?.spans ?? []
+  expect(spans.some((span) => span.text.includes("const") && span.fg.equals(RGBA.fromHex("#ff0000")))).toBe(true)
+  expect(spans.some((span) => span.bg.equals(RGBA.fromHex("#220000")))).toBe(true)
+})
+
 test("code block without language", async () => {
   const markdown = `\`\`\`
 plain code block


### PR DESCRIPTION
Latest opencode broke rendering code blocks on solarized light now that they've switched to the experimental markdown renderer. This definitely fixes it locally, and I think it doesn't break anything else.

## Summary
- apply markdown raw/raw.block styles to fenced code blocks rendered by `MarkdownRenderable`
- add a `renderNode` setter so JSX prop updates trigger block rebuilds
- add regressions for styled code blocks and post-construction `renderNode` updates

## Testing
- bun test src/renderables/__tests__/Markdown.test.ts