### PR TITLE
fix: remove unsupported extmarks demo listener

### DIFF
--- a/packages/core/src/examples/extmarks-demo.ts
+++ b/packages/core/src/examples/extmarks-demo.ts
@@ -6,7 +6,6 @@ import {
   TextRenderable,
   KeyEvent,
   type ExtmarksController,
-  type ExtmarkDeletedEvent,
 } from "../index.js"
 import { setupCommonDemoKeys } from "./lib/standalone-keys.js"
 import { SyntaxStyle } from "../syntax-style.js"
@@ -89,13 +88,6 @@ export async function run(rendererInstance: CliRenderer): Promise<void> {
   }
 
   findAndMarkVirtualRanges()
-
-  extmarksController.on("extmark-deleted", (event: ExtmarkDeletedEvent) => {
-    if (helpText) {
-      const extmark = event.extmark
-      helpText.content = `Deleted extmark at ${extmark.start}-${extmark.end} via ${event.trigger}`
-    }
-  })
 
   helpText = new TextRenderable(renderer, {
     id: "help",


### PR DESCRIPTION
Fix extmarks-demo.ts by removing an unsupported ExtmarksController event listener.

<img width="1257" height="720" alt="PixPin_2026-03-23_10-50-43" src="https://github.com/user-attachments/assets/3457f975-c214-4dc4-9472-8fa4082ec3c8" />

The demo was calling extmarksController.on("extmark-deleted", ...), but ExtmarksController does not define any event API such as on, off, or emit. This change removes that invalid listener and its related type import.
After the fix, the extmarks demo runs normally again and still demonstrates the intended core behaviors.
<img width="1274" height="724" alt="PixPin_2026-03-23_10-57-22" src="https://github.com/user-attachments/assets/fda66691-0d68-404f-9db2-5558eee86471" />
