### PR TITLE
fix(markdown): hide URL suffix for concealed links

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -386,9 +386,6 @@ export class MarkdownRenderable extends Renderable {
           for (const child of token.tokens) {
             this.renderInlineTokenWithStyle(child as MarkedToken, chunks, "markup.link.label", linkHref)
           }
-          chunks.push(this.createChunk(" (", "markup.link", linkHref))
-          chunks.push(this.createChunk(token.href, "markup.link.url", linkHref))
-          chunks.push(this.createChunk(")", "markup.link", linkHref))
         } else {
           chunks.push(this.createChunk("[", "markup.link", linkHref))
           for (const child of token.tokens) {

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -995,7 +995,7 @@ test("links with conceal mode", async () => {
 
   expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
     "
-    Check out OpenTUI (https://github.com/sst/opentui) for more."
+    Check out OpenTUI for more."
   `)
 })
 
@@ -2220,7 +2220,7 @@ test("paragraph links are rendered with markdown conceal behavior", async () => 
 
   const frame = captureFrame()
   expect(frame).toContain("Google")
-  expect(frame).toContain("https://google.com")
+  expect(frame).not.toContain("https://google.com")
   expect(frame).not.toContain("[Google](https://google.com)")
 })
 


### PR DESCRIPTION
## Summary

- Remove redundant ` (url)` suffix from concealed markdown links — the link text is already an OSC 8 hyperlink (Cmd/Ctrl+click), so displaying the raw URL is unnecessary
- Update two existing tests to match the new concealed link output

## Context

When `conceal` is enabled, markdown links `[text](url)` render as `text (https://...)`. Since the link text already carries the `linkHref` for OSC 8 terminal hyperlinks, the parenthesized URL is redundant visual noise. This change makes concealed links render as just `text` — clickable via Cmd/Ctrl+click in supporting terminals.

The non-concealed (`conceal=false`) path is unchanged and still shows the full `[text](url)` syntax.