### PR TITLE
fix(core): convert tree-sitter byte offsets to char indices for multi-byte text

### DIFF
--- a/packages/core/src/lib/tree-sitter-styled-text.ts
+++ b/packages/core/src/lib/tree-sitter-styled-text.ts
@@ -35,6 +35,30 @@ function shouldSuppressInInjection(group: string, meta: any): boolean {
   return group === "markup.raw.block"
 }
 
+/**
+ * Build a mapping from UTF-8 byte offsets to JavaScript string (UTF-16 code unit) indices.
+ * Tree-sitter returns byte offsets, but String.slice() needs character indices.
+ */
+function buildByteToCharMap(content: string): (byteOffset: number) => number {
+  const map = new Map<number, number>()
+  let charIdx = 0
+  let byteIdx = 0
+  for (charIdx = 0; charIdx < content.length; charIdx++) {
+    map.set(byteIdx, charIdx)
+    const code = content.codePointAt(charIdx)!
+    // Advance byte index by the UTF-8 byte length of this code point
+    if (code <= 0x7f) byteIdx += 1
+    else if (code <= 0x7ff) byteIdx += 2
+    else if (code <= 0xffff) byteIdx += 3
+    else {
+      byteIdx += 4
+      charIdx++ // Skip the second half of the surrogate pair
+    }
+  }
+  map.set(byteIdx, charIdx) // End-of-string
+  return (offset: number) => map.get(offset) ?? charIdx
+}
+
 export function treeSitterToTextChunks(
   content: string,
   highlights: SimpleHighlight[],
@@ -45,11 +69,16 @@ export function treeSitterToTextChunks(
   const defaultStyle = syntaxStyle.getStyle("default")
   const concealEnabled = options?.enabled ?? true
 
+  // Convert byte offsets from tree-sitter to JS string character indices
+  const byteToChar = buildByteToCharMap(content)
+
   const injectionContainerRanges: Array<{ start: number; end: number }> = []
   const boundaries: Boundary[] = []
 
   for (let i = 0; i < highlights.length; i++) {
-    const [start, end, , meta] = highlights[i]
+    const [startByte, endByte, , meta] = highlights[i]
+    const start = byteToChar(startByte)
+    const end = byteToChar(endByte)
     if (start === end) continue // Skip zero-length ranges
     if (meta?.containsInjection) {
       injectionContainerRanges.push({ start, end })


### PR DESCRIPTION
## Summary

- Fix text styling broken after emoji/CJK/multi-byte characters in `treeSitterToTextChunks()`
- Add `buildByteToCharMap()` to convert UTF-8 byte offsets from tree-sitter to JavaScript string indices

## Problem

Tree-sitter returns highlight ranges as UTF-8 byte offsets. `treeSitterToTextChunks()` uses these directly with `String.slice()`, which expects UTF-16 character indices. For ASCII text the two are identical, but emoji (e.g. ✅ = 3 bytes, 1 JS char) shifts all subsequent boundaries, leaving text after the first multi-byte character unstyled.

This causes white/invisible text on light terminal backgrounds (e.g. solarized light in tmux + Ghostty), since unstyled text inherits the terminal's default foreground.

## Fix

Convert byte offsets to character indices before use:

```typescript
const byteToChar = buildByteToCharMap(content)
const [startByte, endByte, , meta] = highlights[i]
const start = byteToChar(startByte)
const end = byteToChar(endByte)
```

## Note

`parser.worker.ts` has the same class of bug in `getNodeText()` (line 350) and injection offset arithmetic (lines 462-463), but those are separate code paths affecting injection highlighting. This PR focuses on the text styling fix.

## Related

- #336 (weird artifacts due to emojis)
- #609 (lineStarts byte offset mismatch with multi-byte text)

## Test plan

Verified locally by patching the bundled `@opentui/core` in an OpenCode build and testing with emoji-containing markdown (solarized light, tmux + Ghostty):

- [x] Render markdown containing emoji (e.g. `✅ Pre-Requisites`) — text after emoji retains syntax highlighting
- [x] ASCII-only text is unaffected
- [ ] CJK text highlighting (not tested locally)