### PR TITLE
fix: set wrap width on resize for text buffer renderables

### DIFF
--- a/packages/core/src/renderables/TextBufferRenderable.ts
+++ b/packages/core/src/renderables/TextBufferRenderable.ts
@@ -331,6 +331,9 @@ export abstract class TextBufferRenderable extends Renderable implements LineInf
   }
 
   protected onResize(width: number, height: number): void {
+    if (this._wrapMode !== "none" && width > 0) {
+      this.textBufferView.setWrapWidth(width)
+    }
     this.textBufferView.setViewport(this._scrollX, this._scrollY, width, height)
     this.yogaNode.markDirty()
     this.requestRender()


### PR DESCRIPTION
## Summary

When `wrapMode` is enabled (`"char"` or `"word"`) and a `TextBufferRenderable` is resized, the wrap width was not being updated in `onResize()`. This caused text to retain the old wrap width after a container resize.

The fix adds the same `setWrapWidth` call that already exists in:
- Initialization (`afterSetup`, line ~94)
- The `wrapMode` setter (line ~283)

Both use the identical guard pattern: `if (this._wrapMode !== "none" && width > 0)`.

## Changes

- `packages/core/src/renderables/TextBufferRenderable.ts`: Call `this.textBufferView.setWrapWidth(width)` in `onResize()` when wrap mode is active