### PR TITLE
core: preserve terminal color intent

### DIFF
--- a/packages/core/src/buffer.ts
+++ b/packages/core/src/buffer.ts
@@ -58,6 +58,10 @@ export class OptimizedBuffer {
     bg: Float32Array
     attributes: Uint32Array
   } | null = null
+  private _rawColorTags: {
+    fg: Uint16Array
+    bg: Uint16Array
+  } | null = null
   private _destroyed: boolean = false
 
   get ptr(): Pointer {
@@ -71,6 +75,32 @@ export class OptimizedBuffer {
     if (this._destroyed) throw new Error(`Buffer ${this.id} is destroyed`)
   }
 
+  private ensureRawBufferViews(): void {
+    if (this._rawBuffers !== null && this._rawColorTags !== null) {
+      return
+    }
+
+    const size = this._width * this._height
+    const charPtr = this.lib.bufferGetCharPtr(this.bufferPtr)
+    const fgPtr = this.lib.bufferGetFgPtr(this.bufferPtr)
+    const bgPtr = this.lib.bufferGetBgPtr(this.bufferPtr)
+    const fgTagPtr = this.lib.bufferGetFgTagPtr(this.bufferPtr)
+    const bgTagPtr = this.lib.bufferGetBgTagPtr(this.bufferPtr)
+    const attributesPtr = this.lib.bufferGetAttributesPtr(this.bufferPtr)
+
+    this._rawBuffers = {
+      char: new Uint32Array(toArrayBuffer(charPtr, 0, size * 4)),
+      fg: new Float32Array(toArrayBuffer(fgPtr, 0, size * 4 * 4)),
+      bg: new Float32Array(toArrayBuffer(bgPtr, 0, size * 4 * 4)),
+      attributes: new Uint32Array(toArrayBuffer(attributesPtr, 0, size * 4)),
+    }
+
+    this._rawColorTags = {
+      fg: new Uint16Array(toArrayBuffer(fgTagPtr, 0, size * 2)),
+      bg: new Uint16Array(toArrayBuffer(bgTagPtr, 0, size * 2)),
+    }
+  }
+
   get buffers(): {
     char: Uint32Array
     fg: Float32Array
@@ -78,22 +108,14 @@ export class OptimizedBuffer {
     attributes: Uint32Array
   } {
     this.guard()
-    if (this._rawBuffers === null) {
-      const size = this._width * this._height
-      const charPtr = this.lib.bufferGetCharPtr(this.bufferPtr)
-      const fgPtr = this.lib.bufferGetFgPtr(this.bufferPtr)
-      const bgPtr = this.lib.bufferGetBgPtr(this.bufferPtr)
-      const attributesPtr = this.lib.bufferGetAttributesPtr(this.bufferPtr)
+    this.ensureRawBufferViews()
+    return this._rawBuffers!
+  }
 
-      this._rawBuffers = {
-        char: new Uint32Array(toArrayBuffer(charPtr, 0, size * 4)),
-        fg: new Float32Array(toArrayBuffer(fgPtr, 0, size * 4 * 4)),
-        bg: new Float32Array(toArrayBuffer(bgPtr, 0, size * 4 * 4)),
-        attributes: new Uint32Array(toArrayBuffer(attributesPtr, 0, size * 4)),
-      }
-    }
-
-    return this._rawBuffers
+  private get rawColorTags(): { fg: Uint16Array; bg: Uint16Array } {
+    this.guard()
+    this.ensureRawBufferViews()
+    return this._rawColorTags!
   }
 
   constructor(
@@ -159,6 +181,7 @@ export class OptimizedBuffer {
   public getSpanLines(): CapturedLine[] {
     this.guard()
     const { char, fg, bg, attributes } = this.buffers
+    const { fg: fgTag, bg: bgTag } = this.rawColorTags
     const lines: CapturedLine[] = []
 
     const CHAR_FLAG_CONTINUATION = 0xc0000000 | 0
@@ -177,8 +200,8 @@ export class OptimizedBuffer {
       for (let x = 0; x < this._width; x++) {
         const i = y * this._width + x
         const cp = char[i]
-        const cellFg = RGBA.fromValues(fg[i * 4], fg[i * 4 + 1], fg[i * 4 + 2], fg[i * 4 + 3])
-        const cellBg = RGBA.fromValues(bg[i * 4], bg[i * 4 + 1], bg[i * 4 + 2], bg[i * 4 + 3])
+        const cellFg = RGBA.fromValues(fg[i * 4], fg[i * 4 + 1], fg[i * 4 + 2], fg[i * 4 + 3], fgTag[i])
+        const cellBg = RGBA.fromValues(bg[i * 4], bg[i * 4 + 1], bg[i * 4 + 2], bg[i * 4 + 3], bgTag[i])
         const cellAttrs = attributes[i] & 0xff
 
         // Continuation cells are placeholders for wide characters (emojis, CJK)
@@ -426,6 +449,7 @@ export class OptimizedBuffer {
     this._width = width
     this._height = height
     this._rawBuffers = null
+    this._rawColorTags = null
 
     this.lib.bufferResize(this.bufferPtr, width, height)
   }

--- a/packages/core/src/lib/RGBA.test.ts
+++ b/packages/core/src/lib/RGBA.test.ts
@@ -1,16 +1,40 @@
 import { test, expect, describe } from "bun:test"
-import { RGBA, hexToRgb, rgbToHex, hsvToRgb, parseColor } from "./RGBA.js"
+import {
+  COLOR_TAG_DEFAULT,
+  COLOR_TAG_RGB,
+  RGBA,
+  decodeColorTag,
+  hexToRgb,
+  hsvToRgb,
+  normalizeColorValue,
+  parseColor,
+  rgbToHex,
+} from "./RGBA.js"
 
 describe("RGBA class", () => {
   describe("constructor", () => {
-    test("creates RGBA with Float32Array buffer", () => {
-      const buffer = new Float32Array([0.5, 0.6, 0.7, 0.8])
+    test("uses the provided 5-float buffer", () => {
+      const buffer = new Float32Array([0.5, 0.6, 0.7, 0.8, COLOR_TAG_RGB])
       const rgba = new RGBA(buffer)
       expect(rgba.buffer).toBe(buffer)
+      expect(rgba.tag).toBe(COLOR_TAG_RGB)
     })
 
-    test("buffer is mutable reference", () => {
+    test("upgrades legacy 4-float buffers to explicit RGB tag", () => {
       const buffer = new Float32Array([0.5, 0.6, 0.7, 0.8])
+      const rgba = new RGBA(buffer)
+
+      expect(rgba.buffer).not.toBe(buffer)
+      expect(rgba.buffer).toHaveLength(5)
+      expect(rgba.r).toBeCloseTo(0.5, 5)
+      expect(rgba.g).toBeCloseTo(0.6, 5)
+      expect(rgba.b).toBeCloseTo(0.7, 5)
+      expect(rgba.a).toBeCloseTo(0.8, 5)
+      expect(rgba.tag).toBe(COLOR_TAG_RGB)
+    })
+
+    test("buffer is mutable reference when already 5-float", () => {
+      const buffer = new Float32Array([0.5, 0.6, 0.7, 0.8, COLOR_TAG_RGB])
       const rgba = new RGBA(buffer)
       buffer[0] = 0.9
       expect(rgba.r).toBeCloseTo(0.9, 5)
@@ -18,19 +42,21 @@ describe("RGBA class", () => {
   })
 
   describe("fromArray", () => {
-    test("creates RGBA from Float32Array", () => {
+    test("creates RGBA from legacy 4-float arrays", () => {
       const array = new Float32Array([0.1, 0.2, 0.3, 0.4])
       const rgba = RGBA.fromArray(array)
       expect(rgba.r).toBeCloseTo(0.1, 5)
       expect(rgba.g).toBeCloseTo(0.2, 5)
       expect(rgba.b).toBeCloseTo(0.3, 5)
       expect(rgba.a).toBeCloseTo(0.4, 5)
+      expect(rgba.tag).toBe(COLOR_TAG_RGB)
     })
 
-    test("uses same buffer reference", () => {
-      const array = new Float32Array([0.1, 0.2, 0.3, 0.4])
+    test("uses same buffer reference when already 5-float", () => {
+      const array = new Float32Array([0.1, 0.2, 0.3, 0.4, COLOR_TAG_DEFAULT])
       const rgba = RGBA.fromArray(array)
       expect(rgba.buffer).toBe(array)
+      expect(rgba.tag).toBe(COLOR_TAG_DEFAULT)
     })
   })
 
@@ -117,6 +143,69 @@ describe("RGBA class", () => {
       expect(rgba.g).toBeCloseTo(1.569, 2)
       expect(rgba.b).toBeCloseTo(1.961, 2)
       expect(rgba.a).toBeCloseTo(2.353, 2)
+    })
+  })
+
+  describe("clone", () => {
+    test("creates a detached copy", () => {
+      const original = RGBA.fromValues(0.1, 0.2, 0.3, 0.4)
+      const cloned = RGBA.clone(original)
+      expect(cloned).not.toBe(original)
+      expect(cloned.buffer).not.toBe(original.buffer)
+      expect(cloned.toInts()).toEqual(original.toInts())
+      cloned.r = 0.9
+      expect(original.r).toBeCloseTo(0.1, 5)
+    })
+  })
+
+  describe("intent helpers", () => {
+    test("fromIndex uses ANSI256 fallback snapshots", () => {
+      expect(RGBA.fromIndex(9).toInts()).toEqual([255, 0, 0, 255])
+      expect(RGBA.fromIndex(21).toInts()).toEqual([0, 0, 255, 255])
+      expect(RGBA.fromIndex(232).toInts()).toEqual([8, 8, 8, 255])
+      expect(RGBA.fromIndex(255).toInts()).toEqual([238, 238, 238, 255])
+    })
+
+    test("stores explicit tags in the fifth float", () => {
+      const rgb = RGBA.fromHex("#112233")
+      const indexed = RGBA.fromIndex(6)
+      const defaultFg = RGBA.defaultForeground()
+
+      expect(rgb.buffer).toHaveLength(5)
+      expect(rgb.buffer[4]).toBe(COLOR_TAG_RGB)
+      expect(indexed.buffer[4]).toBe(6)
+      expect(defaultFg.buffer[4]).toBe(COLOR_TAG_DEFAULT)
+    })
+
+    test("does not mutate caller-owned snapshots when constructing tagged colors", () => {
+      const indexedSnapshot = RGBA.fromHex("#112233")
+      const defaultSnapshot = RGBA.fromHex("#abcdef")
+
+      const indexed = RGBA.fromIndex(6, indexedSnapshot)
+      const defaultFg = RGBA.defaultForeground(defaultSnapshot)
+
+      expect(indexed).not.toBe(indexedSnapshot)
+      expect(defaultFg).not.toBe(defaultSnapshot)
+      expect(RGBA.getIntentTag(indexedSnapshot)).toBe(COLOR_TAG_RGB)
+      expect(RGBA.getIntentTag(defaultSnapshot)).toBe(COLOR_TAG_RGB)
+      expect(RGBA.getIntentTag(indexed)).toBe(6)
+      expect(RGBA.getIntentTag(defaultFg)).toBe(COLOR_TAG_DEFAULT)
+      expect(indexed.toInts()).toEqual(indexedSnapshot.toInts())
+      expect(defaultFg.toInts()).toEqual(defaultSnapshot.toInts())
+    })
+
+    test("normalizeColorValue and decodeColorTag preserve color intent", () => {
+      expect(normalizeColorValue(null)).toBeNull()
+      expect(
+        [RGBA.fromHex("#123456"), RGBA.fromIndex(12), RGBA.defaultBackground()].map((color) => [
+          normalizeColorValue(color)?.tag,
+          decodeColorTag(color.tag),
+        ]),
+      ).toEqual([
+        [COLOR_TAG_RGB, { kind: "rgb" }],
+        [12, { kind: "indexed", index: 12 }],
+        [COLOR_TAG_DEFAULT, { kind: "default" }],
+      ])
     })
   })
 
@@ -271,6 +360,14 @@ describe("RGBA class", () => {
       expect(result[1]).toBe(2)
       expect(result[2]).toBe(3)
       expect(result[3]).toBe(4)
+    })
+  })
+
+  describe("equals", () => {
+    test("compares both rgba values and tags", () => {
+      const rgb = RGBA.fromHex("#112233")
+      expect(rgb.equals(RGBA.fromIndex(6, rgb))).toBe(false)
+      expect(RGBA.defaultForeground("#aabbcc").equals(RGBA.defaultForeground("#aabbcc"))).toBe(true)
     })
   })
 

--- a/packages/core/src/lib/RGBA.ts
+++ b/packages/core/src/lib/RGBA.ts
@@ -1,24 +1,162 @@
+export type RGBTriplet = readonly [number, number, number]
+export type ColorKind = "rgb" | "indexed" | "default"
+export type ColorInput = string | RGBA
+
+export const COLOR_TAG_RGB = 256
+export const COLOR_TAG_DEFAULT = 257
+export const DEFAULT_FOREGROUND_RGB: RGBTriplet = [255, 255, 255]
+export const DEFAULT_BACKGROUND_RGB: RGBTriplet = [0, 0, 0]
+
+const RGBA_BUFFER_STRIDE = 5
+
+const ANSI16_RGB: readonly RGBTriplet[] = [
+  [0x00, 0x00, 0x00],
+  [0x80, 0x00, 0x00],
+  [0x00, 0x80, 0x00],
+  [0x80, 0x80, 0x00],
+  [0x00, 0x00, 0x80],
+  [0x80, 0x00, 0x80],
+  [0x00, 0x80, 0x80],
+  [0xc0, 0xc0, 0xc0],
+  [0x80, 0x80, 0x80],
+  [0xff, 0x00, 0x00],
+  [0x00, 0xff, 0x00],
+  [0xff, 0xff, 0x00],
+  [0x00, 0x00, 0xff],
+  [0xff, 0x00, 0xff],
+  [0x00, 0xff, 0xff],
+  [0xff, 0xff, 0xff],
+]
+
+const ANSI_256_CUBE_LEVELS = [0, 95, 135, 175, 215, 255] as const
+
+export interface NormalizedColorValue {
+  rgba: RGBA
+  tag: number
+}
+
+function normalizeColorTag(tag: number | undefined): number {
+  const normalizedTag = tag != null && Number.isFinite(tag) ? Math.round(tag) : COLOR_TAG_RGB
+
+  if (normalizedTag === COLOR_TAG_RGB || normalizedTag === COLOR_TAG_DEFAULT) {
+    return normalizedTag
+  }
+
+  if (Number.isInteger(normalizedTag) && normalizedTag >= 0 && normalizedTag <= 255) {
+    return normalizedTag
+  }
+
+  return COLOR_TAG_RGB
+}
+
+function normalizeRGBABuffer(buffer: Float32Array): Float32Array {
+  if (buffer.length === RGBA_BUFFER_STRIDE) {
+    buffer[4] = normalizeColorTag(buffer[4])
+    return buffer
+  }
+
+  const normalized = new Float32Array(RGBA_BUFFER_STRIDE)
+  normalized[0] = buffer[0] ?? 0
+  normalized[1] = buffer[1] ?? 0
+  normalized[2] = buffer[2] ?? 0
+  normalized[3] = buffer[3] ?? 0
+  normalized[4] = COLOR_TAG_RGB
+
+  return normalized
+}
+
+function withTag(rgba: RGBA, tag: number): RGBA {
+  const tagged = RGBA.clone(rgba)
+  tagged.tag = tag
+  return tagged
+}
+
+function rgbaForAnsi256Index(index: number): RGBA {
+  const [r, g, b] = ansi256IndexToRgb(index)
+  return RGBA.fromInts(r, g, b)
+}
+
+export function normalizeIndexedColorIndex(index: number): number {
+  if (!Number.isInteger(index) || index < 0 || index > 255) {
+    throw new RangeError(`Indexed color must be an integer in the range 0..255, got ${index}`)
+  }
+
+  return index
+}
+
+export function ansi256IndexToRgb(index: number): RGBTriplet {
+  const normalizedIndex = normalizeIndexedColorIndex(index)
+
+  if (normalizedIndex < ANSI16_RGB.length) {
+    return ANSI16_RGB[normalizedIndex]
+  }
+
+  if (normalizedIndex < 232) {
+    const cubeIndex = normalizedIndex - 16
+    const r = Math.floor(cubeIndex / 36)
+    const g = Math.floor(cubeIndex / 6) % 6
+    const b = cubeIndex % 6
+    return [ANSI_256_CUBE_LEVELS[r], ANSI_256_CUBE_LEVELS[g], ANSI_256_CUBE_LEVELS[b]]
+  }
+
+  const value = 8 + (normalizedIndex - 232) * 10
+  return [value, value, value]
+}
+
+export function decodeColorTag(tag: number): { kind: ColorKind; index?: number } {
+  if (tag === COLOR_TAG_DEFAULT) {
+    return { kind: "default" }
+  }
+
+  if (tag === COLOR_TAG_RGB) {
+    return { kind: "rgb" }
+  }
+
+  return { kind: "indexed", index: normalizeIndexedColorIndex(tag) }
+}
+
 export class RGBA {
   buffer: Float32Array
 
   constructor(buffer: Float32Array) {
-    this.buffer = buffer
+    this.buffer = normalizeRGBABuffer(buffer)
   }
 
   static fromArray(array: Float32Array) {
     return new RGBA(array)
   }
 
-  static fromValues(r: number, g: number, b: number, a: number = 1.0) {
-    return new RGBA(new Float32Array([r, g, b, a]))
+  static fromValues(r: number, g: number, b: number, a: number = 1.0, tag: number = COLOR_TAG_RGB) {
+    return new RGBA(new Float32Array([r, g, b, a, normalizeColorTag(tag)]))
   }
 
-  static fromInts(r: number, g: number, b: number, a: number = 255) {
-    return new RGBA(new Float32Array([r / 255, g / 255, b / 255, a / 255]))
+  static clone(rgba: RGBA) {
+    return RGBA.fromValues(rgba.r, rgba.g, rgba.b, rgba.a, rgba.tag)
+  }
+
+  static fromInts(r: number, g: number, b: number, a: number = 255, tag: number = COLOR_TAG_RGB) {
+    return new RGBA(new Float32Array([r / 255, g / 255, b / 255, a / 255, normalizeColorTag(tag)]))
   }
 
   static fromHex(hex: string): RGBA {
     return hexToRgb(hex)
+  }
+
+  static fromIndex(index: number, snapshot?: ColorInput): RGBA {
+    const normalizedIndex = normalizeIndexedColorIndex(index)
+    return withTag(snapshot ? parseColor(snapshot) : rgbaForAnsi256Index(normalizedIndex), normalizedIndex)
+  }
+
+  static defaultForeground(snapshot?: ColorInput): RGBA {
+    return withTag(snapshot ? parseColor(snapshot) : RGBA.fromInts(...DEFAULT_FOREGROUND_RGB), COLOR_TAG_DEFAULT)
+  }
+
+  static defaultBackground(snapshot?: ColorInput): RGBA {
+    return withTag(snapshot ? parseColor(snapshot) : RGBA.fromInts(...DEFAULT_BACKGROUND_RGB), COLOR_TAG_DEFAULT)
+  }
+
+  static getIntentTag(rgba: RGBA): number {
+    return rgba.tag
   }
 
   toInts(): [number, number, number, number] {
@@ -57,6 +195,14 @@ export class RGBA {
     this.buffer[3] = value
   }
 
+  get tag(): number {
+    return normalizeColorTag(this.buffer[4])
+  }
+
+  set tag(value: number) {
+    this.buffer[4] = normalizeColorTag(value)
+  }
+
   map<R>(fn: (value: number) => R) {
     return [fn(this.r), fn(this.g), fn(this.b), fn(this.a)]
   }
@@ -67,11 +213,18 @@ export class RGBA {
 
   equals(other?: RGBA): boolean {
     if (!other) return false
-    return this.r === other.r && this.g === other.g && this.b === other.b && this.a === other.a
+    return (
+      this.r === other.r && this.g === other.g && this.b === other.b && this.a === other.a && this.tag === other.tag
+    )
   }
 }
 
-export type ColorInput = string | RGBA
+export function normalizeColorValue(value: ColorInput | null | undefined): NormalizedColorValue | null {
+  if (value == null) return null
+
+  const rgba = parseColor(value)
+  return { rgba, tag: rgba.tag }
+}
 
 export function hexToRgb(hex: string): RGBA {
   hex = hex.replace(/^#/, "")

--- a/packages/core/src/lib/terminal-palette.test.ts
+++ b/packages/core/src/lib/terminal-palette.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test"
-import { TerminalPalette } from "./terminal-palette.js"
+import { TerminalPalette, normalizeTerminalPalette } from "./terminal-palette.js"
 import { EventEmitter } from "events"
 import { Buffer } from "node:buffer"
 import { ManualClock } from "../testing/manual-clock.js"
@@ -64,6 +64,17 @@ async function advanceClock(clock: ManualClock, ms: number): Promise<void> {
   clock.advance(ms)
   await flushAsync()
 }
+
+test("normalizeTerminalPalette returns detached fallback colors", () => {
+  const normalized = normalizeTerminalPalette(null)
+  normalized.palette[0].r = 1
+  normalized.defaultForeground.g = 0
+
+  const fresh = normalizeTerminalPalette(null)
+
+  expect(fresh.palette[0].toInts()).toEqual([0, 0, 0, 255])
+  expect(fresh.defaultForeground.toInts()).toEqual([255, 255, 255, 255])
+})
 
 test("TerminalPalette detectOSCSupport returns true on response", async () => {
   const { stdin, clock, palette } = createPaletteHarness()

--- a/packages/core/src/lib/terminal-palette.ts
+++ b/packages/core/src/lib/terminal-palette.ts
@@ -1,3 +1,4 @@
+import { RGBA, DEFAULT_BACKGROUND_RGB, DEFAULT_FOREGROUND_RGB, ansi256IndexToRgb } from "./RGBA.js"
 import { SystemClock, type Clock, type TimerHandle } from "./clock.js"
 
 type Hex = string | null
@@ -34,6 +35,12 @@ export interface TerminalPaletteDetector {
   detect(options?: GetPaletteOptions): Promise<TerminalColors>
   detectOSCSupport(timeoutMs?: number): Promise<boolean>
   cleanup(): void
+}
+
+export interface NormalizedTerminalPalette {
+  palette: RGBA[]
+  defaultForeground: RGBA
+  defaultBackground: RGBA
 }
 
 export type OscSubscriptionSource = {
@@ -380,4 +387,48 @@ export function createTerminalPalette(
   clock?: Clock,
 ): TerminalPaletteDetector {
   return new TerminalPalette(stdin, stdout, writeFn, isLegacyTmux, oscSource, clock)
+}
+
+const DEFAULT_FOREGROUND_FALLBACK = RGBA.fromInts(...DEFAULT_FOREGROUND_RGB)
+const DEFAULT_BACKGROUND_FALLBACK = RGBA.fromInts(...DEFAULT_BACKGROUND_RGB)
+
+let fallbackAnsi256Palette: RGBA[] | null = null
+
+function getFallbackAnsi256Palette(): readonly RGBA[] {
+  if (!fallbackAnsi256Palette) {
+    fallbackAnsi256Palette = Array.from({ length: 256 }, (_, index) => {
+      const [r, g, b] = ansi256IndexToRgb(index)
+      return RGBA.fromInts(r, g, b)
+    })
+  }
+
+  return fallbackAnsi256Palette
+}
+
+export function normalizeTerminalPalette(colors?: TerminalColors | null): NormalizedTerminalPalette {
+  const fallbackPalette = getFallbackAnsi256Palette()
+
+  return {
+    palette: Array.from({ length: 256 }, (_, index) => {
+      const detected = colors?.palette[index]
+      return detected ? RGBA.fromHex(detected) : RGBA.clone(fallbackPalette[index])
+    }),
+    defaultForeground: colors?.defaultForeground
+      ? RGBA.fromHex(colors.defaultForeground)
+      : RGBA.clone(DEFAULT_FOREGROUND_FALLBACK),
+    defaultBackground: colors?.defaultBackground
+      ? RGBA.fromHex(colors.defaultBackground)
+      : RGBA.clone(DEFAULT_BACKGROUND_FALLBACK),
+  }
+}
+
+export function buildTerminalPaletteSignature(colors?: TerminalColors | null): string {
+  const normalized = normalizeTerminalPalette(colors)
+  const paletteSignature = normalized.palette.map((color) => color.toInts().join(",")).join(";")
+
+  return [
+    paletteSignature,
+    normalized.defaultForeground.toInts().join(","),
+    normalized.defaultBackground.toInts().join(","),
+  ].join("|")
 }

--- a/packages/core/src/renderables/TextNode.test.ts
+++ b/packages/core/src/renderables/TextNode.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { TextNodeRenderable, isTextNodeRenderable } from "./TextNode.js"
-import { RGBA } from "../lib/RGBA.js"
+import { COLOR_TAG_DEFAULT, RGBA } from "../lib/RGBA.js"
 import { StyledText, red, bold, t } from "../lib/styled-text.js"
 
 describe("TextNodeRenderable", () => {
@@ -44,6 +44,28 @@ describe("TextNodeRenderable", () => {
       expect(node.bg?.g).toBe(0)
       expect(node.bg?.b).toBe(1)
       expect(node.bg?.a).toBe(1)
+    })
+
+    it("should preserve RGBA intent constructors in constructor and setters", () => {
+      const node = new TextNodeRenderable({
+        fg: RGBA.fromIndex(6),
+        bg: RGBA.defaultBackground(),
+      })
+
+      expect(node.fg).toBeDefined()
+      expect(node.bg).toBeDefined()
+      expect(node.fg).toBeInstanceOf(RGBA)
+      expect(node.bg).toBeInstanceOf(RGBA)
+      expect(RGBA.getIntentTag(node.fg!)).toBe(6)
+      expect(RGBA.getIntentTag(node.bg!)).toBe(COLOR_TAG_DEFAULT)
+
+      node.fg = RGBA.defaultForeground()
+      node.bg = RGBA.fromIndex(4)
+
+      expect(node.fg).toBeInstanceOf(RGBA)
+      expect(node.bg).toBeInstanceOf(RGBA)
+      expect(RGBA.getIntentTag(node.fg!)).toBe(COLOR_TAG_DEFAULT)
+      expect(RGBA.getIntentTag(node.bg!)).toBe(4)
     })
 
     it("should handle undefined colors", () => {
@@ -617,9 +639,10 @@ describe("TextNodeRenderable", () => {
 
       expect(chunks).toHaveLength(1)
       expect(chunks[0].text).toBe("Test")
-      expect(chunks[0].fg?.r).toBe(0)
-      expect(chunks[0].fg?.g).toBe(1)
-      expect(chunks[0].fg?.b).toBe(0)
+      expect(chunks[0].fg).toBeInstanceOf(RGBA)
+      expect((chunks[0].fg as RGBA).r).toBe(0)
+      expect((chunks[0].fg as RGBA).g).toBe(1)
+      expect((chunks[0].fg as RGBA).b).toBe(0)
     })
 
     it("should get children using getChildren", () => {

--- a/packages/core/src/renderables/__tests__/Textarea.rendering.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.rendering.test.ts
@@ -4,6 +4,7 @@ import { createTextareaRenderable } from "./renderable-test-utils.js"
 import { RGBA } from "../../lib/RGBA.js"
 import { SyntaxStyle } from "../../syntax-style.js"
 import { OptimizedBuffer } from "../../buffer.js"
+import type { CapturedFrame } from "../../types.js"
 import { fg, t } from "../../lib/index.js"
 import { BoxRenderable } from "../Box.js"
 import { TextareaRenderable } from "../Textarea.js"
@@ -13,6 +14,7 @@ let currentRenderer: TestRenderer
 let renderOnce: () => Promise<void>
 let currentMockInput: MockInput
 let captureFrame: () => string
+let captureSpans: () => CapturedFrame
 let resize: (width: number, height: number) => void
 
 describe("Textarea - Rendering Tests", () => {
@@ -21,6 +23,7 @@ describe("Textarea - Rendering Tests", () => {
       renderer: currentRenderer,
       renderOnce,
       captureCharFrame: captureFrame,
+      captureSpans,
       mockInput: currentMockInput,
       resize,
     } = await createTestRenderer({
@@ -34,6 +37,60 @@ describe("Textarea - Rendering Tests", () => {
   })
 
   describe("Wrapping", () => {
+    it("fills textarea bounds with indexed background color", async () => {
+      const surface = RGBA.fromIndex(254)
+      await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "abc",
+        width: 6,
+        height: 2,
+        backgroundColor: surface,
+        focusedBackgroundColor: surface,
+      })
+
+      const frame = captureSpans()
+      expect(frame.lines[0].spans[0].text).toBe("abc   ")
+      expect(frame.lines[0].spans[0].bg.tag).toBe(254)
+      expect(frame.lines[1].spans[0].text).toBe("      ")
+      expect(frame.lines[1].spans[0].bg.tag).toBe(254)
+    })
+
+    it("fills textarea bounds without double-blending translucent backgrounds", async () => {
+      const surface = RGBA.fromValues(1, 0, 0, 0.5)
+      await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "abc",
+        width: 6,
+        height: 2,
+        backgroundColor: surface,
+        focusedBackgroundColor: surface,
+      })
+
+      const frame = captureSpans()
+      expect(frame.lines[0].spans[0].text).toBe("abc   ")
+      expect(frame.lines[1].spans[0].text).toBe("      ")
+      expect(frame.lines[0].spans[0].bg.r).toBeCloseTo(frame.lines[1].spans[0].bg.r, 5)
+      expect(frame.lines[0].spans[0].bg.g).toBeCloseTo(frame.lines[1].spans[0].bg.g, 5)
+      expect(frame.lines[0].spans[0].bg.b).toBeCloseTo(frame.lines[1].spans[0].bg.b, 5)
+      expect(frame.lines[0].spans[0].bg.a).toBeCloseTo(0.5, 5)
+      expect(frame.lines[1].spans[0].bg.a).toBeCloseTo(0.5, 5)
+    })
+
+    it("fills textarea background while placeholder is shown", async () => {
+      const surface = RGBA.fromIndex(254)
+      await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "",
+        placeholder: "hint",
+        width: 6,
+        height: 2,
+        backgroundColor: surface,
+        focusedBackgroundColor: surface,
+      })
+
+      const frame = captureSpans()
+      expect(frame.lines[0].spans.some((span) => span.text.includes("hint"))).toBe(true)
+      expect(frame.lines[0].spans.slice(0, 2).every((span) => span.bg.tag === 254)).toBe(true)
+      expect(frame.lines[1].spans[0].bg.tag).toBe(254)
+    })
+
     it("should move cursor down through all wrapped visual lines at column 0", async () => {
       // Create a long line that will wrap into multiple visual lines
       const longText =

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -28,7 +28,9 @@ import { isEditBufferRenderable, type EditBufferRenderable } from "./renderables
 import { env, registerEnvVar } from "./lib/env.js"
 import { getTreeSitterClient } from "./lib/tree-sitter/index.js"
 import {
+  buildTerminalPaletteSignature,
   createTerminalPalette,
+  normalizeTerminalPalette,
   type TerminalPaletteDetector,
   type TerminalColors,
   type GetPaletteOptions,
@@ -839,8 +841,13 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private lifecyclePasses: Set<Renderable> = new Set()
   private _openConsoleOnError: boolean = true
   private _paletteDetector: TerminalPaletteDetector | null = null
+  private _paletteCache = new Map<number, TerminalColors>()
   private _cachedPalette: TerminalColors | null = null
   private _paletteDetectionPromise: Promise<TerminalColors> | null = null
+  private _paletteDetectionSize = 0
+  private _paletteEpoch = 0
+  private _publishedPaletteSignature: string | null = null
+  private _palettePublishGeneration = 0
   private _onDestroy?: () => void
   private _themeMode: ThemeMode | null = null
   private _themeModeSource: "none" | "osc" | "csi" = "none"
@@ -952,7 +959,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.clearOnShutdown = config.clearOnShutdown ?? true
     this.lib.setClearOnShutdown(this.rendererPtr, this.clearOnShutdown)
 
-    const forwardEnvKeys = config.forwardEnvKeys ?? [...DEFAULT_FORWARDED_ENV_KEYS]
+    const forwardEnvKeys = config.forwardEnvKeys ?? (config.remote ? [] : [...DEFAULT_FORWARDED_ENV_KEYS])
     for (const key of forwardEnvKeys) {
       const value = process.env[key]
       if (value === undefined) continue
@@ -2598,6 +2605,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     this.queryPixelResolution()
+    this.ensureNativePaletteState()
   }
 
   private stdinListener: (chunk: Buffer | string) => void = ((chunk: Buffer | string) => {
@@ -2648,6 +2656,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this.lib.processCapabilityResponse(this.rendererPtr, sequence)
     this._capabilities = this.lib.getTerminalCapabilities(this.rendererPtr)
+    if (hasStandardCapabilitySignature) {
+      this.forceFullRepaintRequested = true
+      this.requestRender()
+    }
     this.emit(CliRenderEvents.CAPABILITIES, this._capabilities)
 
     const hadPendingSplitStartupCursorSeed = this.pendingSplitStartupCursorSeed
@@ -3656,8 +3668,13 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this._paletteDetector.cleanup()
       this._paletteDetector = null
     }
+    this._paletteCache.clear()
     this._paletteDetectionPromise = null
+    this._paletteDetectionSize = 0
     this._cachedPalette = null
+    this._publishedPaletteSignature = null
+    this._paletteEpoch = 0
+    this._palettePublishGeneration = 0
 
     this.emit(CliRenderEvents.DESTROY)
 
@@ -3850,9 +3867,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.flushPendingSplitCommits(forceSplitRepaint)
       this.pendingSplitFooterTransition = null
     } else {
+      const force = this.forceFullRepaintRequested
       this.forceFullRepaintRequested = false
       this.pendingSplitFooterTransition = null
-      this.lib.render(this.rendererPtr, false)
+      this.lib.render(this.rendererPtr, force)
     }
     // this.dumpStdoutBuffer(Date.now())
     this.renderingNative = false
@@ -4060,40 +4078,37 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   public get paletteDetectionStatus(): "idle" | "detecting" | "cached" {
-    if (this._cachedPalette) return "cached"
     if (this._paletteDetectionPromise) return "detecting"
+    if (this._paletteCache.size > 0) return "cached"
     return "idle"
   }
 
-  public clearPaletteCache(): void {
-    this._cachedPalette = null
+  private getCachedPaletteBySize(size: number): TerminalColors | null {
+    const exactMatch = this._paletteCache.get(size)
+    if (exactMatch) {
+      return exactMatch
+    }
+
+    const largerSize = [...this._paletteCache.keys()].sort((a, b) => a - b).find((candidate) => candidate >= size)
+    if (largerSize === undefined) {
+      return null
+    }
+
+    const source = this._paletteCache.get(largerSize)
+    if (!source) {
+      return null
+    }
+
+    const projected = {
+      ...source,
+      palette: source.palette.slice(0, size),
+    }
+
+    this._paletteCache.set(size, projected)
+    return projected
   }
 
-  /**
-   * Detects the terminal's color palette
-   *
-   * @returns Promise resolving to TerminalColors object containing palette and special colors
-   * @throws Error if renderer is suspended
-   */
-  public async getPalette(options?: GetPaletteOptions): Promise<TerminalColors> {
-    if (this._controlState === RendererControlState.EXPLICIT_SUSPENDED) {
-      throw new Error("Cannot detect palette while renderer is suspended")
-    }
-
-    const requestedSize = options?.size ?? 16
-
-    if (this._cachedPalette && this._cachedPalette.palette.length !== requestedSize) {
-      this._cachedPalette = null
-    }
-
-    if (this._cachedPalette) {
-      return this._cachedPalette
-    }
-
-    if (this._paletteDetectionPromise) {
-      return this._paletteDetectionPromise
-    }
-
+  private ensurePaletteDetector(): TerminalPaletteDetector {
     if (!this._paletteDetector) {
       const isLegacyTmux =
         this.capabilities?.terminal?.name?.toLowerCase()?.includes("tmux") &&
@@ -4110,12 +4125,124 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       )
     }
 
-    this._paletteDetectionPromise = this._paletteDetector.detect(options).then((result) => {
-      this._cachedPalette = result
-      this._paletteDetectionPromise = null
-      return result
-    })
+    return this._paletteDetector
+  }
 
-    return this._paletteDetectionPromise
+  private syncNativePaletteState(colors: TerminalColors | null): void {
+    const signature = buildTerminalPaletteSignature(colors)
+    if (this._publishedPaletteSignature !== null && this._publishedPaletteSignature !== signature) {
+      this._paletteEpoch = (this._paletteEpoch + 1) >>> 0
+    }
+
+    this._publishedPaletteSignature = signature
+
+    const normalized = normalizeTerminalPalette(colors)
+    this.lib.rendererSetPaletteState(
+      this.rendererPtr,
+      normalized.palette,
+      normalized.defaultForeground,
+      normalized.defaultBackground,
+      this._paletteEpoch,
+    )
+  }
+
+  private ensureNativePaletteState(): void {
+    if (!this._terminalIsSetup || this._isDestroyed) return
+    const publishGeneration = this._palettePublishGeneration
+
+    void this.getPalette({ size: 256 })
+      .then((colors) => {
+        if (this._palettePublishGeneration === publishGeneration) {
+          this.syncNativePaletteState(colors)
+        }
+        this.requestRender()
+      })
+      .catch(() => {})
+  }
+
+  public clearPaletteCache(): void {
+    this._paletteCache.clear()
+    this._cachedPalette = null
+  }
+
+  /**
+   * Detects the terminal's color palette
+   *
+   * @returns Promise resolving to TerminalColors object containing palette and special colors
+   * @throws Error if renderer is suspended
+   */
+  public async getPalette(options?: GetPaletteOptions): Promise<TerminalColors> {
+    if (this._controlState === RendererControlState.EXPLICIT_SUSPENDED) {
+      throw new Error("Cannot detect palette while renderer is suspended")
+    }
+
+    const requestedSize = options?.size ?? 16
+    const detectionTimeout = options?.timeout
+
+    const cachedPalette = this.getCachedPaletteBySize(requestedSize)
+    if (cachedPalette) {
+      this._cachedPalette = cachedPalette
+      return cachedPalette
+    }
+
+    if (this._paletteDetectionPromise) {
+      if (this._paletteDetectionSize >= requestedSize) {
+        return this._paletteDetectionPromise.then((palette) => {
+          const cached = this.getCachedPaletteBySize(requestedSize)
+          if (cached) {
+            this._cachedPalette = cached
+            return cached
+          }
+
+          const projected = {
+            ...palette,
+            palette: palette.palette.slice(0, requestedSize),
+          }
+          this._paletteCache.set(requestedSize, projected)
+          this._cachedPalette = projected
+          return projected
+        })
+      }
+
+      await this._paletteDetectionPromise
+
+      const afterWait = this.getCachedPaletteBySize(requestedSize)
+      if (afterWait) {
+        this._cachedPalette = afterWait
+        return afterWait
+      }
+    }
+
+    const detector = this.ensurePaletteDetector()
+    const publishGeneration = this._palettePublishGeneration
+    this._paletteDetectionSize = requestedSize
+    this._paletteDetectionPromise = detector
+      .detect({ ...options, timeout: detectionTimeout })
+      .then((result) => {
+        this._paletteCache.set(result.palette.length, result)
+        this._cachedPalette = result
+        this._paletteDetectionPromise = null
+        this._paletteDetectionSize = 0
+
+        if (this._palettePublishGeneration === publishGeneration) {
+          if (result.palette.length >= 256) {
+            this.syncNativePaletteState(result)
+          } else if (this._terminalIsSetup && !this._paletteCache.has(256)) {
+            this.ensureNativePaletteState()
+          }
+        }
+
+        return result
+      })
+      .catch((error) => {
+        this._paletteDetectionPromise = null
+        this._paletteDetectionSize = 0
+        throw error
+      })
+
+    const detected = await this._paletteDetectionPromise
+    const finalPalette = this.getCachedPaletteBySize(requestedSize) ?? detected
+    this._cachedPalette = finalPalette
+    return finalPalette
   }
 }

--- a/packages/core/src/testing/capture-spans.test.ts
+++ b/packages/core/src/testing/capture-spans.test.ts
@@ -4,6 +4,8 @@ import { TextRenderable } from "../renderables/Text.js"
 import { BoxRenderable } from "../renderables/Box.js"
 import { TextAttributes, type CapturedFrame } from "../types.js"
 import { RGBA } from "../lib/index.js"
+import { StyledText } from "../lib/styled-text.js"
+import { COLOR_TAG_DEFAULT, COLOR_TAG_RGB } from "../lib/RGBA.js"
 
 describe("captureSpans", () => {
   let renderer: TestRenderer
@@ -143,6 +145,27 @@ describe("captureSpans", () => {
 
     expect(allSpans.some((s) => s.fg.r === 1 && s.fg.g === 0)).toBe(true)
     expect(allSpans.some((s) => s.fg.g === 1 && s.fg.r === 0)).toBe(true)
+  })
+
+  test("preserves tag-only color intent differences in captured spans", async () => {
+    const text = new TextRenderable(renderer, {
+      content: new StyledText([
+        { __isChunk: true, text: "A", fg: RGBA.fromHex("#aabbcc") },
+        { __isChunk: true, text: "B", fg: RGBA.defaultForeground("#aabbcc") },
+      ]),
+    })
+
+    renderer.root.add(text)
+    await renderOnce()
+
+    const firstLine = captureSpans().lines[0]
+    const contentSpans = firstLine.spans.filter((span) => span.text.trim().length > 0)
+
+    expect(contentSpans).toHaveLength(2)
+    expect(contentSpans[0].text).toBe("A")
+    expect(contentSpans[1].text).toBe("B")
+    expect(contentSpans[0].fg.tag).toBe(COLOR_TAG_RGB)
+    expect(contentSpans[1].fg.tag).toBe(COLOR_TAG_DEFAULT)
   })
 
   test("handles box-drawing characters without crashing", async () => {

--- a/packages/core/src/tests/renderer.palette.test.ts
+++ b/packages/core/src/tests/renderer.palette.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test"
+import { test, expect, describe, spyOn } from "bun:test"
 import { createTestRenderer, type TestRendererOptions } from "../testing/test-renderer.js"
 import { EventEmitter } from "events"
 import { Buffer } from "node:buffer"
@@ -168,6 +168,28 @@ describe("Palette caching behavior", () => {
 
     const oscSupportChecks = writes.filter((w) => w.includes("\x1b]4;0;?"))
     expect(oscSupportChecks.length).toBeLessThanOrEqual(2)
+
+    renderer.destroy()
+  })
+
+  test("concurrent requests with different sizes redetect for the later caller", async () => {
+    const { renderer, clock } = await createPaletteRenderer()
+
+    const palette16Promise = renderer.getPalette({ size: 16, timeout: 300 })
+    const palette256Promise = renderer.getPalette({ size: 256, timeout: 300 })
+
+    await advancePaletteClock(clock, 300)
+    await flushAsync()
+
+    expect(renderer.paletteDetectionStatus).toBe("detecting")
+
+    await advancePaletteClock(clock, 300)
+
+    const [palette16, palette256] = await Promise.all([palette16Promise, palette256Promise])
+
+    expect(palette16.palette).toHaveLength(16)
+    expect(palette256.palette).toHaveLength(256)
+    expect(palette16).not.toBe(palette256)
 
     renderer.destroy()
   })
@@ -437,6 +459,43 @@ describe("Palette cache invalidation", () => {
     await palettePromise
     expect(renderer.paletteDetectionStatus).toBe("cached")
 
+    renderer.destroy()
+  })
+})
+
+describe("Capability repaint handling", () => {
+  test("capability responses request a forced repaint", async () => {
+    const clock = new ManualClock()
+    const { renderer } = await createTestRenderer({ clock })
+    const lib = (renderer as unknown as { lib: any }).lib
+
+    const renderSpy = spyOn(lib, "render")
+    const originalProcessCapabilityResponse = lib.processCapabilityResponse
+    const originalGetTerminalCapabilities = lib.getTerminalCapabilities
+
+    lib.processCapabilityResponse = () => {}
+    lib.getTerminalCapabilities = () => ({ rgb: true, ansi256: true, unicode: "unicode" })
+
+    // @ts-expect-error - testing private renderer state
+    expect(renderer.forceFullRepaintRequested).toBe(false)
+
+    // @ts-expect-error - testing private renderer method
+    renderer.capabilityHandler("\x1bP>|wezterm\x1b\\")
+
+    // @ts-expect-error - testing private renderer state
+    expect(renderer.forceFullRepaintRequested).toBe(true)
+    // @ts-expect-error - testing private renderer state
+    expect(renderer.updateScheduled).toBe(true)
+
+    // @ts-expect-error - testing private renderer method
+    await renderer.activateFrame()
+
+    const lastCall = renderSpy.mock.calls[renderSpy.mock.calls.length - 1]
+    expect(lastCall?.[1]).toBe(true)
+
+    renderSpy.mockRestore()
+    lib.processCapabilityResponse = originalProcessCapabilityResponse
+    lib.getTerminalCapabilities = originalGetTerminalCapabilities
     renderer.destroy()
   })
 })

--- a/packages/core/src/zig-structs.ts
+++ b/packages/core/src/zig-structs.ts
@@ -1,6 +1,6 @@
 import { defineStruct, defineEnum } from "bun-ffi-structs"
 import { ptr, toArrayBuffer, type Pointer } from "bun:ffi"
-import { RGBA } from "./lib/RGBA.js"
+import { RGBA, COLOR_TAG_RGB, normalizeColorValue } from "./lib/RGBA.js"
 
 const rgbaPackTransform = (rgba?: RGBA) => (rgba ? ptr(rgba.buffer) : null)
 const rgbaUnpackTransform = (ptr?: Pointer) => (ptr ? RGBA.fromArray(new Float32Array(toArrayBuffer(ptr))) : undefined)
@@ -9,6 +9,8 @@ type StyledChunkInput = {
   text: string
   fg?: RGBA | null
   bg?: RGBA | null
+  fg_tag?: number
+  bg_tag?: number
   attributes?: number | null
   link?: { url: string } | string | null
 }
@@ -35,18 +37,33 @@ export const StyledChunkStruct = defineStruct(
         unpackTransform: rgbaUnpackTransform,
       },
     ],
+    ["fg_tag", "u16", { default: COLOR_TAG_RGB }],
+    ["bg_tag", "u16", { default: COLOR_TAG_RGB }],
     ["attributes", "u32", { default: 0 }],
     ["link", "char*", { default: "" }],
     ["link_len", "u64", { lengthOf: "link" }],
   ],
   {
     mapValue: (chunk: StyledChunkInput): StyledChunkInput => {
+      const normalizedFg = normalizeColorValue(chunk.fg ?? null)
+      const normalizedBg = normalizeColorValue(chunk.bg ?? null)
+
       if (!chunk.link || typeof chunk.link === "string") {
-        return chunk
+        return {
+          ...chunk,
+          fg: normalizedFg?.rgba ?? null,
+          bg: normalizedBg?.rgba ?? null,
+          fg_tag: normalizedFg?.tag ?? COLOR_TAG_RGB,
+          bg_tag: normalizedBg?.tag ?? COLOR_TAG_RGB,
+        }
       }
 
       return {
         ...chunk,
+        fg: normalizedFg?.rgba ?? null,
+        bg: normalizedBg?.rgba ?? null,
+        fg_tag: normalizedFg?.tag ?? COLOR_TAG_RGB,
+        bg_tag: normalizedBg?.tag ?? COLOR_TAG_RGB,
         link: chunk.link.url,
       }
     },
@@ -81,6 +98,7 @@ export const TerminalCapabilitiesStruct = defineStruct([
   ["kitty_keyboard", "bool_u8"],
   ["kitty_graphics", "bool_u8"],
   ["rgb", "bool_u8"],
+  ["ansi256", "bool_u8"],
   ["unicode", UnicodeMethodEnum],
   ["sgr_pixels", "bool_u8"],
   ["color_scheme_updates", "bool_u8"],

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -209,6 +209,10 @@ function getOpenTUILib(libPath?: string) {
       args: ["ptr"],
       returns: "ptr",
     },
+    rendererSetPaletteState: {
+      args: ["ptr", "ptr", "usize", "ptr", "ptr", "u32"],
+      returns: "void",
+    },
 
     queryPixelResolution: {
       args: ["ptr"],
@@ -249,6 +253,14 @@ function getOpenTUILib(libPath?: string) {
       returns: "ptr",
     },
     bufferGetBgPtr: {
+      args: ["ptr"],
+      returns: "ptr",
+    },
+    bufferGetFgTagPtr: {
+      args: ["ptr"],
+      returns: "ptr",
+    },
+    bufferGetBgTagPtr: {
       args: ["ptr"],
       returns: "ptr",
     },
@@ -1084,7 +1096,7 @@ function getOpenTUILib(libPath?: string) {
       returns: "void",
     },
     syntaxStyleRegister: {
-      args: ["ptr", "ptr", "usize", "ptr", "ptr", "u8"],
+      args: ["ptr", "ptr", "usize", "ptr", "ptr", "u32"],
       returns: "u32",
     },
     syntaxStyleResolveByName: {
@@ -1451,6 +1463,13 @@ export interface RenderLib {
   ) => number
   getNextBuffer: (renderer: Pointer) => OptimizedBuffer
   getCurrentBuffer: (renderer: Pointer) => OptimizedBuffer
+  rendererSetPaletteState: (
+    renderer: Pointer,
+    palette: readonly RGBA[],
+    defaultForeground: RGBA,
+    defaultBackground: RGBA,
+    paletteEpoch: number,
+  ) => void
   createOptimizedBuffer: (
     width: number,
     height: number,
@@ -1475,6 +1494,8 @@ export interface RenderLib {
   bufferGetCharPtr: (buffer: Pointer) => Pointer
   bufferGetFgPtr: (buffer: Pointer) => Pointer
   bufferGetBgPtr: (buffer: Pointer) => Pointer
+  bufferGetFgTagPtr: (buffer: Pointer) => Pointer
+  bufferGetBgTagPtr: (buffer: Pointer) => Pointer
   bufferGetAttributesPtr: (buffer: Pointer) => Pointer
   bufferGetRespectAlpha: (buffer: Pointer) => boolean
   bufferSetRespectAlpha: (buffer: Pointer, respectAlpha: boolean) => void
@@ -2156,6 +2177,34 @@ class FFIRenderLib implements RenderLib {
     return new OptimizedBuffer(this, bufferPtr, width, height, { id: "current buffer", widthMethod: "unicode" })
   }
 
+  public rendererSetPaletteState(
+    renderer: Pointer,
+    palette: readonly RGBA[],
+    defaultForeground: RGBA,
+    defaultBackground: RGBA,
+    paletteEpoch: number,
+  ): void {
+    const paletteBuffer = new Float32Array(palette.length * 4)
+
+    for (let index = 0; index < palette.length; index++) {
+      const color = palette[index]
+      const base = index * 4
+      paletteBuffer[base] = color.r
+      paletteBuffer[base + 1] = color.g
+      paletteBuffer[base + 2] = color.b
+      paletteBuffer[base + 3] = color.a
+    }
+
+    this.opentui.symbols.rendererSetPaletteState(
+      renderer,
+      paletteBuffer,
+      paletteBuffer.length,
+      defaultForeground.buffer,
+      defaultBackground.buffer,
+      paletteEpoch >>> 0,
+    )
+  }
+
   public bufferGetCharPtr(buffer: Pointer): Pointer {
     const ptr = this.opentui.symbols.bufferGetCharPtr(buffer)
     if (!ptr) {
@@ -2176,6 +2225,22 @@ class FFIRenderLib implements RenderLib {
     const ptr = this.opentui.symbols.bufferGetBgPtr(buffer)
     if (!ptr) {
       throw new Error("Failed to get bg pointer")
+    }
+    return ptr
+  }
+
+  public bufferGetFgTagPtr(buffer: Pointer): Pointer {
+    const ptr = this.opentui.symbols.bufferGetFgTagPtr(buffer)
+    if (!ptr) {
+      throw new Error("Failed to get fg tag pointer")
+    }
+    return ptr
+  }
+
+  public bufferGetBgTagPtr(buffer: Pointer): Pointer {
+    const ptr = this.opentui.symbols.bufferGetBgTagPtr(buffer)
+    if (!ptr) {
+      throw new Error("Failed to get bg tag pointer")
     }
     return ptr
   }
@@ -3747,6 +3812,7 @@ class FFIRenderLib implements RenderLib {
       kitty_keyboard: caps.kitty_keyboard,
       kitty_graphics: caps.kitty_graphics,
       rgb: caps.rgb,
+      ansi256: caps.ansi256,
       unicode: caps.unicode,
       sgr_pixels: caps.sgr_pixels,
       color_scheme_updates: caps.color_scheme_updates,

--- a/packages/core/src/zig/ansi.zig
+++ b/packages/core/src/zig/ansi.zig
@@ -2,11 +2,93 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 pub const RGBA = [4]f32;
+pub const ColorTag = u16;
+pub const COLOR_TAG_RGB: ColorTag = 256;
+pub const COLOR_TAG_DEFAULT: ColorTag = 257;
+
+pub const ColorKind = enum {
+    indexed,
+    rgb,
+    default,
+};
+
+pub const DecodedColorTag = struct {
+    kind: ColorKind,
+    index: ?u8 = null,
+};
 
 pub const AnsiError = error{
     InvalidFormat,
     WriteFailed,
 };
+
+pub const ANSI16_RGB = [_][3]u8{
+    .{ 0x00, 0x00, 0x00 },
+    .{ 0x80, 0x00, 0x00 },
+    .{ 0x00, 0x80, 0x00 },
+    .{ 0x80, 0x80, 0x00 },
+    .{ 0x00, 0x00, 0x80 },
+    .{ 0x80, 0x00, 0x80 },
+    .{ 0x00, 0x80, 0x80 },
+    .{ 0xc0, 0xc0, 0xc0 },
+    .{ 0x80, 0x80, 0x80 },
+    .{ 0xff, 0x00, 0x00 },
+    .{ 0x00, 0xff, 0x00 },
+    .{ 0xff, 0xff, 0x00 },
+    .{ 0x00, 0x00, 0xff },
+    .{ 0xff, 0x00, 0xff },
+    .{ 0x00, 0xff, 0xff },
+    .{ 0xff, 0xff, 0xff },
+};
+
+pub const ANSI_256_CUBE_LEVELS = [_]u8{ 0, 95, 135, 175, 215, 255 };
+
+pub fn rgbaComponentToU8(component: f32) u8 {
+    if (!std.math.isFinite(component)) return 0;
+
+    const clamped = std.math.clamp(component, 0.0, 1.0);
+    return @intFromFloat(@round(clamped * 255.0));
+}
+
+pub fn u8RgbToRgba(r: u8, g: u8, b: u8) RGBA {
+    return .{
+        @as(f32, @floatFromInt(r)) / 255.0,
+        @as(f32, @floatFromInt(g)) / 255.0,
+        @as(f32, @floatFromInt(b)) / 255.0,
+        1.0,
+    };
+}
+
+pub fn fallbackAnsi256Color(index: usize) RGBA {
+    if (index < ANSI16_RGB.len) {
+        return u8RgbToRgba(ANSI16_RGB[index][0], ANSI16_RGB[index][1], ANSI16_RGB[index][2]);
+    }
+
+    if (index < 232) {
+        const cube_index = index - 16;
+        const r = ANSI_256_CUBE_LEVELS[(cube_index / 36) % 6];
+        const g = ANSI_256_CUBE_LEVELS[(cube_index / 6) % 6];
+        const b = ANSI_256_CUBE_LEVELS[cube_index % 6];
+        return u8RgbToRgba(r, g, b);
+    }
+
+    const gray_value: u8 = @intCast(8 + (index - 232) * 10);
+    return u8RgbToRgba(gray_value, gray_value, gray_value);
+}
+
+pub fn colorDistanceSquared(a: RGBA, b: RGBA) f32 {
+    const dr = a[0] - b[0];
+    const dg = a[1] - b[1];
+    const db = a[2] - b[2];
+    return dr * dr + dg * dg + db * db;
+}
+
+pub fn rgbaToRgb24(rgba: RGBA) u32 {
+    const r = @as(u32, rgbaComponentToU8(rgba[0]));
+    const g = @as(u32, rgbaComponentToU8(rgba[1]));
+    const b = @as(u32, rgbaComponentToU8(rgba[2]));
+    return (r << 16) | (g << 8) | b;
+}
 
 pub const ANSI = struct {
     pub const reset = "\x1b[0m";
@@ -29,8 +111,24 @@ pub const ANSI = struct {
         writer.print("\x1b[38;2;{d};{d};{d}m", .{ r, g, b }) catch return AnsiError.WriteFailed;
     }
 
+    pub fn fgIndexedColorOutput(writer: anytype, index: u8) AnsiError!void {
+        writer.print("\x1b[38;5;{d}m", .{index}) catch return AnsiError.WriteFailed;
+    }
+
+    pub fn fgDefaultOutput(writer: anytype) AnsiError!void {
+        writer.writeAll("\x1b[39m") catch return AnsiError.WriteFailed;
+    }
+
     pub fn bgColorOutput(writer: anytype, r: u8, g: u8, b: u8) AnsiError!void {
         writer.print("\x1b[48;2;{d};{d};{d}m", .{ r, g, b }) catch return AnsiError.WriteFailed;
+    }
+
+    pub fn bgIndexedColorOutput(writer: anytype, index: u8) AnsiError!void {
+        writer.print("\x1b[48;5;{d}m", .{index}) catch return AnsiError.WriteFailed;
+    }
+
+    pub fn bgDefaultOutput(writer: anytype) AnsiError!void {
+        writer.writeAll("\x1b[49m") catch return AnsiError.WriteFailed;
     }
 
     // Text attribute constants
@@ -194,6 +292,45 @@ pub const ANSI = struct {
     }
 };
 
+pub fn rgbColorTag() ColorTag {
+    return COLOR_TAG_RGB;
+}
+
+pub fn defaultColorTag() ColorTag {
+    return COLOR_TAG_DEFAULT;
+}
+
+pub fn indexedColorTag(index: u8) ColorTag {
+    return @as(ColorTag, index);
+}
+
+pub fn decodeColorTag(tag: ColorTag) DecodedColorTag {
+    if (tag == COLOR_TAG_DEFAULT) {
+        return .{ .kind = .default };
+    }
+
+    if (tag == COLOR_TAG_RGB) {
+        return .{ .kind = .rgb };
+    }
+
+    return .{
+        .kind = .indexed,
+        .index = @intCast(tag),
+    };
+}
+
+pub fn isRgbColorTag(tag: ColorTag) bool {
+    return tag == COLOR_TAG_RGB;
+}
+
+pub fn isDefaultColorTag(tag: ColorTag) bool {
+    return tag == COLOR_TAG_DEFAULT;
+}
+
+pub fn isIndexedColorTag(tag: ColorTag) bool {
+    return tag < COLOR_TAG_RGB;
+}
+
 pub const TextAttributes = struct {
     pub const NONE: u8 = 0;
     pub const BOLD: u8 = 1 << 0;
@@ -276,4 +413,11 @@ pub fn hsvToRgb(h: f32, s: f32, v: f32) RGBA {
     };
 
     return .{ rgb[0], rgb[1], rgb[2], 1.0 };
+}
+
+test "fallbackAnsi256Color returns base, cube, and grayscale colors" {
+    try std.testing.expectEqual(@as(u32, 0xff0000), rgbaToRgb24(fallbackAnsi256Color(9)));
+    try std.testing.expectEqual(@as(u32, 0x0000ff), rgbaToRgb24(fallbackAnsi256Color(21)));
+    try std.testing.expectEqual(@as(u32, 0x080808), rgbaToRgb24(fallbackAnsi256Color(232)));
+    try std.testing.expectEqual(@as(u32, 0xeeeeee), rgbaToRgb24(fallbackAnsi256Color(255)));
 }

--- a/packages/core/src/zig/buffer.zig
+++ b/packages/core/src/zig/buffer.zig
@@ -16,6 +16,7 @@ const utf8 = @import("utf8.zig");
 const uucode = @import("uucode");
 
 pub const RGBA = ansi.RGBA;
+pub const ColorTag = ansi.ColorTag;
 pub const Vec3f = @Vector(3, f32);
 pub const Vec4f = @Vector(4, f32);
 
@@ -57,6 +58,8 @@ pub const TextSelection = struct {
     end: u32,
     bgColor: ?RGBA,
     fgColor: ?RGBA,
+    bgTag: ColorTag = ansi.COLOR_TAG_RGB,
+    fgTag: ColorTag = ansi.COLOR_TAG_RGB,
 };
 
 pub const ClipRect = struct {
@@ -89,8 +92,21 @@ pub const Cell = struct {
     char: u32,
     fg: RGBA,
     bg: RGBA,
+    fg_tag: ColorTag = ansi.COLOR_TAG_RGB,
+    bg_tag: ColorTag = ansi.COLOR_TAG_RGB,
     attributes: u32,
 };
+
+inline fn taggedCell(char: u32, fg: RGBA, bg: RGBA, attributes: u32, fg_tag: ColorTag, bg_tag: ColorTag) Cell {
+    return .{
+        .char = char,
+        .fg = fg,
+        .bg = bg,
+        .fg_tag = fg_tag,
+        .bg_tag = bg_tag,
+        .attributes = attributes,
+    };
+}
 
 fn isRGBAWithAlpha(color: RGBA) bool {
     return color[3] < 1.0;
@@ -158,12 +174,26 @@ fn blendColors(overlay: RGBA, text: RGBA, blendBackdropColor: ?RGBA) RGBA {
     return .{ blended[0], blended[1], blended[2], resultAlpha };
 }
 
+inline fn blendedTag(blended: bool, source_tag: ColorTag) ColorTag {
+    return if (blended) ansi.COLOR_TAG_RGB else source_tag;
+}
+
+inline fn taggedColorEql(a: RGBA, a_tag: ColorTag, b: RGBA, b_tag: ColorTag) bool {
+    return a_tag == b_tag and
+        a[0] == b[0] and
+        a[1] == b[1] and
+        a[2] == b[2] and
+        a[3] == b[3];
+}
+
 /// Optimized buffer for terminal rendering
 pub const OptimizedBuffer = struct {
     buffer: struct {
         char: []u32,
         fg: []RGBA,
         bg: []RGBA,
+        fg_tag: []ColorTag,
+        bg_tag: []ColorTag,
         attributes: []u32,
     },
     width: u32,
@@ -227,6 +257,12 @@ pub const OptimizedBuffer = struct {
         const bg_buffer = allocator.alloc(RGBA, size) catch return BufferError.OutOfMemory;
         errdefer allocator.free(bg_buffer);
 
+        const fg_tag_buffer = allocator.alloc(ColorTag, size) catch return BufferError.OutOfMemory;
+        errdefer allocator.free(fg_tag_buffer);
+
+        const bg_tag_buffer = allocator.alloc(ColorTag, size) catch return BufferError.OutOfMemory;
+        errdefer allocator.free(bg_tag_buffer);
+
         const attributes_buffer = allocator.alloc(u32, size) catch return BufferError.OutOfMemory;
         errdefer allocator.free(attributes_buffer);
 
@@ -235,6 +271,8 @@ pub const OptimizedBuffer = struct {
                 .char = char_buffer,
                 .fg = fg_buffer,
                 .bg = bg_buffer,
+                .fg_tag = fg_tag_buffer,
+                .bg_tag = bg_tag_buffer,
                 .attributes = attributes_buffer,
             },
             .width = width,
@@ -255,6 +293,8 @@ pub const OptimizedBuffer = struct {
         @memset(self.buffer.char, 0);
         @memset(self.buffer.fg, .{ 0.0, 0.0, 0.0, 0.0 });
         @memset(self.buffer.bg, .{ 0.0, 0.0, 0.0, 0.0 });
+        @memset(self.buffer.fg_tag, ansi.COLOR_TAG_RGB);
+        @memset(self.buffer.bg_tag, ansi.COLOR_TAG_RGB);
         @memset(self.buffer.attributes, 0);
 
         return self;
@@ -272,6 +312,14 @@ pub const OptimizedBuffer = struct {
         return self.buffer.bg.ptr;
     }
 
+    pub fn getFgTagPtr(self: *OptimizedBuffer) [*]ColorTag {
+        return self.buffer.fg_tag.ptr;
+    }
+
+    pub fn getBgTagPtr(self: *OptimizedBuffer) [*]ColorTag {
+        return self.buffer.bg_tag.ptr;
+    }
+
     pub fn getAttributesPtr(self: *OptimizedBuffer) [*]u32 {
         return self.buffer.attributes.ptr;
     }
@@ -284,6 +332,8 @@ pub const OptimizedBuffer = struct {
         self.allocator.free(self.buffer.char);
         self.allocator.free(self.buffer.fg);
         self.allocator.free(self.buffer.bg);
+        self.allocator.free(self.buffer.fg_tag);
+        self.allocator.free(self.buffer.bg_tag);
         self.allocator.free(self.buffer.attributes);
         self.allocator.free(self.id);
         self.allocator.destroy(self);
@@ -408,6 +458,8 @@ pub const OptimizedBuffer = struct {
         self.buffer.char = self.allocator.realloc(self.buffer.char, size) catch return BufferError.OutOfMemory;
         self.buffer.fg = self.allocator.realloc(self.buffer.fg, size) catch return BufferError.OutOfMemory;
         self.buffer.bg = self.allocator.realloc(self.buffer.bg, size) catch return BufferError.OutOfMemory;
+        self.buffer.fg_tag = self.allocator.realloc(self.buffer.fg_tag, size) catch return BufferError.OutOfMemory;
+        self.buffer.bg_tag = self.allocator.realloc(self.buffer.bg_tag, size) catch return BufferError.OutOfMemory;
         self.buffer.attributes = self.allocator.realloc(self.buffer.attributes, size) catch return BufferError.OutOfMemory;
 
         self.width = width;
@@ -430,6 +482,10 @@ pub const OptimizedBuffer = struct {
     }
 
     pub fn clear(self: *OptimizedBuffer, bg: RGBA, char: ?u32) !void {
+        return self.clearWithTags(bg, char, ansi.COLOR_TAG_RGB);
+    }
+
+    pub fn clearWithTags(self: *OptimizedBuffer, bg: RGBA, char: ?u32, bg_tag: ColorTag) !void {
         const cellChar = char orelse DEFAULT_SPACE_CHAR;
         self.link_tracker.clear();
         self.grapheme_tracker.clear();
@@ -437,6 +493,8 @@ pub const OptimizedBuffer = struct {
         @memset(self.buffer.attributes, 0);
         @memset(self.buffer.fg, .{ 1.0, 1.0, 1.0, 1.0 });
         @memset(self.buffer.bg, bg);
+        @memset(self.buffer.fg_tag, ansi.COLOR_TAG_RGB);
+        @memset(self.buffer.bg_tag, bg_tag);
     }
 
     /// Write a single cell and update link tracker. No grapheme tracking,
@@ -537,6 +595,8 @@ pub const OptimizedBuffer = struct {
                 @memset(self.buffer.attributes[index..end_of_line], cell.attributes);
                 @memset(self.buffer.fg[index..end_of_line], cell.fg);
                 @memset(self.buffer.bg[index..end_of_line], cell.bg);
+                @memset(self.buffer.fg_tag[index..end_of_line], cell.fg_tag);
+                @memset(self.buffer.bg_tag[index..end_of_line], cell.bg_tag);
                 const new_link_id = ansi.TextAttributes.getLinkId(cell.attributes);
                 if (new_link_id != 0) {
                     const cells_written = end_of_line - index;
@@ -551,6 +611,8 @@ pub const OptimizedBuffer = struct {
             self.buffer.char[index] = cell.char;
             self.buffer.fg[index] = cell.fg;
             self.buffer.bg[index] = cell.bg;
+            self.buffer.fg_tag[index] = cell.fg_tag;
+            self.buffer.bg_tag[index] = cell.bg_tag;
             self.buffer.attributes[index] = cell.attributes;
 
             const id: u32 = gp.graphemeIdFromChar(cell.char);
@@ -581,6 +643,8 @@ pub const OptimizedBuffer = struct {
 
                     @memset(self.buffer.fg[index + 1 .. index + 1 + max_right], cell.fg);
                     @memset(self.buffer.bg[index + 1 .. index + 1 + max_right], cell.bg);
+                    @memset(self.buffer.fg_tag[index + 1 .. index + 1 + max_right], cell.fg_tag);
+                    @memset(self.buffer.bg_tag[index + 1 .. index + 1 + max_right], cell.bg_tag);
                     @memset(self.buffer.attributes[index + 1 .. index + 1 + max_right], cell.attributes);
                     var k: u32 = 1;
                     while (k <= max_right) : (k += 1) {
@@ -612,6 +676,8 @@ pub const OptimizedBuffer = struct {
         self.buffer.char[index] = cell.char;
         self.buffer.fg[index] = cell.fg;
         self.buffer.bg[index] = cell.bg;
+        self.buffer.fg_tag[index] = cell.fg_tag;
+        self.buffer.bg_tag[index] = cell.bg_tag;
         self.buffer.attributes[index] = cell.attributes;
 
         if (prev_link_id != 0 and prev_link_id != new_link_id) {
@@ -630,6 +696,8 @@ pub const OptimizedBuffer = struct {
             .char = self.buffer.char[index],
             .fg = self.buffer.fg[index],
             .bg = self.buffer.bg[index],
+            .fg_tag = self.buffer.fg_tag[index],
+            .bg_tag = self.buffer.bg_tag[index],
             .attributes = self.buffer.attributes[index],
         };
     }
@@ -761,13 +829,16 @@ pub const OptimizedBuffer = struct {
             const finalChar = if (preserveChar) destCell.char else overlayCell.char;
 
             var finalFg: RGBA = undefined;
+            var finalFgTag: ColorTag = undefined;
             if (preserveChar) {
                 finalFg = blendColors(overlayCell.bg, destCell.fg, self.blendBackdropColor);
+                finalFgTag = ansi.COLOR_TAG_RGB;
             } else {
                 finalFg = if (hasFgAlpha)
                     blendColors(overlayCell.fg, destCell.bg, self.blendBackdropColor)
                 else
                     overlayCell.fg;
+                finalFgTag = blendedTag(hasFgAlpha, overlayCell.fg_tag);
             }
 
             // When preserving char, preserve its base attributes but NOT its link
@@ -781,13 +852,20 @@ pub const OptimizedBuffer = struct {
             const overlayLinkId = ansi.TextAttributes.getLinkId(overlayCell.attributes);
             const finalAttributes = ansi.TextAttributes.setLinkId(@as(u32, baseAttrs), overlayLinkId);
 
-            // When overlay background is fully transparent, preserve destination background alpha
-            const finalBgAlpha = if (overlayCell.bg[3] == 0.0) destCell.bg[3] else overlayCell.bg[3];
+            // A fully transparent overlay background should not retag the
+            // destination background. This matters for non-ASCII width-1 glyphs
+            // that take the generic alpha-blend path instead of the transparent
+            // text fast path.
+            const preserveBgTag = overlayCell.bg[3] == 0.0;
+            const finalBgAlpha = if (preserveBgTag) destCell.bg[3] else overlayCell.bg[3];
+            const finalBgTag = if (preserveBgTag) destCell.bg_tag else blendedTag(hasBgAlpha, overlayCell.bg_tag);
 
             return Cell{
                 .char = finalChar,
                 .fg = finalFg,
                 .bg = .{ blendedBg[0], blendedBg[1], blendedBg[2], finalBgAlpha },
+                .fg_tag = finalFgTag,
+                .bg_tag = finalBgTag,
                 .attributes = finalAttributes,
             };
         }
@@ -803,26 +881,36 @@ pub const OptimizedBuffer = struct {
         fg: RGBA,
         bg: RGBA,
         attributes: u32,
+        fg_tag: ColorTag,
+        bg_tag: ColorTag,
     ) !void {
+        return self.setCellWithAlphaBlendingCell(x, y, taggedCell(char, fg, bg, attributes, fg_tag, bg_tag));
+    }
+
+    fn setCellWithAlphaBlendingCell(self: *OptimizedBuffer, x: u32, y: u32, cell: Cell) !void {
         if (!self.isPointInScissor(@intCast(x), @intCast(y))) return;
 
         const opacity = self.getCurrentOpacity();
-        if (isFullyTransparent(opacity, fg, bg)) return;
-        if (isFullyOpaque(opacity, fg, bg)) {
-            self.set(x, y, Cell{ .char = char, .fg = fg, .bg = bg, .attributes = attributes });
+        if (isFullyTransparent(opacity, cell.fg, cell.bg)) return;
+        if (isFullyOpaque(opacity, cell.fg, cell.bg)) {
+            self.set(x, y, cell);
             return;
         }
 
-        const effectiveFg = RGBA{ fg[0], fg[1], fg[2], fg[3] * opacity };
-        const effectiveBg = RGBA{ bg[0], bg[1], bg[2], bg[3] * opacity };
-
-        const overlayCell = Cell{ .char = char, .fg = effectiveFg, .bg = effectiveBg, .attributes = attributes };
+        const effectiveCell = taggedCell(
+            cell.char,
+            .{ cell.fg[0], cell.fg[1], cell.fg[2], cell.fg[3] * opacity },
+            .{ cell.bg[0], cell.bg[1], cell.bg[2], cell.bg[3] * opacity },
+            cell.attributes,
+            cell.fg_tag,
+            cell.bg_tag,
+        );
 
         if (self.get(x, y)) |destCell| {
-            const blendedCell = self.blendCells(overlayCell, destCell);
+            const blendedCell = self.blendCells(effectiveCell, destCell);
             self.set(x, y, blendedCell);
         } else {
-            self.set(x, y, overlayCell);
+            self.set(x, y, effectiveCell);
         }
     }
 
@@ -835,32 +923,53 @@ pub const OptimizedBuffer = struct {
         bg: RGBA,
         attributes: u32,
     ) !void {
+        return self.setCellWithAlphaBlendingRawTagged(x, y, char, fg, bg, attributes, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
+    }
+
+    pub fn setCellWithAlphaBlendingRawTagged(
+        self: *OptimizedBuffer,
+        x: u32,
+        y: u32,
+        char: u32,
+        fg: RGBA,
+        bg: RGBA,
+        attributes: u32,
+        fg_tag: ColorTag,
+        bg_tag: ColorTag,
+    ) !void {
+        return self.setCellWithAlphaBlendingRawCell(x, y, taggedCell(char, fg, bg, attributes, fg_tag, bg_tag));
+    }
+
+    fn setCellWithAlphaBlendingRawCell(self: *OptimizedBuffer, x: u32, y: u32, cell: Cell) !void {
         if (!self.isPointInScissor(@intCast(x), @intCast(y))) return;
 
         const opacity = self.getCurrentOpacity();
-        if (isFullyTransparent(opacity, fg, bg)) return;
-        if (isFullyOpaque(opacity, fg, bg)) {
-            const overlayCell = Cell{ .char = char, .fg = fg, .bg = bg, .attributes = attributes };
-            assert(!gp.isGraphemeChar(char));
-            assert(!gp.isContinuationChar(char));
-            self.setRaw(x, y, overlayCell);
+        if (isFullyTransparent(opacity, cell.fg, cell.bg)) return;
+        if (isFullyOpaque(opacity, cell.fg, cell.bg)) {
+            assert(!gp.isGraphemeChar(cell.char));
+            assert(!gp.isContinuationChar(cell.char));
+            self.setRaw(x, y, cell);
             return;
         }
 
-        const effectiveFg = RGBA{ fg[0], fg[1], fg[2], fg[3] * opacity };
-        const effectiveBg = RGBA{ bg[0], bg[1], bg[2], bg[3] * opacity };
-
-        const overlayCell = Cell{ .char = char, .fg = effectiveFg, .bg = effectiveBg, .attributes = attributes };
+        const effectiveCell = taggedCell(
+            cell.char,
+            .{ cell.fg[0], cell.fg[1], cell.fg[2], cell.fg[3] * opacity },
+            .{ cell.bg[0], cell.bg[1], cell.bg[2], cell.bg[3] * opacity },
+            cell.attributes,
+            cell.fg_tag,
+            cell.bg_tag,
+        );
 
         if (self.get(x, y)) |destCell| {
-            const blendedCell = self.blendCells(overlayCell, destCell);
+            const blendedCell = self.blendCells(effectiveCell, destCell);
             assert(!gp.isGraphemeChar(blendedCell.char));
             assert(!gp.isContinuationChar(blendedCell.char));
             self.setRaw(x, y, blendedCell);
         } else {
-            assert(!gp.isGraphemeChar(overlayCell.char));
-            assert(!gp.isContinuationChar(overlayCell.char));
-            self.setRaw(x, y, overlayCell);
+            assert(!gp.isGraphemeChar(effectiveCell.char));
+            assert(!gp.isContinuationChar(effectiveCell.char));
+            self.setRaw(x, y, effectiveCell);
         }
     }
 
@@ -869,6 +978,7 @@ pub const OptimizedBuffer = struct {
         index: u32,
         char: u32,
         fg: RGBA,
+        fg_tag: ColorTag,
         attributes: u32,
     ) bool {
         // drawTextBuffer spends a lot of time in generic alpha blending when the
@@ -892,6 +1002,7 @@ pub const OptimizedBuffer = struct {
 
         self.buffer.char[index] = char;
         self.buffer.fg[index] = fg;
+        self.buffer.fg_tag[index] = fg_tag;
         self.buffer.attributes[index] = attributes;
         return true;
     }
@@ -904,8 +1015,10 @@ pub const OptimizedBuffer = struct {
         fg: RGBA,
         bg: RGBA,
         attributes: u32,
+        fg_tag: ColorTag,
+        bg_tag: ColorTag,
     ) !void {
-        try self.setCellWithAlphaBlending(x, y, char, fg, bg, attributes);
+        try self.setCellWithAlphaBlendingCell(x, y, taggedCell(char, fg, bg, attributes, fg_tag, bg_tag));
     }
 
     pub fn fillRect(
@@ -915,6 +1028,7 @@ pub const OptimizedBuffer = struct {
         width: u32,
         height: u32,
         bg: RGBA,
+        bg_tag: ColorTag,
     ) !void {
         if (self.width == 0 or self.height == 0 or width == 0 or height == 0) return;
         if (x >= self.width or y >= self.height) return;
@@ -950,7 +1064,11 @@ pub const OptimizedBuffer = struct {
             while (fillY <= clippedEndY) : (fillY += 1) {
                 var fillX = clippedStartX;
                 while (fillX <= clippedEndX) : (fillX += 1) {
-                    try self.setCellWithAlphaBlending(fillX, fillY, DEFAULT_SPACE_CHAR, .{ 1.0, 1.0, 1.0, 1.0 }, bg, 0);
+                    try self.setCellWithAlphaBlendingCell(
+                        fillX,
+                        fillY,
+                        taggedCell(DEFAULT_SPACE_CHAR, .{ 1.0, 1.0, 1.0, 1.0 }, bg, 0, ansi.COLOR_TAG_RGB, bg_tag),
+                    );
                 }
             }
         } else if (hasAlpha) {
@@ -960,7 +1078,7 @@ pub const OptimizedBuffer = struct {
             while (fillY <= clippedEndY) : (fillY += 1) {
                 var fillX = clippedStartX;
                 while (fillX <= clippedEndX) : (fillX += 1) {
-                    try self.setCellWithAlphaBlendingRaw(fillX, fillY, DEFAULT_SPACE_CHAR, .{ 1.0, 1.0, 1.0, 1.0 }, bg, 0);
+                    try self.setCellWithAlphaBlendingRawTagged(fillX, fillY, DEFAULT_SPACE_CHAR, .{ 1.0, 1.0, 1.0, 1.0 }, bg, 0, ansi.COLOR_TAG_RGB, bg_tag);
                 }
             }
         } else {
@@ -978,9 +1096,39 @@ pub const OptimizedBuffer = struct {
                 @memset(rowSliceChar, @intCast(DEFAULT_SPACE_CHAR));
                 @memset(rowSliceFg, .{ 1.0, 1.0, 1.0, 1.0 });
                 @memset(rowSliceBg, bg);
+                @memset(self.buffer.fg_tag[rowStartIndex .. rowStartIndex + rowWidth], ansi.COLOR_TAG_RGB);
+                @memset(self.buffer.bg_tag[rowStartIndex .. rowStartIndex + rowWidth], bg_tag);
                 @memset(rowSliceAttrs, 0);
             }
         }
+    }
+
+    fn fillRectClipped(
+        self: *OptimizedBuffer,
+        x: i32,
+        y: i32,
+        width: u32,
+        height: u32,
+        bg: RGBA,
+        bg_tag: ColorTag,
+    ) !void {
+        if (width == 0 or height == 0) return;
+
+        const startX = @max(0, x);
+        const startY = @max(0, y);
+        const endX = @min(@as(i32, @intCast(self.width)) - 1, x + @as(i32, @intCast(width)) - 1);
+        const endY = @min(@as(i32, @intCast(self.height)) - 1, y + @as(i32, @intCast(height)) - 1);
+
+        if (startX > endX or startY > endY) return;
+
+        try self.fillRect(
+            @intCast(startX),
+            @intCast(startY),
+            @intCast(endX - startX + 1),
+            @intCast(endY - startY + 1),
+            bg,
+            bg_tag,
+        );
     }
 
     pub fn drawText(
@@ -991,6 +1139,20 @@ pub const OptimizedBuffer = struct {
         fg: RGBA,
         bg: ?RGBA,
         attributes: u32,
+    ) BufferError!void {
+        return self.drawTextWithTags(text, x, y, fg, bg, attributes, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
+    }
+
+    pub fn drawTextWithTags(
+        self: *OptimizedBuffer,
+        text: []const u8,
+        x: u32,
+        y: u32,
+        fg: RGBA,
+        bg: ?RGBA,
+        attributes: u32,
+        fg_tag: ColorTag,
+        bg_tag: ColorTag,
     ) BufferError!void {
         if (x >= self.width or y >= self.height) return;
         if (text.len == 0) return;
@@ -1041,12 +1203,15 @@ pub const OptimizedBuffer = struct {
             }
 
             var bgColor: RGBA = undefined;
+            var effectiveBgTag = bg_tag;
             if (bg) |b| {
                 bgColor = b;
             } else if (self.get(charX, y)) |existingCell| {
                 bgColor = existingCell.bg;
+                effectiveBgTag = existingCell.bg_tag;
             } else {
                 bgColor = .{ 0.0, 0.0, 0.0, 1.0 };
+                effectiveBgTag = ansi.COLOR_TAG_RGB;
             }
 
             const cell_width = utf8.getWidthAt(text, if (at_special) specials[special_idx - 1].byte_offset else byte_offset - 1, tab_width, self.width_method);
@@ -1062,21 +1227,13 @@ pub const OptimizedBuffer = struct {
                     if (tab_x >= self.width) break;
 
                     if (isRGBAWithAlpha(bgColor)) {
-                        try self.setCellWithAlphaBlending(
+                        try self.setCellWithAlphaBlendingCell(
                             tab_x,
                             y,
-                            DEFAULT_SPACE_CHAR,
-                            fg,
-                            bgColor,
-                            attributes,
+                            taggedCell(DEFAULT_SPACE_CHAR, fg, bgColor, attributes, fg_tag, effectiveBgTag),
                         );
                     } else {
-                        self.set(tab_x, y, Cell{
-                            .char = DEFAULT_SPACE_CHAR,
-                            .fg = fg,
-                            .bg = bgColor,
-                            .attributes = attributes,
-                        });
+                        self.set(tab_x, y, taggedCell(DEFAULT_SPACE_CHAR, fg, bgColor, attributes, fg_tag, effectiveBgTag));
                     }
                 }
                 advance_cells += g_width;
@@ -1093,14 +1250,13 @@ pub const OptimizedBuffer = struct {
             }
 
             if (isRGBAWithAlpha(bgColor)) {
-                try self.setCellWithAlphaBlending(charX, y, encoded_char, fg, bgColor, attributes);
+                try self.setCellWithAlphaBlendingCell(
+                    charX,
+                    y,
+                    taggedCell(encoded_char, fg, bgColor, attributes, fg_tag, effectiveBgTag),
+                );
             } else {
-                self.set(charX, y, Cell{
-                    .char = encoded_char,
-                    .fg = fg,
-                    .bg = bgColor,
-                    .attributes = attributes,
-                });
+                self.set(charX, y, taggedCell(encoded_char, fg, bgColor, attributes, fg_tag, effectiveBgTag));
             }
 
             advance_cells += cell_width;
@@ -1169,6 +1325,8 @@ pub const OptimizedBuffer = struct {
                 @memcpy(self.buffer.char[destRowStart .. destRowStart + actualCopyWidth], frameBuffer.buffer.char[srcRowStart .. srcRowStart + actualCopyWidth]);
                 @memcpy(self.buffer.fg[destRowStart .. destRowStart + actualCopyWidth], frameBuffer.buffer.fg[srcRowStart .. srcRowStart + actualCopyWidth]);
                 @memcpy(self.buffer.bg[destRowStart .. destRowStart + actualCopyWidth], frameBuffer.buffer.bg[srcRowStart .. srcRowStart + actualCopyWidth]);
+                @memcpy(self.buffer.fg_tag[destRowStart .. destRowStart + actualCopyWidth], frameBuffer.buffer.fg_tag[srcRowStart .. srcRowStart + actualCopyWidth]);
+                @memcpy(self.buffer.bg_tag[destRowStart .. destRowStart + actualCopyWidth], frameBuffer.buffer.bg_tag[srcRowStart .. srcRowStart + actualCopyWidth]);
                 @memcpy(self.buffer.attributes[destRowStart .. destRowStart + actualCopyWidth], frameBuffer.buffer.attributes[srcRowStart .. srcRowStart + actualCopyWidth]);
             }
             return;
@@ -1193,6 +1351,8 @@ pub const OptimizedBuffer = struct {
                 const srcChar = frameBuffer.buffer.char[srcIndex];
                 const srcFg = frameBuffer.buffer.fg[srcIndex];
                 const srcBg = frameBuffer.buffer.bg[srcIndex];
+                const srcFgTag = frameBuffer.buffer.fg_tag[srcIndex];
+                const srcBgTag = frameBuffer.buffer.bg_tag[srcIndex];
                 const srcAttr = frameBuffer.buffer.attributes[srcIndex];
 
                 if (srcBg[3] == 0.0 and srcFg[3] == 0.0) continue;
@@ -1203,7 +1363,11 @@ pub const OptimizedBuffer = struct {
                         if (graphemeId != lastDrawnGraphemeId) {
                             // We haven't drawn the start character for this grapheme (likely out of bounds to the left)
                             // Draw a space with the same attributes to fill the cell
-                            self.setCellWithAlphaBlending(@intCast(dX), @intCast(dY), DEFAULT_SPACE_CHAR, srcFg, srcBg, srcAttr) catch {};
+                            self.setCellWithAlphaBlendingCell(
+                                @intCast(dX),
+                                @intCast(dY),
+                                taggedCell(DEFAULT_SPACE_CHAR, srcFg, srcBg, srcAttr, srcFgTag, srcBgTag),
+                            ) catch {};
                         }
                         continue;
                     }
@@ -1212,11 +1376,19 @@ pub const OptimizedBuffer = struct {
                         lastDrawnGraphemeId = srcChar & gp.GRAPHEME_ID_MASK;
                     }
 
-                    self.setCellWithAlphaBlending(@intCast(dX), @intCast(dY), srcChar, srcFg, srcBg, srcAttr) catch {};
+                    self.setCellWithAlphaBlendingCell(
+                        @intCast(dX),
+                        @intCast(dY),
+                        taggedCell(srcChar, srcFg, srcBg, srcAttr, srcFgTag, srcBgTag),
+                    ) catch {};
                     continue;
                 }
 
-                self.setCellWithAlphaBlendingRaw(@intCast(dX), @intCast(dY), srcChar, srcFg, srcBg, srcAttr) catch {};
+                self.setCellWithAlphaBlendingRawCell(
+                    @intCast(dX),
+                    @intCast(dY),
+                    taggedCell(srcChar, srcFg, srcBg, srcAttr, srcFgTag, srcBgTag),
+                ) catch {};
             }
         }
     }
@@ -1244,6 +1416,24 @@ pub const OptimizedBuffer = struct {
         if (opacity == 0.0) return;
 
         const virtual_lines = view.getVirtualLines();
+        const viewport = view.getViewport();
+        const text_buffer = view.getTextBuffer();
+        const text_defaults = text_buffer.defaults();
+        const PrefilledViewportBg = struct {
+            bg: RGBA,
+            bg_tag: ColorTag,
+        };
+
+        const prefilledViewportBg: ?PrefilledViewportBg = blk: {
+            if (comptime ViewType != EditorView) break :blk null;
+            const vp = viewport orelse break :blk null;
+            const base_defaults = view.edit_buffer.getTextBuffer().defaults();
+            const default_bg = base_defaults.bg orelse break :blk null;
+            if (default_bg[3] == 0.0) break :blk null;
+            try self.fillRectClipped(x, y, vp.width, vp.height, default_bg, base_defaults.bg_tag);
+            break :blk .{ .bg = default_bg, .bg_tag = base_defaults.bg_tag };
+        };
+
         if (virtual_lines.len == 0) return;
 
         const firstVisibleLine: u32 = if (y < 0) @intCast(-y) else 0;
@@ -1258,13 +1448,11 @@ pub const OptimizedBuffer = struct {
         if (firstVisibleLine >= virtual_lines.len or lastPossibleLine == 0) return;
         if (firstVisibleLine >= lastPossibleLine) return;
 
-        const viewport = view.getViewport();
         const horizontal_offset: u32 = if (viewport) |vp| vp.x else 0;
         const viewport_width: u32 = if (viewport) |vp| vp.width else std.math.maxInt(u32);
 
         var currentX = x;
         var currentY = y + @as(i32, @intCast(firstVisibleLine));
-        const text_buffer = view.getTextBuffer();
         const total_line_count = text_buffer.lineCount();
 
         const line_info = view.getCachedLineInfo();
@@ -1289,12 +1477,15 @@ pub const OptimizedBuffer = struct {
             const spans = vline_span_info.spans;
             const col_offset = vline_span_info.col_offset;
             var span_idx: usize = 0;
-            const defaults = text_buffer.defaults();
-            var lineFg = defaults.fg orelse RGBA{ 1.0, 1.0, 1.0, 1.0 };
-            var lineBg = defaults.bg orelse RGBA{ 0.0, 0.0, 0.0, 0.0 };
-            var lineAttributes = defaults.attributes orelse 0;
+            var lineFg = text_defaults.fg orelse RGBA{ 1.0, 1.0, 1.0, 1.0 };
+            var lineBg = text_defaults.bg orelse RGBA{ 0.0, 0.0, 0.0, 0.0 };
+            var lineFgTag: ColorTag = if (text_defaults.fg != null) text_defaults.fg_tag else ansi.COLOR_TAG_RGB;
+            var lineBgTag: ColorTag = if (text_defaults.bg != null) text_defaults.bg_tag else ansi.COLOR_TAG_RGB;
+            var lineAttributes = text_defaults.attributes orelse 0;
             const defaultFg = lineFg;
             const defaultBg = lineBg;
+            const defaultFgTag = lineFgTag;
+            const defaultBgTag = lineBgTag;
             const defaultAttributes = lineAttributes;
 
             // Find the span that contains the starting render position (col_offset + horizontal_offset)
@@ -1312,8 +1503,14 @@ pub const OptimizedBuffer = struct {
             if (span_idx < spans.len and spans[span_idx].col <= start_col and spans[span_idx].style_id != 0) {
                 if (text_buffer.getSyntaxStyle()) |style| {
                     if (style.resolveById(spans[span_idx].style_id)) |resolved_style| {
-                        if (resolved_style.fg) |fg| lineFg = fg;
-                        if (resolved_style.bg) |bg| lineBg = bg;
+                        if (resolved_style.fg) |fg| {
+                            lineFg = fg;
+                            lineFgTag = resolved_style.fg_tag;
+                        }
+                        if (resolved_style.bg) |bg| {
+                            lineBg = bg;
+                            lineBgTag = resolved_style.bg_tag;
+                        }
                         lineAttributes |= resolved_style.attributes;
                     }
                 }
@@ -1440,13 +1637,21 @@ pub const OptimizedBuffer = struct {
 
                         lineFg = defaultFg;
                         lineBg = defaultBg;
+                        lineFgTag = defaultFgTag;
+                        lineBgTag = defaultBgTag;
                         lineAttributes = defaultAttributes;
 
                         if (text_buffer.getSyntaxStyle()) |style| {
                             if (new_span.style_id != 0) {
                                 if (style.resolveById(new_span.style_id)) |resolved_style| {
-                                    if (resolved_style.fg) |fg| lineFg = fg;
-                                    if (resolved_style.bg) |bg| lineBg = bg;
+                                    if (resolved_style.fg) |fg| {
+                                        lineFg = fg;
+                                        lineFgTag = resolved_style.fg_tag;
+                                    }
+                                    if (resolved_style.bg) |bg| {
+                                        lineBg = bg;
+                                        lineBgTag = resolved_style.bg_tag;
+                                    }
                                     lineAttributes |= resolved_style.attributes;
                                 }
                             }
@@ -1461,12 +1666,16 @@ pub const OptimizedBuffer = struct {
                         if (column_offset_in_line >= vline.ellipsis_pos and column_offset_in_line < vline.ellipsis_pos + ellipsis_width) {
                             lineFg = defaultFg;
                             lineBg = defaultBg;
+                            lineFgTag = defaultFgTag;
+                            lineBgTag = defaultBgTag;
                             lineAttributes = defaultAttributes;
                         } else if (column_offset_in_line >= vline.ellipsis_pos + ellipsis_width) {
                             const suffix_col_pos = vline.truncation_suffix_start + (column_offset_in_line - vline.ellipsis_pos - ellipsis_width);
                             if (spans.len == 0) {
                                 lineFg = defaultFg;
                                 lineBg = defaultBg;
+                                lineFgTag = defaultFgTag;
+                                lineBgTag = defaultBgTag;
                                 lineAttributes = defaultAttributes;
                                 next_change_col = std.math.maxInt(u32);
                             } else {
@@ -1480,12 +1689,20 @@ pub const OptimizedBuffer = struct {
                                 const active_span = spans[span_idx];
                                 lineFg = defaultFg;
                                 lineBg = defaultBg;
+                                lineFgTag = defaultFgTag;
+                                lineBgTag = defaultBgTag;
                                 lineAttributes = defaultAttributes;
                                 if (text_buffer.getSyntaxStyle()) |style| {
                                     if (active_span.style_id != 0) {
                                         if (style.resolveById(active_span.style_id)) |resolved_style| {
-                                            if (resolved_style.fg) |fg| lineFg = fg;
-                                            if (resolved_style.bg) |bg| lineBg = bg;
+                                            if (resolved_style.fg) |fg| {
+                                                lineFg = fg;
+                                                lineFgTag = resolved_style.fg_tag;
+                                            }
+                                            if (resolved_style.bg) |bg| {
+                                                lineBg = bg;
+                                                lineBgTag = resolved_style.bg_tag;
+                                            }
                                             lineAttributes |= resolved_style.attributes;
                                         }
                                     }
@@ -1497,6 +1714,8 @@ pub const OptimizedBuffer = struct {
 
                     var finalFg = lineFg;
                     var finalBg = lineBg;
+                    var finalFgTag = lineFgTag;
+                    var finalBgTag = lineBgTag;
                     const finalAttributes = lineAttributes;
 
                     var cell_idx: u32 = 0;
@@ -1506,13 +1725,17 @@ pub const OptimizedBuffer = struct {
                             if (isSelected) {
                                 if (sel.bgColor) |selBg| {
                                     finalBg = selBg;
+                                    finalBgTag = sel.bgTag;
                                     if (sel.fgColor) |selFg| {
                                         finalFg = selFg;
+                                        finalFgTag = sel.fgTag;
                                     }
                                 } else {
                                     const temp = lineFg;
                                     finalFg = if (lineBg[3] > 0) lineBg else RGBA{ 0.0, 0.0, 0.0, 1.0 };
+                                    finalFgTag = if (lineBg[3] > 0) lineBgTag else ansi.COLOR_TAG_RGB;
                                     finalBg = temp;
+                                    finalBgTag = lineFgTag;
                                 }
                                 break;
                             }
@@ -1527,12 +1750,23 @@ pub const OptimizedBuffer = struct {
 
                     var drawFg = finalFg;
                     var drawBg = finalBg;
+                    var drawFgTag = finalFgTag;
+                    var drawBgTag = finalBgTag;
                     const drawAttributes = finalAttributes;
 
                     if (drawAttributes & (1 << 5) != 0) {
                         const temp = drawFg;
+                        const tempTag = drawFgTag;
                         drawFg = drawBg;
+                        drawFgTag = drawBgTag;
                         drawBg = temp;
+                        drawBgTag = tempTag;
+                    }
+
+                    if (prefilledViewportBg) |prefilledBg| {
+                        if (taggedColorEql(drawBg, drawBgTag, prefilledBg.bg, prefilledBg.bg_tag)) {
+                            drawBg[3] = 0.0;
+                        }
                     }
 
                     // TextBuffer/Textarea typically render opaque glyphs onto a
@@ -1550,21 +1784,19 @@ pub const OptimizedBuffer = struct {
 
                             const char = if (tab_col == 0 and tab_indicator != null) tab_indicator.? else DEFAULT_SPACE_CHAR;
                             const fg = if (tab_col == 0 and tab_indicator_color != null) tab_indicator_color.? else drawFg;
+                            const fgTag = if (tab_col == 0 and tab_indicator_color != null) ansi.COLOR_TAG_RGB else drawFgTag;
 
                             if (useTransparentTextFastPath) {
                                 const index = self.coordsToIndex(@intCast(currentX + @as(i32, @intCast(tab_col))), @intCast(currentY));
-                                if (self.trySetTransparentTextCellFast(index, char, fg, drawAttributes)) {
+                                if (self.trySetTransparentTextCellFast(index, char, fg, fgTag, drawAttributes)) {
                                     continue;
                                 }
                             }
 
-                            try self.setCellWithAlphaBlending(
+                            try self.setCellWithAlphaBlendingCell(
                                 @intCast(currentX + @as(i32, @intCast(tab_col))),
                                 @intCast(currentY),
-                                char,
-                                fg,
-                                drawBg,
-                                drawAttributes,
+                                taggedCell(char, fg, drawBg, drawAttributes, fgTag, drawBgTag),
                             );
                         }
                     } else {
@@ -1584,7 +1816,7 @@ pub const OptimizedBuffer = struct {
 
                         if (useTransparentTextFastPath) {
                             const index = self.coordsToIndex(@intCast(currentX), @intCast(currentY));
-                            if (self.trySetTransparentTextCellFast(index, encoded_char, drawFg, drawAttributes)) {
+                            if (self.trySetTransparentTextCellFast(index, encoded_char, drawFg, drawFgTag, drawAttributes)) {
                                 globalCharPos += g_width;
                                 currentX += @as(i32, @intCast(g_width));
                                 column_in_line += g_width;
@@ -1593,13 +1825,10 @@ pub const OptimizedBuffer = struct {
                             }
                         }
 
-                        try self.setCellWithAlphaBlending(
+                        try self.setCellWithAlphaBlendingCell(
                             @intCast(currentX),
                             @intCast(currentY),
-                            encoded_char,
-                            drawFg,
-                            drawBg,
-                            drawAttributes,
+                            taggedCell(encoded_char, drawFg, drawBg, drawAttributes, drawFgTag, drawBgTag),
                         );
                     }
 
@@ -1650,6 +1879,8 @@ pub const OptimizedBuffer = struct {
         rowCount: u32,
         drawInner: bool,
         drawOuter: bool,
+        border_fg_tag: ColorTag,
+        border_bg_tag: ColorTag,
     ) void {
         if (rowCount == 0 or columnCount == 0) return;
         if (!drawInner and !drawOuter) return;
@@ -1690,7 +1921,7 @@ pub const OptimizedBuffer = struct {
                     const has_right = colBorderIdx < columnCount;
                     const intersection = tableBorderIntersectionByConnections(borderChars, has_up, has_down, has_left, has_right);
 
-                    self.setRaw(@as(u32, @intCast(bx)), @as(u32, @intCast(borderY)), Cell{ .char = intersection, .fg = borderFg, .bg = borderBg, .attributes = 0 });
+                    self.setRaw(@as(u32, @intCast(bx)), @as(u32, @intCast(borderY)), Cell{ .char = intersection, .fg = borderFg, .bg = borderBg, .fg_tag = border_fg_tag, .bg_tag = border_bg_tag, .attributes = 0 });
                 }
 
                 var colIdx: u32 = 0;
@@ -1711,6 +1942,8 @@ pub const OptimizedBuffer = struct {
                         @memset(self.buffer.char[borderYU32 * bufWidth + clampedStart .. borderYU32 * bufWidth + clampedEnd], hChar);
                         @memset(self.buffer.fg[borderYU32 * bufWidth + clampedStart .. borderYU32 * bufWidth + clampedEnd], borderFg);
                         @memset(self.buffer.bg[borderYU32 * bufWidth + clampedStart .. borderYU32 * bufWidth + clampedEnd], borderBg);
+                        @memset(self.buffer.fg_tag[borderYU32 * bufWidth + clampedStart .. borderYU32 * bufWidth + clampedEnd], border_fg_tag);
+                        @memset(self.buffer.bg_tag[borderYU32 * bufWidth + clampedStart .. borderYU32 * bufWidth + clampedEnd], border_bg_tag);
                         @memset(self.buffer.attributes[borderYU32 * bufWidth + clampedStart .. borderYU32 * bufWidth + clampedEnd], 0);
                     }
                 }
@@ -1742,6 +1975,8 @@ pub const OptimizedBuffer = struct {
                     self.buffer.char[idx] = vChar;
                     self.buffer.fg[idx] = borderFg;
                     self.buffer.bg[idx] = borderBg;
+                    self.buffer.fg_tag[idx] = border_fg_tag;
+                    self.buffer.bg_tag[idx] = border_bg_tag;
                     self.buffer.attributes[idx] = 0;
                 }
             }
@@ -1797,7 +2032,7 @@ pub const OptimizedBuffer = struct {
         y: i32,
         width: u32,
         height: u32,
-        borderChars: [*]const u32, // Array of 11 border characters
+        borderChars: [*]const u32,
         borderSides: BorderSides,
         borderColor: RGBA,
         backgroundColor: RGBA,
@@ -1806,6 +2041,8 @@ pub const OptimizedBuffer = struct {
         titleAlignment: u8, // 0=left, 1=center, 2=right
         bottomTitle: ?[]const u8,
         bottomTitleAlignment: u8, // 0=left, 1=center, 2=right
+        border_tag: ColorTag,
+        background_tag: ColorTag,
     ) !void {
         const opacity = self.getCurrentOpacity();
         if (isFullyTransparent(opacity, borderColor, backgroundColor)) return;
@@ -1833,7 +2070,7 @@ pub const OptimizedBuffer = struct {
             if (!borderSides.top and !borderSides.right and !borderSides.bottom and !borderSides.left) {
                 const fillWidth = @as(u32, @intCast(endX - startX + 1));
                 const fillHeight = @as(u32, @intCast(endY - startY + 1));
-                try self.fillRect(@intCast(startX), @intCast(startY), fillWidth, fillHeight, backgroundColor);
+                try self.fillRect(@intCast(startX), @intCast(startY), fillWidth, fillHeight, backgroundColor, background_tag);
             } else {
                 const innerStartX = startX + if (borderSides.left and isAtActualLeft) @as(i32, 1) else @as(i32, 0);
                 const innerStartY = startY + if (borderSides.top and isAtActualTop) @as(i32, 1) else @as(i32, 0);
@@ -1843,7 +2080,7 @@ pub const OptimizedBuffer = struct {
                 if (innerEndX >= innerStartX and innerEndY >= innerStartY) {
                     const fillWidth = @as(u32, @intCast(innerEndX - innerStartX + 1));
                     const fillHeight = @as(u32, @intCast(innerEndY - innerStartY + 1));
-                    try self.fillRect(@intCast(innerStartX), @intCast(innerStartY), fillWidth, fillHeight, backgroundColor);
+                    try self.fillRect(@intCast(innerStartX), @intCast(innerStartY), fillWidth, fillHeight, backgroundColor, background_tag);
                 }
             }
         }
@@ -1882,9 +2119,14 @@ pub const OptimizedBuffer = struct {
                             const index = self.coordsToIndex(@intCast(drawX), @intCast(startY));
                             self.buffer.char[index] = char;
                             self.buffer.fg[index] = borderColor;
+                            self.buffer.fg_tag[index] = border_tag;
                             self.buffer.attributes[index] = 0;
                         } else {
-                            try self.setCellWithAlphaBlending(@intCast(drawX), @intCast(startY), char, borderColor, backgroundColor, 0);
+                            try self.setCellWithAlphaBlendingCell(
+                                @intCast(drawX),
+                                @intCast(startY),
+                                taggedCell(char, borderColor, backgroundColor, 0, border_tag, background_tag),
+                            );
                         }
                     }
                 }
@@ -1912,9 +2154,14 @@ pub const OptimizedBuffer = struct {
                             const index = self.coordsToIndex(@intCast(drawX), @intCast(endY));
                             self.buffer.char[index] = char;
                             self.buffer.fg[index] = borderColor;
+                            self.buffer.fg_tag[index] = border_tag;
                             self.buffer.attributes[index] = 0;
                         } else {
-                            try self.setCellWithAlphaBlending(@intCast(drawX), @intCast(endY), char, borderColor, backgroundColor, 0);
+                            try self.setCellWithAlphaBlendingCell(
+                                @intCast(drawX),
+                                @intCast(endY),
+                                taggedCell(char, borderColor, backgroundColor, 0, border_tag, background_tag),
+                            );
                         }
                     }
                 }
@@ -1934,9 +2181,14 @@ pub const OptimizedBuffer = struct {
                         const index = self.coordsToIndex(@intCast(startX), @intCast(drawY));
                         self.buffer.char[index] = borderChars[@intFromEnum(BorderCharIndex.vertical)];
                         self.buffer.fg[index] = borderColor;
+                        self.buffer.fg_tag[index] = border_tag;
                         self.buffer.attributes[index] = 0;
                     } else {
-                        try self.setCellWithAlphaBlending(@intCast(startX), @intCast(drawY), borderChars[@intFromEnum(BorderCharIndex.vertical)], borderColor, backgroundColor, 0);
+                        try self.setCellWithAlphaBlendingCell(
+                            @intCast(startX),
+                            @intCast(drawY),
+                            taggedCell(borderChars[@intFromEnum(BorderCharIndex.vertical)], borderColor, backgroundColor, 0, border_tag, background_tag),
+                        );
                     }
                 }
 
@@ -1946,9 +2198,14 @@ pub const OptimizedBuffer = struct {
                         const index = self.coordsToIndex(@intCast(endX), @intCast(drawY));
                         self.buffer.char[index] = borderChars[@intFromEnum(BorderCharIndex.vertical)];
                         self.buffer.fg[index] = borderColor;
+                        self.buffer.fg_tag[index] = border_tag;
                         self.buffer.attributes[index] = 0;
                     } else {
-                        try self.setCellWithAlphaBlending(@intCast(endX), @intCast(drawY), borderChars[@intFromEnum(BorderCharIndex.vertical)], borderColor, backgroundColor, 0);
+                        try self.setCellWithAlphaBlendingCell(
+                            @intCast(endX),
+                            @intCast(drawY),
+                            taggedCell(borderChars[@intFromEnum(BorderCharIndex.vertical)], borderColor, backgroundColor, 0, border_tag, background_tag),
+                        );
                     }
                 }
             }
@@ -1956,13 +2213,13 @@ pub const OptimizedBuffer = struct {
 
         if (titleLayout.shouldDraw) {
             if (title) |titleText| {
-                try self.drawText(titleText, @intCast(titleLayout.x), @intCast(startY), borderColor, backgroundColor, 0);
+                try self.drawTextWithTags(titleText, @intCast(titleLayout.x), @intCast(startY), borderColor, backgroundColor, 0, border_tag, background_tag);
             }
         }
 
         if (bottomTitleLayout.shouldDraw) {
             if (bottomTitle) |titleText| {
-                try self.drawText(titleText, @intCast(bottomTitleLayout.x), @intCast(endY), borderColor, backgroundColor, 0);
+                try self.drawTextWithTags(titleText, @intCast(bottomTitleLayout.x), @intCast(endY), borderColor, backgroundColor, 0, border_tag, background_tag);
             }
         }
     }
@@ -2053,7 +2310,16 @@ pub const OptimizedBuffer = struct {
 
                 const cellResult = renderQuadrantBlock(pixelsRgba);
 
-                try self.setCellWithAlphaBlending(x_cell, y_cell, cellResult.char, cellResult.fg, cellResult.bg, 0);
+                try self.setCellWithAlphaBlending(
+                    x_cell,
+                    y_cell,
+                    cellResult.char,
+                    cellResult.fg,
+                    cellResult.bg,
+                    0,
+                    ansi.COLOR_TAG_RGB,
+                    ansi.COLOR_TAG_RGB,
+                );
             }
         }
     }
@@ -2103,7 +2369,7 @@ pub const OptimizedBuffer = struct {
                 char = BLOCK_CHAR;
             }
 
-            self.setCellWithAlphaBlending(cellX, cellY, char, fg, bg, 0) catch {};
+            self.setCellWithAlphaBlending(cellX, cellY, char, fg, bg, 0, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB) catch {};
         }
     }
 
@@ -2123,6 +2389,8 @@ pub const OptimizedBuffer = struct {
         srcHeight: u32,
         fgColor: ?RGBA,
         bgColor: ?RGBA,
+        fg_tag: ColorTag,
+        bg_tag: ColorTag,
     ) void {
         const bg = bgColor orelse RGBA{ 0.0, 0.0, 0.0, 0.0 };
         if (srcWidth == 0 or srcHeight == 0) return;
@@ -2172,9 +2440,9 @@ pub const OptimizedBuffer = struct {
                 const fg: RGBA = .{ baseFg[0], baseFg[1], baseFg[2], gray * baseFg[3] * opacity };
 
                 if (graphemeAware or linkAware) {
-                    self.setCellWithAlphaBlending(destX, destY, char, fg, bg, 0) catch {};
+                    self.setCellWithAlphaBlendingCell(destX, destY, taggedCell(char, fg, bg, 0, fg_tag, bg_tag)) catch {};
                 } else {
-                    self.setCellWithAlphaBlendingRaw(destX, destY, char, fg, bg, 0) catch {};
+                    self.setCellWithAlphaBlendingRawCell(destX, destY, taggedCell(char, fg, bg, 0, fg_tag, bg_tag)) catch {};
                 }
             }
         }
@@ -2189,6 +2457,8 @@ pub const OptimizedBuffer = struct {
         srcHeight: u32,
         fgColor: ?RGBA,
         bgColor: ?RGBA,
+        fg_tag: ColorTag,
+        bg_tag: ColorTag,
     ) void {
         const bg = bgColor orelse RGBA{ 0.0, 0.0, 0.0, 0.0 };
         const termWidth = srcWidth / 2;
@@ -2254,9 +2524,9 @@ pub const OptimizedBuffer = struct {
                 const fg: RGBA = .{ baseFg[0], baseFg[1], baseFg[2], gray * baseFg[3] * opacity };
 
                 if (graphemeAware or linkAware) {
-                    self.setCellWithAlphaBlending(destX, destY, char, fg, bg, 0) catch {};
+                    self.setCellWithAlphaBlendingCell(destX, destY, taggedCell(char, fg, bg, 0, fg_tag, bg_tag)) catch {};
                 } else {
-                    self.setCellWithAlphaBlendingRaw(destX, destY, char, fg, bg, 0) catch {};
+                    self.setCellWithAlphaBlendingRawCell(destX, destY, taggedCell(char, fg, bg, 0, fg_tag, bg_tag)) catch {};
                 }
             }
         }

--- a/packages/core/src/zig/editor-view.zig
+++ b/packages/core/src/zig/editor-view.zig
@@ -312,7 +312,7 @@ pub const EditorView = struct {
         const changed = self.text_buffer_view.setLocalSelection(anchorX, anchorY, focusX, focusY, bgColor, fgColor);
 
         if (changed and updateCursor) {
-            self.updateCursorToSelectionFocus(focusX, focusY);
+            self.syncCursorToSelectionFocus();
         }
 
         return changed;
@@ -322,7 +322,7 @@ pub const EditorView = struct {
         const changed = self.text_buffer_view.updateLocalSelection(anchorX, anchorY, focusX, focusY, bgColor, fgColor);
 
         if (changed and updateCursor) {
-            self.updateCursorToSelectionFocus(focusX, focusY);
+            self.syncCursorToSelectionFocus();
         }
 
         return changed;
@@ -334,7 +334,7 @@ pub const EditorView = struct {
 
     /// Updates the cursor position to match the selection focus position.
     /// Does NOT trigger viewport scrolling - TypeScript layer handles that.
-    fn updateCursorToSelectionFocus(self: *EditorView, _: i32, _: i32) void {
+    pub fn syncCursorToSelectionFocus(self: *EditorView) void {
         const selection = self.text_buffer_view.getSelection() orelse return;
 
         const focus_offset = if (self.text_buffer_view.selection_anchor_offset) |anchor| blk: {

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -25,6 +25,52 @@ pub const CliRenderer = renderer.CliRenderer;
 pub const Terminal = terminal.Terminal;
 pub const RGBA = buffer.RGBA;
 
+const DecodedColor = struct {
+    rgba: RGBA,
+    tag: buffer.ColorTag,
+};
+
+const OptionalDecodedColor = struct {
+    rgba: ?RGBA = null,
+    tag: buffer.ColorTag = ansi.COLOR_TAG_RGB,
+};
+
+inline fn decodePackedColorTag(raw_tag: f32) buffer.ColorTag {
+    const rounded_tag: i32 = @intFromFloat(@round(raw_tag));
+
+    return switch (rounded_tag) {
+        0...255 => @intCast(rounded_tag),
+        ansi.COLOR_TAG_RGB => ansi.COLOR_TAG_RGB,
+        ansi.COLOR_TAG_DEFAULT => ansi.COLOR_TAG_DEFAULT,
+        else => ansi.COLOR_TAG_RGB,
+    };
+}
+
+fn decodePackedColor(color: [*]const f32) DecodedColor {
+    return .{
+        .rgba = .{ color[0], color[1], color[2], color[3] },
+        .tag = decodePackedColorTag(color[4]),
+    };
+}
+
+fn decodeOptionalPackedColor(color: ?[*]const f32) OptionalDecodedColor {
+    if (color) |packed_color| {
+        const decoded = decodePackedColor(packed_color);
+        return .{ .rgba = decoded.rgba, .tag = decoded.tag };
+    }
+
+    return .{};
+}
+
+inline fn selectionStyle(bg: OptionalDecodedColor, fg: OptionalDecodedColor) text_buffer_view.SelectionStyle {
+    return .{
+        .bgColor = bg.rgba,
+        .fgColor = fg.rgba,
+        .bgTag = bg.tag,
+        .fgTag = fg.tag,
+    };
+}
+
 comptime {
     _ = native_span_feed;
 }
@@ -398,6 +444,7 @@ pub const ExternalCapabilities = extern struct {
     kitty_keyboard: bool,
     kitty_graphics: bool,
     rgb: bool,
+    ansi256: bool,
     unicode: u8, // 0 = wcwidth, 1 = unicode
     sgr_pixels: bool,
     color_scheme_updates: bool,
@@ -425,6 +472,7 @@ export fn getTerminalCapabilities(rendererPtr: *renderer.CliRenderer, capsPtr: *
         .kitty_keyboard = caps.kitty_keyboard,
         .kitty_graphics = caps.kitty_graphics,
         .rgb = caps.rgb,
+        .ansi256 = caps.ansi256,
         .unicode = if (caps.unicode == .wcwidth) 0 else 1,
         .sgr_pixels = caps.sgr_pixels,
         .color_scheme_updates = caps.color_scheme_updates,
@@ -452,6 +500,26 @@ export fn processCapabilityResponse(rendererPtr: *renderer.CliRenderer, response
 
 export fn setCursorColor(rendererPtr: *renderer.CliRenderer, color: [*]const f32) void {
     rendererPtr.terminal.setCursorColor(utils.f32PtrToRGBA(color));
+}
+
+export fn rendererSetPaletteState(
+    rendererPtr: *renderer.CliRenderer,
+    palettePtr: [*]const f32,
+    paletteLen: usize,
+    defaultFgPtr: [*]const f32,
+    defaultBgPtr: [*]const f32,
+    paletteEpoch: u32,
+) void {
+    if (paletteLen < 256 * 4) return;
+
+    var palette: [256]renderer.RGBA = undefined;
+    var index: usize = 0;
+    while (index < palette.len) : (index += 1) {
+        const base = index * 4;
+        palette[index] = .{ palettePtr[base], palettePtr[base + 1], palettePtr[base + 2], palettePtr[base + 3] };
+    }
+
+    rendererPtr.setPaletteState(palette[0..], utils.f32PtrToRGBA(defaultFgPtr), utils.f32PtrToRGBA(defaultBgPtr), paletteEpoch);
 }
 
 pub const CursorStyleOptions = extern struct {
@@ -548,7 +616,8 @@ export fn clearClipboardOSC52(rendererPtr: *renderer.CliRenderer, target: u8) bo
 
 // Buffer functions
 export fn bufferClear(bufferPtr: *buffer.OptimizedBuffer, bg: [*]const f32) void {
-    bufferPtr.clear(utils.f32PtrToRGBA(bg), null) catch {};
+    const bg_color = decodePackedColor(bg);
+    bufferPtr.clearWithTags(bg_color.rgba, null, bg_color.tag) catch {};
 }
 
 export fn bufferGetCharPtr(bufferPtr: *buffer.OptimizedBuffer) [*]u32 {
@@ -561,6 +630,14 @@ export fn bufferGetFgPtr(bufferPtr: *buffer.OptimizedBuffer) [*]RGBA {
 
 export fn bufferGetBgPtr(bufferPtr: *buffer.OptimizedBuffer) [*]RGBA {
     return bufferPtr.getBgPtr();
+}
+
+export fn bufferGetFgTagPtr(bufferPtr: *buffer.OptimizedBuffer) [*]buffer.ColorTag {
+    return bufferPtr.getFgTagPtr();
+}
+
+export fn bufferGetBgTagPtr(bufferPtr: *buffer.OptimizedBuffer) [*]buffer.ColorTag {
+    return bufferPtr.getBgTagPtr();
 }
 
 export fn bufferGetAttributesPtr(bufferPtr: *buffer.OptimizedBuffer) [*]u32 {
@@ -592,32 +669,42 @@ export fn bufferWriteResolvedChars(bufferPtr: *buffer.OptimizedBuffer, outputPtr
 }
 
 export fn bufferDrawText(bufferPtr: *buffer.OptimizedBuffer, text: [*]const u8, textLen: usize, x: u32, y: u32, fg: [*]const f32, bg: ?[*]const f32, attributes: u32) void {
-    const rgbaFg = utils.f32PtrToRGBA(fg);
-    const rgbaBg = if (bg) |bgPtr| utils.f32PtrToRGBA(bgPtr) else null;
-    bufferPtr.drawText(text[0..textLen], x, y, rgbaFg, rgbaBg, attributes) catch {};
+    const fg_color = decodePackedColor(fg);
+    const bg_color = decodeOptionalPackedColor(bg);
+    bufferPtr.drawTextWithTags(
+        text[0..textLen],
+        x,
+        y,
+        fg_color.rgba,
+        bg_color.rgba,
+        attributes,
+        fg_color.tag,
+        bg_color.tag,
+    ) catch {};
 }
 
 export fn bufferSetCellWithAlphaBlending(bufferPtr: *buffer.OptimizedBuffer, x: u32, y: u32, char: u32, fg: [*]const f32, bg: [*]const f32, attributes: u32) void {
-    const rgbaFg = utils.f32PtrToRGBA(fg);
-    const rgbaBg = utils.f32PtrToRGBA(bg);
-    bufferPtr.setCellWithAlphaBlending(x, y, char, rgbaFg, rgbaBg, attributes) catch {};
+    const fg_color = decodePackedColor(fg);
+    const bg_color = decodePackedColor(bg);
+    bufferPtr.setCellWithAlphaBlending(x, y, char, fg_color.rgba, bg_color.rgba, attributes, fg_color.tag, bg_color.tag) catch {};
 }
 
 export fn bufferSetCell(bufferPtr: *buffer.OptimizedBuffer, x: u32, y: u32, char: u32, fg: [*]const f32, bg: [*]const f32, attributes: u32) void {
-    const rgbaFg = utils.f32PtrToRGBA(fg);
-    const rgbaBg = utils.f32PtrToRGBA(bg);
-    const cell = buffer.Cell{
+    const fg_color = decodePackedColor(fg);
+    const bg_color = decodePackedColor(bg);
+    bufferPtr.set(x, y, .{
         .char = char,
-        .fg = rgbaFg,
-        .bg = rgbaBg,
+        .fg = fg_color.rgba,
+        .bg = bg_color.rgba,
+        .fg_tag = fg_color.tag,
+        .bg_tag = bg_color.tag,
         .attributes = attributes,
-    };
-    bufferPtr.set(x, y, cell);
+    });
 }
 
 export fn bufferFillRect(bufferPtr: *buffer.OptimizedBuffer, x: u32, y: u32, width: u32, height: u32, bg: [*]const f32) void {
-    const rgbaBg = utils.f32PtrToRGBA(bg);
-    bufferPtr.fillRect(x, y, width, height, rgbaBg) catch {};
+    const bg_color = decodePackedColor(bg);
+    bufferPtr.fillRect(x, y, width, height, bg_color.rgba, bg_color.tag) catch {};
 }
 
 export fn bufferColorMatrix(bufferPtr: *buffer.OptimizedBuffer, matrixPtr: [*]const f32, cellMaskPtr: [*]const f32, cellMaskCount: usize, strength: f32, target: u8) void {
@@ -640,15 +727,35 @@ export fn bufferDrawPackedBuffer(bufferPtr: *buffer.OptimizedBuffer, data: [*]co
 }
 
 export fn bufferDrawGrayscaleBuffer(bufferPtr: *buffer.OptimizedBuffer, posX: i32, posY: i32, intensities: [*]const f32, srcWidth: u32, srcHeight: u32, fg: ?[*]const f32, bg: ?[*]const f32) void {
-    const rgbaFg = if (fg) |fgPtr| utils.f32PtrToRGBA(fgPtr) else null;
-    const rgbaBg = if (bg) |bgPtr| utils.f32PtrToRGBA(bgPtr) else null;
-    bufferPtr.drawGrayscaleBuffer(posX, posY, intensities, srcWidth, srcHeight, rgbaFg, rgbaBg);
+    const fg_color = decodeOptionalPackedColor(fg);
+    const bg_color = decodeOptionalPackedColor(bg);
+    bufferPtr.drawGrayscaleBuffer(
+        posX,
+        posY,
+        intensities,
+        srcWidth,
+        srcHeight,
+        fg_color.rgba,
+        bg_color.rgba,
+        fg_color.tag,
+        bg_color.tag,
+    );
 }
 
 export fn bufferDrawGrayscaleBufferSupersampled(bufferPtr: *buffer.OptimizedBuffer, posX: i32, posY: i32, intensities: [*]const f32, srcWidth: u32, srcHeight: u32, fg: ?[*]const f32, bg: ?[*]const f32) void {
-    const rgbaFg = if (fg) |fgPtr| utils.f32PtrToRGBA(fgPtr) else null;
-    const rgbaBg = if (bg) |bgPtr| utils.f32PtrToRGBA(bgPtr) else null;
-    bufferPtr.drawGrayscaleBufferSupersampled(posX, posY, intensities, srcWidth, srcHeight, rgbaFg, rgbaBg);
+    const fg_color = decodeOptionalPackedColor(fg);
+    const bg_color = decodeOptionalPackedColor(bg);
+    bufferPtr.drawGrayscaleBufferSupersampled(
+        posX,
+        posY,
+        intensities,
+        srcWidth,
+        srcHeight,
+        fg_color.rgba,
+        bg_color.rgba,
+        fg_color.tag,
+        bg_color.tag,
+    );
 }
 
 export fn bufferPushScissorRect(bufferPtr: *buffer.OptimizedBuffer, x: i32, y: i32, width: u32, height: u32) void {
@@ -722,16 +829,20 @@ export fn bufferDrawGrid(
     rowCount: u32,
     options: *const ExternalGridDrawOptions,
 ) void {
+    const border_fg = decodePackedColor(borderFg);
+    const border_bg = decodePackedColor(borderBg);
     bufferPtr.drawGrid(
         borderChars,
-        utils.f32PtrToRGBA(borderFg),
-        utils.f32PtrToRGBA(borderBg),
+        border_fg.rgba,
+        border_bg.rgba,
         columnOffsets,
         columnCount,
         rowOffsets,
         rowCount,
         options.draw_inner,
         options.draw_outer,
+        border_fg.tag,
+        border_bg.tag,
     );
 }
 
@@ -750,6 +861,8 @@ export fn bufferDrawBox(
     bottomTitle: ?[*]const u8,
     bottomTitleLen: u32,
 ) void {
+    const border_color = decodePackedColor(borderColor);
+    const background_color = decodePackedColor(backgroundColor);
     const borderSides = buffer.BorderSides{
         .top = (packedOptions & 0b1000) != 0,
         .right = (packedOptions & 0b0100) != 0,
@@ -771,13 +884,15 @@ export fn bufferDrawBox(
         height,
         borderChars,
         borderSides,
-        utils.f32PtrToRGBA(borderColor),
-        utils.f32PtrToRGBA(backgroundColor),
+        border_color.rgba,
+        background_color.rgba,
         shouldFill,
         titleSlice,
         titleAlignment,
         bottomTitleSlice,
         bottomTitleAlignment,
+        border_color.tag,
+        background_color.tag,
     ) catch {};
 }
 
@@ -914,13 +1029,13 @@ export fn textBufferClear(tb: *text_buffer.UnifiedTextBuffer) void {
 }
 
 export fn textBufferSetDefaultFg(tb: *text_buffer.UnifiedTextBuffer, fg: ?[*]const f32) void {
-    const fgColor = if (fg) |fgPtr| utils.f32PtrToRGBA(fgPtr) else null;
-    tb.setDefaultFg(fgColor);
+    const fg_color = decodeOptionalPackedColor(fg);
+    tb.setDefaultFgWithTag(fg_color.rgba, fg_color.tag);
 }
 
 export fn textBufferSetDefaultBg(tb: *text_buffer.UnifiedTextBuffer, bg: ?[*]const f32) void {
-    const bgColor = if (bg) |bgPtr| utils.f32PtrToRGBA(bgPtr) else null;
-    tb.setDefaultBg(bgColor);
+    const bg_color = decodeOptionalPackedColor(bg);
+    tb.setDefaultBgWithTag(bg_color.rgba, bg_color.tag);
 }
 
 export fn textBufferSetDefaultAttributes(tb: *text_buffer.UnifiedTextBuffer, attr: ?[*]const u32) void {
@@ -1006,9 +1121,9 @@ export fn destroyTextBufferView(view: *text_buffer_view.UnifiedTextBufferView) v
 }
 
 export fn textBufferViewSetSelection(view: *text_buffer_view.UnifiedTextBufferView, start: u32, end: u32, bgColor: ?[*]const f32, fgColor: ?[*]const f32) void {
-    const bg = if (bgColor) |bgPtr| utils.f32PtrToRGBA(bgPtr) else null;
-    const fg = if (fgColor) |fgPtr| utils.f32PtrToRGBA(fgPtr) else null;
-    view.setSelection(start, end, bg, fg);
+    const bg = decodeOptionalPackedColor(bgColor);
+    const fg = decodeOptionalPackedColor(fgColor);
+    view.setSelectionStyle(start, end, selectionStyle(bg, fg));
 }
 
 export fn textBufferViewResetSelection(view: *text_buffer_view.UnifiedTextBufferView) void {
@@ -1020,21 +1135,21 @@ export fn textBufferViewGetSelectionInfo(view: *text_buffer_view.UnifiedTextBuff
 }
 
 export fn textBufferViewSetLocalSelection(view: *text_buffer_view.UnifiedTextBufferView, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const f32, fgColor: ?[*]const f32) bool {
-    const bg = if (bgColor) |bgPtr| utils.f32PtrToRGBA(bgPtr) else null;
-    const fg = if (fgColor) |fgPtr| utils.f32PtrToRGBA(fgPtr) else null;
-    return view.setLocalSelection(anchorX, anchorY, focusX, focusY, bg, fg);
+    const bg = decodeOptionalPackedColor(bgColor);
+    const fg = decodeOptionalPackedColor(fgColor);
+    return view.setLocalSelectionStyle(anchorX, anchorY, focusX, focusY, selectionStyle(bg, fg));
 }
 
 export fn textBufferViewUpdateSelection(view: *text_buffer_view.UnifiedTextBufferView, end: u32, bgColor: ?[*]const f32, fgColor: ?[*]const f32) void {
-    const bg = if (bgColor) |bgPtr| utils.f32PtrToRGBA(bgPtr) else null;
-    const fg = if (fgColor) |fgPtr| utils.f32PtrToRGBA(fgPtr) else null;
-    view.updateSelection(end, bg, fg);
+    const bg = decodeOptionalPackedColor(bgColor);
+    const fg = decodeOptionalPackedColor(fgColor);
+    view.updateSelectionStyle(end, selectionStyle(bg, fg));
 }
 
 export fn textBufferViewUpdateLocalSelection(view: *text_buffer_view.UnifiedTextBufferView, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const f32, fgColor: ?[*]const f32) bool {
-    const bg = if (bgColor) |bgPtr| utils.f32PtrToRGBA(bgPtr) else null;
-    const fg = if (fgColor) |fgPtr| utils.f32PtrToRGBA(fgPtr) else null;
-    return view.updateLocalSelection(anchorX, anchorY, focusX, focusY, bg, fg);
+    const bg = decodeOptionalPackedColor(bgColor);
+    const fg = decodeOptionalPackedColor(fgColor);
+    return view.updateLocalSelectionStyle(anchorX, anchorY, focusX, focusY, selectionStyle(bg, fg));
 }
 
 export fn textBufferViewResetLocalSelection(view: *text_buffer_view.UnifiedTextBufferView) void {
@@ -1457,9 +1572,9 @@ export fn editorViewSetWrapMode(view: *editor_view.EditorView, mode: u8) void {
 
 // EditorView selection methods - delegate to TextBufferView
 export fn editorViewSetSelection(view: *editor_view.EditorView, start: u32, end: u32, bgColor: ?[*]const f32, fgColor: ?[*]const f32) void {
-    const bg = if (bgColor) |bgPtr| utils.f32PtrToRGBA(bgPtr) else null;
-    const fg = if (fgColor) |fgPtr| utils.f32PtrToRGBA(fgPtr) else null;
-    view.text_buffer_view.setSelection(start, end, bg, fg);
+    const bg = decodeOptionalPackedColor(bgColor);
+    const fg = decodeOptionalPackedColor(fgColor);
+    view.text_buffer_view.setSelectionStyle(start, end, selectionStyle(bg, fg));
 }
 
 export fn editorViewResetSelection(view: *editor_view.EditorView) void {
@@ -1471,23 +1586,31 @@ export fn editorViewGetSelection(view: *editor_view.EditorView) u64 {
 }
 
 export fn editorViewSetLocalSelection(view: *editor_view.EditorView, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const f32, fgColor: ?[*]const f32, updateCursor: bool, followCursor: bool) bool {
-    const bg = if (bgColor) |bgPtr| utils.f32PtrToRGBA(bgPtr) else null;
-    const fg = if (fgColor) |fgPtr| utils.f32PtrToRGBA(fgPtr) else null;
+    const bg = decodeOptionalPackedColor(bgColor);
+    const fg = decodeOptionalPackedColor(fgColor);
     view.setSelectionFollowCursor(followCursor);
-    return view.setLocalSelection(anchorX, anchorY, focusX, focusY, bg, fg, updateCursor);
+    const changed = view.text_buffer_view.setLocalSelectionStyle(anchorX, anchorY, focusX, focusY, selectionStyle(bg, fg));
+    if (changed and updateCursor) {
+        view.syncCursorToSelectionFocus();
+    }
+    return changed;
 }
 
 export fn editorViewUpdateSelection(view: *editor_view.EditorView, end: u32, bgColor: ?[*]const f32, fgColor: ?[*]const f32) void {
-    const bg = if (bgColor) |bgPtr| utils.f32PtrToRGBA(bgPtr) else null;
-    const fg = if (fgColor) |fgPtr| utils.f32PtrToRGBA(fgPtr) else null;
-    view.updateSelection(end, bg, fg);
+    const bg = decodeOptionalPackedColor(bgColor);
+    const fg = decodeOptionalPackedColor(fgColor);
+    view.text_buffer_view.updateSelectionStyle(end, selectionStyle(bg, fg));
 }
 
 export fn editorViewUpdateLocalSelection(view: *editor_view.EditorView, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const f32, fgColor: ?[*]const f32, updateCursor: bool, followCursor: bool) bool {
-    const bg = if (bgColor) |bgPtr| utils.f32PtrToRGBA(bgPtr) else null;
-    const fg = if (fgColor) |fgPtr| utils.f32PtrToRGBA(fgPtr) else null;
+    const bg = decodeOptionalPackedColor(bgColor);
+    const fg = decodeOptionalPackedColor(fgColor);
     view.setSelectionFollowCursor(followCursor);
-    return view.updateLocalSelection(anchorX, anchorY, focusX, focusY, bg, fg, updateCursor);
+    const changed = view.text_buffer_view.updateLocalSelectionStyle(anchorX, anchorY, focusX, focusY, selectionStyle(bg, fg));
+    if (changed and updateCursor) {
+        view.syncCursorToSelectionFocus();
+    }
+    return changed;
 }
 
 export fn editorViewResetLocalSelection(view: *editor_view.EditorView) void {
@@ -1764,9 +1887,15 @@ export fn destroySyntaxStyle(style: *syntax_style.SyntaxStyle) void {
 
 export fn syntaxStyleRegister(style: *syntax_style.SyntaxStyle, namePtr: [*]const u8, nameLen: usize, fg: ?[*]const f32, bg: ?[*]const f32, attributes: u32) u32 {
     const name = namePtr[0..nameLen];
-    const fgColor = if (fg) |fgPtr| utils.f32PtrToRGBA(fgPtr) else null;
-    const bgColor = if (bg) |bgPtr| utils.f32PtrToRGBA(bgPtr) else null;
-    return style.registerStyle(name, fgColor, bgColor, attributes) catch 0;
+    const fg_color = decodeOptionalPackedColor(fg);
+    const bg_color = decodeOptionalPackedColor(bg);
+    return style.registerStyleDefinition(name, .{
+        .fg = fg_color.rgba,
+        .bg = bg_color.rgba,
+        .fg_tag = fg_color.tag,
+        .bg_tag = bg_color.tag,
+        .attributes = attributes,
+    }) catch 0;
 }
 
 export fn syntaxStyleResolveByName(style: *syntax_style.SyntaxStyle, namePtr: [*]const u8, nameLen: usize) u32 {
@@ -1934,7 +2063,7 @@ export fn bufferDrawChar(
     bg: [*]const f32,
     attributes: u32,
 ) void {
-    const rgbaFg = utils.f32PtrToRGBA(fg);
-    const rgbaBg = utils.f32PtrToRGBA(bg);
-    bufferPtr.drawChar(char, x, y, rgbaFg, rgbaBg, attributes) catch {};
+    const fg_color = decodePackedColor(fg);
+    const bg_color = decodePackedColor(bg);
+    bufferPtr.drawChar(char, x, y, fg_color.rgba, bg_color.rgba, attributes, fg_color.tag, bg_color.tag) catch {};
 }

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -27,13 +27,6 @@ pub const RendererError = error{
     WriteFailed,
 };
 
-fn rgbaComponentToU8(component: f32) u8 {
-    if (!std.math.isFinite(component)) return 0;
-
-    const clamped = std.math.clamp(component, 0.0, 1.0);
-    return @intFromFloat(@round(clamped * 255.0));
-}
-
 pub const DebugOverlayCorner = enum {
     topLeft,
     topRight,
@@ -191,6 +184,13 @@ pub const CliRenderer = struct {
     lastCursorY: ?u32 = null,
     lastCursorVisible: ?bool = null,
     lastMousePointerStyle: Terminal.MousePointerStyle = .default,
+    palette_rgba: [256]RGBA,
+    default_fg_rgba: RGBA,
+    default_bg_rgba: RGBA,
+    palette_epoch: u32,
+    last_rendered_palette_epoch: ?u32 = null,
+    force_full_repaint: bool = false,
+    palette_index_cache: std.AutoHashMapUnmanaged(u64, u8) = .{},
 
     // Preallocated output buffer
     var outputBuffer: [OUTPUT_BUFFER_SIZE]u8 = undefined;
@@ -321,8 +321,13 @@ pub const CliRenderer = struct {
             .hitGridWidth = width,
             .hitGridHeight = height,
             .hitScissorStack = hitScissorStack,
+            .palette_rgba = undefined,
+            .default_fg_rgba = .{ 1.0, 1.0, 1.0, 1.0 },
+            .default_bg_rgba = .{ 0.0, 0.0, 0.0, 1.0 },
+            .palette_epoch = 0,
         };
 
+        self.resetFallbackPaletteState();
         nextBuffer.setBlendBackdropColor(.{ self.backgroundColor[0], self.backgroundColor[1], self.backgroundColor[2], 1.0 });
 
         try currentBuffer.clear(.{ self.backgroundColor[0], self.backgroundColor[1], self.backgroundColor[2], self.backgroundColor[3] }, CLEAR_CHAR);
@@ -360,6 +365,7 @@ pub const CliRenderer = struct {
         self.statSamples.stdoutWriteTime.deinit(self.allocator);
         self.statSamples.cellsUpdated.deinit(self.allocator);
         self.statSamples.frameCallbackTime.deinit(self.allocator);
+        self.palette_index_cache.deinit(self.allocator);
 
         self.allocator.free(self.currentHitGrid);
         self.allocator.free(self.nextHitGrid);
@@ -587,6 +593,108 @@ pub const CliRenderer = struct {
             const b: u8 = @intFromFloat(@round(@min(rgba[2] * 255.0, 255.0)));
             ansi.ANSI.setTerminalBgColorOutput(writer, r, g, b) catch {};
             writer.flush() catch {};
+        }
+    }
+
+    fn resetFallbackPaletteState(self: *CliRenderer) void {
+        for (0..self.palette_rgba.len) |index| {
+            self.palette_rgba[index] = ansi.fallbackAnsi256Color(index);
+        }
+        self.default_fg_rgba = .{ 1.0, 1.0, 1.0, 1.0 };
+        self.default_bg_rgba = .{ 0.0, 0.0, 0.0, 1.0 };
+    }
+
+    pub fn setPaletteState(self: *CliRenderer, palette: []const RGBA, default_fg: RGBA, default_bg: RGBA, palette_epoch: u32) void {
+        self.resetFallbackPaletteState();
+
+        const copy_len = @min(palette.len, self.palette_rgba.len);
+        for (palette[0..copy_len], 0..) |color, index| {
+            self.palette_rgba[index] = color;
+        }
+
+        self.default_fg_rgba = default_fg;
+        self.default_bg_rgba = default_bg;
+
+        if (self.palette_epoch != palette_epoch) {
+            self.palette_epoch = palette_epoch;
+            self.force_full_repaint = true;
+            self.palette_index_cache.clearRetainingCapacity();
+        }
+    }
+
+    fn cachedNearestPaletteIndex(self: *CliRenderer, rgba: RGBA) u8 {
+        const rgb24 = ansi.rgbaToRgb24(rgba);
+        const key = (@as(u64, self.palette_epoch) << 24) | @as(u64, rgb24);
+
+        if (self.palette_index_cache.get(key)) |cached| {
+            return cached;
+        }
+
+        var best_index: u8 = 0;
+        var best_distance = std.math.inf(f32);
+
+        for (self.palette_rgba, 0..) |candidate, index| {
+            const distance = ansi.colorDistanceSquared(rgba, candidate);
+            if (distance < best_distance) {
+                best_distance = distance;
+                best_index = @intCast(index);
+            }
+        }
+
+        self.palette_index_cache.put(self.allocator, key, best_index) catch {};
+        return best_index;
+    }
+
+    fn emitColor(self: *CliRenderer, writer: anytype, rgba: RGBA, tag: ansi.ColorTag, is_background: bool) void {
+        const caps = self.terminal.getCapabilities();
+        const decoded = ansi.decodeColorTag(tag);
+
+        if (decoded.kind == .default) {
+            if (is_background) {
+                ansi.ANSI.bgDefaultOutput(writer) catch {};
+            } else {
+                ansi.ANSI.fgDefaultOutput(writer) catch {};
+            }
+            return;
+        }
+
+        if (is_background and decoded.kind == .rgb and rgba[3] < 0.001) {
+            ansi.ANSI.bgDefaultOutput(writer) catch {};
+            return;
+        }
+
+        if (decoded.kind == .indexed and caps.ansi256) {
+            const index = decoded.index orelse 0;
+            if (is_background) {
+                ansi.ANSI.bgIndexedColorOutput(writer, index) catch {};
+            } else {
+                ansi.ANSI.fgIndexedColorOutput(writer, index) catch {};
+            }
+            return;
+        }
+
+        if (!caps.rgb and caps.ansi256) {
+            const index: u8 = if (decoded.kind == .indexed)
+                decoded.index orelse 0
+            else
+                self.cachedNearestPaletteIndex(rgba);
+
+            if (is_background) {
+                ansi.ANSI.bgIndexedColorOutput(writer, index) catch {};
+            } else {
+                ansi.ANSI.fgIndexedColorOutput(writer, index) catch {};
+            }
+            return;
+        }
+
+        const r = ansi.rgbaComponentToU8(rgba[0]);
+        const g = ansi.rgbaComponentToU8(rgba[1]);
+        const b = ansi.rgbaComponentToU8(rgba[2]);
+
+        if (is_background) {
+            ansi.ANSI.bgColorOutput(writer, r, g, b) catch {};
+        } else {
+            ansi.ANSI.fgColorOutput(writer, r, g, b) catch {};
         }
     }
 
@@ -931,6 +1039,8 @@ pub const CliRenderer = struct {
     ) void {
         var currentFg: ?RGBA = null;
         var currentBg: ?RGBA = null;
+        var currentFgTag: ?ansi.ColorTag = null;
+        var currentBgTag: ?ansi.ColorTag = null;
         var currentAttributes: i32 = -1;
         var currentLinkId: u32 = 0;
         var utf8Buf: [4]u8 = undefined;
@@ -947,8 +1057,8 @@ pub const CliRenderer = struct {
                 const x = @as(u32, @intCast(ux));
                 const cell = snapshot.get(x, y) orelse continue;
 
-                const fgMatch = currentFg != null and buf.rgbaEqual(currentFg.?, cell.fg, colorEpsilon);
-                const bgMatch = currentBg != null and buf.rgbaEqual(currentBg.?, cell.bg, colorEpsilon);
+                const fgMatch = currentFg != null and currentFgTag != null and currentFgTag.? == cell.fg_tag and buf.rgbaEqual(currentFg.?, cell.fg, colorEpsilon);
+                const bgMatch = currentBg != null and currentBgTag != null and currentBgTag.? == cell.bg_tag and buf.rgbaEqual(currentBg.?, cell.bg, colorEpsilon);
                 const sameAttributes = fgMatch and bgMatch and @as(i32, @intCast(cell.attributes)) == currentAttributes;
 
                 const linkId = if (hyperlinksEnabled) ansi.TextAttributes.getLinkId(cell.attributes) else 0;
@@ -972,23 +1082,12 @@ pub const CliRenderer = struct {
 
                     currentFg = cell.fg;
                     currentBg = cell.bg;
+                    currentFgTag = cell.fg_tag;
+                    currentBgTag = cell.bg_tag;
                     currentAttributes = @as(i32, @intCast(cell.attributes));
 
-                    const fgR = rgbaComponentToU8(cell.fg[0]);
-                    const fgG = rgbaComponentToU8(cell.fg[1]);
-                    const fgB = rgbaComponentToU8(cell.fg[2]);
-
-                    const bgR = rgbaComponentToU8(cell.bg[0]);
-                    const bgG = rgbaComponentToU8(cell.bg[1]);
-                    const bgB = rgbaComponentToU8(cell.bg[2]);
-                    const bgA = cell.bg[3];
-
-                    ansi.ANSI.fgColorOutput(writer, fgR, fgG, fgB) catch {};
-                    if (bgA < 0.001) {
-                        writer.writeAll("\x1b[49m") catch {};
-                    } else {
-                        ansi.ANSI.bgColorOutput(writer, bgR, bgG, bgB) catch {};
-                    }
+                    self.emitColor(writer, cell.fg, cell.fg_tag, false);
+                    self.emitColor(writer, cell.bg, cell.bg_tag, true);
 
                     ansi.TextAttributes.applyAttributesOutputWriter(writer, cell.attributes) catch {};
                 }
@@ -1030,6 +1129,11 @@ pub const CliRenderer = struct {
             writer.writeAll(ansi.ANSI.reset) catch {};
             // Guarantee short rows do not leave stale content from prior frame data.
             writer.writeAll(ansi.ANSI.eraseToEndOfLine) catch {};
+            currentFg = null;
+            currentBg = null;
+            currentFgTag = null;
+            currentBgTag = null;
+            currentAttributes = -1;
 
             const is_last_row = @as(u32, @intCast(uy + 1)) >= snapshot.height;
             if (!is_last_row or trailing_newline) {
@@ -1042,10 +1146,6 @@ pub const CliRenderer = struct {
                 writer.writeAll(ansi.ANSI.reset) catch {};
                 writer.writeAll(ansi.ANSI.eraseToEndOfLine) catch {};
             }
-
-            currentFg = null;
-            currentBg = null;
-            currentAttributes = -1;
         }
     }
 
@@ -1169,6 +1269,8 @@ pub const CliRenderer = struct {
     fn prepareRenderFrame(self: *CliRenderer, force: bool, reset_output_buffer: bool, sync_started: bool) void {
         const renderStartTime = std.time.microTimestamp();
         var cellsUpdated: u32 = 0;
+        const palette_force = self.last_rendered_palette_epoch == null or self.last_rendered_palette_epoch.? != self.palette_epoch;
+        const should_force = force or self.force_full_repaint or palette_force;
 
         if (reset_output_buffer) {
             resetActiveOutputBuffer();
@@ -1183,6 +1285,8 @@ pub const CliRenderer = struct {
 
         var currentFg: ?RGBA = null;
         var currentBg: ?RGBA = null;
+        var currentFgTag: ?ansi.ColorTag = null;
+        var currentBgTag: ?ansi.ColorTag = null;
         var currentAttributes: i32 = -1;
         var currentLinkId: u32 = 0;
         var utf8Buf: [4]u8 = undefined;
@@ -1203,11 +1307,13 @@ pub const CliRenderer = struct {
 
                 if (currentCell == null or nextCell == null) continue;
 
-                if (!force) {
+                if (!should_force) {
                     const charEqual = currentCell.?.char == nextCell.?.char;
                     const attrEqual = currentCell.?.attributes == nextCell.?.attributes;
+                    const fgTagEqual = currentCell.?.fg_tag == nextCell.?.fg_tag;
+                    const bgTagEqual = currentCell.?.bg_tag == nextCell.?.bg_tag;
 
-                    if (charEqual and attrEqual and
+                    if (charEqual and attrEqual and fgTagEqual and bgTagEqual and
                         buf.rgbaEqual(currentCell.?.fg, nextCell.?.fg, colorEpsilon) and
                         buf.rgbaEqual(currentCell.?.bg, nextCell.?.bg, colorEpsilon))
                     {
@@ -1227,8 +1333,8 @@ pub const CliRenderer = struct {
                     frame_started = true;
                 }
 
-                const fgMatch = currentFg != null and buf.rgbaEqual(currentFg.?, cell.fg, colorEpsilon);
-                const bgMatch = currentBg != null and buf.rgbaEqual(currentBg.?, cell.bg, colorEpsilon);
+                const fgMatch = currentFg != null and currentFgTag != null and currentFgTag.? == cell.fg_tag and buf.rgbaEqual(currentFg.?, cell.fg, colorEpsilon);
+                const bgMatch = currentBg != null and currentBgTag != null and currentBgTag.? == cell.bg_tag and buf.rgbaEqual(currentBg.?, cell.bg, colorEpsilon);
                 const sameAttributes = fgMatch and bgMatch and @as(i32, @intCast(cell.attributes)) == currentAttributes;
 
                 const linkId = if (hyperlinksEnabled) ansi.TextAttributes.getLinkId(cell.attributes) else 0;
@@ -1259,27 +1365,14 @@ pub const CliRenderer = struct {
 
                     currentFg = cell.fg;
                     currentBg = cell.bg;
+                    currentFgTag = cell.fg_tag;
+                    currentBgTag = cell.bg_tag;
                     currentAttributes = @as(i32, @intCast(cell.attributes));
 
                     ansi.ANSI.moveToOutput(writer, x + 1, y + 1 + self.renderOffset) catch {};
 
-                    const fgR = rgbaComponentToU8(cell.fg[0]);
-                    const fgG = rgbaComponentToU8(cell.fg[1]);
-                    const fgB = rgbaComponentToU8(cell.fg[2]);
-
-                    const bgR = rgbaComponentToU8(cell.bg[0]);
-                    const bgG = rgbaComponentToU8(cell.bg[1]);
-                    const bgB = rgbaComponentToU8(cell.bg[2]);
-                    const bgA = cell.bg[3];
-
-                    ansi.ANSI.fgColorOutput(writer, fgR, fgG, fgB) catch {};
-
-                    // If alpha is 0 (transparent), use terminal default background instead of black
-                    if (bgA < 0.001) {
-                        writer.writeAll("\x1b[49m") catch {};
-                    } else {
-                        ansi.ANSI.bgColorOutput(writer, bgR, bgG, bgB) catch {};
-                    }
+                    self.emitColor(writer, cell.fg, cell.fg_tag, false);
+                    self.emitColor(writer, cell.bg, cell.bg_tag, true);
 
                     ansi.TextAttributes.applyAttributesOutputWriter(writer, cell.attributes) catch {};
                 }
@@ -1371,9 +1464,9 @@ pub const CliRenderer = struct {
                 },
             }
 
-            const cursorR = rgbaComponentToU8(cursorColor[0]);
-            const cursorG = rgbaComponentToU8(cursorColor[1]);
-            const cursorB = rgbaComponentToU8(cursorColor[2]);
+            const cursorR = ansi.rgbaComponentToU8(cursorColor[0]);
+            const cursorG = ansi.rgbaComponentToU8(cursorColor[1]);
+            const cursorB = ansi.rgbaComponentToU8(cursorColor[2]);
 
             const styleTag: u8 = @intFromEnum(cursorStyle.style);
             const styleChanged = (self.lastCursorStyleTag == null or self.lastCursorStyleTag.? != styleTag) or
@@ -1446,6 +1539,8 @@ pub const CliRenderer = struct {
 
         self.renderStats.cellsUpdated = cellsUpdated;
         self.renderStats.renderTime = renderTime;
+        self.last_rendered_palette_epoch = self.palette_epoch;
+        self.force_full_repaint = false;
 
         self.nextRenderBuffer.clear(.{ self.backgroundColor[0], self.backgroundColor[1], self.backgroundColor[2], self.backgroundColor[3] }, null) catch {};
 
@@ -1909,7 +2004,7 @@ pub const CliRenderer = struct {
             },
         }
 
-        self.nextRenderBuffer.fillRect(x, y, width, height, .{ 20.0 / 255.0, 20.0 / 255.0, 40.0 / 255.0, 1.0 }) catch {};
+        self.nextRenderBuffer.fillRect(x, y, width, height, .{ 20.0 / 255.0, 20.0 / 255.0, 40.0 / 255.0, 1.0 }, ansi.COLOR_TAG_RGB) catch {};
         self.nextRenderBuffer.drawText("Debug Information", x + 1, y + 1, .{ 1.0, 1.0, 100.0 / 255.0, 1.0 }, .{ 0.0, 0.0, 0.0, 0.0 }, ansi.TextAttributes.BOLD) catch {};
 
         var row: u32 = 2;

--- a/packages/core/src/zig/syntax-style.zig
+++ b/packages/core/src/zig/syntax-style.zig
@@ -1,13 +1,17 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const ansi = @import("ansi.zig");
 const buffer = @import("buffer.zig");
 const events = @import("event-emitter.zig");
 
 pub const RGBA = buffer.RGBA;
+pub const ColorTag = buffer.ColorTag;
 
 pub const StyleDefinition = struct {
     fg: ?RGBA,
     bg: ?RGBA,
+    fg_tag: ColorTag = ansi.COLOR_TAG_RGB,
+    bg_tag: ColorTag = ansi.COLOR_TAG_RGB,
     attributes: u32,
 };
 
@@ -64,13 +68,9 @@ pub const SyntaxStyle = struct {
         self.global_allocator.destroy(self);
     }
 
-    pub fn registerStyle(self: *SyntaxStyle, name: []const u8, fg: ?RGBA, bg: ?RGBA, attributes: u32) SyntaxStyleError!u32 {
+    fn putStyle(self: *SyntaxStyle, name: []const u8, definition: StyleDefinition) SyntaxStyleError!u32 {
         if (self.name_to_id.get(name)) |existing_id| {
-            try self.id_to_style.put(self.allocator, existing_id, StyleDefinition{
-                .fg = fg,
-                .bg = bg,
-                .attributes = attributes,
-            });
+            try self.id_to_style.put(self.allocator, existing_id, definition);
             return existing_id;
         }
 
@@ -80,13 +80,21 @@ pub const SyntaxStyle = struct {
         const owned_name = self.allocator.dupe(u8, name) catch return SyntaxStyleError.OutOfMemory;
 
         try self.name_to_id.put(self.allocator, owned_name, id);
-        try self.id_to_style.put(self.allocator, id, StyleDefinition{
+        try self.id_to_style.put(self.allocator, id, definition);
+
+        return id;
+    }
+
+    pub fn registerStyle(self: *SyntaxStyle, name: []const u8, fg: ?RGBA, bg: ?RGBA, attributes: u32) SyntaxStyleError!u32 {
+        return self.registerStyleDefinition(name, .{
             .fg = fg,
             .bg = bg,
             .attributes = attributes,
         });
+    }
 
-        return id;
+    pub fn registerStyleDefinition(self: *SyntaxStyle, name: []const u8, definition: StyleDefinition) SyntaxStyleError!u32 {
+        return self.putStyle(name, definition);
     }
 
     pub fn resolveById(self: *const SyntaxStyle, id: u32) ?StyleDefinition {
@@ -126,8 +134,14 @@ pub const SyntaxStyle = struct {
 
         for (ids) |id| {
             if (self.resolveById(id)) |style| {
-                if (style.fg) |fg| merged.fg = fg;
-                if (style.bg) |bg| merged.bg = bg;
+                if (style.fg) |fg| {
+                    merged.fg = fg;
+                    merged.fg_tag = style.fg_tag;
+                }
+                if (style.bg) |bg| {
+                    merged.bg = bg;
+                    merged.bg_tag = style.bg_tag;
+                }
                 // Attributes are OR'd together
                 merged.attributes |= style.attributes;
             }

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -15,6 +15,7 @@ pub const Capabilities = struct {
     kitty_keyboard: bool = false,
     kitty_graphics: bool = false,
     rgb: bool = false,
+    ansi256: bool = false,
     unicode: WidthMethod = .unicode,
     sgr_pixels: bool = false,
     color_scheme_updates: bool = false,
@@ -314,6 +315,7 @@ pub fn enableDetectedFeatures(self: *Terminal, tty: anytype, use_kitty_keyboard:
     if (builtin.os.tag == .windows) {
         // Windows-specific defaults for ConPTY
         self.caps.rgb = true;
+        self.caps.ansi256 = true;
         self.caps.bracketed_paste = true;
     }
 
@@ -370,15 +372,16 @@ fn checkEnvironmentOverrides(self: *Terminal) void {
     self.caps.bracketed_paste = true;
 
     if (self.caps.rgb) {
+        self.caps.ansi256 = true;
         self.caps.hyperlinks = true;
     }
 
-    if (self.opts.remote) {
-        return;
-    }
-
     var env_map_storage: ?std.process.EnvMap = null;
-    const env_map: *const std.process.EnvMap = self.opts.env_map orelse blk: {
+    const maybe_env_map: ?*const std.process.EnvMap = self.opts.env_map orelse blk: {
+        if (self.opts.remote) {
+            break :blk null;
+        }
+
         env_map_storage = std.process.getEnvMap(std.heap.page_allocator) catch |err| {
             logger.err("Failed to get environment map: {}", .{err});
             return;
@@ -386,6 +389,12 @@ fn checkEnvironmentOverrides(self: *Terminal) void {
         break :blk &env_map_storage.?;
     };
     defer if (env_map_storage) |*map| map.deinit();
+
+    if (maybe_env_map == null) {
+        return;
+    }
+
+    const env_map = maybe_env_map.?;
 
     if (!self.term_info.from_xtversion) {
         if (env_map.get("TMUX")) |_| {
@@ -405,6 +414,12 @@ fn checkEnvironmentOverrides(self: *Terminal) void {
             if (std.mem.indexOf(u8, term, "alacritty") != null) {
                 self.caps.explicit_cursor_positioning = true;
             }
+        }
+    }
+
+    if (env_map.get("TERM")) |term| {
+        if (std.ascii.indexOfIgnoreCase(term, "256color") != null) {
+            self.caps.ansi256 = true;
         }
     }
 
@@ -456,6 +471,7 @@ fn checkEnvironmentOverrides(self: *Terminal) void {
             std.mem.eql(u8, colorterm, "24bit"))
         {
             self.caps.rgb = true;
+            self.caps.ansi256 = true;
         }
     }
 
@@ -788,6 +804,7 @@ pub fn processCapabilityResponse(self: *Terminal, response: []const u8) void {
         self.caps.kitty_graphics = true;
         self.caps.unicode = .unicode;
         self.caps.rgb = true;
+        self.caps.ansi256 = true;
         self.caps.sixel = true;
         self.caps.bracketed_paste = true;
         self.caps.hyperlinks = true;

--- a/packages/core/src/zig/tests/buffer_test.zig
+++ b/packages/core/src/zig/tests/buffer_test.zig
@@ -103,6 +103,191 @@ test "OptimizedBuffer - drawText with ASCII" {
     try std.testing.expectEqual(@as(u32, 'e'), cell_e.char);
 }
 
+test "OptimizedBuffer - alpha blending downgrades blended tags to rgb" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var buf = try OptimizedBuffer.init(
+        std.testing.allocator,
+        4,
+        1,
+        .{ .pool = pool, .id = "tag-blend-buffer" },
+    );
+    defer buf.deinit();
+
+    const base_fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
+    const base_bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try buf.clear(base_bg, null);
+
+    try buf.setCellWithAlphaBlending(
+        0,
+        0,
+        'B',
+        RGBA{ 1.0, 0.0, 0.0, 0.5 },
+        base_bg,
+        0,
+        ansi.indexedColorTag(3),
+        ansi.indexedColorTag(4),
+    );
+
+    const fg_blended_cell = buf.get(0, 0).?;
+    try std.testing.expectEqual(ansi.COLOR_TAG_RGB, fg_blended_cell.fg_tag);
+    try std.testing.expectEqual(ansi.indexedColorTag(4), fg_blended_cell.bg_tag);
+
+    // Establish a destination foreground, then blend background alpha over it.
+    buf.set(0, 0, .{
+        .char = 'A',
+        .fg = base_fg,
+        .bg = base_bg,
+        .fg_tag = ansi.indexedColorTag(1),
+        .bg_tag = ansi.indexedColorTag(2),
+        .attributes = 0,
+    });
+
+    try buf.setCellWithAlphaBlending(
+        0,
+        0,
+        'C',
+        RGBA{ 1.0, 0.0, 0.0, 1.0 },
+        RGBA{ 0.0, 1.0, 0.0, 0.5 },
+        0,
+        ansi.indexedColorTag(5),
+        ansi.indexedColorTag(6),
+    );
+
+    const bg_blended_cell = buf.get(0, 0).?;
+    try std.testing.expectEqual(ansi.indexedColorTag(5), bg_blended_cell.fg_tag);
+    try std.testing.expectEqual(ansi.COLOR_TAG_RGB, bg_blended_cell.bg_tag);
+}
+
+test "OptimizedBuffer - drawFrameBuffer preserves explicit tags on opaque copy" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var src = try OptimizedBuffer.init(
+        std.testing.allocator,
+        2,
+        1,
+        .{ .pool = pool, .id = "src-tag-copy-buffer" },
+    );
+    defer src.deinit();
+
+    var dst = try OptimizedBuffer.init(
+        std.testing.allocator,
+        2,
+        1,
+        .{ .pool = pool, .id = "dst-tag-copy-buffer" },
+    );
+    defer dst.deinit();
+
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try src.clear(bg, null);
+    try dst.clear(bg, null);
+
+    src.set(0, 0, .{
+        .char = 'X',
+        .fg = RGBA{ 1.0, 1.0, 1.0, 1.0 },
+        .bg = RGBA{ 0.0, 0.5, 0.5, 1.0 },
+        .fg_tag = ansi.COLOR_TAG_DEFAULT,
+        .bg_tag = ansi.indexedColorTag(6),
+        .attributes = 0,
+    });
+
+    dst.drawFrameBuffer(0, 0, src, null, null, null, null);
+
+    const copied = dst.get(0, 0).?;
+    try std.testing.expectEqual(ansi.COLOR_TAG_DEFAULT, copied.fg_tag);
+    try std.testing.expectEqual(ansi.indexedColorTag(6), copied.bg_tag);
+}
+
+test "OptimizedBuffer - drawTextBuffer transparent fast path preserves destination background tags" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, &local_link_pool, .unicode);
+    defer tb.deinit();
+    try tb.setText("A");
+    tb.setDefaultFgWithTag(RGBA{ 1.0, 1.0, 1.0, 1.0 }, ansi.COLOR_TAG_DEFAULT);
+    tb.setDefaultBgWithTag(RGBA{ 0.0, 0.0, 0.0, 0.0 }, ansi.COLOR_TAG_DEFAULT);
+
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    var buf = try OptimizedBuffer.init(
+        std.testing.allocator,
+        1,
+        1,
+        .{ .pool = pool, .id = "transparent-text-fast-tags" },
+    );
+    defer buf.deinit();
+
+    const stale_bg = RGBA{ 0.0, 0.0, 1.0, 1.0 };
+    buf.set(0, 0, .{
+        .char = 'Z',
+        .fg = RGBA{ 1.0, 0.0, 0.0, 1.0 },
+        .bg = stale_bg,
+        .fg_tag = ansi.indexedColorTag(1),
+        .bg_tag = ansi.indexedColorTag(6),
+        .attributes = ansi.TextAttributes.BOLD,
+    });
+
+    try buf.drawTextBuffer(view, 0, 0);
+
+    const cell = buf.get(0, 0).?;
+    try std.testing.expectEqual(@as(u32, 'A'), cell.char);
+    try std.testing.expectEqual(ansi.COLOR_TAG_DEFAULT, cell.fg_tag);
+    try std.testing.expectEqual(ansi.indexedColorTag(6), cell.bg_tag);
+    try std.testing.expectEqual(stale_bg, cell.bg);
+}
+
+test "OptimizedBuffer - drawTextBuffer transparent non-ascii preserves destination background tags" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, &local_link_pool, .unicode);
+    defer tb.deinit();
+    try tb.setText("·");
+    tb.setDefaultFgWithTag(RGBA{ 1.0, 1.0, 1.0, 1.0 }, ansi.COLOR_TAG_DEFAULT);
+    tb.setDefaultBgWithTag(RGBA{ 0.0, 0.0, 0.0, 0.0 }, ansi.COLOR_TAG_DEFAULT);
+
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    var buf = try OptimizedBuffer.init(
+        std.testing.allocator,
+        1,
+        1,
+        .{ .pool = pool, .id = "transparent-text-non-ascii-tags" },
+    );
+    defer buf.deinit();
+
+    const stale_bg = RGBA{ 0.0, 0.0, 1.0, 1.0 };
+    buf.set(0, 0, .{
+        .char = 'Z',
+        .fg = RGBA{ 1.0, 0.0, 0.0, 1.0 },
+        .bg = stale_bg,
+        .fg_tag = ansi.indexedColorTag(1),
+        .bg_tag = ansi.indexedColorTag(6),
+        .attributes = ansi.TextAttributes.BOLD,
+    });
+
+    try buf.drawTextBuffer(view, 0, 0);
+
+    const cell = buf.get(0, 0).?;
+    try std.testing.expect(gp.isGraphemeChar(cell.char));
+    try std.testing.expectEqual(ansi.COLOR_TAG_DEFAULT, cell.fg_tag);
+    try std.testing.expectEqual(ansi.indexedColorTag(6), cell.bg_tag);
+    try std.testing.expectEqual(stale_bg, cell.bg);
+}
+
 test "OptimizedBuffer - repeated emoji rendering should not exhaust pool" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
@@ -1625,7 +1810,7 @@ test "OptimizedBuffer - fillRect removes links" {
     try std.testing.expect(ansi.TextAttributes.hasLink(buf.get(10, 0).?.attributes));
 
     // Fill rect over first link
-    try buf.fillRect(0, 0, 6, 1, bg);
+    try buf.fillRect(0, 0, 6, 1, bg, ansi.COLOR_TAG_RGB);
 
     // Cells in rect should have no link
     try std.testing.expect(!ansi.TextAttributes.hasLink(buf.get(0, 0).?.attributes));
@@ -1656,7 +1841,7 @@ test "OptimizedBuffer - fillRect alpha path preserves underlying text without tr
     try std.testing.expect(!buf.link_tracker.hasAny());
 
     const overlay_bg = RGBA{ 0.0, 0.0, 1.0, 0.5 };
-    try buf.fillRect(0, 0, 3, 3, overlay_bg);
+    try buf.fillRect(0, 0, 3, 3, overlay_bg, ansi.COLOR_TAG_RGB);
 
     const preserved = buf.get(1, 1).?;
     try std.testing.expectEqual(@as(u32, 'X'), preserved.char);
@@ -1693,7 +1878,7 @@ test "OptimizedBuffer - fillRect transparent path is a no-op without trackers" {
     try std.testing.expect(!buf.link_tracker.hasAny());
 
     const transparent_bg = RGBA{ 0.0, 0.0, 0.0, 0.0 };
-    try buf.fillRect(0, 0, 3, 3, transparent_bg);
+    try buf.fillRect(0, 0, 3, 3, transparent_bg, ansi.COLOR_TAG_RGB);
 
     const preserved = buf.get(1, 1).?;
     try std.testing.expectEqual(@as(u32, 'X'), preserved.char);
@@ -1716,7 +1901,7 @@ test "OptimizedBuffer - fillRect transparent path is a no-op without trackers" {
     try std.testing.expectEqual(ansi.TextAttributes.UNDERLINE, unchangedSpace.attributes);
 }
 
-test "OptimizedBuffer - drawBox transparent border preserves destination background without trackers" {
+test "OptimizedBuffer - drawBox transparent border preserves destination background tags without trackers" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
 
@@ -1732,23 +1917,32 @@ test "OptimizedBuffer - drawBox transparent border preserves destination backgro
     const yellow_fg = RGBA{ 1.0, 1.0, 0.0, 1.0 };
     const green_fg = RGBA{ 0.0, 1.0, 0.0, 1.0 };
     const transparent_bg = RGBA{ 0.0, 0.0, 0.0, 0.0 };
-    try buf.clear(red_bg, null);
-    try buf.drawText("A", 0, 1, yellow_fg, red_bg, ansi.TextAttributes.BOLD);
+    try buf.clearWithTags(red_bg, null, ansi.indexedColorTag(6));
+    buf.set(0, 1, .{
+        .char = 'A',
+        .fg = yellow_fg,
+        .bg = red_bg,
+        .fg_tag = ansi.COLOR_TAG_DEFAULT,
+        .bg_tag = ansi.indexedColorTag(6),
+        .attributes = ansi.TextAttributes.BOLD,
+    });
 
     try std.testing.expect(!buf.grapheme_tracker.hasAny());
     try std.testing.expect(!buf.link_tracker.hasAny());
 
     const border_chars = [_]u32{ 0x250c, 0x2510, 0x2514, 0x2518, 0x2500, 0x2502, 0, 0, 0, 0, 0 };
-    try buf.drawBox(0, 0, 4, 4, &border_chars, .{ .left = true }, green_fg, transparent_bg, false, null, 0, null, 0);
+    try buf.drawBox(0, 0, 4, 4, &border_chars, .{ .left = true }, green_fg, transparent_bg, false, null, 0, null, 0, ansi.indexedColorTag(4), ansi.COLOR_TAG_RGB);
 
     const cell = buf.get(0, 1).?;
     try std.testing.expectEqual(@as(u32, 0x2502), cell.char);
     try std.testing.expectEqual(green_fg[0], cell.fg[0]);
     try std.testing.expectEqual(green_fg[1], cell.fg[1]);
     try std.testing.expectEqual(green_fg[2], cell.fg[2]);
+    try std.testing.expectEqual(ansi.indexedColorTag(4), cell.fg_tag);
     try std.testing.expectEqual(red_bg[0], cell.bg[0]);
     try std.testing.expectEqual(red_bg[1], cell.bg[1]);
     try std.testing.expectEqual(red_bg[2], cell.bg[2]);
+    try std.testing.expectEqual(ansi.indexedColorTag(6), cell.bg_tag);
     try std.testing.expectEqual(@as(u32, 0), cell.attributes);
 }
 
@@ -1893,7 +2087,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer basic rendering" {
         1.0,  0.0,  0.5,
     };
 
-    buf.drawGrayscaleBuffer(2, 1, &intensities, 3, 3, null, bg);
+    buf.drawGrayscaleBuffer(2, 1, &intensities, 3, 3, null, bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell_0_0 = buf.get(2, 1).?;
     try std.testing.expectEqual(@as(u32, 32), cell_0_0.char);
@@ -1932,7 +2126,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer negative position clipping" {
         0.5, 0.5, 0.5, 0.5,
     };
 
-    buf.drawGrayscaleBuffer(-1, -1, &intensities, 4, 4, null, bg);
+    buf.drawGrayscaleBuffer(-1, -1, &intensities, 4, 4, null, bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell_0_0 = buf.get(0, 0).?;
     try std.testing.expect(cell_0_0.char != 32);
@@ -1965,7 +2159,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer negative position fully clipped" {
         1.0, 1.0, 1.0, 1.0,
     };
 
-    buf.drawGrayscaleBuffer(-10, -10, &intensities, 4, 4, null, bg);
+    buf.drawGrayscaleBuffer(-10, -10, &intensities, 4, 4, null, bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell = buf.get(0, 0).?;
     try std.testing.expectEqual(@as(u32, 32), cell.char);
@@ -1997,7 +2191,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer respects scissor rect" {
         1.0, 1.0, 1.0, 1.0,
     };
 
-    buf.drawGrayscaleBuffer(0, 0, &intensities, 4, 4, null, bg);
+    buf.drawGrayscaleBuffer(0, 0, &intensities, 4, 4, null, bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell_0_0 = buf.get(0, 0).?;
     const cell_1_1 = buf.get(1, 1).?;
@@ -2034,7 +2228,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer intensity to character mapping" {
         1.0,
     };
 
-    buf.drawGrayscaleBuffer(0, 0, &intensities, 4, 1, null, bg);
+    buf.drawGrayscaleBuffer(0, 0, &intensities, 4, 1, null, bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell_0 = buf.get(0, 0).?;
     try std.testing.expectEqual(@as(u32, 32), cell_0.char);
@@ -2077,7 +2271,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer alpha blending preserves underlying 
         1.0, 1.0, 1.0,
     };
 
-    buf.drawGrayscaleBuffer(0, 0, &intensities, 3, 3, null, semi_transparent_bg);
+    buf.drawGrayscaleBuffer(0, 0, &intensities, 3, 3, null, semi_transparent_bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell = buf.get(1, 1).?;
     try std.testing.expect(cell.bg[0] > 0.1);
@@ -2112,7 +2306,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer fully transparent bg preserves under
         1.0, 1.0, 1.0,
     };
 
-    buf.drawGrayscaleBuffer(0, 0, &intensities, 3, 3, null, transparent_bg);
+    buf.drawGrayscaleBuffer(0, 0, &intensities, 3, 3, null, transparent_bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell = buf.get(1, 1).?;
     try std.testing.expectEqual(@as(f32, 0.0), cell.bg[0]);
@@ -2146,7 +2340,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer opaque bg overwrites underlying" {
         1.0, 1.0, 1.0,
     };
 
-    buf.drawGrayscaleBuffer(0, 0, &intensities, 3, 3, null, blue_bg);
+    buf.drawGrayscaleBuffer(0, 0, &intensities, 3, 3, null, blue_bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell = buf.get(1, 1).?;
     try std.testing.expectEqual(@as(f32, 0.0), cell.bg[0]);
@@ -2180,7 +2374,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer with opacity stack" {
         1.0, 1.0, 1.0,
     };
 
-    buf.drawGrayscaleBuffer(0, 0, &intensities, 3, 3, null, blue_bg);
+    buf.drawGrayscaleBuffer(0, 0, &intensities, 3, 3, null, blue_bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     buf.popOpacity();
 
@@ -2214,7 +2408,7 @@ test "OptimizedBuffer - drawGrayscaleBufferSupersampled alpha blending" {
     };
 
     const semi_transparent_bg = RGBA{ 0.0, 0.0, 1.0, 0.5 };
-    buf.drawGrayscaleBufferSupersampled(0, 0, &intensities, 4, 4, null, semi_transparent_bg);
+    buf.drawGrayscaleBufferSupersampled(0, 0, &intensities, 4, 4, null, semi_transparent_bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell = buf.get(0, 0).?;
     try std.testing.expect(cell.bg[0] > 0.1);
@@ -2246,7 +2440,7 @@ test "OptimizedBuffer - drawGrayscaleBufferSupersampled fully transparent preser
     };
 
     const transparent_bg = RGBA{ 0.0, 0.0, 1.0, 0.0 };
-    buf.drawGrayscaleBufferSupersampled(0, 0, &intensities, 4, 4, null, transparent_bg);
+    buf.drawGrayscaleBufferSupersampled(0, 0, &intensities, 4, 4, null, transparent_bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell = buf.get(0, 0).?;
     try std.testing.expectEqual(@as(f32, 0.0), cell.bg[0]);
@@ -2280,7 +2474,7 @@ test "OptimizedBuffer - drawGrayscaleBufferSupersampled respects scissor" {
         1.0, 1.0, 1.0, 1.0,
     };
 
-    buf.drawGrayscaleBufferSupersampled(0, 0, &intensities, 4, 4, null, bg);
+    buf.drawGrayscaleBufferSupersampled(0, 0, &intensities, 4, 4, null, bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const inCell = buf.get(0, 0).?;
     const outCell = buf.get(2, 2).?;
@@ -2317,7 +2511,7 @@ test "OptimizedBuffer - drawGrayscaleBufferSupersampled with opacity stack" {
     };
 
     const blue_bg = RGBA{ 0.0, 0.0, 1.0, 1.0 };
-    buf.drawGrayscaleBufferSupersampled(0, 0, &intensities, 4, 4, null, blue_bg);
+    buf.drawGrayscaleBufferSupersampled(0, 0, &intensities, 4, 4, null, blue_bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     buf.popOpacity();
 
@@ -2345,7 +2539,7 @@ test "OptimizedBuffer - blendColors with transparent destination" {
 
     const semi_white = RGBA{ 1.0, 1.0, 1.0, 0.5 };
     const transparent_fg = RGBA{ 0.0, 0.0, 0.0, 0.0 };
-    try buf.setCellWithAlphaBlending(0, 0, 'X', semi_white, transparent_fg, 0);
+    try buf.setCellWithAlphaBlending(0, 0, 'X', semi_white, transparent_fg, 0, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell = buf.get(0, 0).?;
     try std.testing.expect(cell.fg[0] > 0.45);
@@ -2372,7 +2566,7 @@ test "OptimizedBuffer - blend backdrop flattens transparent destination" {
 
     const opaque_fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
     const semi_black_bg = RGBA{ 0.0, 0.0, 0.0, 0.5 };
-    try buf.setCellWithAlphaBlending(0, 0, buffer_mod.DEFAULT_SPACE_CHAR, opaque_fg, semi_black_bg, 0);
+    try buf.setCellWithAlphaBlending(0, 0, buffer_mod.DEFAULT_SPACE_CHAR, opaque_fg, semi_black_bg, 0, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell = buf.get(0, 0).?;
     try std.testing.expect(cell.bg[0] > 0.45);
@@ -2408,7 +2602,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer with custom fg color" {
     };
 
     const red_fg = RGBA{ 1.0, 0.0, 0.0, 1.0 };
-    buf.drawGrayscaleBuffer(0, 0, &intensities, 3, 3, red_fg, black_bg);
+    buf.drawGrayscaleBuffer(0, 0, &intensities, 3, 3, red_fg, black_bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell = buf.get(1, 1).?;
     try std.testing.expect(cell.fg[0] > 0.9);
@@ -2441,7 +2635,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer custom fg with partial intensity" {
 
     const green_fg = RGBA{ 0.0, 1.0, 0.0, 1.0 };
     const transparent_bg = RGBA{ 0.0, 0.0, 0.0, 0.0 };
-    buf.drawGrayscaleBuffer(0, 0, &intensities, 3, 3, green_fg, transparent_bg);
+    buf.drawGrayscaleBuffer(0, 0, &intensities, 3, 3, green_fg, transparent_bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell = buf.get(1, 1).?;
     try std.testing.expect(cell.fg[1] > 0.2);
@@ -2473,7 +2667,7 @@ test "OptimizedBuffer - drawGrayscaleBufferSupersampled with custom fg color" {
     };
 
     const cyan_fg = RGBA{ 0.0, 1.0, 1.0, 1.0 };
-    buf.drawGrayscaleBufferSupersampled(0, 0, &intensities, 4, 4, cyan_fg, black_bg);
+    buf.drawGrayscaleBufferSupersampled(0, 0, &intensities, 4, 4, cyan_fg, black_bg, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     const cell = buf.get(0, 0).?;
     try std.testing.expect(cell.fg[0] < 0.1);

--- a/packages/core/src/zig/tests/editor-view_test.zig
+++ b/packages/core/src/zig/tests/editor-view_test.zig
@@ -4,6 +4,7 @@ const edit_buffer = @import("../edit-buffer.zig");
 const text_buffer = @import("../text-buffer.zig");
 const text_buffer_view = @import("../text-buffer-view.zig");
 const opt_buffer_mod = @import("../buffer.zig");
+const ansi = @import("../ansi.zig");
 const gp = @import("../grapheme.zig");
 const link = @import("../link.zig");
 
@@ -2840,6 +2841,93 @@ test "EditorView - placeholder shrink clears tail and preserves background" {
     try std.testing.expectEqual(@as(f32, panel_bg[1]), tail.bg[1]);
     try std.testing.expectEqual(@as(f32, panel_bg[2]), tail.bg[2]);
     try std.testing.expectEqual(@as(f32, panel_bg[3]), tail.bg[3]);
+}
+
+test "EditorView - translucent default background fills viewport without double blending" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 6, 2);
+    defer ev.deinit();
+
+    try eb.setText("abc");
+    eb.tb.setDefaultBgWithTag(.{ 1.0, 0.0, 0.0, 0.5 }, ansi.COLOR_TAG_RGB);
+
+    var opt_buffer = try opt_buffer_mod.OptimizedBuffer.init(
+        std.testing.allocator,
+        6,
+        2,
+        .{ .pool = pool, .width_method = .wcwidth },
+    );
+    defer opt_buffer.deinit();
+
+    try opt_buffer.clear(.{ 0.0, 0.0, 0.0, 1.0 }, 32);
+    try opt_buffer.drawEditorView(ev, 0, 0);
+
+    const text_cell = opt_buffer.get(0, 0).?;
+    const trailing_cell = opt_buffer.get(3, 0).?;
+    const blank_row_cell = opt_buffer.get(0, 1).?;
+
+    try std.testing.expectEqual(@as(u32, 'a'), text_cell.char);
+    try std.testing.expectEqual(@as(u32, 32), trailing_cell.char);
+    try std.testing.expectEqual(@as(u32, 32), blank_row_cell.char);
+    try std.testing.expectEqual(text_cell.bg, trailing_cell.bg);
+    try std.testing.expectEqual(trailing_cell.bg, blank_row_cell.bg);
+}
+
+test "EditorView - placeholder uses original default background fill" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 6, 2);
+    defer ev.deinit();
+
+    const placeholder_text = "hint";
+    const placeholder_fg = text_buffer.RGBA{ 0.5, 0.5, 0.5, 1.0 };
+    const placeholder_chunks = [_]text_buffer.StyledChunk{.{
+        .text_ptr = placeholder_text.ptr,
+        .text_len = placeholder_text.len,
+        .fg_ptr = @ptrCast(&placeholder_fg),
+        .bg_ptr = null,
+        .attributes = 0,
+    }};
+
+    eb.tb.setDefaultBgWithTag(.{ 0.89411765, 0.89411765, 0.89411765, 1.0 }, ansi.indexedColorTag(254));
+    try ev.setPlaceholderStyledText(&placeholder_chunks);
+
+    var opt_buffer = try opt_buffer_mod.OptimizedBuffer.init(
+        std.testing.allocator,
+        6,
+        2,
+        .{ .pool = pool, .width_method = .wcwidth },
+    );
+    defer opt_buffer.deinit();
+
+    try opt_buffer.clear(.{ 0.0, 0.0, 0.0, 1.0 }, 32);
+    try opt_buffer.drawEditorView(ev, 0, 0);
+
+    const text_cell = opt_buffer.get(0, 0).?;
+    const trailing_cell = opt_buffer.get(4, 0).?;
+    const blank_row_cell = opt_buffer.get(0, 1).?;
+
+    try std.testing.expectEqual(@as(u32, 'h'), text_cell.char);
+    try std.testing.expectEqual(@as(u32, 32), trailing_cell.char);
+    try std.testing.expectEqual(@as(u32, 32), blank_row_cell.char);
+    try std.testing.expectEqual(ansi.indexedColorTag(254), text_cell.bg_tag);
+    try std.testing.expectEqual(ansi.indexedColorTag(254), trailing_cell.bg_tag);
+    try std.testing.expectEqual(ansi.indexedColorTag(254), blank_row_cell.bg_tag);
+    try std.testing.expectEqual(@as(f32, 1.0), text_cell.bg[3]);
+    try std.testing.expectEqual(@as(f32, 1.0), blank_row_cell.bg[3]);
 }
 
 test "EditorView - tab indicator set and get" {

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -841,6 +841,221 @@ test "renderer - hyperlink spanning multiple rows uses same id" {
     try std.testing.expectEqual(@as(usize, 1), count);
 }
 
+test "renderer - explicit default and indexed tags use ANSI default/indexed output" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        4,
+        1,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    cli_renderer.terminal.caps.rgb = true;
+    cli_renderer.terminal.caps.ansi256 = true;
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    next_buffer.set(0, 0, buffer.Cell{
+        .char = 'A',
+        .fg = RGBA{ 1.0, 1.0, 1.0, 1.0 },
+        .bg = RGBA{ 0.0, 0.0, 0.0, 1.0 },
+        .fg_tag = ansi.COLOR_TAG_DEFAULT,
+        .bg_tag = ansi.COLOR_TAG_RGB,
+        .attributes = 0,
+    });
+    next_buffer.set(1, 0, buffer.Cell{
+        .char = 'B',
+        .fg = RGBA{ 0.2, 0.7, 0.9, 1.0 },
+        .bg = RGBA{ 0.0, 0.0, 0.0, 1.0 },
+        .fg_tag = ansi.indexedColorTag(6),
+        .bg_tag = ansi.COLOR_TAG_RGB,
+        .attributes = 0,
+    });
+
+    cli_renderer.render(false);
+
+    const output = cli_renderer.getLastOutputForTest();
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[39m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[38;5;6m") != null);
+}
+
+test "renderer - indexed snapshots fall back to rgb and explicit bg default resets without ansi256" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        2,
+        1,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    cli_renderer.terminal.caps.rgb = true;
+    cli_renderer.terminal.caps.ansi256 = false;
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    next_buffer.set(0, 0, buffer.Cell{
+        .char = 'A',
+        .fg = RGBA{ 0.2, 0.4, 0.6, 1.0 },
+        .bg = RGBA{ 0.0, 0.0, 0.0, 1.0 },
+        .fg_tag = ansi.indexedColorTag(6),
+        .bg_tag = ansi.COLOR_TAG_DEFAULT,
+        .attributes = 0,
+    });
+
+    cli_renderer.render(false);
+
+    const output = cli_renderer.getLastOutputForTest();
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[38;2;51;102;153m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[38;5;6m") == null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[49m") != null);
+}
+
+test "renderer - rgb colors fall back to ANSI256 mapping when rgb is unavailable" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        2,
+        1,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    cli_renderer.terminal.caps.rgb = false;
+    cli_renderer.terminal.caps.ansi256 = true;
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    try next_buffer.drawText("A", 0, 0, RGBA{ 0.95, 0.1, 0.1, 1.0 }, RGBA{ 0.0, 0.0, 0.0, 1.0 }, 0);
+
+    cli_renderer.render(false);
+
+    const output = cli_renderer.getLastOutputForTest();
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[38;5;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[38;2;") == null);
+}
+
+test "renderer - rgb fallback uses published palette state" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        2,
+        1,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    cli_renderer.terminal.caps.rgb = false;
+    cli_renderer.terminal.caps.ansi256 = true;
+
+    const target = RGBA{ 0.3, 0.6, 0.9, 1.0 };
+    var palette = [_]RGBA{RGBA{ 0.0, 0.0, 0.0, 1.0 }} ** 256;
+    palette[42] = target;
+    cli_renderer.setPaletteState(palette[0..], RGBA{ 1.0, 1.0, 1.0, 1.0 }, RGBA{ 0.0, 0.0, 0.0, 1.0 }, 1);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    try next_buffer.drawText("A", 0, 0, target, RGBA{ 0.0, 0.0, 0.0, 1.0 }, 0);
+
+    cli_renderer.render(false);
+
+    const output = cli_renderer.getLastOutputForTest();
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[38;5;42m") != null);
+}
+
+test "renderer - palette epoch changes force repaint and use new palette mapping" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        2,
+        1,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    cli_renderer.terminal.caps.rgb = false;
+    cli_renderer.terminal.caps.ansi256 = true;
+
+    const target = RGBA{ 0.3, 0.6, 0.9, 1.0 };
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+
+    var palette_a = [_]RGBA{RGBA{ 0.0, 0.0, 0.0, 1.0 }} ** 256;
+    palette_a[42] = target;
+    cli_renderer.setPaletteState(palette_a[0..], RGBA{ 1.0, 1.0, 1.0, 1.0 }, bg, 1);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    try next_buffer.drawText("A", 0, 0, target, bg, 0);
+    cli_renderer.render(false);
+
+    const first_output = cli_renderer.getLastOutputForTest();
+    try std.testing.expect(std.mem.indexOf(u8, first_output, "\x1b[38;5;42m") != null);
+
+    try next_buffer.drawText("A", 0, 0, target, bg, 0);
+    cli_renderer.render(false);
+
+    const second_output = cli_renderer.getLastOutputForTest();
+    try std.testing.expect(std.mem.indexOf(u8, second_output, "A") == null);
+
+    var palette_b = [_]RGBA{RGBA{ 0.0, 0.0, 0.0, 1.0 }} ** 256;
+    palette_b[77] = target;
+    cli_renderer.setPaletteState(palette_b[0..], RGBA{ 1.0, 1.0, 1.0, 1.0 }, bg, 2);
+
+    try next_buffer.drawText("A", 0, 0, target, bg, 0);
+    cli_renderer.render(false);
+
+    const third_output = cli_renderer.getLastOutputForTest();
+    try std.testing.expect(std.mem.indexOf(u8, third_output, "A") != null);
+    try std.testing.expect(std.mem.indexOf(u8, third_output, "\x1b[38;5;77m") != null);
+}
+
+test "renderer - transparent rgb backgrounds still emit 49 reset" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        2,
+        1,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    cli_renderer.terminal.caps.rgb = true;
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    try next_buffer.drawText("A", 0, 0, RGBA{ 1.0, 1.0, 1.0, 1.0 }, RGBA{ 0.0, 0.0, 0.0, 0.0 }, 0);
+
+    cli_renderer.render(false);
+
+    const output = cli_renderer.getLastOutputForTest();
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[49m") != null);
+}
+
 // ============================================================================
 // GRAPHEME CURSOR POSITIONING TESTS
 // ============================================================================
@@ -1493,6 +1708,9 @@ test "renderer - commitSplitFooterSnapshot appends styled snapshot before footer
     );
     defer cli_renderer.destroy();
 
+    cli_renderer.terminal.caps.rgb = true;
+    cli_renderer.terminal.caps.ansi256 = true;
+
     _ = cli_renderer.resetSplitScrollback(2, 2);
 
     const next_buffer = cli_renderer.getNextBuffer();
@@ -1527,6 +1745,63 @@ test "renderer - commitSplitFooterSnapshot appends styled snapshot before footer
     try std.testing.expect(sync_index != null);
     try std.testing.expect(sync_index.? < snapshot_text_index.?);
     try std.testing.expect(footer_clear_index == null);
+}
+
+test "renderer - commitSplitFooterSnapshot preserves indexed and default color tags" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        8,
+        4,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    cli_renderer.terminal.caps.rgb = true;
+    cli_renderer.terminal.caps.ansi256 = true;
+
+    _ = cli_renderer.resetSplitScrollback(2, 2);
+
+    var snapshot = try OptimizedBuffer.init(
+        std.testing.allocator,
+        2,
+        1,
+        .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
+    );
+    defer snapshot.deinit();
+
+    try snapshot.clear(.{ 0.0, 0.0, 0.0, 0.0 }, 0);
+    snapshot.set(0, 0, buffer.Cell{
+        .char = 'A',
+        .fg = RGBA{ 1.0, 1.0, 1.0, 1.0 },
+        .bg = RGBA{ 0.0, 0.0, 0.0, 1.0 },
+        .fg_tag = ansi.COLOR_TAG_DEFAULT,
+        .bg_tag = ansi.COLOR_TAG_RGB,
+        .attributes = 0,
+    });
+    snapshot.set(1, 0, buffer.Cell{
+        .char = 'B',
+        .fg = RGBA{ 0.2, 0.4, 0.6, 1.0 },
+        .bg = RGBA{ 0.0, 0.0, 0.0, 1.0 },
+        .fg_tag = ansi.indexedColorTag(6),
+        .bg_tag = ansi.COLOR_TAG_DEFAULT,
+        .attributes = 0,
+    });
+
+    _ = cli_renderer.commitSplitFooterSnapshotBatched(snapshot, 2, true, false, 2, false, true, true);
+
+    const output = cli_renderer.getLastOutputForTest();
+    try std.testing.expect(std.mem.indexOf(u8, output, "A") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "B") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[39m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[38;5;6m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[49m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[38;2;51;102;153m") == null);
 }
 
 test "renderer - commitSplitFooterSnapshot does not emit NUL padding for short rows" {

--- a/packages/core/src/zig/tests/terminal_test.zig
+++ b/packages/core/src/zig/tests/terminal_test.zig
@@ -110,22 +110,33 @@ test "environment variables - should be overridden by xtversion" {
     try testing.expect(term.term_info.from_xtversion);
 }
 
-test "remote ignores env overrides but accepts capability responses" {
+test "remote without forwarded env map ignores local env overrides" {
+    const term = Terminal.init(.{ .remote = true });
+
+    try testing.expect(!term.in_tmux);
+    try testing.expect(!term.caps.osc52);
+    try testing.expect(!term.caps.explicit_cursor_positioning);
+}
+
+test "remote applies forwarded env overrides and capability responses" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
     var env = std.process.EnvMap.init(testing.allocator);
     defer env.deinit();
     try env.put("TMUX", "/tmp/tmux-1000/default,12345,0");
+    try env.put("TERM", "screen-256color");
     try env.put("TERM_PROGRAM", "iTerm.app");
     try env.put("WT_SESSION", "test-session");
 
     var term = Terminal.init(.{ .remote = true, .env_map = &env });
 
-    try testing.expect(!term.in_tmux);
-    try testing.expect(!term.caps.osc52);
-    try testing.expect(!term.caps.explicit_cursor_positioning);
+    try testing.expect(term.in_tmux);
+    try testing.expect(term.caps.osc52);
+    try testing.expect(term.caps.explicit_cursor_positioning);
+    try testing.expect(term.caps.ansi256);
 
     term.processCapabilityResponse("\x1bP>|kitty(0.40.1)\x1b\\");
+    try testing.expect(term.caps.rgb);
     try testing.expect(term.caps.osc52);
 }
 
@@ -178,6 +189,22 @@ test "environment overrides - does not enable hyperlinks for WSL non-xterm terms
     const term = Terminal.init(.{ .env_map = &env });
 
     try testing.expect(!term.caps.hyperlinks);
+}
+
+test "setHostEnvVar detects ansi256 separately from rgb" {
+    var env = std.process.EnvMap.init(testing.allocator);
+    defer env.deinit();
+    try env.put("TERM", "screen-256color");
+
+    var term = Terminal.init(.{ .env_map = &env });
+    defer term.deinit();
+
+    try testing.expect(term.caps.ansi256);
+    try testing.expect(!term.caps.rgb);
+
+    try term.setHostEnvVar(testing.allocator, "COLORTERM", "truecolor");
+    try testing.expect(term.caps.rgb);
+    try testing.expect(term.caps.ansi256);
 }
 
 test "parseXtversion - terminal name only" {
@@ -487,6 +514,30 @@ test "processCapabilityResponse - ghostty does not set explicit_cursor_positioni
     const response = "\x1bP>|ghostty 1.1.3\x1b\\";
     term.processCapabilityResponse(response);
 
+    try testing.expect(!term.caps.explicit_cursor_positioning);
+}
+
+test "processCapabilityResponse - wezterm applies osc52 and hyperlink heuristics" {
+    var term: Terminal = .{};
+
+    const response = "\x1bP>|wezterm\x1b\\";
+    term.processCapabilityResponse(response);
+
+    try testing.expect(!term.caps.rgb);
+    try testing.expect(!term.caps.ansi256);
+    try testing.expect(term.caps.osc52);
+    try testing.expect(term.caps.hyperlinks);
+}
+
+test "processCapabilityResponse - foot applies osc52 heuristic without explicit cursor positioning" {
+    var term: Terminal = .{};
+
+    const response = "\x1bP>|foot 1.17.2\x1b\\";
+    term.processCapabilityResponse(response);
+
+    try testing.expect(!term.caps.rgb);
+    try testing.expect(!term.caps.ansi256);
+    try testing.expect(term.caps.osc52);
     try testing.expect(!term.caps.explicit_cursor_positioning);
 }
 

--- a/packages/core/src/zig/tests/text-buffer-drawing_test.zig
+++ b/packages/core/src/zig/tests/text-buffer-drawing_test.zig
@@ -159,7 +159,7 @@ test "drawTextBuffer - transparent background preserves underlying non-space und
     const blue_bg = RGBA{ 0.0, 0.0, 1.0, 1.0 };
     const green_fg = RGBA{ 0.0, 1.0, 0.0, 1.0 };
     try opt_buffer.clear(red_bg, 32);
-    try opt_buffer.drawChar('X', 1, 0, green_fg, blue_bg, ansi.TextAttributes.BOLD);
+    try opt_buffer.drawChar('X', 1, 0, green_fg, blue_bg, ansi.TextAttributes.BOLD, ansi.COLOR_TAG_RGB, ansi.COLOR_TAG_RGB);
 
     try opt_buffer.drawTextBuffer(view, 0, 0);
 

--- a/packages/core/src/zig/text-buffer-view.zig
+++ b/packages/core/src/zig/text-buffer-view.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const ansi = @import("ansi.zig");
 const tb = @import("text-buffer.zig");
 const seg_mod = @import("text-buffer-segment.zig");
 const iter_mod = @import("text-buffer-iterators.zig");
@@ -18,6 +19,20 @@ const GraphemeInfo = seg_mod.GraphemeInfo;
 
 pub const TextBufferViewError = error{
     OutOfMemory,
+};
+
+pub const SelectionStyle = struct {
+    bgColor: ?RGBA = null,
+    fgColor: ?RGBA = null,
+    bgTag: ansi.ColorTag = ansi.COLOR_TAG_RGB,
+    fgTag: ansi.ColorTag = ansi.COLOR_TAG_RGB,
+
+    pub fn rgb(bgColor: ?RGBA, fgColor: ?RGBA) SelectionStyle {
+        return .{
+            .bgColor = bgColor,
+            .fgColor = fgColor,
+        };
+    }
 };
 
 /// Viewport defines a rectangular window into the virtual line space
@@ -503,23 +518,32 @@ pub const UnifiedTextBufferView = struct {
         return self.virtual_lines_arena.queryCapacity();
     }
 
-    pub fn setSelection(self: *Self, start: u32, end: u32, bgColor: ?RGBA, fgColor: ?RGBA) void {
-        self.selection = TextSelection{
+    fn selectionFromStyle(start: u32, end: u32, style: SelectionStyle) TextSelection {
+        return .{
             .start = start,
             .end = end,
-            .bgColor = bgColor,
-            .fgColor = fgColor,
+            .bgColor = style.bgColor,
+            .fgColor = style.fgColor,
+            .bgTag = style.bgTag,
+            .fgTag = style.fgTag,
         };
     }
 
+    pub fn setSelection(self: *Self, start: u32, end: u32, bgColor: ?RGBA, fgColor: ?RGBA) void {
+        self.setSelectionStyle(start, end, SelectionStyle.rgb(bgColor, fgColor));
+    }
+
+    pub fn setSelectionStyle(self: *Self, start: u32, end: u32, style: SelectionStyle) void {
+        self.selection = selectionFromStyle(start, end, style);
+    }
+
     pub fn updateSelection(self: *Self, end: u32, bgColor: ?RGBA, fgColor: ?RGBA) void {
+        self.updateSelectionStyle(end, SelectionStyle.rgb(bgColor, fgColor));
+    }
+
+    pub fn updateSelectionStyle(self: *Self, end: u32, style: SelectionStyle) void {
         if (self.selection) |sel| {
-            self.selection = TextSelection{
-                .start = sel.start,
-                .end = end,
-                .bgColor = bgColor,
-                .fgColor = fgColor,
-            };
+            self.selection = selectionFromStyle(sel.start, end, style);
         }
     }
 
@@ -548,6 +572,10 @@ pub const UnifiedTextBufferView = struct {
     }
 
     pub fn setLocalSelection(self: *Self, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?RGBA, fgColor: ?RGBA) bool {
+        return self.setLocalSelectionStyle(anchorX, anchorY, focusX, focusY, SelectionStyle.rgb(bgColor, fgColor));
+    }
+
+    pub fn setLocalSelectionStyle(self: *Self, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, style: SelectionStyle) bool {
         self.updateVirtualLines();
         if (self.truncate and self.viewport != null) {
             self.ensureTruncation();
@@ -598,12 +626,7 @@ pub const UnifiedTextBufferView = struct {
         const new_end = @max(anchor_offset, focus_offset);
 
         // Always store selection, even if zero-width, to preserve anchor for updateLocalSelection
-        const new_selection = TextSelection{
-            .start = new_start,
-            .end = new_end,
-            .bgColor = bgColor,
-            .fgColor = fgColor,
-        };
+        const new_selection = selectionFromStyle(new_start, new_end, style);
 
         const selection_changed = if (self.selection) |old_sel|
             old_sel.start != new_selection.start or old_sel.end != new_selection.end
@@ -615,14 +638,18 @@ pub const UnifiedTextBufferView = struct {
     }
 
     pub fn updateLocalSelection(self: *Self, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?RGBA, fgColor: ?RGBA) bool {
+        return self.updateLocalSelectionStyle(anchorX, anchorY, focusX, focusY, SelectionStyle.rgb(bgColor, fgColor));
+    }
+
+    pub fn updateLocalSelectionStyle(self: *Self, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, style: SelectionStyle) bool {
         if (self.selection_anchor_offset) |_| {
-            return self.updateLocalSelectionFocusOnly(focusX, focusY, bgColor, fgColor);
+            return self.updateLocalSelectionFocusOnly(focusX, focusY, style);
         } else {
-            return self.setLocalSelection(anchorX, anchorY, focusX, focusY, bgColor, fgColor);
+            return self.setLocalSelectionStyle(anchorX, anchorY, focusX, focusY, style);
         }
     }
 
-    fn updateLocalSelectionFocusOnly(self: *Self, focusX: i32, focusY: i32, bgColor: ?RGBA, fgColor: ?RGBA) bool {
+    fn updateLocalSelectionFocusOnly(self: *Self, focusX: i32, focusY: i32, style: SelectionStyle) bool {
         const anchor_offset = self.selection_anchor_offset orelse return false;
 
         self.updateVirtualLines();
@@ -650,12 +677,7 @@ pub const UnifiedTextBufferView = struct {
             new_end = @min(new_end + 1, text_end_offset);
         }
 
-        self.selection = TextSelection{
-            .start = new_start,
-            .end = new_end,
-            .bgColor = bgColor,
-            .fgColor = fgColor,
-        };
+        self.selection = selectionFromStyle(new_start, new_end, style);
 
         return true;
     }

--- a/packages/core/src/zig/text-buffer.zig
+++ b/packages/core/src/zig/text-buffer.zig
@@ -21,6 +21,9 @@ const LineInfo = iter_mod.LineInfo;
 pub const TextChunk = seg_mod.TextChunk;
 pub const MemRegistry = mem_registry_mod.MemRegistry;
 pub const RGBA = seg_mod.RGBA;
+pub const ColorTag = ansi.ColorTag;
+pub const COLOR_TAG_RGB = ansi.COLOR_TAG_RGB;
+pub const COLOR_TAG_DEFAULT = ansi.COLOR_TAG_DEFAULT;
 pub const TextSelection = seg_mod.TextSelection;
 pub const TextBufferError = seg_mod.TextBufferError;
 pub const Highlight = seg_mod.Highlight;
@@ -38,6 +41,8 @@ pub const StyledChunk = extern struct {
     text_len: usize,
     fg_ptr: ?[*]const f32,
     bg_ptr: ?[*]const f32,
+    fg_tag: ansi.ColorTag = ansi.COLOR_TAG_RGB,
+    bg_tag: ansi.ColorTag = ansi.COLOR_TAG_RGB,
     attributes: u32,
     link_ptr: ?[*]const u8 = null,
     link_len: usize = 0,
@@ -49,6 +54,8 @@ pub const UnifiedTextBuffer = struct {
     mem_registry: MemRegistry,
     default_fg: ?RGBA,
     default_bg: ?RGBA,
+    default_fg_tag: ansi.ColorTag,
+    default_bg_tag: ansi.ColorTag,
     default_attributes: ?u32,
 
     allocator: Allocator,
@@ -88,6 +95,8 @@ pub const UnifiedTextBuffer = struct {
     pub const Defaults = struct {
         fg: ?RGBA,
         bg: ?RGBA,
+        fg_tag: ansi.ColorTag,
+        bg_tag: ansi.ColorTag,
         attributes: ?u32,
     };
 
@@ -96,6 +105,8 @@ pub const UnifiedTextBuffer = struct {
         return .{
             .fg = self.default_fg,
             .bg = self.default_bg,
+            .fg_tag = self.default_fg_tag,
+            .bg_tag = self.default_bg_tag,
             .attributes = self.default_attributes,
         };
     }
@@ -194,6 +205,8 @@ pub const UnifiedTextBuffer = struct {
             .mem_registry = mem_registry,
             .default_fg = null,
             .default_bg = null,
+            .default_fg_tag = ansi.COLOR_TAG_RGB,
+            .default_bg_tag = ansi.COLOR_TAG_RGB,
             .default_attributes = null,
             .allocator = internal_allocator,
             .global_allocator = global_allocator,
@@ -379,11 +392,21 @@ pub const UnifiedTextBuffer = struct {
 
     // Default colors/attributes
     pub fn setDefaultFg(self: *Self, fg: ?RGBA) void {
+        self.setDefaultFgWithTag(fg, ansi.COLOR_TAG_RGB);
+    }
+
+    pub fn setDefaultFgWithTag(self: *Self, fg: ?RGBA, fg_tag: ansi.ColorTag) void {
         self.default_fg = fg;
+        self.default_fg_tag = fg_tag;
     }
 
     pub fn setDefaultBg(self: *Self, bg: ?RGBA) void {
+        self.setDefaultBgWithTag(bg, ansi.COLOR_TAG_RGB);
+    }
+
+    pub fn setDefaultBgWithTag(self: *Self, bg: ?RGBA, bg_tag: ansi.ColorTag) void {
         self.default_bg = bg;
+        self.default_bg_tag = bg_tag;
     }
 
     pub fn setDefaultAttributes(self: *Self, attributes: ?u32) void {
@@ -393,6 +416,8 @@ pub const UnifiedTextBuffer = struct {
     pub fn resetDefaults(self: *Self) void {
         self.default_fg = null;
         self.default_bg = null;
+        self.default_fg_tag = ansi.COLOR_TAG_RGB;
+        self.default_bg_tag = ansi.COLOR_TAG_RGB;
         self.default_attributes = null;
     }
 
@@ -1082,7 +1107,13 @@ pub const UnifiedTextBuffer = struct {
 
                     var style_name_buf: [64]u8 = undefined;
                     const style_name = std.fmt.bufPrint(&style_name_buf, "chunk{d}", .{i}) catch continue;
-                    const style_id = (@constCast(style)).registerStyle(style_name, fg, bg, attributes) catch continue;
+                    const style_id = (@constCast(style)).registerStyleDefinition(style_name, .{
+                        .fg = fg,
+                        .bg = bg,
+                        .fg_tag = chunk.fg_tag,
+                        .bg_tag = chunk.bg_tag,
+                        .attributes = attributes,
+                    }) catch continue;
 
                     self.addHighlightByCharRange(char_pos, char_pos + chunk_len, style_id, 1, 0) catch {};
                 }


### PR DESCRIPTION
Flattening indexed and default colors into RGBA snapshots makes palette-relative roles lose meaning before the renderer sees them. Carry a color tag alongside RGBA through the TS, FFI, buffer, and native renderer, and publish the active terminal palette so the renderer can emit 39/49, keep 38;5 slots stable, and remap RGB fallback after palette changes instead of reusing stale indices