### PR TITLE
fix(core): prefer motion over wheel bits in mouse parsing

### DIFF
--- a/packages/core/src/lib/parse.mouse.test.ts
+++ b/packages/core/src/lib/parse.mouse.test.ts
@@ -158,9 +158,9 @@ describe("MouseParser basic (X10) mode", () => {
       expect(e.modifiers).toEqual({ shift: true, alt: true, ctrl: true })
     })
 
-    test("scroll bit takes priority over motion bit: byte 96 (64|32) → 'scroll'", () => {
+    test("motion bit takes priority over scroll bit: byte 96 (64|32) → 'move'", () => {
       const e = parser.parseMouseEvent(encodeBasic(96, 10, 5))!
-      expect(e.type).toBe("scroll")
+      expect(e.type).toBe("move")
     })
 
     test("release without motion bit is still 'up'", () => {
@@ -290,24 +290,24 @@ describe("MouseParser SGR mode", () => {
       expect(e).toMatchObject({ type: "scroll", scroll: { direction: "right", delta: 1 } })
     })
 
-    test("scroll+motion code 96 (64|32) is treated as scroll up", () => {
-      // Seen in URxvt capture: ESC[<96;...M while moving during wheel scroll.
+    test("scroll+motion code 96 (64|32) is treated as move", () => {
+      // Seen in URxvt: motion can arrive with both bits set while scrolling.
       const e = parser.parseMouseEvent(encodeSGR(96, 80, 66, true))!
       expect(e).toMatchObject({
-        type: "scroll",
+        type: "move",
         x: 80,
         y: 66,
-        scroll: { direction: "up", delta: 1 },
+        scroll: undefined,
       })
     })
 
-    test("scroll+motion code 97 (65|32) is treated as scroll down", () => {
+    test("scroll+motion code 97 (65|32) is treated as move", () => {
       const e = parser.parseMouseEvent(encodeSGR(97, 80, 66, true))!
       expect(e).toMatchObject({
-        type: "scroll",
+        type: "move",
         x: 80,
         y: 66,
-        scroll: { direction: "down", delta: 1 },
+        scroll: undefined,
       })
     })
 
@@ -486,13 +486,13 @@ describe("MouseParser parseAllMouseEvents (multi-event chunks)", () => {
     expect(events[2]).toMatchObject({ type: "scroll", scroll: { direction: "down" } })
   })
 
-  test("chunk with scroll+motion codes (96/97) keeps scroll semantics", () => {
+  test("chunk with scroll+motion codes (96/97) keeps motion semantics", () => {
     const buf = Buffer.concat([encodeSGR(64, 82, 67, true), encodeSGR(96, 81, 67, true), encodeSGR(97, 80, 67, true)])
     const events = parser.parseAllMouseEvents(buf)
     expect(events).toHaveLength(3)
     expect(events[0]).toMatchObject({ type: "scroll", scroll: { direction: "up" } })
-    expect(events[1]).toMatchObject({ type: "scroll", scroll: { direction: "up" }, x: 81, y: 67 })
-    expect(events[2]).toMatchObject({ type: "scroll", scroll: { direction: "down" }, x: 80, y: 67 })
+    expect(events[1]).toMatchObject({ type: "move", x: 81, y: 67, scroll: undefined })
+    expect(events[2]).toMatchObject({ type: "move", x: 80, y: 67, scroll: undefined })
   })
 
   test("returns empty array for non-mouse data", () => {

--- a/packages/core/src/lib/parse.mouse.ts
+++ b/packages/core/src/lib/parse.mouse.ts
@@ -153,13 +153,7 @@ export class MouseParser {
     let type: MouseEventType
     let scrollInfo: ScrollInfo | undefined
 
-    if (isScroll && pressRelease === "M") {
-      type = "scroll"
-      scrollInfo = {
-        direction: scrollDirection!,
-        delta: 1,
-      }
-    } else if (isMotion) {
+    if (isMotion) {
       const isDragging = this.mouseButtonsPressed.size > 0
 
       if (button === 3) {
@@ -168,6 +162,12 @@ export class MouseParser {
         type = "drag"
       } else {
         type = "move"
+      }
+    } else if (isScroll && pressRelease === "M") {
+      type = "scroll"
+      scrollInfo = {
+        direction: scrollDirection!,
+        delta: 1,
       }
     } else {
       type = pressRelease === "M" ? "down" : "up"
@@ -205,16 +205,16 @@ export class MouseParser {
     let actualButton: number
     let scrollInfo: ScrollInfo | undefined
 
-    if (isScroll) {
+    if (isMotion) {
+      type = "move"
+      actualButton = button === 3 ? -1 : button
+    } else if (isScroll) {
       type = "scroll"
       actualButton = 0
       scrollInfo = {
         direction: scrollDirection!,
         delta: 1,
       }
-    } else if (isMotion) {
-      type = "move"
-      actualButton = button === 3 ? -1 : button
     } else {
       type = button === 3 ? "up" : "down"
       actualButton = button === 3 ? 0 : button


### PR DESCRIPTION
urxvt can apparently send mouse packets with both the motion and wheel bits set
while the pointer moves during a scroll. We treated those packets as scroll
events, which turned small mouse movements into extra wheel input and made the
screen jump.

I checked https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Mouse-Tracking and it doesn't specifically say what to do here, but from the script session the user shared this sseems like a good solution, because you get a scroll event, then these combined events, etc.

Fixes #661
