### PR TITLE
fix: remove duplicate Extmarks demo entry

### DIFF
--- a/packages/core/src/examples/index.ts
+++ b/packages/core/src/examples/index.ts
@@ -197,12 +197,6 @@ const examples: Example[] = [
     destroy: linkDemo.destroy,
   },
   {
-    name: "Extmarks Demo",
-    description: "Virtual extmarks - text ranges that cursor jumps over, like inline tags and links",
-    run: extmarksDemo.run,
-    destroy: extmarksDemo.destroy,
-  },
-  {
     name: "Opacity Demo",
     description: "Box opacity and transparency effects with animated opacity transitions",
     run: opacityExample.run,


### PR DESCRIPTION
## Summary

- remove the duplicated `Extmarks Demo` registration from the examples menu