### PR TITLE
fix(core): pass theme default fg/bg to code block renderables

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -425,6 +425,7 @@ export class MarkdownRenderable extends Renderable {
   }
 
   private createMarkdownCodeRenderable(content: string, id: string, marginBottom: number = 0): CodeRenderable {
+    const defaultStyle = this.getStyle("default")
     return new CodeRenderable(this.ctx, {
       id,
       content,
@@ -435,12 +436,15 @@ export class MarkdownRenderable extends Renderable {
       streaming: true,
       onChunks: this._linkifyMarkdownChunks,
       treeSitterClient: this._treeSitterClient,
+      fg: defaultStyle?.fg,
+      bg: defaultStyle?.bg,
       width: "100%",
       marginBottom,
     })
   }
 
   private createCodeRenderable(token: Tokens.Code, id: string, marginBottom: number = 0): Renderable {
+    const defaultStyle = this.getStyle("default")
     return new CodeRenderable(this.ctx, {
       id,
       content: token.text,
@@ -450,28 +454,36 @@ export class MarkdownRenderable extends Renderable {
       drawUnstyledText: !(this._streaming && this._concealCode),
       streaming: this._streaming,
       treeSitterClient: this._treeSitterClient,
+      fg: defaultStyle?.fg,
+      bg: defaultStyle?.bg,
       width: "100%",
       marginBottom,
     })
   }
 
   private applyMarkdownCodeRenderable(renderable: CodeRenderable, content: string, marginBottom: number): void {
+    const defaultStyle = this.getStyle("default")
     renderable.content = content
     renderable.filetype = "markdown"
     renderable.syntaxStyle = this._syntaxStyle
     renderable.conceal = this._conceal
     renderable.drawUnstyledText = false
     renderable.streaming = true
+    renderable.fg = defaultStyle?.fg
+    renderable.bg = defaultStyle?.bg
     renderable.marginBottom = marginBottom
   }
 
   private applyCodeBlockRenderable(renderable: CodeRenderable, token: Tokens.Code, marginBottom: number): void {
+    const defaultStyle = this.getStyle("default")
     renderable.content = token.text
     renderable.filetype = token.lang || undefined
     renderable.syntaxStyle = this._syntaxStyle
     renderable.conceal = this._concealCode
     renderable.drawUnstyledText = !(this._streaming && this._concealCode)
     renderable.streaming = this._streaming
+    renderable.fg = defaultStyle?.fg
+    renderable.bg = defaultStyle?.bg
     renderable.marginBottom = marginBottom
   }
 

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -2285,3 +2285,79 @@ test("paragraph updates do not flash raw markdown markers", async () => {
   expect(finalFrame).toContain("Second value")
   expect(finalFrame).not.toContain("**Second**")
 })
+
+test("code block without language uses syntaxStyle default fg and bg", async () => {
+  const customStyle = SyntaxStyle.fromStyles({
+    default: { fg: RGBA.fromValues(0.22, 0.23, 0.26, 1), bg: RGBA.fromValues(0.98, 0.98, 0.98, 1) },
+  })
+
+  const markdown = `\`\`\`
+plain code block
+\`\`\``
+
+  const md = createMarkdownRenderable({
+    id: "markdown-code-fg",
+    content: markdown,
+    syntaxStyle: customStyle,
+    conceal: true,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const frame = captureSpans()
+  const findSpanContaining = (text: string) => {
+    for (const line of frame.lines) {
+      const span = line.spans.find((candidate) => candidate.text.includes(text))
+      if (span) return span
+    }
+    return undefined
+  }
+
+  const codeSpan = findSpanContaining("plain code block")
+  expect(codeSpan).toBeDefined()
+  expect(codeSpan!.fg.r).toBeCloseTo(0.22, 1)
+  expect(codeSpan!.fg.g).toBeCloseTo(0.23, 1)
+  expect(codeSpan!.fg.b).toBeCloseTo(0.26, 1)
+  expect(codeSpan!.bg.r).toBeCloseTo(0.98, 1)
+  expect(codeSpan!.bg.g).toBeCloseTo(0.98, 1)
+  expect(codeSpan!.bg.b).toBeCloseTo(0.98, 1)
+})
+
+test("code block with language uses syntaxStyle default fg and bg for unstyled tokens", async () => {
+  const customStyle = SyntaxStyle.fromStyles({
+    default: { fg: RGBA.fromValues(0.22, 0.23, 0.26, 1), bg: RGBA.fromValues(0.98, 0.98, 0.98, 1) },
+  })
+
+  const markdown = `\`\`\`unknownlang
+some unstyled text
+\`\`\``
+
+  const md = createMarkdownRenderable({
+    id: "markdown-code-fg-lang",
+    content: markdown,
+    syntaxStyle: customStyle,
+    conceal: true,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const frame = captureSpans()
+  const findSpanContaining = (text: string) => {
+    for (const line of frame.lines) {
+      const span = line.spans.find((candidate) => candidate.text.includes(text))
+      if (span) return span
+    }
+    return undefined
+  }
+
+  const codeSpan = findSpanContaining("some unstyled text")
+  expect(codeSpan).toBeDefined()
+  expect(codeSpan!.fg.r).toBeCloseTo(0.22, 1)
+  expect(codeSpan!.fg.g).toBeCloseTo(0.23, 1)
+  expect(codeSpan!.fg.b).toBeCloseTo(0.26, 1)
+  expect(codeSpan!.bg.r).toBeCloseTo(0.98, 1)
+  expect(codeSpan!.bg.g).toBeCloseTo(0.98, 1)
+  expect(codeSpan!.bg.b).toBeCloseTo(0.98, 1)
+})


### PR DESCRIPTION
## Summary

Fixes #836

`MarkdownRenderable` was creating `CodeRenderable` instances without passing `fg` and `bg` from the syntax style's `"default"` scope. This caused code blocks — especially those without a language annotation — to fall back to the hardcoded white foreground (`RGBA(1,1,1,1)`) in `TextBufferRenderable`, making text invisible on light terminal backgrounds.

## Changes

- **`Markdown.ts`**: Pass `fg` and `bg` from `this.getStyle("default")` to `CodeRenderable` in all four relevant methods:
  - `createCodeRenderable()` — fenced code blocks
  - `createMarkdownCodeRenderable()` — markdown paragraph blocks
  - `applyCodeBlockRenderable()` — code block updates (e.g. streaming)
  - `applyMarkdownCodeRenderable()` — markdown paragraph updates

- **`Markdown.test.ts`**: Add two tests verifying that code blocks (with and without a language annotation) use the syntax style's default `fg` and `bg` instead of the hardcoded white.

## How it works

```
Theme JSON (e.g. one-light)
  ↓ text: "#383A42"
SyntaxStyle → getStyle("default") → { fg, bg }
  ↓
MarkdownRenderable
  ↓ passes fg/bg to CodeRenderable  ← NEW
CodeRenderable (extends TextBufferRenderable)
  ↓ uses theme fg/bg instead of hardcoded white
Screen → correct text color on light backgrounds
```

## Testing

All 96 existing tests pass plus 2 new tests added. Ran with `bun test packages/core/src/renderables/__tests__/Markdown.test.ts`.