### PR TITLE
fix(core): Markdown and selection rendering improvements

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -456,9 +456,12 @@ export class MarkdownRenderable extends Renderable {
   }
 
   private applyMarkdownCodeRenderable(renderable: CodeRenderable, content: string, marginBottom: number): void {
+    const defaultStyle = this.getStyle("markup.raw") || this.getStyle("default")
     renderable.content = content
     renderable.filetype = "markdown"
     renderable.syntaxStyle = this._syntaxStyle
+    renderable.fg = defaultStyle?.fg
+    renderable.bg = defaultStyle?.bg
     renderable.conceal = this._conceal
     renderable.drawUnstyledText = false
     renderable.streaming = true
@@ -466,9 +469,12 @@ export class MarkdownRenderable extends Renderable {
   }
 
   private applyCodeBlockRenderable(renderable: CodeRenderable, token: Tokens.Code, marginBottom: number): void {
+    const defaultStyle = this.getStyle("markup.raw.block") || this.getStyle("default")
     renderable.content = token.text
     renderable.filetype = token.lang || undefined
     renderable.syntaxStyle = this._syntaxStyle
+    renderable.fg = defaultStyle?.fg
+    renderable.bg = defaultStyle?.bg
     renderable.conceal = this._concealCode
     renderable.drawUnstyledText = !(this._streaming && this._concealCode)
     renderable.streaming = this._streaming

--- a/packages/core/src/zig/buffer.zig
+++ b/packages/core/src/zig/buffer.zig
@@ -1424,9 +1424,8 @@ pub const OptimizedBuffer = struct {
                                         finalFg = selFg;
                                     }
                                 } else {
-                                    const temp = lineFg;
-                                    finalFg = if (lineBg[3] > 0) lineBg else RGBA{ 0.0, 0.0, 0.0, 1.0 };
-                                    finalBg = temp;
+                                    finalFg = lineBg;
+                                    finalBg = lineFg;
                                 }
                                 break;
                             }


### PR DESCRIPTION
Fixes [opencode#16470](https://github.com/anomalyco/opencode/issues/16470 )

This PR improves markdown code blocks readability in light mode. 

The fist change in Markdown.ts forwards the style fg & bg color to the markdown renderables to make the text visible in normal rendering. Before (top) and after (bottom):

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/9399c59e-539a-486f-ace7-3d401103edb8" />

The second change in buffer.zig improves the rendering on selection. This change not only impacts markdown but the whole UI. When the regular background is transparent, the font defaults to black on selection, which is barely readable in many cases.

Selection Before:
<img width="640" height="317" alt="select-before" src="https://github.com/user-attachments/assets/825cb2c8-1801-40ea-af38-120715fc6889" />

Selection After:
<img width="651" height="287" alt="select-after" src="https://github.com/user-attachments/assets/fd0b823e-69b0-4879-908c-b25fb4667a63" />
