### PR TITLE
fix: disable mouse tracking before restoring cooked mode in finalizeDestroy

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1930,7 +1930,14 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       console.error("Error destroying root renderable:", e instanceof Error ? e.stack : String(e))
     }
 
-    // Remove listener before destroying parser
+    // Disable mouse tracking while still in raw mode so the terminal stops
+    // generating SGR mouse events before we restore cooked mode. Without this,
+    // any mouse movement between setRawMode(false) and destroyRenderer() leaks
+    // partial escape sequences (e.g. "35;80;40M") onto the user's shell prompt.
+    if (this._useMouse) {
+      this.disableMouse()
+    }
+
     this.stdin.removeListener("data", this.stdinListener)
     if (this.stdin.setRawMode) {
       this.stdin.setRawMode(false)


### PR DESCRIPTION
## Summary

- Fixes leaked SGR mouse escape sequences (e.g. `35;80;40M`) appearing on the shell prompt after renderer destroy

## Problem

When `finalizeDestroy()` tears down the renderer, it calls `setRawMode(false)` before mouse tracking has been disabled. In the window between restoring cooked mode and `destroyRenderer()` sending the mouse disable sequences, any mouse movement generates SGR escape events (`\x1b[<35;80;40M`) from the terminal. Since raw mode is off and the stdin listener has been removed, the terminal echoes these as visible garbage on the user's prompt.

This is easily reproduced in OpenCode: `/exit` while moving the mouse, and partial escape sequence bytes print after the shell prompt.

https://github.com/user-attachments/assets/8d481504-727e-4519-ad11-683f8f96c765

## Fix

Call `disableMouse()` **before** `setRawMode(false)` in `finalizeDestroy()`, matching the ordering already used in `suspend()` (which does not have this bug).

The corrected sequence:
1. `disableMouse()` — sends `\x1b[?1000l`, `\x1b[?1002l`, `\x1b[?1006l` while still in raw mode
2. Remove stdin listener
3. `setRawMode(false)` — restore cooked mode only after mouse tracking is off
4. `destroyRenderer()` — clean up native resources