### PR TITLE
fix: initialize renderer clock before timers

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -589,6 +589,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.maxFps = config.maxFps || 60
     this.targetFrameTime = 1000 / this.targetFps
     this.minTargetFrameTime = 1000 / this.maxFps
+    this.clock = config.clock ?? new SystemClock()
     this.memorySnapshotInterval = config.memorySnapshotInterval ?? 0
     this.gatherStats = config.gatherStats || false
     this.maxStatSamples = config.maxStatSamples || 300
@@ -633,8 +634,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     })
 
     this.addExitListeners()
-
-    this.clock = config.clock ?? new SystemClock()
 
     const stdinParserMaxBufferBytes = config.stdinParserMaxBufferBytes ?? DEFAULT_STDIN_PARSER_MAX_BUFFER_BYTES
     this.stdinParser = new StdinParser({


### PR DESCRIPTION
Firstly, I found this.
<img width="1964" height="550" alt="image" src="https://github.com/user-attachments/assets/50ecb188-095f-4f18-bd1f-c41ceb818498" />

When memorySnapshotInterval is enabled, CliRenderer was starting the memory snapshot timer before this.clock was initialized, which caused this.clock.setInterval to throw at startup.

Then, after this fix.
<img width="2254" height="1098" alt="image" src="https://github.com/user-attachments/assets/b08331c7-e283-4633-8816-0ee9555c72e4" />

