### PR TITLE
clock: use performance.now as time source

### DIFF
--- a/packages/core/src/lib/clock.ts
+++ b/packages/core/src/lib/clock.ts
@@ -10,7 +10,11 @@ export interface Clock {
 
 export class SystemClock implements Clock {
   public now(): number {
-    return Date.now()
+    if (!globalThis.performance || typeof globalThis.performance.now !== "function") {
+      throw new Error("SystemClock requires globalThis.performance.now()")
+    }
+
+    return globalThis.performance.now()
   }
 
   public setTimeout(fn: () => void, delayMs: number): TimerHandle {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -722,6 +722,22 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     return this._currentFocusedRenderable
   }
 
+  private normalizeClockTime(now: number, fallback: number): number {
+    if (Number.isFinite(now)) {
+      return now
+    }
+
+    return Number.isFinite(fallback) ? fallback : 0
+  }
+
+  private getElapsedMs(now: number, then: number): number {
+    if (!Number.isFinite(now) || !Number.isFinite(then)) {
+      return 0
+    }
+
+    return Math.max(now - then, 0)
+  }
+
   public focusRenderable(renderable: Renderable) {
     if (this._currentFocusedRenderable === renderable) return
 
@@ -793,8 +809,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     if (!this.updateScheduled && !this.renderTimeout) {
       this.updateScheduled = true
-      const now = this.clock.now()
-      const elapsed = now - this.lastTime
+      const now = this.normalizeClockTime(this.clock.now(), this.lastTime)
+      const elapsed = this.getElapsedMs(now, this.lastTime)
       const delay = Math.max(this.minTargetFrameTime - elapsed, 0)
 
       if (delay === 0) {
@@ -2008,7 +2024,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private startRenderLoop(): void {
     if (!this._isRunning) return
 
-    this.lastTime = this.clock.now()
+    this.lastTime = this.normalizeClockTime(this.clock.now(), 0)
     this.frameCount = 0
     this.lastFpsTime = this.lastTime
     this.currentFps = 0
@@ -2026,14 +2042,14 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.renderTimeout = null
     }
     try {
-      const now = this.clock.now()
-      const elapsed = now - this.lastTime
+      const now = this.normalizeClockTime(this.clock.now(), this.lastTime)
+      const elapsed = this.getElapsedMs(now, this.lastTime)
 
       const deltaTime = elapsed
       this.lastTime = now
 
       this.frameCount++
-      if (now - this.lastFpsTime >= 1000) {
+      if (this.getElapsedMs(now, this.lastFpsTime) >= 1000) {
         this.currentFps = this.frameCount
         this.frameCount = 0
         this.lastFpsTime = now

--- a/packages/core/src/testing/manual-clock.ts
+++ b/packages/core/src/testing/manual-clock.ts
@@ -27,6 +27,17 @@ export class ManualClock implements Clock {
     return this.time
   }
 
+  public setTime(time: number): void {
+    const targetTime = Math.floor(time)
+
+    if (targetTime >= this.time) {
+      this.advance(targetTime - this.time)
+      return
+    }
+
+    this.time = targetTime
+  }
+
   public setTimeout(fn: () => void, delayMs: number): TimerHandle {
     return this.schedule(fn, delayMs, false)
   }

--- a/packages/core/src/tests/renderer.clock.test.ts
+++ b/packages/core/src/tests/renderer.clock.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { SystemClock } from "../lib/clock.js"
+import { createTestRenderer, type TestRenderer } from "../testing/test-renderer.js"
+import { ManualClock } from "../testing/manual-clock.js"
+
+let clock: ManualClock
+let renderer: TestRenderer
+let renderOnce: () => Promise<void>
+
+beforeEach(async () => {
+  clock = new ManualClock()
+  ;({ renderer, renderOnce } = await createTestRenderer({ clock, maxFps: 60 }))
+})
+
+afterEach(() => {
+  renderer.destroy()
+})
+
+test("requestRender() does not stall after a backward clock jump", async () => {
+  clock.setTime(10_000)
+  // @ts-expect-error - inspect private renderer timing state in regression test
+  renderer.lastTime = 10_000
+  clock.setTime(8_000)
+
+  let renderCalled = false
+  // @ts-expect-error - intercept private render method in regression test
+  renderer.renderNative = () => {
+    renderCalled = true
+  }
+
+  renderer.requestRender()
+  clock.advance(20)
+  await Promise.resolve()
+
+  expect(renderCalled).toBe(true)
+})
+
+test("requestRender() uses SystemClock by default when no clock is injected", async () => {
+  const originalNow = globalThis.performance.now
+  let nowValue = 10_000
+  let defaultRenderer: TestRenderer | null = null
+
+  globalThis.performance.now = () => nowValue
+
+  try {
+    ;({ renderer: defaultRenderer } = await createTestRenderer({ maxFps: 60 }))
+
+    // @ts-expect-error - inspect private renderer clock in regression test
+    expect(defaultRenderer.clock).toBeInstanceOf(SystemClock)
+
+    // @ts-expect-error - inspect private renderer timing state in regression test
+    defaultRenderer.lastTime = 10_000
+    nowValue = 8_000
+
+    let renderCalled = false
+    // @ts-expect-error - intercept private render method in regression test
+    defaultRenderer.renderNative = () => {
+      renderCalled = true
+    }
+
+    defaultRenderer.requestRender()
+    await Bun.sleep(20)
+
+    expect(renderCalled).toBe(true)
+  } finally {
+    defaultRenderer?.destroy()
+    globalThis.performance.now = originalNow
+  }
+})
+
+test("loop() clamps negative deltaTime after a backward clock jump", async () => {
+  const deltas: number[] = []
+
+  renderer.setFrameCallback(async (deltaTime) => {
+    deltas.push(deltaTime)
+  })
+
+  clock.setTime(10_000)
+  // @ts-expect-error - inspect private renderer timing state in regression test
+  renderer.lastTime = 10_000
+  // @ts-expect-error - inspect private renderer timing state in regression test
+  renderer.lastFpsTime = 10_000
+  clock.setTime(8_000)
+
+  await renderOnce()
+
+  expect(deltas).toEqual([0])
+})


### PR DESCRIPTION
Date.now() can jump backward on VM/WSL sync, which stalls
the render loop or produces negative frame deltas. Use
performance.now() for monotonic time and clamp elapsed values
in the renderer so backward jumps degrade to a zero-delta
frame instead of a stall.

Fix #775
