### PR TITLE
test: speed up palette detection tests

### DIFF
--- a/packages/core/src/lib/terminal-palette.test.ts
+++ b/packages/core/src/lib/terminal-palette.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test"
 import { TerminalPalette } from "./terminal-palette"
 import { EventEmitter } from "events"
 import { Buffer } from "node:buffer"
+import { ManualClock } from "../testing/manual-clock"
 
 class MockStream extends EventEmitter {
   isTTY = true
@@ -14,15 +15,64 @@ class MockStream extends EventEmitter {
   }
 }
 
-test("TerminalPalette detectOSCSupport returns true on response", async () => {
+function createPaletteHarness(
+  options: {
+    writeFn?: (data: string | Buffer) => boolean
+    oscSource?: {
+      subscribeOsc(handler: (sequence: string) => void): () => void
+    }
+  } = {},
+) {
   const stdin = new MockStream() as any
   const stdout = new MockStream() as any
+  const clock = new ManualClock()
+  const palette = new TerminalPalette(stdin, stdout, options.writeFn, false, options.oscSource, clock)
 
-  const palette = new TerminalPalette(stdin, stdout)
+  return { stdin, stdout, clock, palette }
+}
+
+async function flushAsync(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+async function startPaletteDetection(
+  options: {
+    timeout?: number
+    size?: number
+    writeFn?: (data: string | Buffer) => boolean
+  } = {},
+) {
+  const timeout = options.timeout ?? 2000
+  const harness = createPaletteHarness({ writeFn: options.writeFn })
+  const detectPromise = harness.palette.detect({
+    timeout,
+    size: options.size ?? 256,
+  })
+
+  harness.stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
+  await flushAsync()
+
+  return { ...harness, detectPromise, timeout }
+}
+
+async function advanceClock(clock: ManualClock, ms: number): Promise<void> {
+  await flushAsync()
+  // Flush queued 0ms mock terminal responses before advancing the real timeout window.
+  clock.advance(0)
+  await flushAsync()
+  clock.advance(ms)
+  await flushAsync()
+}
+
+test("TerminalPalette detectOSCSupport returns true on response", async () => {
+  const { stdin, clock, palette } = createPaletteHarness()
 
   const detectPromise = palette.detectOSCSupport(500)
 
   stdin.emit("data", Buffer.from("\x1b]4;0;#ff0000\x07"))
+
+  await advanceClock(clock, 500)
 
   const result = await detectPromise
 
@@ -30,34 +80,30 @@ test("TerminalPalette detectOSCSupport returns true on response", async () => {
 })
 
 test("TerminalPalette detectOSCSupport returns false on timeout", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { clock, palette } = createPaletteHarness()
 
-  const palette = new TerminalPalette(stdin, stdout)
+  const detectPromise = palette.detectOSCSupport(100)
 
-  const result = await palette.detectOSCSupport(100)
+  await advanceClock(clock, 300)
+
+  const result = await detectPromise
 
   expect(result).toBe(false)
 })
 
 test("TerminalPalette parses OSC 4 hex format correctly", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     for (let i = 0; i < 256; i++) {
       const color = i === 0 ? "#ff00aa" : i === 1 ? "#00ff00" : i === 2 ? "#0000ff" : "#000000"
       stdin.emit("data", Buffer.from(`\x1b]4;${i};${color}\x07`))
     }
     stdin.emit("data", Buffer.from("\x1b]10;#aabbcc\x07"))
     stdin.emit("data", Buffer.from("\x1b]11;#ddeeff\x07"))
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -69,21 +115,16 @@ test("TerminalPalette parses OSC 4 hex format correctly", async () => {
 })
 
 test("TerminalPalette parses OSC 4 rgb format with 4 hex digits", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit("data", Buffer.from("\x1b]4;0;rgb:ffff/0000/aaaa\x07"))
     for (let i = 1; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -92,21 +133,16 @@ test("TerminalPalette parses OSC 4 rgb format with 4 hex digits", async () => {
 })
 
 test("TerminalPalette parses OSC 4 rgb format with 2 hex digits", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit("data", Buffer.from("\x1b]4;0;rgb:ff/00/aa\x07"))
     for (let i = 1; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -115,16 +151,9 @@ test("TerminalPalette parses OSC 4 rgb format with 2 hex digits", async () => {
 })
 
 test("TerminalPalette handles multiple color responses in single buffer", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit(
       "data",
       Buffer.from(
@@ -138,7 +167,9 @@ test("TerminalPalette handles multiple color responses in single buffer", async 
     for (let i = 4; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -149,21 +180,16 @@ test("TerminalPalette handles multiple color responses in single buffer", async 
 })
 
 test("TerminalPalette handles BEL terminator", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit("data", Buffer.from("\x1b]4;0;#ff0000\x07"))
     for (let i = 1; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -171,21 +197,16 @@ test("TerminalPalette handles BEL terminator", async () => {
 })
 
 test("TerminalPalette handles ST terminator", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit("data", Buffer.from("\x1b]4;0;#00ff00\x1b\\"))
     for (let i = 1; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -193,21 +214,16 @@ test("TerminalPalette handles ST terminator", async () => {
 })
 
 test("TerminalPalette scales color components correctly", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit("data", Buffer.from("\x1b]4;0;rgb:ffff/0000/0000\x07"))
     for (let i = 1; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -215,18 +231,13 @@ test("TerminalPalette scales color components correctly", async () => {
 })
 
 test("TerminalPalette returns null for colors that don't respond", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection({ timeout: 1000 })
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 1000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit("data", Buffer.from("\x1b]4;0;#ff0000\x07"))
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -235,16 +246,9 @@ test("TerminalPalette returns null for colors that don't respond", async () => {
 })
 
 test("TerminalPalette handles response split across chunks", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit("data", Buffer.from("\x1b]4;0;#ff"))
     stdin.emit("data", Buffer.from("00aa\x07"))
 
@@ -255,7 +259,9 @@ test("TerminalPalette handles response split across chunks", async () => {
     for (let i = 2; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -264,16 +270,9 @@ test("TerminalPalette handles response split across chunks", async () => {
 })
 
 test("TerminalPalette handles OSC response mixed with mouse events", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit("data", Buffer.from("\x1b]4;0;#ff00aa\x07"))
     stdin.emit("data", Buffer.from("\x1b[<0;10;5M"))
     stdin.emit("data", Buffer.from("\x1b]4;1;#00ff00\x07"))
@@ -284,7 +283,9 @@ test("TerminalPalette handles OSC response mixed with mouse events", async () =>
     for (let i = 3; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -294,16 +295,9 @@ test("TerminalPalette handles OSC response mixed with mouse events", async () =>
 })
 
 test("TerminalPalette handles OSC response mixed with key events", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit("data", Buffer.from("\x1b]4;0;#ff00aa\x07"))
     stdin.emit("data", Buffer.from("hello"))
     stdin.emit("data", Buffer.from("\x1b]4;1;#00ff00\x07"))
@@ -315,7 +309,9 @@ test("TerminalPalette handles OSC response mixed with key events", async () => {
     for (let i = 4; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -326,16 +322,9 @@ test("TerminalPalette handles OSC response mixed with key events", async () => {
 })
 
 test("TerminalPalette handles response split mid-escape sequence", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit("data", Buffer.from("\x1b"))
     stdin.emit("data", Buffer.from("]4;0;#ff00aa\x07"))
 
@@ -351,7 +340,9 @@ test("TerminalPalette handles response split mid-escape sequence", async () => {
     for (let i = 4; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -362,16 +353,9 @@ test("TerminalPalette handles response split mid-escape sequence", async () => {
 })
 
 test("TerminalPalette handles mixed ANSI sequences and OSC responses", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit("data", Buffer.from("\x1b[2J"))
     stdin.emit("data", Buffer.from("\x1b]4;0;#ff00aa\x07"))
     stdin.emit("data", Buffer.from("\x1b[H"))
@@ -383,7 +367,9 @@ test("TerminalPalette handles mixed ANSI sequences and OSC responses", async () 
     for (let i = 3; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -393,16 +379,9 @@ test("TerminalPalette handles mixed ANSI sequences and OSC responses", async () 
 })
 
 test("TerminalPalette handles complex chunking with partial responses", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     const response0 = "\x1b]4;0;rgb:ffff/0000/aaaa\x07"
     for (let i = 0; i < response0.length; i += 3) {
       stdin.emit("data", Buffer.from(response0.slice(i, i + 3)))
@@ -420,7 +399,9 @@ test("TerminalPalette handles complex chunking with partial responses", async ()
     for (let i = 2; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -429,16 +410,9 @@ test("TerminalPalette handles complex chunking with partial responses", async ()
 })
 
 test("TerminalPalette ignores malformed responses and waits for valid ones", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit("data", Buffer.from("\x1b]4;0;#ff00\x07"))
     stdin.emit("data", Buffer.from("\x1b]4;1;rgb:gg00/0000/0000\x07"))
     stdin.emit("data", Buffer.from("\x1b]4;2;#zzzzzz\x07"))
@@ -450,7 +424,9 @@ test("TerminalPalette ignores malformed responses and waits for valid ones", asy
     for (let i = 3; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -460,16 +436,9 @@ test("TerminalPalette ignores malformed responses and waits for valid ones", asy
 })
 
 test("TerminalPalette handles buffer overflow gracefully", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     const junkData = "x".repeat(10000)
     stdin.emit("data", Buffer.from(junkData))
 
@@ -479,7 +448,9 @@ test("TerminalPalette handles buffer overflow gracefully", async () => {
     for (let i = 2; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -488,16 +459,9 @@ test("TerminalPalette handles buffer overflow gracefully", async () => {
 })
 
 test("TerminalPalette handles all 256 colors in a single blob", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     let blob = ""
     for (let i = 0; i < 256; i++) {
       const color = i === 0 ? "#ff0011" : i === 1 ? "#00ff22" : i === 255 ? "#aabbcc" : "#000000"
@@ -505,7 +469,9 @@ test("TerminalPalette handles all 256 colors in a single blob", async () => {
     }
 
     stdin.emit("data", Buffer.from(blob))
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -516,16 +482,9 @@ test("TerminalPalette handles all 256 colors in a single blob", async () => {
 })
 
 test("TerminalPalette handles blob split across multiple chunks", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     let blob = ""
     for (let i = 0; i < 256; i++) {
       const color = i === 5 ? "#112233" : i === 100 ? "#445566" : i === 200 ? "#778899" : "#000000"
@@ -536,7 +495,9 @@ test("TerminalPalette handles blob split across multiple chunks", async () => {
     for (let i = 0; i < blob.length; i += chunkSize) {
       stdin.emit("data", Buffer.from(blob.slice(i, i + chunkSize)))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -547,16 +508,9 @@ test("TerminalPalette handles blob split across multiple chunks", async () => {
 })
 
 test("TerminalPalette handles blob with mixed junk data", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     let blob = ""
     for (let i = 0; i < 256; i++) {
       const color = i === 10 ? "#abcdef" : i === 50 ? "#fedcba" : "#000000"
@@ -574,7 +528,9 @@ test("TerminalPalette handles blob with mixed junk data", async () => {
     }
 
     stdin.emit("data", Buffer.from(blob))
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -584,16 +540,9 @@ test("TerminalPalette handles blob with mixed junk data", async () => {
 })
 
 test("TerminalPalette handles realistic terminal response pattern", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     let chunk1 = ""
     for (let i = 0; i <= 5; i++) {
       chunk1 += `\x1b]4;${i};#ff0000\x07`
@@ -619,7 +568,9 @@ test("TerminalPalette handles realistic terminal response pattern", async () => 
       chunk4 += `\x1b]4;${i};#ffffff\x07`
     }
     stdin.emit("data", Buffer.from(chunk4))
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -635,8 +586,6 @@ test("TerminalPalette handles realistic terminal response pattern", async () => 
 })
 
 test("TerminalPalette uses custom write function when provided", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
   const writtenData: string[] = []
 
   const customWrite = (data: string | Buffer) => {
@@ -644,11 +593,13 @@ test("TerminalPalette uses custom write function when provided", async () => {
     return true
   }
 
-  const palette = new TerminalPalette(stdin, stdout, customWrite)
+  const { stdin, clock, palette } = createPaletteHarness({ writeFn: customWrite })
 
   const detectPromise = palette.detectOSCSupport(500)
 
   stdin.emit("data", Buffer.from("\x1b]4;0;#ff0000\x07"))
+
+  await advanceClock(clock, 500)
 
   const result = await detectPromise
 
@@ -658,8 +609,6 @@ test("TerminalPalette uses custom write function when provided", async () => {
 })
 
 test("TerminalPalette uses custom write function for palette detection", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
   const writtenData: string[] = []
 
   const customWrite = (data: string | Buffer) => {
@@ -667,18 +616,16 @@ test("TerminalPalette uses custom write function for palette detection", async (
     return true
   }
 
-  const palette = new TerminalPalette(stdin, stdout, customWrite)
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection({ writeFn: customWrite })
 
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     for (let i = 0; i < 256; i++) {
       const color = "#aabbcc"
       stdin.emit("data", Buffer.from(`\x1b]4;${i};${color}\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   await detectPromise
 
@@ -696,6 +643,7 @@ test("TerminalPalette uses custom write function for palette detection", async (
 })
 
 test("TerminalPalette falls back to stdout.write when no custom write function provided", async () => {
+  const clock = new ManualClock()
   const stdin = new MockStream() as any
   const writtenData: string[] = []
 
@@ -705,11 +653,13 @@ test("TerminalPalette falls back to stdout.write when no custom write function p
     return true
   }
 
-  const palette = new TerminalPalette(stdin, stdout)
+  const palette = new TerminalPalette(stdin, stdout, undefined, false, undefined, clock)
 
   const detectPromise = palette.detectOSCSupport(500)
 
   stdin.emit("data", Buffer.from("\x1b]4;0;#ff0000\x07"))
+
+  await advanceClock(clock, 500)
 
   const result = await detectPromise
 
@@ -719,8 +669,6 @@ test("TerminalPalette falls back to stdout.write when no custom write function p
 })
 
 test("TerminalPalette custom write function can intercept and modify output", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
   const interceptedWrites: string[] = []
   let actualWrites = 0
 
@@ -730,11 +678,13 @@ test("TerminalPalette custom write function can intercept and modify output", as
     return true
   }
 
-  const palette = new TerminalPalette(stdin, stdout, customWrite)
+  const { stdin, clock, palette } = createPaletteHarness({ writeFn: customWrite })
 
   const detectPromise = palette.detectOSCSupport(500)
 
   stdin.emit("data", Buffer.from("\x1b]4;0;#ff0000\x07"))
+
+  await advanceClock(clock, 500)
 
   await detectPromise
 
@@ -744,16 +694,9 @@ test("TerminalPalette custom write function can intercept and modify output", as
 })
 
 test("TerminalPalette detects all special OSC colors (10-19)", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     for (let i = 0; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
@@ -766,7 +709,9 @@ test("TerminalPalette detects all special OSC colors (10-19)", async () => {
     stdin.emit("data", Buffer.from("\x1b]16;#ff0007\x07"))
     stdin.emit("data", Buffer.from("\x1b]17;#ff0008\x07"))
     stdin.emit("data", Buffer.from("\x1b]19;#ff0009\x07"))
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -782,22 +727,17 @@ test("TerminalPalette detects all special OSC colors (10-19)", async () => {
 })
 
 test("TerminalPalette handles special colors in rgb format", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     for (let i = 0; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
     stdin.emit("data", Buffer.from("\x1b]10;rgb:ffff/0000/0000\x07"))
     stdin.emit("data", Buffer.from("\x1b]11;rgb:0000/ffff/0000\x07"))
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -806,22 +746,17 @@ test("TerminalPalette handles special colors in rgb format", async () => {
 })
 
 test("TerminalPalette handles missing special colors gracefully", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     for (let i = 0; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
     stdin.emit("data", Buffer.from("\x1b]10;#ff0001\x07"))
     stdin.emit("data", Buffer.from("\x1b]11;#ff0002\x07"))
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -833,22 +768,17 @@ test("TerminalPalette handles missing special colors gracefully", async () => {
 })
 
 test("TerminalPalette special colors with ST terminator", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     for (let i = 0; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
     stdin.emit("data", Buffer.from("\x1b]10;#aabbcc\x1b\\"))
     stdin.emit("data", Buffer.from("\x1b]11;#ddeeff\x1b\\"))
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -857,16 +787,9 @@ test("TerminalPalette special colors with ST terminator", async () => {
 })
 
 test("TerminalPalette handles mixed palette and special color responses", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, clock, detectPromise, timeout } = await startPaletteDetection()
 
-  const palette = new TerminalPalette(stdin, stdout)
-
-  const detectPromise = palette.detect({ timeout: 2000, size: 256 })
-
-  stdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
-
-  setTimeout(() => {
+  clock.setTimeout(() => {
     stdin.emit("data", Buffer.from("\x1b]4;0;#010203\x07"))
     stdin.emit("data", Buffer.from("\x1b]10;#aabbcc\x07"))
     stdin.emit("data", Buffer.from("\x1b]4;1;#040506\x07"))
@@ -874,7 +797,9 @@ test("TerminalPalette handles mixed palette and special color responses", async 
     for (let i = 2; i < 256; i++) {
       stdin.emit("data", Buffer.from(`\x1b]4;${i};#000000\x07`))
     }
-  }, 400)
+  }, 0)
+
+  await advanceClock(clock, timeout)
 
   const result = await detectPromise
 
@@ -885,14 +810,15 @@ test("TerminalPalette handles mixed palette and special color responses", async 
 })
 
 test("TerminalPalette returns null special colors on non-TTY", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { stdin, stdout, clock, palette } = createPaletteHarness()
   stdin.isTTY = false
   stdout.isTTY = false
 
-  const palette = new TerminalPalette(stdin, stdout)
+  const detectPromise = palette.detect({ timeout: 100 })
 
-  const result = await palette.detect({ timeout: 100 })
+  await advanceClock(clock, 100)
+
+  const result = await detectPromise
 
   expect(result.defaultForeground).toBe(null)
   expect(result.defaultBackground).toBe(null)
@@ -901,12 +827,13 @@ test("TerminalPalette returns null special colors on non-TTY", async () => {
 })
 
 test("TerminalPalette returns null special colors on OSC not supported", async () => {
-  const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
+  const { clock, palette } = createPaletteHarness()
 
-  const palette = new TerminalPalette(stdin, stdout)
+  const detectPromise = palette.detect({ timeout: 100 })
 
-  const result = await palette.detect({ timeout: 100 })
+  await advanceClock(clock, 300)
+
+  const result = await detectPromise
 
   expect(result.defaultForeground).toBe(null)
   expect(result.defaultBackground).toBe(null)
@@ -916,7 +843,6 @@ test("TerminalPalette returns null special colors on OSC not supported", async (
 
 test("TerminalPalette can read OSC from router subscription source", async () => {
   const stdin = new MockStream() as any
-  const stdout = new MockStream() as any
 
   const handlers = new Set<(sequence: string) => void>()
   let subscribeCount = 0
@@ -933,12 +859,16 @@ test("TerminalPalette can read OSC from router subscription source", async () =>
     },
   }
 
-  const palette = new TerminalPalette(stdin, stdout, undefined, false, oscSource)
+  const clock = new ManualClock()
+  const stdout = new MockStream() as any
+  const palette = new TerminalPalette(stdin, stdout, undefined, false, oscSource, clock)
 
   const detectPromise = palette.detectOSCSupport(500)
   for (const handler of handlers) {
     handler("\x1b]4;0;#ff0000\x07")
   }
+
+  await advanceClock(clock, 500)
 
   const supported = await detectPromise
   expect(supported).toBe(true)

--- a/packages/core/src/lib/terminal-palette.ts
+++ b/packages/core/src/lib/terminal-palette.ts
@@ -1,4 +1,8 @@
+import { SystemClock, type Clock, type TimerHandle } from "./clock"
+
 type Hex = string | null
+
+const SYSTEM_CLOCK = new SystemClock()
 
 const OSC4_RESPONSE =
   /\x1b]4;(\d+);(?:(?:rgb:)([0-9a-fA-F]+)\/([0-9a-fA-F]+)\/([0-9a-fA-F]+)|#([0-9a-fA-F]{6}))(?:\x07|\x1b\\)/g
@@ -68,6 +72,7 @@ export class TerminalPalette implements TerminalPaletteDetector {
   private activeQuerySessions: Array<() => void> = []
   private inLegacyTmux: boolean
   private oscSource?: OscSubscriptionSource
+  private readonly clock: Clock
 
   constructor(
     stdin: NodeJS.ReadStream,
@@ -75,12 +80,14 @@ export class TerminalPalette implements TerminalPaletteDetector {
     writeFn?: WriteFunction,
     isLegacyTmux?: boolean,
     oscSource?: OscSubscriptionSource,
+    clock?: Clock,
   ) {
     this.stdin = stdin
     this.stdout = stdout
     this.writeFn = writeFn || ((data: string | Buffer) => stdout.write(data))
     this.inLegacyTmux = isLegacyTmux ?? false
     this.oscSource = oscSource
+    this.clock = clock ?? SYSTEM_CLOCK
   }
 
   /**
@@ -112,7 +119,7 @@ export class TerminalPalette implements TerminalPaletteDetector {
   }
 
   private createQuerySession() {
-    const timers = new Set<NodeJS.Timeout>()
+    const timers = new Set<TimerHandle>()
     const subscriptions = new Set<() => void>()
     let closed = false
 
@@ -121,7 +128,7 @@ export class TerminalPalette implements TerminalPaletteDetector {
       closed = true
 
       for (const timer of timers) {
-        clearTimeout(timer)
+        this.clock.clearTimeout(timer)
       }
       timers.clear()
 
@@ -137,18 +144,18 @@ export class TerminalPalette implements TerminalPaletteDetector {
     this.activeQuerySessions.push(cleanup)
 
     return {
-      setTimer: (fn: () => void, ms: number): NodeJS.Timeout => {
-        const timer = setTimeout(fn, ms)
+      setTimer: (fn: () => void, ms: number): TimerHandle => {
+        const timer = this.clock.setTimeout(fn, ms)
         timers.add(timer)
         return timer
       },
-      resetTimer: (existing: NodeJS.Timeout | null, fn: () => void, ms: number): NodeJS.Timeout => {
+      resetTimer: (existing: TimerHandle | null, fn: () => void, ms: number): TimerHandle => {
         if (existing) {
-          clearTimeout(existing)
+          this.clock.clearTimeout(existing)
           timers.delete(existing)
         }
 
-        const timer = setTimeout(fn, ms)
+        const timer = this.clock.setTimeout(fn, ms)
         timers.add(timer)
         return timer
       },
@@ -211,7 +218,7 @@ export class TerminalPalette implements TerminalPaletteDetector {
     return new Promise<Map<number, Hex>>((resolve) => {
       const session = this.createQuerySession()
       let buffer = ""
-      let idleTimer: NodeJS.Timeout | null = null
+      let idleTimer: TimerHandle | null = null
       let settled = false
 
       const finish = () => {
@@ -269,7 +276,7 @@ export class TerminalPalette implements TerminalPaletteDetector {
     return new Promise<Record<number, Hex>>((resolve) => {
       const session = this.createQuerySession()
       let buffer = ""
-      let idleTimer: NodeJS.Timeout | null = null
+      let idleTimer: TimerHandle | null = null
       let settled = false
 
       const finish = () => {
@@ -370,6 +377,7 @@ export function createTerminalPalette(
   writeFn?: WriteFunction,
   isLegacyTmux?: boolean,
   oscSource?: OscSubscriptionSource,
+  clock?: Clock,
 ): TerminalPaletteDetector {
-  return new TerminalPalette(stdin, stdout, writeFn, isLegacyTmux, oscSource)
+  return new TerminalPalette(stdin, stdout, writeFn, isLegacyTmux, oscSource, clock)
 }

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -108,6 +108,7 @@ export interface CliRendererConfig {
   prependInputHandlers?: ((sequence: string) => boolean)[]
   stdinParserMaxBufferBytes?: number
   stdinParserClock?: Clock
+  paletteClock?: Clock
   onDestroy?: () => void
 }
 
@@ -463,6 +464,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private _paletteDetector: TerminalPaletteDetector | null = null
   private _cachedPalette: TerminalColors | null = null
   private _paletteDetectionPromise: Promise<TerminalColors> | null = null
+  private paletteClock?: Clock
   private _onDestroy?: () => void
   private _themeMode: ThemeMode | null = null
 
@@ -640,6 +642,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this._console = new TerminalConsole(this, config.consoleOptions)
     this.useConsole = config.useConsole ?? true
     this._openConsoleOnError = config.openConsoleOnError ?? process.env.NODE_ENV !== "production"
+    this.paletteClock = config.paletteClock
     this._onDestroy = config.onDestroy
 
     global.requestAnimationFrame = (callback: FrameRequestCallback) => {
@@ -2334,9 +2337,16 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       const isLegacyTmux =
         this.capabilities?.terminal?.name?.toLowerCase()?.includes("tmux") &&
         this.capabilities?.terminal?.version?.localeCompare("3.6") < 0
-      this._paletteDetector = createTerminalPalette(this.stdin, this.stdout, this.writeOut.bind(this), isLegacyTmux, {
-        subscribeOsc: this.subscribeOsc.bind(this),
-      })
+      this._paletteDetector = createTerminalPalette(
+        this.stdin,
+        this.stdout,
+        this.writeOut.bind(this),
+        isLegacyTmux,
+        {
+          subscribeOsc: this.subscribeOsc.bind(this),
+        },
+        this.paletteClock,
+      )
     }
 
     this._paletteDetectionPromise = this._paletteDetector.detect(options).then((result) => {

--- a/packages/core/src/tests/renderer.palette.test.ts
+++ b/packages/core/src/tests/renderer.palette.test.ts
@@ -1,11 +1,28 @@
 import { test, expect, describe } from "bun:test"
-import { createTestRenderer } from "../testing/test-renderer"
+import { createTestRenderer, type TestRendererOptions } from "../testing/test-renderer"
 import { EventEmitter } from "events"
 import { Buffer } from "node:buffer"
 import { Readable } from "node:stream"
 import tty from "tty"
+import { ManualClock } from "../testing/manual-clock"
+import type { GetPaletteOptions, TerminalColors } from "../lib/terminal-palette"
 
-function createMockStreams() {
+const OSC_SUPPORT_TIMEOUT_MS = 300
+
+function flushAsync(): Promise<void> {
+  return Promise.resolve().then(() => Promise.resolve())
+}
+
+function schedule(clock: ManualClock | undefined, fn: () => void): void {
+  if (clock) {
+    clock.setTimeout(fn, 0)
+    return
+  }
+
+  process.nextTick(fn)
+}
+
+function createMockStreams(clock?: ManualClock) {
   const mockStdin = new Readable({ read() {} }) as tty.ReadStream
   mockStdin.isTTY = true
   mockStdin.setRawMode = () => mockStdin
@@ -21,21 +38,27 @@ function createMockStreams() {
     write: (data: string | Buffer) => {
       writes.push(data.toString())
       const dataStr = data.toString()
-      if (dataStr.includes("\x1b]4;0;?")) {
-        process.nextTick(() => {
+      if (dataStr === "\x1b]4;0;?\x07") {
+        schedule(clock, () => {
           mockStdin.emit("data", Buffer.from("\x1b]4;0;rgb:0000/0000/0000\x07"))
         })
       } else if (dataStr.includes("\x1b]4;")) {
-        process.nextTick(() => {
+        schedule(clock, () => {
           for (let i = 0; i < 16; i++) {
             mockStdin.emit("data", Buffer.from(`\x1b]4;${i};rgb:1000/2000/3000\x07`))
           }
         })
       } else if (dataStr.includes("\x1b]10;?")) {
-        process.nextTick(() => {
+        schedule(clock, () => {
           mockStdin.emit("data", Buffer.from("\x1b]10;#ffffff\x07"))
           mockStdin.emit("data", Buffer.from("\x1b]11;#000000\x07"))
           mockStdin.emit("data", Buffer.from("\x1b]12;#00ff00\x07"))
+          mockStdin.emit("data", Buffer.from("\x1b]13;#ffffff\x07"))
+          mockStdin.emit("data", Buffer.from("\x1b]14;#000000\x07"))
+          mockStdin.emit("data", Buffer.from("\x1b]15;#ffffff\x07"))
+          mockStdin.emit("data", Buffer.from("\x1b]16;#000000\x07"))
+          mockStdin.emit("data", Buffer.from("\x1b]17;#333333\x07"))
+          mockStdin.emit("data", Buffer.from("\x1b]19;#cccccc\x07"))
         })
       }
       return true
@@ -45,17 +68,54 @@ function createMockStreams() {
   return { mockStdin, mockStdout, writes }
 }
 
+async function advancePaletteClock(clock: ManualClock, ms: number): Promise<void> {
+  await flushAsync()
+  // Flush queued 0ms mock terminal responses before advancing the real timeout window.
+  clock.advance(0)
+  await flushAsync()
+  clock.advance(ms)
+  await flushAsync()
+}
+
+async function detectPaletteAndAdvanceClock(
+  renderer: {
+    getPalette(options?: GetPaletteOptions): Promise<TerminalColors>
+    paletteDetectionStatus: "idle" | "detecting" | "cached"
+  },
+  clock: ManualClock,
+  options?: GetPaletteOptions,
+): Promise<TerminalColors> {
+  const palettePromise = renderer.getPalette(options)
+
+  if (renderer.paletteDetectionStatus === "detecting") {
+    const detectionTimeoutMs = Math.max(options?.timeout ?? 5000, OSC_SUPPORT_TIMEOUT_MS)
+    await advancePaletteClock(clock, detectionTimeoutMs)
+  } else {
+    await flushAsync()
+  }
+
+  return palettePromise
+}
+
+async function createPaletteRenderer(options: Partial<TestRendererOptions> = {}) {
+  const clock = new ManualClock()
+  const { mockStdin, mockStdout, writes } = createMockStreams(clock)
+  const { renderer } = await createTestRenderer({
+    stdin: mockStdin,
+    stdout: mockStdout,
+    paletteClock: clock,
+    ...options,
+  })
+
+  return { renderer, mockStdin, mockStdout, writes, clock }
+}
+
 describe("Palette caching behavior", () => {
   test("getPalette returns cached palette on subsequent calls", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
-
-    const palette1 = await renderer.getPalette({ timeout: 300 })
-    const palette2 = await renderer.getPalette({ timeout: 300 })
+    const palette1 = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
+    const palette2 = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
 
     expect(palette1).toBe(palette2)
     expect(palette1).toEqual(palette2)
@@ -64,15 +124,10 @@ describe("Palette caching behavior", () => {
   })
 
   test("getPalette caches correctly with non-256 size parameter", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
-
-    const palette1 = await renderer.getPalette({ size: 16, timeout: 300 })
-    const palette2 = await renderer.getPalette({ size: 16, timeout: 300 })
+    const palette1 = await detectPaletteAndAdvanceClock(renderer, clock, { size: 16, timeout: 300 })
+    const palette2 = await detectPaletteAndAdvanceClock(renderer, clock, { size: 16, timeout: 300 })
 
     expect(palette1).toBe(palette2)
     expect(renderer.paletteDetectionStatus).toBe("cached")
@@ -81,39 +136,32 @@ describe("Palette caching behavior", () => {
   })
 
   test("cached palette is returned instantly", async () => {
-    const { mockStdin, mockStdout, writes } = createMockStreams()
+    const { renderer, clock, mockStdin, mockStdout, writes } = await createPaletteRenderer()
 
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
-
-    await renderer.getPalette({ timeout: 300 })
+    await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
     const writeCountAfterFirst = writes.length
 
-    const start = Date.now()
-    await renderer.getPalette({ timeout: 300 })
-    const duration = Date.now() - start
+    const timeAfterFirstDetection = clock.now()
+    await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
 
-    expect(duration).toBeLessThan(50)
+    expect(clock.now()).toBe(timeAfterFirstDetection)
     expect(writes.length).toBe(writeCountAfterFirst)
 
     renderer.destroy()
   })
 
   test("multiple concurrent calls share same detection", async () => {
-    const { mockStdin, mockStdout, writes } = createMockStreams()
+    const { renderer, clock, mockStdin, mockStdout, writes } = await createPaletteRenderer()
 
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
+    const palettePromises = [
+      renderer.getPalette({ timeout: 300 }),
+      renderer.getPalette({ timeout: 300 }),
+      renderer.getPalette({ timeout: 300 }),
+    ]
 
-    const [palette1, palette2, palette3] = await Promise.all([
-      renderer.getPalette({ timeout: 300 }),
-      renderer.getPalette({ timeout: 300 }),
-      renderer.getPalette({ timeout: 300 }),
-    ])
+    await advancePaletteClock(clock, 300)
+
+    const [palette1, palette2, palette3] = await Promise.all(palettePromises)
 
     expect(palette1).toBe(palette2)
     expect(palette2).toBe(palette3)
@@ -125,23 +173,18 @@ describe("Palette caching behavior", () => {
   })
 
   test("palette detector created only once", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
-
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
     // @ts-expect-error - accessing private property for testing
     expect(renderer._paletteDetector).toBeNull()
 
-    await renderer.getPalette({ timeout: 300 })
+    await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
 
     // @ts-expect-error - accessing private property for testing
     const detector1 = renderer._paletteDetector
     expect(detector1).not.toBeNull()
 
-    await renderer.getPalette({ timeout: 300 })
+    await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
 
     // @ts-expect-error - accessing private property for testing
     const detector2 = renderer._paletteDetector
@@ -151,17 +194,12 @@ describe("Palette caching behavior", () => {
   })
 
   test("cache persists with different timeout values", async () => {
-    const { mockStdin, mockStdout, writes } = createMockStreams()
+    const { renderer, clock, mockStdin, mockStdout, writes } = await createPaletteRenderer()
 
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
-
-    const palette1 = await renderer.getPalette({ timeout: 100 })
+    const palette1 = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 100 })
     const writeCountAfterFirst = writes.length
 
-    const palette2 = await renderer.getPalette({ timeout: 5000 })
+    const palette2 = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 5000 })
 
     expect(writes.length).toBe(writeCountAfterFirst)
     expect(palette1).toBe(palette2)
@@ -170,23 +208,18 @@ describe("Palette caching behavior", () => {
   })
 
   test("cache persists across renderer lifecycle", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
-
-    const palette1 = await renderer.getPalette({ timeout: 300 })
+    const palette1 = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
 
     renderer.start()
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await flushAsync()
     renderer.pause()
     renderer.suspend()
     renderer.resume()
     renderer.stop()
 
-    const palette2 = await renderer.getPalette({ timeout: 100 })
+    const palette2 = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 100 })
     expect(palette1).toBe(palette2)
 
     renderer.destroy()
@@ -195,6 +228,7 @@ describe("Palette caching behavior", () => {
 
 describe("Palette detection with non-TTY", () => {
   test("handles non-TTY streams gracefully", async () => {
+    const clock = new ManualClock()
     const mockStdin = new EventEmitter() as any
     mockStdin.isTTY = false
     mockStdin.setRawMode = () => {}
@@ -212,13 +246,14 @@ describe("Palette detection with non-TTY", () => {
     const { renderer } = await createTestRenderer({
       stdin: mockStdin,
       stdout: mockStdout,
+      paletteClock: clock,
     })
 
-    const palette = await renderer.getPalette({ timeout: 100 })
+    const palette = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 100 })
 
     expect(typeof palette === "object" && palette !== null && Array.isArray(palette.palette)).toBe(true)
 
-    const cached = await renderer.getPalette({ timeout: 100 })
+    const cached = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 100 })
     expect(palette).toBe(cached)
 
     renderer.destroy()
@@ -227,6 +262,7 @@ describe("Palette detection with non-TTY", () => {
 
 describe("Palette detection with OSC responses", () => {
   test("detects colors from OSC responses", async () => {
+    const clock = new ManualClock()
     const mockStdin = new EventEmitter() as any
     mockStdin.isTTY = true
     mockStdin.setRawMode = () => {}
@@ -240,7 +276,7 @@ describe("Palette detection with OSC responses", () => {
       rows: 24,
       write: (data: string | Buffer) => {
         const dataStr = data.toString()
-        setImmediate(() => {
+        clock.setTimeout(() => {
           if (dataStr.includes("\x1b]4;0;?")) {
             mockStdin.emit("data", Buffer.from("\x1b]4;0;#000000\x07"))
           }
@@ -253,7 +289,7 @@ describe("Palette detection with OSC responses", () => {
               mockStdin.emit("data", Buffer.from(`\x1b]4;${i};#808080\x07`))
             }
           }
-        })
+        }, 0)
         return true
       },
     } as any
@@ -262,9 +298,10 @@ describe("Palette detection with OSC responses", () => {
       stdin: mockStdin,
       stdout: mockStdout,
       useThread: false,
+      paletteClock: clock,
     })
 
-    const palette = await renderer.getPalette({ timeout: 300 })
+    const palette = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
 
     expect(typeof palette === "object" && palette !== null && Array.isArray(palette.palette)).toBe(true)
     expect(palette.palette.length).toBeGreaterThanOrEqual(16)
@@ -273,13 +310,14 @@ describe("Palette detection with OSC responses", () => {
     expect(palette.palette[2]).toBe("#00ff00")
     expect(palette.palette[3]).toBe("#0000ff")
 
-    const cached = await renderer.getPalette({ timeout: 100 })
+    const cached = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 100 })
     expect(palette).toBe(cached)
 
     renderer.destroy()
   })
 
   test("handles RGB format responses", async () => {
+    const clock = new ManualClock()
     const mockStdin = new EventEmitter() as any
     mockStdin.isTTY = true
     mockStdin.setRawMode = () => {}
@@ -293,7 +331,7 @@ describe("Palette detection with OSC responses", () => {
       rows: 24,
       write: (data: string | Buffer) => {
         const dataStr = data.toString()
-        setImmediate(() => {
+        clock.setTimeout(() => {
           if (dataStr.includes("\x1b]4;0;?")) {
             mockStdin.emit("data", Buffer.from("\x1b]4;0;rgb:0000/0000/0000\x07"))
           }
@@ -305,7 +343,7 @@ describe("Palette detection with OSC responses", () => {
               mockStdin.emit("data", Buffer.from(`\x1b]4;${i};rgb:1111/1111/1111\x07`))
             }
           }
-        })
+        }, 0)
         return true
       },
     } as any
@@ -314,9 +352,10 @@ describe("Palette detection with OSC responses", () => {
       stdin: mockStdin,
       stdout: mockStdout,
       useThread: false,
+      paletteClock: clock,
     })
 
-    const palette = await renderer.getPalette({ timeout: 300 })
+    const palette = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
 
     expect(palette.palette[0]).toBe("#000000")
     expect(palette.palette[1]).toBe("#ff0000")
@@ -328,12 +367,7 @@ describe("Palette detection with OSC responses", () => {
 
 describe("Palette integration tests", () => {
   test("palette detection does not interfere with input handling", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
-
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
     const keysReceived: string[] = []
     renderer.keyInput.on("keypress", (event) => {
@@ -346,10 +380,11 @@ describe("Palette integration tests", () => {
     mockStdin.emit("data", Buffer.from("b"))
     mockStdin.emit("data", Buffer.from("c"))
 
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    await flushAsync()
 
     expect(keysReceived.length).toBeGreaterThanOrEqual(3)
 
+    await advancePaletteClock(clock, 300)
     await palettePromise
 
     renderer.destroy()
@@ -359,18 +394,12 @@ describe("Palette integration tests", () => {
     const configs = [{ width: 40, height: 10 }, { width: 120, height: 40 }, { useMouse: false }]
 
     for (const config of configs) {
-      const { mockStdin, mockStdout } = createMockStreams()
+      const { renderer: testRenderer, clock, mockStdin, mockStdout } = await createPaletteRenderer(config)
 
-      const { renderer: testRenderer } = await createTestRenderer({
-        ...config,
-        stdin: mockStdin,
-        stdout: mockStdout,
-      })
-
-      const palette = await testRenderer.getPalette({ timeout: 300 })
+      const palette = await detectPaletteAndAdvanceClock(testRenderer, clock, { timeout: 300 })
       expect(typeof palette === "object" && palette !== null && Array.isArray(palette.palette)).toBe(true)
 
-      const cached = await testRenderer.getPalette({ timeout: 100 })
+      const cached = await detectPaletteAndAdvanceClock(testRenderer, clock, { timeout: 100 })
       expect(palette).toBe(cached)
 
       testRenderer.destroy()
@@ -380,20 +409,15 @@ describe("Palette integration tests", () => {
 
 describe("Palette cache invalidation", () => {
   test("clearPaletteCache invalidates cache", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
-
-    const palette1 = await renderer.getPalette({ timeout: 300 })
+    const palette1 = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
     expect(renderer.paletteDetectionStatus).toBe("cached")
 
     renderer.clearPaletteCache()
     expect(renderer.paletteDetectionStatus).toBe("idle")
 
-    const palette2 = await renderer.getPalette({ timeout: 300 })
+    const palette2 = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
 
     expect(palette1).not.toBe(palette2)
     expect(renderer.paletteDetectionStatus).toBe("cached")
@@ -402,18 +426,14 @@ describe("Palette cache invalidation", () => {
   })
 
   test("paletteDetectionStatus tracks detection lifecycle", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
-
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
     expect(renderer.paletteDetectionStatus).toBe("idle")
 
     const palettePromise = renderer.getPalette({ timeout: 300 })
     expect(renderer.paletteDetectionStatus).toBe("detecting")
 
+    await advancePaletteClock(clock, 300)
     await palettePromise
     expect(renderer.paletteDetectionStatus).toBe("cached")
 
@@ -423,12 +443,7 @@ describe("Palette cache invalidation", () => {
 
 describe("Palette detection with suspended renderer", () => {
   test("getPalette throws error when renderer is suspended", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
-
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
     renderer.suspend()
 
@@ -440,17 +455,12 @@ describe("Palette detection with suspended renderer", () => {
   })
 
   test("getPalette works after resume", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
-
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
     renderer.suspend()
     renderer.resume()
 
-    const palette = await renderer.getPalette({ timeout: 300 })
+    const palette = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
     expect(typeof palette === "object" && palette !== null && Array.isArray(palette.palette)).toBe(true)
 
     renderer.destroy()
@@ -459,14 +469,9 @@ describe("Palette detection with suspended renderer", () => {
 
 describe("Palette detector cleanup", () => {
   test("destroy cleans up palette detector", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
-
-    await renderer.getPalette({ timeout: 300 })
+    await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
 
     renderer.destroy()
 
@@ -479,14 +484,9 @@ describe("Palette detector cleanup", () => {
   })
 
   test("multiple destroy calls don't cause errors", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
-
-    await renderer.getPalette({ timeout: 300 })
+    await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 300 })
 
     expect(() => {
       renderer.destroy()
@@ -496,12 +496,7 @@ describe("Palette detector cleanup", () => {
   })
 
   test("palette detection uses router OSC source without extra stdin listeners", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
-
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
     const baselineListenerCount = mockStdin.listenerCount("data")
     const palettePromise = renderer.getPalette({ timeout: 300 })
@@ -509,6 +504,7 @@ describe("Palette detector cleanup", () => {
     const duringDetectionCount = mockStdin.listenerCount("data")
     expect(duringDetectionCount).toBe(baselineListenerCount)
 
+    await advancePaletteClock(clock, 300)
     await palettePromise
 
     const afterDetectionCount = mockStdin.listenerCount("data")
@@ -520,6 +516,7 @@ describe("Palette detector cleanup", () => {
 
 describe("Palette detection error handling", () => {
   test("handles timeout gracefully", async () => {
+    const clock = new ManualClock()
     const mockStdin = new EventEmitter() as any
     mockStdin.isTTY = true
     mockStdin.setRawMode = () => {}
@@ -537,9 +534,10 @@ describe("Palette detection error handling", () => {
     const { renderer } = await createTestRenderer({
       stdin: mockStdin,
       stdout: mockStdout,
+      paletteClock: clock,
     })
 
-    const palette = await renderer.getPalette({ timeout: 100 })
+    const palette = await detectPaletteAndAdvanceClock(renderer, clock, { timeout: 100 })
     expect(typeof palette === "object" && palette !== null && Array.isArray(palette.palette)).toBe(true)
     expect(palette.palette.every((c) => c === null)).toBe(true)
 
@@ -547,15 +545,11 @@ describe("Palette detection error handling", () => {
   })
 
   test("handles stdin listener restoration on error", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
-
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
     try {
       const palettePromise = renderer.getPalette({ timeout: 300 })
+      await advancePaletteClock(clock, 300)
       await palettePromise
     } catch (error) {}
 
@@ -568,24 +562,18 @@ describe("Palette detection error handling", () => {
 
 describe("Palette cache with different sizes", () => {
   test("cache works correctly when requesting size=16 twice", async () => {
-    const { mockStdin, mockStdout, writes } = createMockStreams()
+    const { renderer, clock, mockStdin, mockStdout, writes } = await createPaletteRenderer()
 
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
-
-    const palette1 = await renderer.getPalette({ size: 16, timeout: 300 })
+    const palette1 = await detectPaletteAndAdvanceClock(renderer, clock, { size: 16, timeout: 300 })
     const writeCountAfterFirst = writes.length
 
     expect(renderer.paletteDetectionStatus).toBe("cached")
     expect(palette1.palette.length).toBe(16)
 
-    const start = Date.now()
-    const palette2 = await renderer.getPalette({ size: 16, timeout: 300 })
-    const elapsed = Date.now() - start
+    const timeAfterFirstDetection = clock.now()
+    const palette2 = await detectPaletteAndAdvanceClock(renderer, clock, { size: 16, timeout: 300 })
 
-    expect(elapsed).toBeLessThan(50)
+    expect(clock.now()).toBe(timeAfterFirstDetection)
     expect(writes.length).toBe(writeCountAfterFirst)
     expect(palette1).toBe(palette2)
     expect(renderer.paletteDetectionStatus).toBe("cached")
@@ -594,18 +582,12 @@ describe("Palette cache with different sizes", () => {
   })
 
   test("cache is invalidated when requesting different size", async () => {
-    const { mockStdin, mockStdout, writes } = createMockStreams()
+    const { renderer, clock, mockStdin, mockStdout, writes } = await createPaletteRenderer({ useThread: false })
 
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-      useThread: false,
-    })
-
-    const palette1 = await renderer.getPalette({ size: 16, timeout: 300 })
+    const palette1 = await detectPaletteAndAdvanceClock(renderer, clock, { size: 16, timeout: 300 })
     const writeCountAfter16 = writes.length
 
-    const palette2 = await renderer.getPalette({ size: 256, timeout: 300 })
+    const palette2 = await detectPaletteAndAdvanceClock(renderer, clock, { size: 256, timeout: 300 })
     const writeCountAfter256 = writes.length
 
     expect(writeCountAfter256).toBeGreaterThan(writeCountAfter16)
@@ -615,19 +597,14 @@ describe("Palette cache with different sizes", () => {
   })
 
   test("cache persists across multiple identical size requests", async () => {
-    const { mockStdin, mockStdout, writes } = createMockStreams()
+    const { renderer, clock, mockStdin, mockStdout, writes } = await createPaletteRenderer()
 
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
-
-    const palette1 = await renderer.getPalette({ size: 16, timeout: 300 })
+    const palette1 = await detectPaletteAndAdvanceClock(renderer, clock, { size: 16, timeout: 300 })
     const writeCountAfterFirst = writes.length
 
-    const palette2 = await renderer.getPalette({ size: 16, timeout: 300 })
-    const palette3 = await renderer.getPalette({ size: 16, timeout: 300 })
-    const palette4 = await renderer.getPalette({ size: 16, timeout: 300 })
+    const palette2 = await detectPaletteAndAdvanceClock(renderer, clock, { size: 16, timeout: 300 })
+    const palette3 = await detectPaletteAndAdvanceClock(renderer, clock, { size: 16, timeout: 300 })
+    const palette4 = await detectPaletteAndAdvanceClock(renderer, clock, { size: 16, timeout: 300 })
 
     expect(writes.length).toBe(writeCountAfterFirst)
     expect(palette1).toBe(palette2)
@@ -638,23 +615,14 @@ describe("Palette cache with different sizes", () => {
   })
 
   test("cached call is significantly faster than initial detection", async () => {
-    const { mockStdin, mockStdout } = createMockStreams()
+    const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 
-    const { renderer } = await createTestRenderer({
-      stdin: mockStdin,
-      stdout: mockStdout,
-    })
+    await detectPaletteAndAdvanceClock(renderer, clock, { size: 16, timeout: 300 })
+    const timeAfterFirstDetection = clock.now()
 
-    const start1 = performance.now()
-    await renderer.getPalette({ size: 16, timeout: 300 })
-    const elapsed1 = performance.now() - start1
+    await detectPaletteAndAdvanceClock(renderer, clock, { size: 16, timeout: 300 })
 
-    const start2 = performance.now()
-    await renderer.getPalette({ size: 16, timeout: 300 })
-    const elapsed2 = performance.now() - start2
-
-    expect(elapsed2).toBeLessThan(10)
-    expect(elapsed2).toBeLessThan(elapsed1 / 10)
+    expect(clock.now()).toBe(timeAfterFirstDetection)
 
     renderer.destroy()
   })


### PR DESCRIPTION
Add clock into palette detection so getPalette tests. This removes wall-clock waits and makes the suite deterministic.

```
time bun test src/lib/terminal-palette.test.ts src/tests/renderer.palette.test.ts 2>/dev/null
bun test v1.3.10 (30e609e0)

real	0m0.574s
user	0m0.652s
sys	0m0.062s
```

instead of

```
time bun test src/lib/terminal-palette.test.ts src/tests/renderer.palette.test.ts 2>/dev/null
bun test v1.3.10 (30e609e0)

real	0m47.758s
user	0m1.476s
sys	0m0.421s
```