### PR TITLE
fix(core): fix _hasManualScroll lifecycle for correct sticky scroll re-engagement

### DIFF
--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -752,7 +752,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
 
         if (this._stickyStart && !this._hasManualScroll) {
           this.applyStickyStart(this._stickyStart)
-        } else {
+        } else if (!this._hasManualScroll) {
           if (this._stickyScrollTop) {
             this.scrollTop = 0
           } else if (this._stickyScrollBottom && newMaxScrollTop > 0) {

--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -564,12 +564,6 @@ export class ScrollBoxRenderable extends BoxRenderable {
         }
       }
 
-      // Only mark as manual scroll if there's meaningful scrollable content
-      const maxScrollTop = Math.max(0, this.scrollHeight - this.viewport.height)
-      const maxScrollLeft = Math.max(0, this.scrollWidth - this.viewport.width)
-      if (maxScrollTop > 1 || maxScrollLeft > 1) {
-        this._hasManualScroll = true
-      }
     }
 
     if (event.type === "drag" && event.isDragging) {
@@ -582,13 +576,11 @@ export class ScrollBoxRenderable extends BoxRenderable {
   public handleKeyPress(key: KeyEvent): boolean {
     // Let scrollbars handle their own acceleration
     if (this.verticalScrollBar.handleKeyPress(key)) {
-      this._hasManualScroll = true
       this.scrollAccel.reset()
       this.resetScrollAccumulators()
       return true
     }
     if (this.horizontalScrollBar.handleKeyPress(key)) {
-      this._hasManualScroll = true
       this.scrollAccel.reset()
       this.resetScrollAccumulators()
       return true


### PR DESCRIPTION
## Summary

Two fixes to make `_hasManualScroll` behave correctly in `ScrollBoxRenderable`:

1. **Guard the `else` branch in `recalculateBarProps()`** with `!this._hasManualScroll`, making it consistent with the `stickyStart` branch which already has this guard.

2. **Remove redundant `_hasManualScroll = true` sets** in `onMouseEvent` and `handleKeyPress` that unconditionally override the correct state already managed by the `scrollTop`/`scrollLeft` setters and `updateStickyState()`.

## Context

This is a follow-up to the work done in #531 and #722, which addressed two earlier aspects of the same underlying problem:

- **#530 / #531** — `_hasManualScroll` was never reset, permanently breaking sticky scroll after user interaction. Fixed by clearing the flag in `updateStickyState()` when the user scrolls back to the sticky edge.
- **#709 / #722** — Content size changes during streaming accidentally cleared `_hasManualScroll` through `updateStickyState()` during recalculation. Fixed by adding the `_isApplyingStickyScroll` re-entrancy guard.

PR #722 solved the **flag corruption** (the flag is no longer accidentally cleared), but two problems remained:

### Problem 1: Missing guard in `recalculateBarProps()`

The `else` branch force-scrolls via `_stickyScrollBottom` / `_stickyScrollTop` without checking `_hasManualScroll`:

```typescript
// Branch 1: correctly guarded ✅
if (this._stickyStart && !this._hasManualScroll) {
    this.applyStickyStart(this._stickyStart)
// Branch 2: missing guard ❌
} else {
    if (this._stickyScrollBottom && newMaxScrollTop > 0) {
        this.scrollTop = newMaxScrollTop  // force-scrolls even if user scrolled up
    }
}
```

**Fix:** Change `} else {` to `} else if (!this._hasManualScroll) {`.

### Problem 2: Redundant `_hasManualScroll = true` in input handlers

Both `onMouseEvent` (line 571) and `handleKeyPress` (lines 585, 591) unconditionally set `_hasManualScroll = true` after scroll events. This runs **after** `updateStickyState()` has already correctly cleared the flag (when the user is at the sticky edge), permanently re-setting it to `true`:

```
1. onMouseEvent → this.scrollTop += delta
2.   scrollTop setter → updateStickyState() → "at bottom" → _hasManualScroll = false ✅
3. Back in onMouseEvent:
     this._hasManualScroll = true  // ← overrides the correct state! ❌
```

This means scrolling to the bottom never re-engages auto-scroll, because `_hasManualScroll` is stuck on `true`.

**Fix:** Remove the redundant sets. The `scrollTop`/`scrollLeft` setters already handle `_hasManualScroll` correctly with `isAtStickyPosition()` checks, and the scrollbar `onChange` callbacks do the same. The removed code only ran in two cases:
- After actual scroll movement → already handled by the setter
- After sub-pixel accumulation (no actual movement) → shouldn't mark as manual scroll anyway

## Why this matters for consumers with `stickyStart` set

Any consumer using `stickyStart="bottom"` (e.g., OpenCode's session view) is affected:

- **Normal auto-scroll (user hasn't scrolled up):** `_stickyStart` is truthy, `_hasManualScroll` is `false` → `true && true` → **branch 1 runs** → `applyStickyStart("bottom")` → correctly auto-scrolls. Branch 2 is never reached.

- **User scrolls up during streaming:** `_stickyStart` is still truthy, but `_hasManualScroll` is now `true` → `true && false` → **branch 1 fails** → falls to branch 2. Without the guard, branch 2 force-scrolls back to bottom.

So for any consumer with `stickyStart` set, the **only way to reach branch 2 is when `_hasManualScroll` is `true`** — exactly the case where force-scrolling should be blocked.

## How it works end-to-end

- **User scrolls up during streaming**: `_hasManualScroll = true` → guard blocks force-scrolling → viewport stays put
- **User scrolls back to bottom**: `scrollTop` setter sees `isAtStickyPosition() === true` → doesn't set `_hasManualScroll`; `updateStickyState()` clears it → `_hasManualScroll = false` → auto-scroll resumes on next content resize
- **On submit / session change**: `scrollTo` resets position → `_hasManualScroll` clears → sticky scroll re-engages

## Test plan

- [ ] Verify auto-scroll to bottom works normally when not manually scrolling
- [ ] Scroll up during streaming content growth → viewport should stay at user's position
- [ ] Scroll back to bottom → auto-scroll should re-engage
- [ ] Test with `stickyStart="bottom"` and without `stickyStart` set
- [ ] Verify horizontal sticky scroll behaves consistently
- [ ] Keyboard scrolling (arrow keys / page up/down) follows same behavior