### PR TITLE
fix(core): resume() drops keystrokes due to deferred listener registration

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1311,8 +1311,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.stdin.setRawMode(true)
     }
 
-    this.stdin.resume()
     this.stdin.on("data", this.stdinListener)
+    this.stdin.resume()
   }
 
   private dispatchMouseEvent(
@@ -1862,14 +1862,14 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.stdin.setRawMode(true)
     }
 
+    // Drain any input buffered during suspension before registering the
+    // listener. Adding a "data" listener can auto-resume a Readable, so the
+    // drain must come first while the stream is still paused and read()
+    // pulls from the internal buffer rather than being a flowing-mode no-op.
+    while (this.stdin.read() !== null) {}
+    this.stdin.on("data", this.stdinListener)
     this.stdin.resume()
     this.addExitListeners()
-
-    setImmediate(() => {
-      // Consume any existing stdin data to avoid processing stale input
-      while (this.stdin.read() !== null) {}
-      this.stdin.on("data", this.stdinListener)
-    })
 
     this.lib.resumeRenderer(this.rendererPtr)
 

--- a/packages/core/src/tests/renderer.control.test.ts
+++ b/packages/core/src/tests/renderer.control.test.ts
@@ -277,7 +277,7 @@ test("multiple suspend/resume cycles work correctly", () => {
   expect(renderer.controlState).toBe(RendererControlState.EXPLICIT_PAUSED)
 })
 
-test("keyboard input is suspended when renderer is suspended", async () => {
+test("keyboard input is suspended when renderer is suspended", () => {
   renderer.start()
 
   let keyEventReceived = false
@@ -295,8 +295,6 @@ test("keyboard input is suspended when renderer is suspended", async () => {
   mockInput.pressKey("b")
   expect(keyEventReceived).toBe(false)
   renderer.resume()
-  // Wait for renderer to consume stale input and re-register listeners
-  await new Promise((r) => setImmediate(r))
   mockInput.pressKey("c")
   expect(keyEventReceived).toBe(true)
   renderer.keyInput.off("keypress", onKeypress)
@@ -335,7 +333,7 @@ test("mouse input is suspended when renderer is suspended", async () => {
   renderer.root.remove(testRenderable.id)
 })
 
-test("paste input is suspended when renderer is suspended", async () => {
+test("paste input is suspended when renderer is suspended", () => {
   renderer.start()
 
   let pasteEventReceived = false
@@ -354,11 +352,74 @@ test("paste input is suspended when renderer is suspended", async () => {
   expect(pasteEventReceived).toBe(false)
 
   renderer.resume()
-  // Wait for renderer to consume stale input and re-register listeners
-  await new Promise((r) => setImmediate(r))
 
   mockInput.pasteBracketedText("pasted text 3")
   expect(pasteEventReceived).toBe(true)
 
   renderer.keyInput.off("paste", onPaste)
+})
+
+test("keystrokes received immediately after resume() without yielding", () => {
+  renderer.start()
+
+  const received: string[] = []
+  const onKeypress = (e: { name: string }) => received.push(e.name)
+  renderer.keyInput.on("keypress", onKeypress)
+
+  renderer.suspend()
+  renderer.resume()
+  mockInput.pressKey("a")
+  mockInput.pressKey("b")
+
+  expect(received).toEqual(["a", "b"])
+  renderer.keyInput.off("keypress", onKeypress)
+})
+
+test("keystrokes survive multiple rapid suspend/resume cycles", () => {
+  renderer.start()
+
+  const received: string[] = []
+  const onKeypress = (e: { name: string }) => received.push(e.name)
+  renderer.keyInput.on("keypress", onKeypress)
+
+  for (let i = 0; i < 5; i++) {
+    renderer.suspend()
+    renderer.resume()
+  }
+  mockInput.pressKey("a")
+
+  expect(received).toEqual(["a"])
+  renderer.keyInput.off("keypress", onKeypress)
+})
+
+test("input buffered during suspension is drained on resume", () => {
+  renderer.start()
+
+  const received: string[] = []
+  const onKeypress = (e: { name: string }) => received.push(e.name)
+  renderer.keyInput.on("keypress", onKeypress)
+
+  renderer.suspend()
+  // Simulate stale input accumulating in stdin's internal buffer during
+  // suspension (e.g. from a child process or kernel line buffer).
+  // push() writes to the Readable's internal buffer without emitting.
+  renderer.stdin.push(Buffer.from("x"))
+  renderer.resume()
+  mockInput.pressKey("a")
+
+  // "x" should have been drained — only "a" received
+  expect(received).toEqual(["a"])
+  renderer.keyInput.off("keypress", onKeypress)
+})
+
+test("suspend/resume does not leak stdin listeners", () => {
+  renderer.start()
+  const baseline = renderer.stdin.listenerCount("data")
+
+  for (let i = 0; i < 10; i++) {
+    renderer.suspend()
+    renderer.resume()
+  }
+
+  expect(renderer.stdin.listenerCount("data")).toBe(baseline)
 })

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -2104,7 +2104,6 @@ describe("stdin routing", () => {
 
       renderer.suspend()
       renderer.resume()
-      await new Promise((resolve) => setImmediate(resolve))
 
       renderer.stdin.emit("data", Buffer.from("x"))
       advanceClock(clock)


### PR DESCRIPTION
## Problem

`resume()` calls `stdin.resume()` then defers listener registration into a `setImmediate`:

```ts
this.stdin.resume()
this.addExitListeners()
setImmediate(() => {
  while (this.stdin.read() !== null) {}
  this.stdin.on("data", this.stdinListener)
})
```

The stream starts flowing immediately, but `stdinListener` isn't attached until the next macrotask. Any keystrokes arriving in that gap are silently lost — which is exactly the window where a user types after `fg`.

`setupInput()` has a milder variant of the same bug: `resume()` before `on("data")`.

The drain loop was introduced in #331 to discard stale input from child process suspension. The placement made it ineffective: `read()` returns null in flowing mode because data goes through events, not pull. Stale bytes were only "discarded" by accident — emitted as `data` events with no listener present.

**Repro:** in the test suite, `mockInput.pressKey()` right after `renderer.resume()` is silently dropped. The existing tests masked this by yielding a macrotask (`await new Promise(r => setImmediate(r))`) before asserting.

## Fix

Reorder `resume()` to: drain → register listener → resume stream:

```ts
while (this.stdin.read() !== null) {}
this.stdin.on("data", this.stdinListener)
this.stdin.resume()
```

The ordering is load-bearing:

1. **Drain first** — `read()` pulls from the internal buffer in paused mode, discarding stale input (#331's scenario).
2. **Register listener second** — must come after the drain. Adding a `data` listener can auto-resume a paused Readable, flushing stale bytes through the listener before the drain runs.
3. **Resume last** — starts flowing mode. New data hits the registered listener with zero gap.

`setupInput()` just swaps the two lines (no drain needed at init).

## Tests

**Modified:** removed three `setImmediate` yield workarounds (2 in `renderer.control`, 1 in `renderer.input`). The tests now assert synchronous delivery — they'd fail if the fix were wrong.

**New (4):**
- "keystrokes received immediately after resume() without yielding" — core invariant.
- "keystrokes survive multiple rapid suspend/resume cycles" — 5 cycles, no accumulation.
- "input buffered during suspension is drained on resume" — `push()` bytes into stdin during suspension, verifies they're discarded. Directly tests the #331 scenario.
- "suspend/resume does not leak stdin listeners" — 10 cycles, `listenerCount("data")` stays constant.

## Background

I hit this in 0.1.88 while building a TUI on OpenTUI and patched the bundled JS. When 0.1.90 shipped, `setupInput()` had its `setImmediate` removed but the ordering was still wrong, and `resume()` still defers via `setImmediate`. I've been running a patched build since.

The `setImmediate` + drain pattern was introduced in #770 (building on #331). The intent was sound — this fix keeps the drain but moves it to where `read()` actually works.