### PR TITLE
feat: add Cmd+Backspace keybinding to delete to line start

### DIFF
--- a/packages/core/src/renderables/Textarea.ts
+++ b/packages/core/src/renderables/Textarea.ts
@@ -118,6 +118,7 @@ const defaultTextareaKeybindings: KeyBinding[] = [
   { name: "right", super: true, action: "visual-line-end" },
   { name: "up", super: true, action: "buffer-home" },
   { name: "down", super: true, action: "buffer-end" },
+  { name: "backspace", super: true, action: "delete-to-line-start" },
   { name: "left", super: true, shift: true, action: "select-visual-line-home" },
   { name: "right", super: true, shift: true, action: "select-visual-line-end" },
   { name: "up", super: true, shift: true, action: "select-buffer-home" },


### PR DESCRIPTION
Cmd+Backspace deletes to line start. standard macOS behavior that's missing from the default Textarea bindings. Matches the existing super+arrow keybindings that already handle line-level navigation.