### PR TITLE
core: refactor/fix renderer api options

### DIFF
--- a/packages/core/src/benchmark/markdown-benchmark.ts
+++ b/packages/core/src/benchmark/markdown-benchmark.ts
@@ -350,20 +350,16 @@ if (spawnPerScenario && !scenarioFilter) {
   process.exit(0)
 }
 
-process.env.OTUI_OVERRIDE_STDOUT = "false"
-process.env.OTUI_USE_ALTERNATE_SCREEN = "false"
-
 const renderer = await createCliRenderer({
   exitOnCtrlC: true,
   targetFps,
   maxFps,
   testing,
-  useAlternateScreen: false,
-  useConsole: false,
+  screenMode: "main-screen",
+  externalOutputMode: "passthrough",
+  consoleMode: "disabled",
   useMouse: false,
 })
-
-renderer.disableStdoutInterception()
 
 renderer.requestRender = () => {}
 
@@ -1740,11 +1736,7 @@ async function runSpawnedScenarios(plans: ScenarioPlan[]): Promise<void> {
     const child = Bun.spawn([process.execPath, new URL(import.meta.url).pathname, ...args], {
       stdout: "inherit",
       stderr: "inherit",
-      env: {
-        ...process.env,
-        OTUI_OVERRIDE_STDOUT: "false",
-        OTUI_USE_ALTERNATE_SCREEN: "false",
-      },
+      env: process.env,
     })
     const exitCode = await child.exited
     if (exitCode !== 0) {

--- a/packages/core/src/benchmark/text-table-benchmark.ts
+++ b/packages/core/src/benchmark/text-table-benchmark.ts
@@ -272,8 +272,9 @@ if (scenarioFilter && filteredScenarios.length === 0) {
 const { renderer, renderOnce } = await createTestRenderer({
   width,
   height,
-  useAlternateScreen: false,
-  useConsole: false,
+  screenMode: "main-screen",
+  externalOutputMode: "passthrough",
+  consoleMode: "disabled",
 })
 
 renderer.requestRender = () => {}

--- a/packages/core/src/examples/split-mode-demo.ts
+++ b/packages/core/src/examples/split-mode-demo.ts
@@ -1,4 +1,4 @@
-import { createCliRenderer, TextRenderable, t, type CliRenderer, BoxRenderable, bold, fg } from "../index.js"
+import { BoxRenderable, bold, createCliRenderer, fg, TextRenderable, t, type CliRenderer } from "../index.js"
 import { setupCommonDemoKeys } from "./lib/standalone-keys.js"
 import { createTimeline, type JSAnimation, Timeline } from "../animation/Timeline.js"
 
@@ -306,7 +306,9 @@ class SplitModeAnimations {
 
 export function run(rendererInstance: CliRenderer): void {
   rendererInstance.setBackgroundColor("#001122")
-  rendererInstance.experimental_splitHeight = 20
+  rendererInstance.footerHeight = 20
+  rendererInstance.screenMode = "split-footer"
+  rendererInstance.externalOutputMode = "capture-stdout"
 
   animationSystem = new SplitModeAnimations(rendererInstance)
 
@@ -343,8 +345,8 @@ export function run(rendererInstance: CliRenderer): void {
 
   console.log("=== Split Mode Demo ===")
   console.log(`Terminal size: ${rendererInstance.terminalWidth}x${rendererInstance.terminalHeight}`)
-  console.log(`Renderer split height: ${rendererInstance.experimental_splitHeight}`)
-  console.log(`Renderer offset: ${rendererInstance.terminalHeight - rendererInstance.experimental_splitHeight}`)
+  console.log(`Renderer split height: ${rendererInstance.footerHeight}`)
+  console.log(`Renderer offset: ${rendererInstance.terminalHeight - rendererInstance.footerHeight}`)
   console.log("Console output should appear here and scroll naturally")
   console.log("The renderer should stay fixed at the bottom as a footer")
   console.log(`Test output running at ${testOutputInterval}ms intervals (use M/L to adjust speed)`)
@@ -366,22 +368,25 @@ export function run(rendererInstance: CliRenderer): void {
 
   keyHandler = (key) => {
     if (key.name === "+") {
-      const currentHeight = rendererInstance.experimental_splitHeight || 0
+      const currentHeight = rendererInstance.footerHeight
       const newHeight = Math.min(currentHeight + 1, rendererInstance.terminalHeight - 5)
-      rendererInstance.experimental_splitHeight = newHeight
+      rendererInstance.footerHeight = newHeight
       console.log(`Split height increased to ${newHeight}`)
     } else if (key.name === "-") {
-      const currentHeight = rendererInstance.experimental_splitHeight || 0
+      const currentHeight = rendererInstance.footerHeight
       const newHeight = Math.max(currentHeight - 1, 5)
-      rendererInstance.experimental_splitHeight = newHeight
+      rendererInstance.footerHeight = newHeight
       console.log(`Split height decreased to ${newHeight}`)
     } else if (key.name === "0") {
-      if (rendererInstance.experimental_splitHeight > 0) {
-        rendererInstance.experimental_splitHeight = 0
-        console.log("Switched to fullscreen mode")
+      if (rendererInstance.screenMode === "split-footer") {
+        rendererInstance.externalOutputMode = "passthrough"
+        rendererInstance.screenMode = "main-screen"
+        console.log("Switched to main-screen mode")
       } else {
-        rendererInstance.experimental_splitHeight = 20
-        console.log("Switched to split mode (height 10)")
+        rendererInstance.footerHeight = 20
+        rendererInstance.screenMode = "split-footer"
+        rendererInstance.externalOutputMode = "capture-stdout"
+        console.log("Switched to split-footer mode (height 20)")
       }
     } else if (key.name === "m") {
       testOutputInterval = Math.max(5, testOutputInterval - 5)
@@ -427,7 +432,8 @@ export function destroy(rendererInstance: CliRenderer): void {
   }
 
   rendererInstance.clearFrameCallbacks()
-  rendererInstance.experimental_splitHeight = 0
+  rendererInstance.externalOutputMode = "passthrough"
+  rendererInstance.screenMode = "main-screen"
 }
 
 if (import.meta.main) {
@@ -435,8 +441,10 @@ if (import.meta.main) {
     targetFps: 30,
     exitOnCtrlC: true,
     useMouse: true,
-    useAlternateScreen: false,
-    useConsole: false,
+    screenMode: "split-footer",
+    footerHeight: 20,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
   })
 
   run(renderer)

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -39,28 +39,29 @@ import { StdinParser, type StdinEvent, type StdinParserProtocolContext } from ".
 
 registerEnvVar({
   name: "OTUI_DUMP_CAPTURES",
-  description: "Dump captured output when the renderer exits.",
+  description: "Dump captured stdout and console caches when the renderer exit handler runs.",
   type: "boolean",
   default: false,
 })
 
 registerEnvVar({
   name: "OTUI_NO_NATIVE_RENDER",
-  description: "Disable native rendering. This will not actually output ansi and is useful for debugging.",
+  description:
+    "Skip the Zig/native frame renderer. Useful for debugging the render loop; split-footer stdout flushing may still write ANSI.",
   type: "boolean",
   default: false,
 })
 
 registerEnvVar({
   name: "OTUI_USE_ALTERNATE_SCREEN",
-  description: "Use the terminal alternate screen buffer.",
+  description: "When explicitly set, force screen mode selection: true=alternate-screen, false=main-screen.",
   type: "boolean",
   default: true,
 })
 
 registerEnvVar({
   name: "OTUI_OVERRIDE_STDOUT",
-  description: "Override the stdout stream. This is useful for debugging.",
+  description: "When explicitly set, force stdout routing: false=passthrough, true=capture in split-footer mode.",
   type: "boolean",
   default: true,
 })
@@ -80,40 +81,175 @@ registerEnvVar({
 })
 
 export interface CliRendererConfig {
+  // Read input from this stream. Defaults to process.stdin.
   stdin?: NodeJS.ReadStream
+
+  // Use a custom stdout stream for size detection and stdout interception.
+  // Native frame output still goes to the real TTY.
   stdout?: NodeJS.WriteStream
+
+  // Tell the native renderer it is driving a remote terminal.
   remote?: boolean
+
+  // Skip terminal setup. Useful in tests.
   testing?: boolean
+
+  // Call renderer.destroy() when Ctrl+C is pressed. Defaults to true.
   exitOnCtrlC?: boolean
+
+  // Clean up on these signals. Defaults to the common termination signals.
   exitSignals?: NodeJS.Signals[]
+
+  // Forward these env var names to native terminal detection.
   forwardEnvKeys?: string[]
+
+  // Wait this long before handling resize events. Defaults to 100 ms.
   debounceDelay?: number
+
+  // Aim for this many frames per second in continuous mode. Defaults to 30.
   targetFps?: number
+
+  // Cap immediate re-renders at this frame rate. Defaults to 60.
   maxFps?: number
+
+  // Emit memory snapshots on this interval in ms. Set 0 to disable.
   memorySnapshotInterval?: number
+
+  // Render from a separate thread when the platform supports it.
   useThread?: boolean
+
+  // Collect frame timing stats for the debug overlay.
   gatherStats?: boolean
+
+  // Keep this many timing samples. Defaults to 300.
   maxStatSamples?: number
+
+  // Pass options to the built-in console overlay.
   consoleOptions?: Omit<ConsoleOptions, "clock">
+
+  // Run these hooks after each render pass.
   postProcessFns?: ((buffer: OptimizedBuffer, deltaTime: number) => void)[]
+
+  // Track mouse move events. Defaults to true.
   enableMouseMovement?: boolean
+
+  // Enable mouse input. Defaults to true.
   useMouse?: boolean
+
+  // Focus the nearest focusable renderable on left click. Defaults to true.
   autoFocus?: boolean
-  useAlternateScreen?: boolean
-  useConsole?: boolean
-  experimental_splitHeight?: number
+
+  // Choose where the renderer owns terminal space. Defaults to "alternate-screen".
+  screenMode?: ScreenMode
+
+  // Set the requested footer height for "split-footer". Defaults to 12.
+  footerHeight?: number
+
+  // Choose what happens to writes that go through `stdout.write`.
+  externalOutputMode?: ExternalOutputMode
+
+  // Choose what the built-in console overlay does.
+  consoleMode?: ConsoleMode
+
+  // Set Kitty keyboard protocol flags, or null to disable them.
   useKittyKeyboard?: KittyKeyboardOptions | null
+
+  // Fill the render buffer with this background color. Default transparent.
   backgroundColor?: ColorInput
+
+  // Open the console overlay on uncaught errors. Defaults to true in development.
   openConsoleOnError?: boolean
+
+  // Run these input handlers before the built-in handlers.
   prependInputHandlers?: ((sequence: string) => boolean)[]
+
+  // Cap the stdin parser buffer size in bytes. Defaults to 64 MB.
   stdinParserMaxBufferBytes?: number
+
+  // Use a custom clock for timers and tests.
   clock?: Clock
+
+  // Run after destroy() finishes cleanup.
   onDestroy?: () => void
 }
+
+// Controls how the renderer uses terminal space:
+//
+// - "alternate-screen": Use the terminal's alternate screen buffer.
+//
+// - "main-screen": Render on the main screen.
+//
+// - "split-footer": Keep the renderer in a reserved footer on the main screen.
+export type ScreenMode = "alternate-screen" | "main-screen" | "split-footer"
+
+// Controls writes that go through the configured `stdout.write`.
+//
+// - "capture-stdout": Queue stdout and replay it above the split footer.
+//   Only valid with "split-footer".
+//
+// - "passthrough": Leave stdout alone.
+export type ExternalOutputMode = "capture-stdout" | "passthrough"
+
+// Controls the built-in console overlay:
+//
+// - "console-overlay": Capture `console.*` output and show the overlay.
+//
+// - "disabled": Hide the overlay. `OTUI_USE_CONSOLE` controls global console
+//   capture.
+export type ConsoleMode = "console-overlay" | "disabled"
 
 export type PixelResolution = {
   width: number
   height: number
+}
+
+const DEFAULT_FOOTER_HEIGHT = 12
+
+function normalizeFooterHeight(footerHeight: number | undefined): number {
+  if (footerHeight === undefined) {
+    return DEFAULT_FOOTER_HEIGHT
+  }
+
+  if (!Number.isFinite(footerHeight)) {
+    throw new Error("footerHeight must be a finite number")
+  }
+
+  const normalizedFooterHeight = Math.trunc(footerHeight)
+  if (normalizedFooterHeight <= 0) {
+    throw new Error("footerHeight must be greater than 0")
+  }
+
+  return normalizedFooterHeight
+}
+
+function resolveModes(config: CliRendererConfig): {
+  screenMode: ScreenMode
+  footerHeight: number
+  externalOutputMode: ExternalOutputMode
+} {
+  let screenMode = config.screenMode ?? "alternate-screen"
+  if (process.env.OTUI_USE_ALTERNATE_SCREEN !== undefined) {
+    screenMode = env.OTUI_USE_ALTERNATE_SCREEN ? "alternate-screen" : "main-screen"
+  }
+
+  const footerHeight =
+    screenMode === "split-footer" ? normalizeFooterHeight(config.footerHeight) : DEFAULT_FOOTER_HEIGHT
+
+  let externalOutputMode =
+    config.externalOutputMode ?? (screenMode === "split-footer" ? "capture-stdout" : "passthrough")
+  if (process.env.OTUI_OVERRIDE_STDOUT !== undefined) {
+    externalOutputMode = env.OTUI_OVERRIDE_STDOUT && screenMode === "split-footer" ? "capture-stdout" : "passthrough"
+  }
+
+  if (externalOutputMode === "capture-stdout" && screenMode !== "split-footer") {
+    throw new Error('externalOutputMode "capture-stdout" requires screenMode "split-footer"')
+  }
+
+  return {
+    screenMode,
+    footerHeight,
+    externalOutputMode,
+  }
 }
 
 const DEFAULT_FORWARDED_ENV_KEYS = [
@@ -287,11 +423,11 @@ export async function createCliRenderer(config: CliRendererConfig = {}): Promise
   }
   const stdin = config.stdin || process.stdin
   const stdout = config.stdout || process.stdout
+  const { screenMode, footerHeight } = resolveModes(config)
 
   const width = stdout.columns || 80
   const height = stdout.rows || 24
-  const renderHeight =
-    config.experimental_splitHeight && config.experimental_splitHeight > 0 ? config.experimental_splitHeight : height
+  const renderHeight = screenMode === "split-footer" ? footerHeight : height
 
   const ziglib = resolveRenderLib()
   const rendererPtr = ziglib.createRenderer(width, renderHeight, {
@@ -430,7 +566,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private enableMouseMovement: boolean = false
   private _useMouse: boolean = true
   private autoFocus: boolean = true
-  private _useAlternateScreen: boolean = env.OTUI_USE_ALTERNATE_SCREEN
+  private _screenMode: ScreenMode = "alternate-screen"
+  private _footerHeight: number = DEFAULT_FOOTER_HEIGHT
+  private _externalOutputMode: ExternalOutputMode = "passthrough"
   private _suspendedMouseEnabled: boolean = false
   private _previousControlState: RendererControlState = RendererControlState.IDLE
   private capturedRenderable?: Renderable
@@ -554,14 +692,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.width = width
     this.height = height
     this._useThread = config.useThread === undefined ? false : config.useThread
-    this._splitHeight = config.experimental_splitHeight || 0
+    const { screenMode, footerHeight, externalOutputMode } = resolveModes(config)
 
-    if (this._splitHeight > 0) {
-      capture.on("write", this.captureCallback)
-      this.renderOffset = height - this._splitHeight
-      this.height = this._splitHeight
-      lib.setRenderOffset(rendererPtr, this.renderOffset)
-    }
+    this._footerHeight = footerHeight
+    this._screenMode = screenMode
 
     this.rendererPtr = rendererPtr
 
@@ -598,7 +732,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.enableMouseMovement = config.enableMouseMovement ?? true
     this._useMouse = config.useMouse ?? true
     this.autoFocus = config.autoFocus ?? true
-    this._useAlternateScreen = config.useAlternateScreen ?? env.OTUI_USE_ALTERNATE_SCREEN
     this.nextRenderBuffer = this.lib.getNextBuffer(this.rendererPtr)
     this.currentRenderBuffer = this.lib.getCurrentBuffer(this.rendererPtr)
     this.postProcessFns = config.postProcessFns || []
@@ -608,10 +741,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     if (this.memorySnapshotInterval > 0) {
       this.startMemorySnapshotTimer()
-    }
-
-    if (env.OTUI_OVERRIDE_STDOUT) {
-      this.stdout.write = this.interceptStdoutWrite.bind(this)
     }
 
     // Handle terminal resize
@@ -659,7 +788,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       ...(config.consoleOptions ?? {}),
       clock: this.clock,
     })
-    this.useConsole = config.useConsole ?? true
+    this.consoleMode = config.consoleMode ?? "console-overlay"
+    this.applyScreenMode(screenMode, false, false)
+    this.externalOutputMode = externalOutputMode
     this._openConsoleOnError = config.openConsoleOnError ?? process.env.NODE_ENV !== "production"
     this._onDestroy = config.onDestroy
 
@@ -837,13 +968,13 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.resolveIdleIfNeeded()
   }
 
-  public get useConsole(): boolean {
-    return this._useConsole
+  public get consoleMode(): ConsoleMode {
+    return this._useConsole ? "console-overlay" : "disabled"
   }
 
-  public set useConsole(value: boolean) {
-    this._useConsole = value
-    if (value) {
+  public set consoleMode(mode: ConsoleMode) {
+    this._useConsole = mode === "console-overlay"
+    if (this._useConsole) {
       this.console.activate()
     } else {
       this.console.deactivate()
@@ -924,8 +1055,45 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
   }
 
-  public get experimental_splitHeight(): number {
-    return this._splitHeight
+  public get screenMode(): ScreenMode {
+    return this._screenMode
+  }
+
+  public set screenMode(mode: ScreenMode) {
+    if (this.externalOutputMode === "capture-stdout" && mode !== "split-footer") {
+      throw new Error('externalOutputMode "capture-stdout" requires screenMode "split-footer"')
+    }
+
+    this.applyScreenMode(mode)
+  }
+
+  public get footerHeight(): number {
+    return this._footerHeight
+  }
+
+  public set footerHeight(footerHeight: number) {
+    const normalizedFooterHeight = normalizeFooterHeight(footerHeight)
+    if (normalizedFooterHeight === this._footerHeight) {
+      return
+    }
+
+    this._footerHeight = normalizedFooterHeight
+    if (this.screenMode === "split-footer") {
+      this.applyScreenMode("split-footer")
+    }
+  }
+
+  public get externalOutputMode(): ExternalOutputMode {
+    return this._externalOutputMode
+  }
+
+  public set externalOutputMode(mode: ExternalOutputMode) {
+    if (mode === "capture-stdout" && this.screenMode !== "split-footer") {
+      throw new Error('externalOutputMode "capture-stdout" requires screenMode "split-footer"')
+    }
+
+    this._externalOutputMode = mode
+    this.stdout.write = mode === "capture-stdout" ? this.interceptStdoutWrite : this.realStdoutWrite
   }
 
   public get liveRequestCount(): number {
@@ -957,55 +1125,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.lib.setKittyKeyboardFlags(this.rendererPtr, flags)
   }
 
-  public set experimental_splitHeight(splitHeight: number) {
-    if (splitHeight < 0) splitHeight = 0
-
-    const prevSplitHeight = this._splitHeight
-
-    if (splitHeight > 0) {
-      this._splitHeight = splitHeight
-      this.renderOffset = this._terminalHeight - this._splitHeight
-      this.height = this._splitHeight
-
-      if (prevSplitHeight === 0) {
-        this.useConsole = false
-        capture.on("write", this.captureCallback)
-        const freedLines = this._terminalHeight - this._splitHeight
-        const scrollDown = ANSI.scrollDown(freedLines)
-        this.writeOut(scrollDown)
-      } else if (prevSplitHeight > this._splitHeight) {
-        const freedLines = prevSplitHeight - this._splitHeight
-        const scrollDown = ANSI.scrollDown(freedLines)
-        this.writeOut(scrollDown)
-      } else if (prevSplitHeight < this._splitHeight) {
-        const additionalLines = this._splitHeight - prevSplitHeight
-        const scrollUp = ANSI.scrollUp(additionalLines)
-        this.writeOut(scrollUp)
-      }
-    } else {
-      if (prevSplitHeight > 0) {
-        this.flushStdoutCache(this._terminalHeight, true)
-
-        capture.off("write", this.captureCallback)
-        this.useConsole = true
-      }
-
-      this._splitHeight = 0
-      this.renderOffset = 0
-      this.height = this._terminalHeight
-    }
-
-    this.width = this._terminalWidth
-    this.lib.setRenderOffset(this.rendererPtr, this.renderOffset)
-    this.lib.resizeRenderer(this.rendererPtr, this.width, this.height)
-    this.nextRenderBuffer = this.lib.getNextBuffer(this.rendererPtr)
-
-    this._console.resize(this.width, this.height)
-    this.root.resize(this.width, this.height)
-    this.emit(CliRenderEvents.RESIZE, this.width, this.height)
-    this.requestRender()
-  }
-
   private interceptStdoutWrite = (chunk: any, encoding?: any, callback?: any): boolean => {
     const text = chunk.toString()
 
@@ -1021,8 +1140,76 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     return true
   }
 
-  public disableStdoutInterception(): void {
-    this.stdout.write = this.realStdoutWrite
+  private applyScreenMode(screenMode: ScreenMode, emitResize: boolean = true, requestRender: boolean = true): void {
+    const prevScreenMode = this._screenMode
+    const prevSplitHeight = this._splitHeight
+    const nextSplitHeight = screenMode === "split-footer" ? this._footerHeight : 0
+
+    if (prevScreenMode === screenMode && prevSplitHeight === nextSplitHeight) {
+      return
+    }
+
+    const prevUseAlternateScreen = prevScreenMode === "alternate-screen"
+    const nextUseAlternateScreen = screenMode === "alternate-screen"
+    const terminalScreenModeChanged = this._terminalIsSetup && prevUseAlternateScreen !== nextUseAlternateScreen
+    const leavingSplitFooter = prevSplitHeight > 0 && nextSplitHeight === 0
+
+    if (this._terminalIsSetup && leavingSplitFooter) {
+      this.flushStdoutCache(this._terminalHeight, true)
+    }
+
+    if (this._terminalIsSetup && !terminalScreenModeChanged) {
+      if (prevSplitHeight === 0 && nextSplitHeight > 0) {
+        const freedLines = this._terminalHeight - nextSplitHeight
+        const scrollDown = ANSI.scrollDown(freedLines)
+        this.writeOut(scrollDown)
+      } else if (prevSplitHeight > nextSplitHeight && nextSplitHeight > 0) {
+        const freedLines = prevSplitHeight - nextSplitHeight
+        const scrollDown = ANSI.scrollDown(freedLines)
+        this.writeOut(scrollDown)
+      } else if (prevSplitHeight < nextSplitHeight && prevSplitHeight > 0) {
+        const additionalLines = nextSplitHeight - prevSplitHeight
+        const scrollUp = ANSI.scrollUp(additionalLines)
+        this.writeOut(scrollUp)
+      }
+    }
+
+    if (prevSplitHeight === 0 && nextSplitHeight > 0) {
+      capture.on("write", this.captureCallback)
+    } else if (prevSplitHeight > 0 && nextSplitHeight === 0) {
+      capture.off("write", this.captureCallback)
+    }
+
+    this._screenMode = screenMode
+    this._splitHeight = nextSplitHeight
+    this.renderOffset = nextSplitHeight > 0 ? this._terminalHeight - nextSplitHeight : 0
+    this.width = this._terminalWidth
+    this.height = nextSplitHeight > 0 ? nextSplitHeight : this._terminalHeight
+
+    this.lib.setRenderOffset(this.rendererPtr, this.renderOffset)
+    this.lib.resizeRenderer(this.rendererPtr, this.width, this.height)
+    this.nextRenderBuffer = this.lib.getNextBuffer(this.rendererPtr)
+    this.currentRenderBuffer = this.lib.getCurrentBuffer(this.rendererPtr)
+
+    this._console.resize(this.width, this.height)
+    this.root.resize(this.width, this.height)
+
+    if (terminalScreenModeChanged) {
+      this.lib.suspendRenderer(this.rendererPtr)
+      this.lib.setupTerminal(this.rendererPtr, nextUseAlternateScreen)
+
+      if (this._useMouse) {
+        this.enableMouse()
+      }
+    }
+
+    if (emitResize) {
+      this.emit(CliRenderEvents.RESIZE, this.width, this.height)
+    }
+
+    if (requestRender) {
+      this.requestRender()
+    }
   }
 
   // TODO: Move this to native
@@ -1094,7 +1281,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       privateCapabilityRepliesActive: true,
       explicitWidthCprActive: true,
     })
-    this.lib.setupTerminal(this.rendererPtr, this._useAlternateScreen)
+    this.lib.setupTerminal(this.rendererPtr, this._screenMode === "alternate-screen")
     this._capabilities = this.lib.getTerminalCapabilities(this.rendererPtr)
 
     if (this.debugOverlay.enabled) {
@@ -2015,7 +2202,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.stdinParser = null
     this.oscSubscribers.clear()
     this._console.destroy()
-    this.disableStdoutInterception()
+    this.externalOutputMode = "passthrough"
 
     if (this._splitHeight > 0) {
       this.flushStdoutCache(this._splitHeight, true)

--- a/packages/core/src/testing/test-renderer.ts
+++ b/packages/core/src/testing/test-renderer.ts
@@ -1,4 +1,4 @@
-import { Readable } from "stream"
+import { Readable, Writable } from "stream"
 import { CliRenderer, type CliRendererConfig } from "../renderer.js"
 import { resolveRenderLib } from "../zig.js"
 import { createMockKeys } from "./mock-keys.js"
@@ -17,6 +17,26 @@ export type MockMouse = ReturnType<typeof createMockMouse>
 
 const decoder = new TextDecoder()
 
+class TestWriteStream extends Writable {
+  public readonly isTTY = true
+  public readonly columns: number
+  public readonly rows: number
+
+  constructor(columns: number, rows: number) {
+    super()
+    this.columns = columns
+    this.rows = rows
+  }
+
+  _write(_chunk: any, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    callback()
+  }
+
+  getColorDepth(): number {
+    return 24
+  }
+}
+
 export async function createTestRenderer(options: TestRendererOptions): Promise<{
   renderer: TestRenderer
   mockInput: MockInput
@@ -26,19 +46,17 @@ export async function createTestRenderer(options: TestRendererOptions): Promise<
   captureSpans: () => CapturedFrame
   resize: (width: number, height: number) => void
 }> {
-  process.env.OTUI_USE_CONSOLE = "false"
-
   // Convert legacy kittyKeyboard boolean to new format
   const useKittyKeyboard = options.kittyKeyboard ? { events: true } : options.useKittyKeyboard
 
   const renderer = await setupTestRenderer({
     ...options,
     useKittyKeyboard,
-    useAlternateScreen: false,
-    useConsole: false,
+    screenMode: options.screenMode ?? "main-screen",
+    footerHeight: options.footerHeight ?? 12,
+    consoleMode: options.consoleMode ?? "disabled",
+    externalOutputMode: options.externalOutputMode ?? "passthrough",
   })
-
-  renderer.disableStdoutInterception()
 
   const mockInput = createMockKeys(renderer, {
     kittyKeyboard: options.kittyKeyboard,
@@ -81,12 +99,10 @@ export async function createTestRenderer(options: TestRendererOptions): Promise<
 
 async function setupTestRenderer(config: TestRendererOptions) {
   const stdin = config.stdin || (new Readable({ read() {} }) as NodeJS.ReadStream)
-  const stdout = config.stdout || process.stdout
-
-  const width = config.width || stdout.columns || 80
-  const height = config.height || stdout.rows || 24
-  const renderHeight =
-    config.experimental_splitHeight && config.experimental_splitHeight > 0 ? config.experimental_splitHeight : height
+  const width = config.width || config.stdout?.columns || process.stdout.columns || 80
+  const height = config.height || config.stdout?.rows || process.stdout.rows || 24
+  const stdout = config.stdout || (new TestWriteStream(width, height) as unknown as NodeJS.WriteStream)
+  const renderHeight = config.screenMode === "split-footer" ? (config.footerHeight ?? 12) : height
 
   const ziglib = resolveRenderLib()
   const rendererPtr = ziglib.createRenderer(width, renderHeight, {

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -1,26 +1,46 @@
 import { afterEach, beforeEach, expect, test } from "bun:test"
 
+import { capture } from "../console.ts"
 import { clearEnvCache } from "../lib/env.ts"
 import { createTestRenderer, type TestRenderer } from "../testing/test-renderer.js"
 import { ManualClock } from "../testing/manual-clock.js"
 
 let renderer: TestRenderer | null = null
 let previousShowConsole: string | undefined
+let previousUseAlternateScreen: string | undefined
+let previousOverrideStdout: string | undefined
 
 beforeEach(() => {
   previousShowConsole = process.env.SHOW_CONSOLE
+  previousUseAlternateScreen = process.env.OTUI_USE_ALTERNATE_SCREEN
+  previousOverrideStdout = process.env.OTUI_OVERRIDE_STDOUT
   delete process.env.SHOW_CONSOLE
+  delete process.env.OTUI_USE_ALTERNATE_SCREEN
+  delete process.env.OTUI_OVERRIDE_STDOUT
   clearEnvCache()
 })
 
 afterEach(() => {
   renderer?.destroy()
   renderer = null
+  capture.claimOutput()
 
   if (previousShowConsole === undefined) {
     delete process.env.SHOW_CONSOLE
   } else {
     process.env.SHOW_CONSOLE = previousShowConsole
+  }
+
+  if (previousUseAlternateScreen === undefined) {
+    delete process.env.OTUI_USE_ALTERNATE_SCREEN
+  } else {
+    process.env.OTUI_USE_ALTERNATE_SCREEN = previousUseAlternateScreen
+  }
+
+  if (previousOverrideStdout === undefined) {
+    delete process.env.OTUI_OVERRIDE_STDOUT
+  } else {
+    process.env.OTUI_OVERRIDE_STDOUT = previousOverrideStdout
   }
 
   clearEnvCache()
@@ -62,4 +82,104 @@ test("CliRenderer uses its shared clock for debounced resize", async () => {
 
   expect(renderer.width).toBe(70)
   expect(renderer.height).toBe(30)
+})
+
+test("CliRenderer applies explicit screen and output modes", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+
+  expect(renderer.screenMode).toBe("split-footer")
+  expect(renderer.footerHeight).toBe(6)
+  expect(renderer.externalOutputMode).toBe("capture-stdout")
+  expect(renderer.consoleMode).toBe("disabled")
+})
+
+test("CliRenderer rejects captured output outside split-footer mode", async () => {
+  await expect(
+    createTestRenderer({
+      screenMode: "main-screen",
+      externalOutputMode: "capture-stdout",
+    }),
+  ).rejects.toThrow('externalOutputMode "capture-stdout" requires screenMode "split-footer"')
+})
+
+test("CliRenderer flushes captured output when leaving split-footer for alternate-screen", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+    useThread: false,
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  ;(renderer as any).lib.suspendRenderer = () => {}
+  ;(renderer as any).lib.setupTerminal = () => {}
+
+  capture.write("stdout", "pending output\n")
+  renderer.externalOutputMode = "passthrough"
+  renderer.screenMode = "alternate-screen"
+
+  expect(capture.size).toBe(0)
+})
+
+test("CliRenderer allows env to force main-screen mode", async () => {
+  process.env.OTUI_USE_ALTERNATE_SCREEN = "false"
+  clearEnvCache()
+
+  const result = await createTestRenderer({
+    screenMode: "alternate-screen",
+  })
+
+  renderer = result.renderer
+
+  expect(renderer.screenMode).toBe("main-screen")
+})
+
+test("CliRenderer allows env to force alternate-screen mode", async () => {
+  process.env.OTUI_USE_ALTERNATE_SCREEN = "true"
+  clearEnvCache()
+
+  const result = await createTestRenderer({
+    screenMode: "main-screen",
+  })
+
+  renderer = result.renderer
+
+  expect(renderer.screenMode).toBe("alternate-screen")
+})
+
+test("CliRenderer allows env to force passthrough stdout", async () => {
+  process.env.OTUI_OVERRIDE_STDOUT = "false"
+  clearEnvCache()
+
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    externalOutputMode: "capture-stdout",
+  })
+
+  renderer = result.renderer
+
+  expect(renderer.externalOutputMode).toBe("passthrough")
+})
+
+test("CliRenderer allows env to force captured stdout in split-footer", async () => {
+  process.env.OTUI_OVERRIDE_STDOUT = "true"
+  clearEnvCache()
+
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    externalOutputMode: "passthrough",
+  })
+
+  renderer = result.renderer
+
+  expect(renderer.externalOutputMode).toBe("capture-stdout")
 })

--- a/packages/core/src/tests/renderer.mouse.test.ts
+++ b/packages/core/src/tests/renderer.mouse.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, test } from "bun:test"
 import { createTestRenderer, MouseButtons, type MockMouse, type TestRenderer } from "../testing.js"
 import { Renderable, type RenderableOptions } from "../Renderable.js"
+import type { MouseEvent } from "../renderer.js"
 import type { RenderContext } from "../types.js"
 import type { Selection } from "../lib/selection.js"
-import type { MouseEvent } from "../renderer.js"
 
 class TestRenderable extends Renderable {
   public selectionActive = false
@@ -198,9 +198,10 @@ describe("renderer handleMouseData", () => {
 
       await mockMouse.scroll(target.x + 1, target.y + 1, "down")
 
-      expect(scrollEvent?.type).toBe("scroll")
-      expect(scrollEvent?.scroll?.direction).toBe("down")
-      expect(scrollEvent?.scroll?.delta).toBe(1)
+      expect(scrollEvent).not.toBeNull()
+      expect(scrollEvent!.type).toBe("scroll")
+      expect(scrollEvent!.scroll?.direction).toBe("down")
+      expect(scrollEvent!.scroll?.delta).toBe(1)
     } finally {
       renderer.destroy()
     }
@@ -264,7 +265,7 @@ describe("renderer handleMouseData", () => {
 
   test("console mouse handling consumes events inside console bounds", async () => {
     try {
-      renderer.useConsole = true
+      renderer.consoleMode = "console-overlay"
       renderer.console.show()
 
       const target = new TestRenderable(renderer, {
@@ -299,7 +300,7 @@ describe("renderer handleMouseData", () => {
 
   test("console mouse handling falls through when not handled", async () => {
     try {
-      renderer.useConsole = true
+      renderer.consoleMode = "console-overlay"
       renderer.console.show()
 
       const target = new TestRenderable(renderer, {
@@ -375,8 +376,10 @@ describe("renderer handleMouseData", () => {
       await mockMouse.release(endX, endY)
 
       expect(renderer.hasSelection).toBe(true)
-      expect(dragEvent?.isDragging).toBe(true)
-      expect(upEvent?.isDragging).toBe(true)
+      expect(dragEvent).not.toBeNull()
+      expect(upEvent).not.toBeNull()
+      expect(dragEvent!.isDragging).toBe(true)
+      expect(upEvent!.isDragging).toBe(true)
       expect(renderer.getSelection()?.isDragging).toBe(false)
     } finally {
       renderer.destroy()
@@ -897,7 +900,7 @@ describe("renderer handleMouseData", () => {
         modifiers: { shift: true, alt: true },
       })
 
-      expect(modifiers).toEqual({ shift: true, alt: true, ctrl: false })
+      expect(modifiers!).toEqual({ shift: true, alt: true, ctrl: false })
     } finally {
       renderer.destroy()
     }
@@ -1212,7 +1215,8 @@ describe("renderer handleMouseData split height", () => {
     ;({ renderer, mockMouse, renderOnce } = await createTestRenderer({
       width: 40,
       height: baseHeight,
-      experimental_splitHeight: splitHeight,
+      screenMode: "split-footer",
+      footerHeight: splitHeight,
     }))
   })
 
@@ -1240,7 +1244,8 @@ describe("renderer handleMouseData split height", () => {
 
       const screenY = renderOffset + target.y + 1
       await mockMouse.click(target.x + 1, screenY)
-      expect(downEvent?.y).toBe(target.y + 1)
+      expect(downEvent).not.toBeNull()
+      expect(downEvent!.y).toBe(target.y + 1)
     } finally {
       renderer.destroy()
     }

--- a/packages/core/src/tests/renderer.useMouse.test.ts
+++ b/packages/core/src/tests/renderer.useMouse.test.ts
@@ -12,7 +12,6 @@ describe("useMouse configuration", () => {
     const { renderer } = await createTestRenderer({
       useMouse: true,
       exitOnCtrlC: false,
-      useAlternateScreen: false,
     })
 
     expect(renderer.useMouse).toBe(true)
@@ -23,7 +22,6 @@ describe("useMouse configuration", () => {
     const { renderer } = await createTestRenderer({
       useMouse: false,
       exitOnCtrlC: false,
-      useAlternateScreen: false,
     })
 
     expect(renderer.useMouse).toBe(false)
@@ -34,7 +32,6 @@ describe("useMouse configuration", () => {
     const { renderer } = await createTestRenderer({
       useMouse: false,
       exitOnCtrlC: false,
-      useAlternateScreen: false,
     })
 
     expect(renderer.useMouse).toBe(false)

--- a/packages/react/examples/index.tsx
+++ b/packages/react/examples/index.tsx
@@ -101,7 +101,7 @@ export const ExamplesIndex = () => {
   const [selected, setSelected] = useState(-1)
 
   useEffect(() => {
-    renderer.useConsole = true
+    renderer.consoleMode = "console-overlay"
   }, [renderer])
 
   useKeyboard((key) => {

--- a/packages/solid/examples/components/ExampleSelector.tsx
+++ b/packages/solid/examples/components/ExampleSelector.tsx
@@ -128,7 +128,7 @@ const ExampleSelector = () => {
   const renderer = useRenderer()
 
   onMount(() => {
-    renderer.useConsole = true
+    renderer.consoleMode = "console-overlay"
     // renderer.console.show();
   })
 

--- a/packages/solid/examples/components/tab-select-demo.tsx
+++ b/packages/solid/examples/components/tab-select-demo.tsx
@@ -35,7 +35,7 @@ export default function TabSelectDemo() {
   const [activeTab, setActiveTab] = createSignal(0)
 
   onMount(() => {
-    renderer.useConsole = true
+    renderer.consoleMode = "console-overlay"
     renderer.console.show()
   })
 

--- a/packages/solid/examples/repro-empty-styled-text.tsx
+++ b/packages/solid/examples/repro-empty-styled-text.tsx
@@ -7,7 +7,7 @@ process.env.DEBUG = "true"
 const EmptyStyledTextTest = () => {
   const renderer = useRenderer()
 
-  renderer.useConsole = true
+  renderer.consoleMode = "console-overlay"
   renderer.console.show()
 
   const [showBox, setShowBox] = createSignal(false)

--- a/packages/solid/examples/repro-filter-list.tsx
+++ b/packages/solid/examples/repro-filter-list.tsx
@@ -6,7 +6,7 @@ process.env.DEBUG = "true"
 const FilterListTest = () => {
   const renderer = useRenderer()
 
-  renderer.useConsole = true
+  renderer.consoleMode = "console-overlay"
   renderer.console.show()
 
   const [filter, setFilter] = createSignal("")

--- a/packages/solid/examples/repro-onSubmit.tsx
+++ b/packages/solid/examples/repro-onSubmit.tsx
@@ -6,7 +6,7 @@ process.env.DEBUG = "true"
 const InputTest = () => {
   const renderer = useRenderer()
 
-  renderer.useConsole = true
+  renderer.consoleMode = "console-overlay"
   renderer.console.show()
 
   const [sig, setS] = createSignal(0)

--- a/packages/web/src/content/docs/core-concepts/renderer.mdx
+++ b/packages/web/src/content/docs/core-concepts/renderer.mdx
@@ -24,24 +24,118 @@ const renderer = await createCliRenderer({
 The factory function does three things:
 
 1. Loads the native Zig rendering library
-2. Configures terminal settings (mouse, keyboard protocol, and alternate screen)
+2. Configures terminal settings (mouse, keyboard protocol, and the selected screen mode)
 3. Returns an initialized `CliRenderer` instance
 
 ## Configuration options
 
-| Option                | Type               | Default   | Description                                                                        |
-| --------------------- | ------------------ | --------- | ---------------------------------------------------------------------------------- |
-| `exitOnCtrlC`         | `boolean`          | `true`    | Call `renderer.destroy()` when Ctrl+C is pressed                                   |
-| `exitSignals`         | `NodeJS.Signals[]` | see below | Signals that trigger cleanup ([details](/core-concepts/lifecycle#signal-handling)) |
-| `targetFps`           | `number`           | `30`      | Target frames per second for the render loop                                       |
-| `maxFps`              | `number`           | `60`      | Maximum FPS for immediate re-renders                                               |
-| `useMouse`            | `boolean`          | `true`    | Enable mouse input and tracking                                                    |
-| `autoFocus`           | `boolean`          | `true`    | Focus nearest focusable on left click                                              |
-| `enableMouseMovement` | `boolean`          | `true`    | Track mouse movement (not just clicks)                                             |
-| `useAlternateScreen`  | `boolean`          | `true`    | Use terminal alternate screen buffer                                               |
-| `consoleOptions`      | `ConsoleOptions`   | -         | Options for the built-in console overlay                                           |
-| `openConsoleOnError`  | `boolean`          | `true`    | Auto-open console when errors occur (dev only)                                     |
-| `onDestroy`           | `() => void`       | -         | Callback executed when renderer is destroyed                                       |
+This page covers the options that most apps set directly.
+`CliRendererConfig` also includes lower-level hooks for testing and tuning, such as `stdin`, `stdout`, `clock`,
+`postProcessFns`, and `prependInputHandlers`.
+
+| Option                | Type                           | Default              | Description                                                                             |
+| --------------------- | ------------------------------ | -------------------- | --------------------------------------------------------------------------------------- |
+| `screenMode`          | `ScreenMode`                   | `"alternate-screen"` | How the renderer uses terminal space ([details](#screen-modes))                         |
+| `footerHeight`        | `number`                       | `12`                 | Requested footer rows for `"split-footer"` mode                                         |
+| `externalOutputMode`  | `ExternalOutputMode`           | varies               | How writes to `stdout.write` are handled ([details](#external-output-mode))             |
+| `consoleMode`         | `ConsoleMode`                  | `"console-overlay"`  | How the built-in console overlay behaves ([details](#console-mode))                     |
+| `exitOnCtrlC`         | `boolean`                      | `true`               | Call `renderer.destroy()` when Ctrl+C is pressed                                        |
+| `exitSignals`         | `NodeJS.Signals[]`             | see below            | Signals that trigger cleanup ([details](/docs/core-concepts/lifecycle#signal-handling)) |
+| `targetFps`           | `number`                       | `30`                 | Target frames per second for the render loop                                            |
+| `maxFps`              | `number`                       | `60`                 | Maximum FPS cap for immediate re-renders                                                |
+| `useMouse`            | `boolean`                      | `true`               | Enable mouse input                                                                      |
+| `autoFocus`           | `boolean`                      | `true`               | Focus the nearest focusable renderable on left click                                    |
+| `enableMouseMovement` | `boolean`                      | `true`               | Track mouse movement, not just clicks and scrolls                                       |
+| `useKittyKeyboard`    | `KittyKeyboardOptions \| null` | `{}`                 | Kitty keyboard protocol settings, or `null` to disable                                  |
+| `backgroundColor`     | `ColorInput`                   | transparent          | Background color for the render buffer                                                  |
+| `consoleOptions`      | `ConsoleOptions`               | -                    | Options forwarded to the built-in console overlay                                       |
+| `openConsoleOnError`  | `boolean`                      | `true` (dev)         | Open the console overlay on uncaught errors                                             |
+| `onDestroy`           | `() => void`                   | -                    | Run after the renderer finishes cleanup                                                 |
+
+You can also change `screenMode`, `footerHeight`, `externalOutputMode`, and `consoleMode` at runtime through their
+matching `renderer` properties.
+
+## Screen modes
+
+The `screenMode` option controls whether OpenTUI owns the alternate screen or a reserved region of the main screen. You
+can also change modes at runtime by setting `renderer.screenMode`.
+
+### `"alternate-screen"` (default)
+
+Switches to the terminal's alternate screen buffer. The original scrollback content is preserved and restored when the
+renderer exits. This is the standard mode for full-screen TUI applications.
+
+```typescript
+const renderer = await createCliRenderer({
+  screenMode: "alternate-screen",
+})
+```
+
+### `"main-screen"`
+
+Renders on the terminal's main screen without switching buffers. OpenTUI still reserves a render region by scrolling terminal content, so this is not a true scrollback-native inline or direct renderer. Use it when you want the UI to stay on the main screen for testing, benchmarks, or short-lived tools.
+
+```typescript
+const renderer = await createCliRenderer({
+  screenMode: "main-screen",
+})
+```
+
+### `"split-footer"`
+
+Pins the renderer to a reserved footer region at the bottom of the terminal. The area above the footer stays available for normal program output. This is the closest thing OpenTUI currently has to a direct-render mode, but it still uses the same buffered main-screen renderer rather than a separate inline backend.
+
+The `footerHeight` option controls how many rows the footer requests (default: 12). When using split-footer mode, `externalOutputMode` defaults to `"capture-stdout"` so that writes to `stdout.write` can be replayed above the footer instead of overlapping it.
+
+```typescript
+const renderer = await createCliRenderer({
+  screenMode: "split-footer",
+  footerHeight: 20,
+})
+
+// Change footer height at runtime
+renderer.footerHeight = 15
+```
+
+## External output mode
+
+The `externalOutputMode` option controls what happens to writes that go through the renderer's configured `stdout.write` while the renderer is active. It does not change `stderr`, and it is separate from the built-in console overlay.
+
+The native renderer still paints to the real TTY. `externalOutputMode` only changes the TypeScript-side `stdout.write` path.
+
+- **`"capture-stdout"`**: Intercepts `stdout.write`, queues the text, and flushes it above the footer during split-footer renders. Only valid when `screenMode` is `"split-footer"`.
+- **`"passthrough"`**: Leaves `stdout.write` untouched. Output goes directly to the terminal.
+
+The default depends on the screen mode: `"capture-stdout"` for split-footer, `"passthrough"` for everything else.
+
+```typescript
+// Captured stdout appears above the footer
+const renderer = await createCliRenderer({
+  screenMode: "split-footer",
+  externalOutputMode: "capture-stdout",
+})
+
+// Switch at runtime
+renderer.externalOutputMode = "passthrough"
+```
+
+## Console mode
+
+The `consoleMode` option controls the built-in console overlay (`TerminalConsole`).
+
+- **`"console-overlay"`** (default): Captures console output (console.log, console.error, etc.) and renders it in a toggleable panel within the TUI.
+- **`"disabled"`**: Hides and deactivates the overlay surface.
+
+Current caveat: `consoleMode` only changes the overlay surface.
+If you need plain `console.*` behavior, set `OTUI_USE_CONSOLE=false`.
+
+```typescript
+const renderer = await createCliRenderer({
+  screenMode: "split-footer",
+  externalOutputMode: "capture-stdout",
+  consoleMode: "disabled",
+})
+```
 
 ## The root renderable
 
@@ -252,13 +346,11 @@ Destroying the renderer restores the terminal to its original state, disables mo
 
 ## Environment variables
 
-| Variable                    | Description                                  |
-| --------------------------- | -------------------------------------------- |
-| `OTUI_USE_ALTERNATE_SCREEN` | Override alternate screen setting            |
-| `OTUI_SHOW_STATS`           | Show debug overlay at startup                |
-| `OTUI_DEBUG`                | Enable debug input capture                   |
-| `OTUI_NO_NATIVE_RENDER`     | Disable native rendering (for debugging)     |
-| `OTUI_DUMP_CAPTURES`        | Dump captured output when the renderer exits |
-| `OTUI_OVERRIDE_STDOUT`      | Override stdout stream (for debugging)       |
-| `OTUI_USE_CONSOLE`          | Enable/disable built-in console              |
-| `SHOW_CONSOLE`              | Show console at startup                      |
+See the [environment variable reference](/docs/reference/env-vars) for the full list.
+
+The renderer-specific ones you will most likely care about are:
+
+- `OTUI_USE_CONSOLE` controls global `console.*` capture.
+- `SHOW_CONSOLE` opens the built-in console overlay at startup.
+- `OTUI_NO_NATIVE_RENDER` skips the Zig/native frame renderer. In `"split-footer"` mode, the current stdout flush path can still write ANSI.
+- `OTUI_DUMP_CAPTURES` dumps captured stdout and console caches from the renderer exit handler.

--- a/packages/web/src/content/docs/reference/env-vars.mdx
+++ b/packages/web/src/content/docs/reference/env-vars.mdx
@@ -10,28 +10,29 @@ OpenTUI reads environment variables at runtime. Bun loads `.env` automatically, 
 
 ## Variables
 
-| Variable                       | Type      | Default | Description                                                |
-| ------------------------------ | --------- | ------- | ---------------------------------------------------------- |
-| `OTUI_TS_STYLE_WARN`           | `string`  | `false` | Enable warnings for missing syntax styles                  |
-| `OTUI_TREE_SITTER_WORKER_PATH` | `string`  | `""`    | Path to the Tree-sitter worker                             |
-| `XDG_CONFIG_HOME`              | `string`  | `""`    | Base directory for user-specific configuration files       |
-| `XDG_DATA_HOME`                | `string`  | `""`    | Base directory for user-specific data files                |
-| `OTUI_DEBUG_FFI`               | `boolean` | `false` | Enable debug logging for the FFI bindings                  |
-| `OTUI_SHOW_STATS`              | `boolean` | `false` | Show the debug overlay at startup                          |
-| `OTUI_TRACE_FFI`               | `boolean` | `false` | Enable tracing for the FFI bindings                        |
-| `OPENTUI_FORCE_WCWIDTH`        | `boolean` | `false` | Use wcwidth for character width calculations               |
-| `OPENTUI_FORCE_UNICODE`        | `boolean` | `false` | Force Mode 2026 Unicode support in terminal capabilities   |
-| `OPENTUI_GRAPHICS`             | `boolean` | `true`  | Enable Kitty graphics protocol detection                   |
-| `OPENTUI_FORCE_NOZWJ`          | `boolean` | `false` | Use no_zwj width method (Unicode without ZWJ joining)      |
-| `OPENTUI_FORCE_EXPLICIT_WIDTH` | `string`  | -       | Force explicit width detection (`true`/`1` or `false`/`0`) |
-| `OTUI_USE_CONSOLE`             | `boolean` | `true`  | Enable or disable the built-in console capture             |
-| `SHOW_CONSOLE`                 | `boolean` | `false` | Show the console overlay at startup                        |
-| `OTUI_DUMP_CAPTURES`           | `boolean` | `false` | Dump captured output when the renderer exits               |
-| `OTUI_NO_NATIVE_RENDER`        | `boolean` | `false` | Disable native rendering (debug only)                      |
-| `OTUI_USE_ALTERNATE_SCREEN`    | `boolean` | `true`  | Use the terminal alternate screen buffer                   |
-| `OTUI_OVERRIDE_STDOUT`         | `boolean` | `true`  | Override the stdout stream (debug only)                    |
-| `OTUI_DEBUG`                   | `boolean` | `false` | Enable debug mode to capture raw input                     |
+| Variable                       | Type      | Default | Description                                                   |
+| ------------------------------ | --------- | ------- | ------------------------------------------------------------- |
+| `OTUI_TS_STYLE_WARN`           | `string`  | `false` | Enable warnings for missing syntax styles                     |
+| `OTUI_TREE_SITTER_WORKER_PATH` | `string`  | `""`    | Path to the Tree-sitter worker                                |
+| `XDG_CONFIG_HOME`              | `string`  | `""`    | Base directory for user-specific configuration files          |
+| `XDG_DATA_HOME`                | `string`  | `""`    | Base directory for user-specific data files                   |
+| `OTUI_DEBUG_FFI`               | `boolean` | `false` | Enable debug logging for the FFI bindings                     |
+| `OTUI_SHOW_STATS`              | `boolean` | `false` | Show the debug overlay at startup                             |
+| `OTUI_TRACE_FFI`               | `boolean` | `false` | Enable tracing for the FFI bindings                           |
+| `OPENTUI_FORCE_WCWIDTH`        | `boolean` | `false` | Use wcwidth for character width calculations                  |
+| `OPENTUI_FORCE_UNICODE`        | `boolean` | `false` | Force Mode 2026 Unicode support in terminal capabilities      |
+| `OPENTUI_GRAPHICS`             | `boolean` | `true`  | Enable Kitty graphics protocol detection                      |
+| `OPENTUI_FORCE_NOZWJ`          | `boolean` | `false` | Use no_zwj width method (Unicode without ZWJ joining)         |
+| `OPENTUI_FORCE_EXPLICIT_WIDTH` | `string`  | -       | Force explicit width detection (`true`/`1` or `false`/`0`)    |
+| `OTUI_USE_CONSOLE`             | `boolean` | `true`  | Enable global `console.*` capture for the built-in overlay    |
+| `SHOW_CONSOLE`                 | `boolean` | `false` | Open the built-in console overlay at startup                  |
+| `OTUI_DUMP_CAPTURES`           | `boolean` | `false` | Dump captured stdout and console caches from the exit handler |
+| `OTUI_NO_NATIVE_RENDER`        | `boolean` | `false` | Skip the Zig/native frame renderer                            |
+| `OTUI_DEBUG`                   | `boolean` | `false` | Capture all raw stdin input for debugging                     |
 
 ## Notes
 
 - `OPENTUI_FORCE_EXPLICIT_WIDTH=false` skips OSC 66 queries on older terminals.
+- Disable global `console.*` capture with `OTUI_USE_CONSOLE=false`. `consoleMode` only changes the overlay surface.
+- `OTUI_NO_NATIVE_RENDER` still runs the render loop. In `"split-footer"` mode, the current stdout flush path can still emit ANSI cursor movement and clear sequences.
+- `OTUI_DUMP_CAPTURES` runs from the renderer exit handler. A direct `renderer.destroy()` call does not trigger it by itself.


### PR DESCRIPTION
Cleaned up CliRenderer config by replacing overlapping renderer flags with explicit modes.

The current config uses useAlternateScreen, useConsole, and experimental_splitHeight. That setup makes it hard for you to tell:

- where the renderer draws
- whether it captures stdout or passes it through
- whether the console overlay is enabled

This makes it explicit:

- screenMode: alternate-screen | main-screen | split-footer
- externalOutputMode: capture-stdout | passthrough
- consoleMode: console-overlay | disabled

Goal is to make CliRenderer configuration simpler and easier to understand. It replaces implicit flag combinations with explicit modes.

It's a breaking API change, obviously.