### PR TITLE
feat(core): double/triple word/line select + click-drag word snap 

### DIFF
--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -4,6 +4,7 @@ import { OptimizedBuffer } from "./buffer.js"
 import type { KeyEvent, PasteEvent } from "./lib/KeyHandler.js"
 import type { MouseEventType } from "./lib/parse.mouse.js"
 import type { Selection } from "./lib/selection.js"
+import type { SelectionCoordinateBounds } from "./lib/selection-primitives.js"
 import {
   parseAlign,
   parseAlignItems,
@@ -376,6 +377,14 @@ export abstract class Renderable extends BaseRenderable {
 
   public shouldStartSelection(x: number, y: number): boolean {
     return false
+  }
+
+  public getWordSelectionBounds(x: number, y: number): SelectionCoordinateBounds | null {
+    return null
+  }
+
+  public getLineSelectionBounds(x: number, y: number): SelectionCoordinateBounds | null {
+    return null
   }
 
   public focus(): void {

--- a/packages/core/src/lib/selection-primitives.ts
+++ b/packages/core/src/lib/selection-primitives.ts
@@ -1,0 +1,209 @@
+import type { RGBA } from "./RGBA.js"
+
+export interface SelectionCoordinateBounds {
+  anchor: { x: number; y: number }
+  focus: { x: number; y: number }
+}
+
+export interface ProbedVisualLine {
+  text: string
+  width: number
+  getPrefixText: (x: number) => string
+}
+
+export interface SelectionProbeView {
+  getSelection(): { start: number; end: number } | null
+  setSelection(start: number, end: number, bgColor?: RGBA, fgColor?: RGBA): void
+  resetSelection(): void
+  setLocalSelection(
+    anchorX: number,
+    anchorY: number,
+    focusX: number,
+    focusY: number,
+    bgColor?: RGBA,
+    fgColor?: RGBA,
+    ...extra: unknown[]
+  ): boolean
+  getSelectedText(): string
+}
+
+type GraphemeClass = "word" | "cjk-word" | "whitespace" | "other"
+
+const PROBE_MAX_X = 1_000_000
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" })
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+function classifyGrapheme(grapheme: string): GraphemeClass {
+  if (/^\s+$/u.test(grapheme)) return "whitespace"
+  if (/^[A-Za-z0-9_]+$/u.test(grapheme)) return "word"
+  if (/^[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]+$/u.test(grapheme)) {
+    return "cjk-word"
+  }
+  if (/^[\p{Letter}\p{Number}\p{Mark}_]+$/u.test(grapheme)) return "word"
+  // Punctuation/symbols intentionally remain their own class so double-click
+  // behavior splits tokens like "foo-bar" or "foo/bar" at punctuation boundaries.
+  return "other"
+}
+
+function getGraphemeBounds(text: string): Array<{ segment: string; start: number; end: number; kind: GraphemeClass }> {
+  const bounds: Array<{ segment: string; start: number; end: number; kind: GraphemeClass }> = []
+
+  for (const part of graphemeSegmenter.segment(text)) {
+    bounds.push({
+      segment: part.segment,
+      start: part.index,
+      end: part.index + part.segment.length,
+      kind: classifyGrapheme(part.segment),
+    })
+  }
+
+  return bounds
+}
+
+function findGraphemeIndexAt(textIndex: number, graphemes: Array<{ start: number; end: number }>): number {
+  for (let i = 0; i < graphemes.length; i += 1) {
+    const grapheme = graphemes[i]!
+
+    if (textIndex <= grapheme.end) {
+      return i
+    }
+  }
+
+  return graphemes.length - 1
+}
+
+function findStartXForTextIndex(line: ProbedVisualLine, startTextIndex: number): number {
+  if (startTextIndex <= 0) return 0
+
+  let low = 0
+  let high = line.width
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2)
+    if (line.getPrefixText(mid).length > startTextIndex) {
+      high = mid
+    } else {
+      low = mid + 1
+    }
+  }
+
+  return clamp(low - 1, 0, line.width)
+}
+
+function findEndXForTextIndex(line: ProbedVisualLine, endTextIndex: number): number {
+  if (endTextIndex <= 0) return 0
+
+  let low = 0
+  let high = line.width
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2)
+    if (line.getPrefixText(mid).length >= endTextIndex) {
+      high = mid
+    } else {
+      low = mid + 1
+    }
+  }
+
+  return clamp(low, 0, line.width)
+}
+
+export function getWordSelectionBoundsForVisualLine(
+  line: ProbedVisualLine,
+  localX: number,
+): { startX: number; endX: number } | null {
+  if (line.width <= 0 || line.text.length === 0) return null
+
+  const clickTextIndex = line.getPrefixText(clamp(localX, 0, line.width)).length
+  const graphemes = getGraphemeBounds(line.text)
+
+  if (graphemes.length === 0) return null
+
+  const clickedIndex = findGraphemeIndexAt(clickTextIndex, graphemes)
+  const clicked = graphemes[clickedIndex]
+  if (!clicked) return null
+
+  let startIndex = clickedIndex
+  while (startIndex > 0 && graphemes[startIndex - 1]?.kind === clicked.kind) {
+    startIndex -= 1
+  }
+
+  let endIndex = clickedIndex
+  while (endIndex + 1 < graphemes.length && graphemes[endIndex + 1]?.kind === clicked.kind) {
+    endIndex += 1
+  }
+
+  const startTextIndex = graphemes[startIndex]?.start ?? 0
+  const endTextIndex = graphemes[endIndex]?.end ?? line.text.length
+
+  return {
+    startX: findStartXForTextIndex(line, startTextIndex),
+    endX: findEndXForTextIndex(line, endTextIndex),
+  }
+}
+
+function withSelectionProbe<T>(view: SelectionProbeView, selectionBg: RGBA | undefined, selectionFg: RGBA | undefined, run: () => T): T {
+  const previousSelection = view.getSelection()
+
+  try {
+    return run()
+  } finally {
+    if (previousSelection) {
+      view.setSelection(previousSelection.start, previousSelection.end, selectionBg, selectionFg)
+    } else {
+      view.resetSelection()
+    }
+  }
+}
+
+export function createVisualLineProbe(
+  view: SelectionProbeView,
+  localY: number,
+  height: number,
+  selectionBg: RGBA | undefined,
+  selectionFg: RGBA | undefined,
+): (ProbedVisualLine & { localY: number }) | null {
+  // We currently "probe" line content by temporarily setting a local selection,
+  // reading selected text, then restoring the prior selection in a finally block.
+  // This keeps behavior correct with wrapping/continuation cells but mutates view
+  // selection state briefly and can be chatty over FFI when called repeatedly.
+  // TODO: replace this path with a dedicated native API for coordinate-range text.
+  if (height <= 0) return null
+
+  const clampedY = Math.max(0, Math.min(Math.floor(localY), height - 1))
+  const line = withSelectionProbe(view, selectionBg, selectionFg, () => {
+    view.setLocalSelection(0, clampedY, PROBE_MAX_X, clampedY, selectionBg, selectionFg)
+
+    const selection = view.getSelection()
+    return {
+      text: view.getSelectedText(),
+      width: selection ? selection.end - selection.start : 0,
+    }
+  })
+
+  const prefixCache = new Map<number, string>([
+    [0, ""],
+    [line.width, line.text],
+  ])
+
+  return {
+    ...line,
+    localY: clampedY,
+    getPrefixText: (x: number) => {
+      const clampedX = Math.max(0, Math.min(Math.floor(x), line.width))
+      const cached = prefixCache.get(clampedX)
+      if (cached !== undefined) return cached
+
+      const prefix = withSelectionProbe(view, selectionBg, selectionFg, () => {
+        view.setLocalSelection(0, clampedY, clampedX, clampedY, selectionBg, selectionFg)
+        return view.getSelectedText()
+      })
+
+      prefixCache.set(clampedX, prefix)
+      return prefix
+    },
+  }
+}

--- a/packages/core/src/renderables/EditBufferRenderable.ts
+++ b/packages/core/src/renderables/EditBufferRenderable.ts
@@ -3,6 +3,11 @@ import { convertGlobalToLocalSelection, Selection, type LocalSelectionBounds } f
 import { EditBuffer, type LogicalCursor } from "../edit-buffer.js"
 import { EditorView, type VisualCursor } from "../editor-view.js"
 import { RGBA, parseColor } from "../lib/RGBA.js"
+import {
+  createVisualLineProbe,
+  getWordSelectionBoundsForVisualLine,
+  type SelectionCoordinateBounds,
+} from "../lib/selection-primitives.js"
 import type { RenderContext, Highlight, CursorStyleOptions, LineInfoProvider, LineInfo } from "../types.js"
 import type { OptimizedBuffer } from "../buffer.js"
 import { MeasureMode } from "yoga-layout"
@@ -522,6 +527,29 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
 
   getSelection(): { start: number; end: number } | null {
     return this.editorView.getSelection()
+  }
+
+  public getWordSelectionBounds(x: number, y: number): SelectionCoordinateBounds | null {
+    const probe = createVisualLineProbe(this.editorView, y - this.y, this.height, this._selectionBg, this._selectionFg)
+    if (!probe) return null
+
+    const bounds = getWordSelectionBoundsForVisualLine(probe, x - this.x)
+    if (!bounds) return null
+
+    return {
+      anchor: { x: this.x + bounds.startX, y: this.y + probe.localY },
+      focus: { x: this.x + bounds.endX, y: this.y + probe.localY },
+    }
+  }
+
+  public getLineSelectionBounds(_x: number, y: number): SelectionCoordinateBounds | null {
+    const probe = createVisualLineProbe(this.editorView, y - this.y, this.height, this._selectionBg, this._selectionFg)
+    if (!probe) return null
+
+    return {
+      anchor: { x: this.x, y: this.y + probe.localY },
+      focus: { x: this.x + probe.width, y: this.y + probe.localY },
+    }
   }
 
   // Undefined = 0,

--- a/packages/core/src/renderables/TextBufferRenderable.ts
+++ b/packages/core/src/renderables/TextBufferRenderable.ts
@@ -3,6 +3,11 @@ import { convertGlobalToLocalSelection, Selection, type LocalSelectionBounds } f
 import { TextBuffer, type TextChunk } from "../text-buffer.js"
 import { TextBufferView } from "../text-buffer-view.js"
 import { RGBA, parseColor } from "../lib/RGBA.js"
+import {
+  createVisualLineProbe,
+  getWordSelectionBoundsForVisualLine,
+  type SelectionCoordinateBounds,
+} from "../lib/selection-primitives.js"
 import { type RenderContext, type LineInfoProvider } from "../types.js"
 import type { OptimizedBuffer } from "../buffer.js"
 import { MeasureMode } from "yoga-layout"
@@ -473,6 +478,29 @@ export abstract class TextBufferRenderable extends Renderable implements LineInf
 
   getSelection(): { start: number; end: number } | null {
     return this.textBufferView.getSelection()
+  }
+
+  public getWordSelectionBounds(x: number, y: number): SelectionCoordinateBounds | null {
+    const probe = createVisualLineProbe(this.textBufferView, y - this.y, this.height, this._selectionBg, this._selectionFg)
+    if (!probe) return null
+
+    const bounds = getWordSelectionBoundsForVisualLine(probe, x - this.x)
+    if (!bounds) return null
+
+    return {
+      anchor: { x: this.x + bounds.startX, y: this.y + probe.localY },
+      focus: { x: this.x + bounds.endX, y: this.y + probe.localY },
+    }
+  }
+
+  public getLineSelectionBounds(_x: number, y: number): SelectionCoordinateBounds | null {
+    const probe = createVisualLineProbe(this.textBufferView, y - this.y, this.height, this._selectionBg, this._selectionFg)
+    if (!probe) return null
+
+    return {
+      anchor: { x: this.x, y: this.y + probe.localY },
+      focus: { x: this.x + probe.width, y: this.y + probe.localY },
+    }
   }
 
   render(buffer: OptimizedBuffer, deltaTime: number): void {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -221,6 +221,7 @@ export class MouseEvent {
   public readonly scroll?: ScrollInfo
   public readonly target: Renderable | null
   public readonly isDragging?: boolean
+  public readonly clickCount: number
   private _propagationStopped: boolean = false
   private _defaultPrevented: boolean = false
 
@@ -232,7 +233,10 @@ export class MouseEvent {
     return this._defaultPrevented
   }
 
-  constructor(target: Renderable | null, attributes: RawMouseEvent & { source?: Renderable; isDragging?: boolean }) {
+  constructor(
+    target: Renderable | null,
+    attributes: RawMouseEvent & { source?: Renderable; isDragging?: boolean; clickCount?: number },
+  ) {
     this.target = target
     this.type = attributes.type
     this.button = attributes.button
@@ -242,6 +246,7 @@ export class MouseEvent {
     this.scroll = attributes.scroll
     this.source = attributes.source
     this.isDragging = attributes.isDragging
+    this.clickCount = attributes.clickCount ?? 0
   }
 
   public stopPropagation(): void {
@@ -439,6 +444,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private currentSelection: Selection | null = null
   private selectionContainers: Renderable[] = []
+  private wordSelectionOrigin: { renderable: Renderable; start: { x: number; y: number }; end: { x: number; y: number } } | null = null
   private clipboard: Clipboard
 
   private _splitHeight: number = 0
@@ -466,6 +472,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private _hasPointer: boolean = false
   private _lastPointerModifiers: RawMouseEvent["modifiers"] = { shift: false, alt: false, ctrl: false }
   private _currentMousePointerStyle: MousePointerStyle | undefined = undefined
+  private _lastClickInfo: { x: number; y: number; button: number; count: number; timeMs: number } | null = null
+  private _activeClickCount: number = 0
+  private _activePointerSequence: { button: number; x: number; y: number; dragged: boolean } | null = null
 
   private _currentFocusedRenderable: Renderable | null = null
   private lifecyclePasses: Set<Renderable> = new Set()
@@ -1317,9 +1326,65 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.stdin.resume()
   }
 
+  private getMouseEventClickCount(mouseEvent: RawMouseEvent): number {
+    const nowMs = this.clock.now()
+
+    if (mouseEvent.type === "down") {
+      const withinThreshold =
+        this._lastClickInfo &&
+        this._lastClickInfo.button === mouseEvent.button &&
+        this._lastClickInfo.x === mouseEvent.x &&
+        this._lastClickInfo.y === mouseEvent.y &&
+        nowMs - this._lastClickInfo.timeMs <= 400
+
+      this._activePointerSequence = {
+        button: mouseEvent.button,
+        x: mouseEvent.x,
+        y: mouseEvent.y,
+        dragged: false,
+      }
+      this._activeClickCount = withinThreshold ? this._lastClickInfo.count + 1 : 1
+      return this._activeClickCount
+    }
+
+    if (mouseEvent.type === "drag") {
+      if (this._activePointerSequence && this._activePointerSequence.button === mouseEvent.button) {
+        this._activePointerSequence.dragged = true
+      }
+      return this._activeClickCount
+    }
+
+    if (mouseEvent.type === "up") {
+      const wasDrag = this._activePointerSequence?.dragged === true
+      const clickCount = wasDrag ? 0 : this._activeClickCount || 1
+
+      if (wasDrag) {
+        this._lastClickInfo = null
+      } else {
+        this._lastClickInfo = {
+          x: mouseEvent.x,
+          y: mouseEvent.y,
+          button: mouseEvent.button,
+          count: clickCount,
+          timeMs: nowMs,
+        }
+      }
+
+      this._activePointerSequence = null
+      this._activeClickCount = 0
+      return clickCount
+    }
+
+    if (mouseEvent.type === "move") {
+      return this._activeClickCount
+    }
+
+    return 0
+  }
+
   private dispatchMouseEvent(
     target: Renderable,
-    attributes: RawMouseEvent & { source?: Renderable; isDragging?: boolean },
+    attributes: RawMouseEvent & { source?: Renderable; isDragging?: boolean; clickCount?: number },
   ): MouseEvent {
     const event = new MouseEvent(target, attributes)
     target.processMouseEvent(event)
@@ -1346,27 +1411,32 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       mouseEvent.y -= this.renderOffset
     }
 
-    this._latestPointer.x = mouseEvent.x
-    this._latestPointer.y = mouseEvent.y
+    const mouseEventWithClickCount = {
+      ...mouseEvent,
+      clickCount: this.getMouseEventClickCount(mouseEvent),
+    }
+
+    this._latestPointer.x = mouseEventWithClickCount.x
+    this._latestPointer.y = mouseEventWithClickCount.y
     this._hasPointer = true
-    this._lastPointerModifiers = mouseEvent.modifiers
+    this._lastPointerModifiers = mouseEventWithClickCount.modifiers
 
     if (this._console.visible) {
       const consoleBounds = this._console.bounds
       if (
-        mouseEvent.x >= consoleBounds.x &&
-        mouseEvent.x < consoleBounds.x + consoleBounds.width &&
-        mouseEvent.y >= consoleBounds.y &&
-        mouseEvent.y < consoleBounds.y + consoleBounds.height
+        mouseEventWithClickCount.x >= consoleBounds.x &&
+        mouseEventWithClickCount.x < consoleBounds.x + consoleBounds.width &&
+        mouseEventWithClickCount.y >= consoleBounds.y &&
+        mouseEventWithClickCount.y < consoleBounds.y + consoleBounds.height
       ) {
-        const event = new MouseEvent(null, mouseEvent)
+        const event = new MouseEvent(null, mouseEventWithClickCount)
         const handled = this._console.handleMouse(event)
         if (handled) return true
       }
     }
 
-    if (mouseEvent.type === "scroll") {
-      const maybeRenderableId = this.hitTest(mouseEvent.x, mouseEvent.y)
+    if (mouseEventWithClickCount.type === "scroll") {
+      const maybeRenderableId = this.hitTest(mouseEventWithClickCount.x, mouseEventWithClickCount.y)
       const maybeRenderable = Renderable.renderablesByNumber.get(maybeRenderableId)
       const fallbackTarget =
         this._currentFocusedRenderable &&
@@ -1377,51 +1447,65 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       const scrollTarget = maybeRenderable ?? fallbackTarget
 
       if (scrollTarget) {
-        const event = new MouseEvent(scrollTarget, mouseEvent)
+        const event = new MouseEvent(scrollTarget, mouseEventWithClickCount)
         scrollTarget.processMouseEvent(event)
       }
       return true
     }
 
-    const maybeRenderableId = this.hitTest(mouseEvent.x, mouseEvent.y)
+    const maybeRenderableId = this.hitTest(mouseEventWithClickCount.x, mouseEventWithClickCount.y)
     const sameElement = maybeRenderableId === this.lastOverRenderableNum
     this.lastOverRenderableNum = maybeRenderableId
     const maybeRenderable = Renderable.renderablesByNumber.get(maybeRenderableId)
 
     if (
-      mouseEvent.type === "down" &&
-      mouseEvent.button === MouseButton.LEFT &&
+      mouseEventWithClickCount.type === "down" &&
+      mouseEventWithClickCount.button === MouseButton.LEFT &&
       !this.currentSelection?.isDragging &&
-      !mouseEvent.modifiers.ctrl
+      !mouseEventWithClickCount.modifiers.ctrl
     ) {
       const canStartSelection = Boolean(
         maybeRenderable &&
         maybeRenderable.selectable &&
         !maybeRenderable.isDestroyed &&
-        maybeRenderable.shouldStartSelection(mouseEvent.x, mouseEvent.y),
+        maybeRenderable.shouldStartSelection(mouseEventWithClickCount.x, mouseEventWithClickCount.y),
       )
 
       if (canStartSelection && maybeRenderable) {
-        this.startSelection(maybeRenderable, mouseEvent.x, mouseEvent.y)
-        this.dispatchMouseEvent(maybeRenderable, mouseEvent)
+        const cc = mouseEventWithClickCount.clickCount
+        if (cc >= 3) {
+          this.selectLine(mouseEventWithClickCount.x, mouseEventWithClickCount.y)
+        } else if (cc === 2) {
+          this.selectWord(mouseEventWithClickCount.x, mouseEventWithClickCount.y)
+          if (this.currentSelection) {
+            this.currentSelection.isDragging = true
+          }
+        } else {
+          this.startSelection(maybeRenderable, mouseEventWithClickCount.x, mouseEventWithClickCount.y)
+        }
+        this.dispatchMouseEvent(maybeRenderable, mouseEventWithClickCount)
         return true
       }
     }
 
-    if (mouseEvent.type === "drag" && this.currentSelection?.isDragging) {
-      this.updateSelection(maybeRenderable, mouseEvent.x, mouseEvent.y)
+    if (mouseEventWithClickCount.type === "drag" && this.currentSelection?.isDragging) {
+      if (this.wordSelectionOrigin) {
+        this.updateSelectionWordSnap(mouseEventWithClickCount.x, mouseEventWithClickCount.y)
+      } else {
+        this.updateSelection(maybeRenderable, mouseEventWithClickCount.x, mouseEventWithClickCount.y)
+      }
 
       if (maybeRenderable) {
-        const event = new MouseEvent(maybeRenderable, { ...mouseEvent, isDragging: true })
+        const event = new MouseEvent(maybeRenderable, { ...mouseEventWithClickCount, isDragging: true })
         maybeRenderable.processMouseEvent(event)
       }
 
       return true
     }
 
-    if (mouseEvent.type === "up" && this.currentSelection?.isDragging) {
+    if (mouseEventWithClickCount.type === "up" && this.currentSelection?.isDragging) {
       if (maybeRenderable) {
-        const event = new MouseEvent(maybeRenderable, { ...mouseEvent, isDragging: true })
+        const event = new MouseEvent(maybeRenderable, { ...mouseEventWithClickCount, isDragging: true })
         maybeRenderable.processMouseEvent(event)
       }
 
@@ -1429,27 +1513,31 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       return true
     }
 
-    if (mouseEvent.type === "down" && mouseEvent.button === MouseButton.LEFT && this.currentSelection) {
-      if (mouseEvent.modifiers.ctrl) {
+    if (
+      mouseEventWithClickCount.type === "down" &&
+      mouseEventWithClickCount.button === MouseButton.LEFT &&
+      this.currentSelection
+    ) {
+      if (mouseEventWithClickCount.modifiers.ctrl) {
         this.currentSelection.isDragging = true
-        this.updateSelection(maybeRenderable, mouseEvent.x, mouseEvent.y)
+        this.updateSelection(maybeRenderable, mouseEventWithClickCount.x, mouseEventWithClickCount.y)
         return true
       }
     }
 
-    if (!sameElement && (mouseEvent.type === "drag" || mouseEvent.type === "move")) {
+    if (!sameElement && (mouseEventWithClickCount.type === "drag" || mouseEventWithClickCount.type === "move")) {
       if (
         this.lastOverRenderable &&
         this.lastOverRenderable !== this.capturedRenderable &&
         !this.lastOverRenderable.isDestroyed
       ) {
-        const event = new MouseEvent(this.lastOverRenderable, { ...mouseEvent, type: "out" })
+        const event = new MouseEvent(this.lastOverRenderable, { ...mouseEventWithClickCount, type: "out" })
         this.lastOverRenderable.processMouseEvent(event)
       }
       this.lastOverRenderable = maybeRenderable
       if (maybeRenderable) {
         const event = new MouseEvent(maybeRenderable, {
-          ...mouseEvent,
+          ...mouseEventWithClickCount,
           type: "over",
           source: this.capturedRenderable,
         })
@@ -1457,19 +1545,19 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       }
     }
 
-    if (this.capturedRenderable && mouseEvent.type !== "up") {
-      const event = new MouseEvent(this.capturedRenderable, mouseEvent)
+    if (this.capturedRenderable && mouseEventWithClickCount.type !== "up") {
+      const event = new MouseEvent(this.capturedRenderable, mouseEventWithClickCount)
       this.capturedRenderable.processMouseEvent(event)
       return true
     }
 
-    if (this.capturedRenderable && mouseEvent.type === "up") {
-      const event = new MouseEvent(this.capturedRenderable, { ...mouseEvent, type: "drag-end" })
+    if (this.capturedRenderable && mouseEventWithClickCount.type === "up") {
+      const event = new MouseEvent(this.capturedRenderable, { ...mouseEventWithClickCount, type: "drag-end" })
       this.capturedRenderable.processMouseEvent(event)
-      this.capturedRenderable.processMouseEvent(new MouseEvent(this.capturedRenderable, mouseEvent))
+      this.capturedRenderable.processMouseEvent(new MouseEvent(this.capturedRenderable, mouseEventWithClickCount))
       if (maybeRenderable) {
         const event = new MouseEvent(maybeRenderable, {
-          ...mouseEvent,
+          ...mouseEventWithClickCount,
           type: "drop",
           source: this.capturedRenderable,
         })
@@ -1485,18 +1573,18 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     let event: MouseEvent | undefined
     if (maybeRenderable) {
-      if (mouseEvent.type === "drag" && mouseEvent.button === MouseButton.LEFT) {
+      if (mouseEventWithClickCount.type === "drag" && mouseEventWithClickCount.button === MouseButton.LEFT) {
         this.setCapturedRenderable(maybeRenderable)
       } else {
         this.setCapturedRenderable(undefined)
       }
-      event = this.dispatchMouseEvent(maybeRenderable, mouseEvent)
+      event = this.dispatchMouseEvent(maybeRenderable, mouseEventWithClickCount)
     } else {
       this.setCapturedRenderable(undefined)
       this.lastOverRenderable = undefined
     }
 
-    if (!event?.defaultPrevented && mouseEvent.type === "down" && this.currentSelection) {
+    if (!event?.defaultPrevented && mouseEventWithClickCount.type === "down" && this.currentSelection) {
       this.clearSelection()
     }
 
@@ -2237,6 +2325,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.currentSelection = null
     }
     this.selectionContainers = []
+    this.wordSelectionOrigin = null
   }
 
   /**
@@ -2252,6 +2341,82 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.currentSelection.isStart = true
 
     this.notifySelectablesOfSelectionChange()
+  }
+
+  private setSelectionBounds(renderable: Renderable, anchor: { x: number; y: number }, focus: { x: number; y: number }): void {
+    this.clearSelection()
+    this.selectionContainers.push(renderable.parent || this.root)
+    this.currentSelection = new Selection(renderable, anchor, focus)
+    this.currentSelection.isStart = true
+    this.currentSelection.isDragging = false
+    this.notifySelectablesOfSelectionChange()
+  }
+
+  public selectWord(x: number, y: number): void {
+    const maybeRenderableId = this.hitTest(x, y)
+    const maybeRenderable = Renderable.renderablesByNumber.get(maybeRenderableId)
+    const bounds = maybeRenderable?.getWordSelectionBounds(x, y)
+
+    if (!maybeRenderable || !bounds) return
+
+    this.setSelectionBounds(maybeRenderable, bounds.anchor, bounds.focus)
+    this.finishSelection()
+    this.wordSelectionOrigin = {
+      renderable: maybeRenderable,
+      start: bounds.anchor,
+      end: bounds.focus,
+    }
+  }
+
+  public selectLine(x: number, y: number): void {
+    const maybeRenderableId = this.hitTest(x, y)
+    const maybeRenderable = Renderable.renderablesByNumber.get(maybeRenderableId)
+    const bounds = maybeRenderable?.getLineSelectionBounds(x, y)
+
+    if (!maybeRenderable || !bounds) return
+
+    this.setSelectionBounds(maybeRenderable, bounds.anchor, bounds.focus)
+    this.finishSelection()
+  }
+
+  public updateSelectionWordSnap(x: number, y: number): void {
+    const origin = this.wordSelectionOrigin
+    if (!origin || origin.renderable.isDestroyed) return
+
+    const bounds = origin.renderable.getWordSelectionBounds(x, y)
+    if (!bounds) return
+
+    const comparePoints = (left: { x: number; y: number }, right: { x: number; y: number }): number => {
+      if (left.y !== right.y) return left.y - right.y
+      return left.x - right.x
+    }
+
+    const isBeforeOrigin = comparePoints(bounds.focus, origin.start) <= 0
+    const isAfterOrigin = comparePoints(bounds.anchor, origin.end) >= 0
+
+    if (isBeforeOrigin) {
+      this.setSelectionBounds(origin.renderable, origin.end, bounds.anchor)
+      if (this.currentSelection) {
+        this.currentSelection.isDragging = true
+      }
+      this.wordSelectionOrigin = origin
+      return
+    }
+
+    if (isAfterOrigin) {
+      this.setSelectionBounds(origin.renderable, origin.start, bounds.focus)
+      if (this.currentSelection) {
+        this.currentSelection.isDragging = true
+      }
+      this.wordSelectionOrigin = origin
+      return
+    }
+
+    this.setSelectionBounds(origin.renderable, origin.start, origin.end)
+    if (this.currentSelection) {
+      this.currentSelection.isDragging = true
+    }
+    this.wordSelectionOrigin = origin
   }
 
   public updateSelection(

--- a/packages/core/src/tests/renderer.word-selection.test.ts
+++ b/packages/core/src/tests/renderer.word-selection.test.ts
@@ -1,0 +1,864 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { createTestRenderer, type MockMouse, type TestRenderer } from "../testing.js"
+import { TextRenderable } from "../renderables/Text.js"
+import { TextareaRenderable } from "../renderables/Textarea.js"
+import { CliRenderEvents } from "../renderer.js"
+
+describe("word and line selection", () => {
+  let renderer: TestRenderer
+  let mockMouse: MockMouse
+  let renderOnce: () => Promise<void>
+
+  beforeEach(async () => {
+    ;({ renderer, mockMouse, renderOnce } = await createTestRenderer({ width: 60, height: 20 }))
+  })
+
+  afterEach(() => {
+    renderer.destroy()
+  })
+
+  test("MouseEvent.clickCount tracks repeated clicks at the same position", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "click-count-text",
+      position: "absolute",
+      left: 1,
+      top: 1,
+      width: 20,
+      height: 1,
+      content: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    const counts: number[] = []
+    text.onMouseDown = (event) => {
+      counts.push(event.clickCount)
+    }
+
+    await mockMouse.click(text.x + 1, text.y)
+    await mockMouse.click(text.x + 1, text.y)
+    await Bun.sleep(450)
+    await mockMouse.click(text.x + 1, text.y)
+    await mockMouse.click(text.x + 2, text.y)
+
+    expect(counts).toEqual([1, 2, 1, 1])
+  })
+
+  test("MouseEvent.clickCount reaches 3 on a triple click", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "triple-click-text",
+      position: "absolute",
+      left: 1,
+      top: 1,
+      width: 20,
+      height: 1,
+      content: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    const counts: number[] = []
+    text.onMouseDown = (event) => {
+      counts.push(event.clickCount)
+    }
+
+    await mockMouse.click(text.x + 1, text.y)
+    await mockMouse.click(text.x + 1, text.y)
+    await mockMouse.click(text.x + 1, text.y)
+
+    expect(counts).toEqual([1, 2, 3])
+  })
+
+  test("MouseEvent.clickCount resets when the pointer position changes", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "position-reset-click-count-text",
+      position: "absolute",
+      left: 1,
+      top: 1,
+      width: 20,
+      height: 1,
+      content: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    const counts: number[] = []
+    text.onMouseDown = (event) => {
+      counts.push(event.clickCount)
+    }
+
+    await mockMouse.click(text.x + 1, text.y)
+    await mockMouse.click(text.x + 1, text.y)
+    await mockMouse.click(text.x + 2, text.y)
+
+    expect(counts).toEqual([1, 2, 1])
+  })
+
+  test("MouseEvent.clickCount is 0 on mouse up after a drag", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "drag-mouseup-click-count-text",
+      position: "absolute",
+      left: 1,
+      top: 1,
+      width: 20,
+      height: 2,
+      content: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    let upClickCount: number | null = null
+    text.onMouseUp = (event) => {
+      upClickCount = event.clickCount
+    }
+
+    await mockMouse.drag(text.x + 1, text.y, text.x + 4, text.y)
+
+    expect(upClickCount).toBe(0)
+  })
+
+  test("MouseEvent.clickCount does not treat drags as prior clicks", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "drag-reset-click-count-text",
+      position: "absolute",
+      left: 1,
+      top: 1,
+      width: 20,
+      height: 2,
+      content: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    const counts: number[] = []
+    text.onMouseDown = (event) => {
+      counts.push(event.clickCount)
+    }
+
+    await mockMouse.drag(text.x + 1, text.y, text.x + 4, text.y)
+    await mockMouse.click(text.x + 4, text.y)
+
+    expect(counts).toEqual([1, 1])
+  })
+
+  test("MouseEvent.clickCount is reported consistently on mouse up", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "mouseup-click-count-text",
+      position: "absolute",
+      left: 1,
+      top: 1,
+      width: 20,
+      height: 1,
+      content: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    const upCounts: number[] = []
+    text.onMouseUp = (event) => {
+      upCounts.push(event.clickCount)
+    }
+
+    await mockMouse.click(text.x + 1, text.y)
+    await mockMouse.click(text.x + 1, text.y)
+
+    expect(upCounts).toEqual([1, 2])
+  })
+
+  test("MouseEvent.clickCount resets when the mouse button changes", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "button-reset-click-count-text",
+      position: "absolute",
+      left: 1,
+      top: 1,
+      width: 20,
+      height: 1,
+      content: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    const counts: number[] = []
+    text.onMouseDown = (event) => {
+      counts.push(event.clickCount)
+    }
+
+    await mockMouse.click(text.x + 1, text.y)
+    await mockMouse.click(text.x + 1, text.y)
+    await mockMouse.click(text.x + 1, text.y, 2)
+
+    expect(counts).toEqual([1, 2, 1])
+  })
+
+  test("renderer.selectWord selects the word under the cursor in text renderables", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "select-word-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "alpha beta gamma",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 7, text.y)
+
+    expect(text.getSelectedText()).toBe("beta")
+    expect(renderer.getSelection()?.getSelectedText()).toBe("beta")
+  })
+
+  test("renderer.selectLine selects the full visual line under the cursor", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "select-line-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 20,
+      height: 3,
+      content: "first\nsecond\nthird",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectLine(text.x + 2, text.y + 1)
+
+    expect(text.getSelectedText()).toBe("second")
+    expect(renderer.getSelection()?.getSelectedText()).toBe("second")
+  })
+
+  test("renderer.selectLine can target empty logical lines", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "empty-line-select-line-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 20,
+      height: 3,
+      content: "first\n\nthird",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectLine(text.x, text.y + 1)
+
+    expect(text.getSelectedText()).toBe("")
+  })
+
+  test("renderer.selectLine uses visual lines for wrapped text", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "wrapped-select-line-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 6,
+      height: 3,
+      content: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectLine(text.x + 1, text.y)
+
+    expect(text.getSelectedText()).toBe("alpha ")
+  })
+
+  test("renderer.updateSelectionWordSnap extends a word selection by whole words", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "word-snap-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "alpha beta gamma",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 1, text.y)
+    renderer.updateSelectionWordSnap(text.x + 8, text.y)
+
+    expect(text.getSelectedText()).toBe("alpha beta")
+    expect(renderer.getSelection()?.getSelectedText()).toBe("alpha beta")
+  })
+
+  test("renderer.selectWord works on wrapped continuation lines", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "wrapped-select-word-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 6,
+      height: 3,
+      content: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 1, text.y + 1)
+
+    expect(text.getSelectedText()).toBe("beta")
+  })
+
+  test("renderer.updateSelectionWordSnap can extend backward by whole words", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "word-snap-reverse-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "alpha beta gamma",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 7, text.y)
+    renderer.updateSelectionWordSnap(text.x + 1, text.y)
+
+    expect(text.getSelectedText()).toBe("alpha beta")
+  })
+
+  test("renderer.selectWord treats the continuation cell of a wide CJK grapheme as part of the same word", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "cjk-continuation-cell-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "abc日 def",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 5, text.y)
+
+    expect(text.getSelectedText()).toBe("日")
+  })
+
+  test("renderer.selectWord respects CJK and ASCII word boundaries", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "cjk-word-boundary-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "abc日 def",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 4, text.y)
+    expect(text.getSelectedText()).toBe("日")
+
+    renderer.selectWord(text.x + 1, text.y)
+    expect(text.getSelectedText()).toBe("abc")
+  })
+
+  test("renderer.updateSelectionWordSnap can extend across logical line breaks", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "logical-line-word-snap-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 20,
+      height: 3,
+      content: "alpha\nbeta gamma",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 1, text.y + 1)
+    renderer.updateSelectionWordSnap(text.x + 1, text.y)
+
+    expect(text.getSelectedText()).toBe("alpha\nbeta")
+  })
+
+  test("renderer.updateSelectionWordSnap can extend across wrapped visual lines", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "wrapped-word-snap-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 6,
+      height: 3,
+      content: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 1, text.y)
+    renderer.updateSelectionWordSnap(text.x + 1, text.y + 1)
+
+    expect(text.getSelectedText()).toBe("alpha beta")
+  })
+
+  test("renderer.selectWord splits tab-separated tokens at whitespace boundaries", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "tab-separated-word-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "foo\tbar baz",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 6, text.y)
+
+    expect(text.getSelectedText()).toBe("bar")
+  })
+
+  test("renderer.selectWord splits hyphenated tokens at punctuation boundaries", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "hyphenated-word-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "foo-bar baz",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 1, text.y)
+    expect(text.getSelectedText()).toBe("foo")
+
+    renderer.selectWord(text.x + 5, text.y)
+    expect(text.getSelectedText()).toBe("bar")
+  })
+
+  test("renderer.selectWord groups decomposed accented latin text as one word", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "decomposed-accented-word-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "cafe\u0301 noir",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 3, text.y)
+
+    expect(text.getSelectedText()).toBe("cafe\u0301")
+  })
+
+  test("renderer.selectWord groups accented latin text as one word", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "accented-word-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "café noir",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 3, text.y)
+
+    expect(text.getSelectedText()).toBe("café")
+  })
+
+  test("renderer.selectWord treats the continuation cell of a wide emoji grapheme as part of the same cluster", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "emoji-continuation-cell-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "hi 👨‍👩‍👧‍👦 there",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 5, text.y)
+
+    expect(text.getSelectedText()).toBe("👨‍👩‍👧‍👦")
+  })
+
+  test("renderer.selectWord keeps emoji grapheme clusters intact", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "emoji-word-text",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "hi 👨‍👩‍👧‍👦 there",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    renderer.selectWord(text.x + 4, text.y)
+
+    expect(text.getSelectedText()).toBe("👨‍👩‍👧‍👦")
+  })
+
+  test("renderer.selectWord treats the continuation cell of a wide CJK grapheme as part of the same word in textareas", async () => {
+    const textarea = new TextareaRenderable(renderer, {
+      id: "cjk-continuation-cell-textarea",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 3,
+      initialValue: "abc日 def",
+      selectable: true,
+    })
+    renderer.root.add(textarea)
+    await renderOnce()
+
+    renderer.selectWord(textarea.x + 5, textarea.y)
+
+    expect(textarea.getSelectedText()).toBe("日")
+  })
+
+  test("renderer.selectWord splits tab-separated tokens at whitespace boundaries in textareas", async () => {
+    const textarea = new TextareaRenderable(renderer, {
+      id: "tab-separated-word-textarea",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 3,
+      initialValue: "foo\tbar baz",
+      selectable: true,
+    })
+    renderer.root.add(textarea)
+    await renderOnce()
+
+    renderer.selectWord(textarea.x + 6, textarea.y)
+
+    expect(textarea.getSelectedText()).toBe("bar")
+  })
+
+  test("renderer.selectLine can target empty logical lines in textareas", async () => {
+    const textarea = new TextareaRenderable(renderer, {
+      id: "empty-line-select-line-textarea",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 20,
+      height: 4,
+      initialValue: "first\n\nthird",
+      selectable: true,
+    })
+    renderer.root.add(textarea)
+    await renderOnce()
+
+    renderer.selectLine(textarea.x, textarea.y + 1)
+
+    expect(textarea.getSelectedText()).toBe("")
+  })
+
+  test("renderer.selectLine works for textarea renderables", async () => {
+    const textarea = new TextareaRenderable(renderer, {
+      id: "select-line-textarea",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 4,
+      initialValue: "first\nsecond\nthird",
+      selectable: true,
+    })
+    renderer.root.add(textarea)
+    await renderOnce()
+
+    renderer.selectLine(textarea.x + 1, textarea.y + 1)
+
+    expect(textarea.getSelectedText()).toBe("second")
+  })
+
+  test("renderer.selectLine works for wrapped textarea visual lines", async () => {
+    const textarea = new TextareaRenderable(renderer, {
+      id: "wrapped-select-line-textarea",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 6,
+      height: 4,
+      initialValue: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(textarea)
+    await renderOnce()
+
+    renderer.selectLine(textarea.x + 1, textarea.y + 1)
+
+    expect(textarea.getSelectedText()).toBe("beta")
+  })
+
+  test("renderer.selectWord works on wrapped textarea continuation lines", async () => {
+    const textarea = new TextareaRenderable(renderer, {
+      id: "wrapped-select-word-textarea",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 6,
+      height: 4,
+      initialValue: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(textarea)
+    await renderOnce()
+
+    renderer.selectWord(textarea.x + 1, textarea.y + 1)
+
+    expect(textarea.getSelectedText()).toBe("beta")
+  })
+
+  test("renderer.updateSelectionWordSnap works across logical line breaks in textareas", async () => {
+    const textarea = new TextareaRenderable(renderer, {
+      id: "logical-line-word-snap-textarea",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 20,
+      height: 4,
+      initialValue: "alpha\nbeta gamma",
+      selectable: true,
+    })
+    renderer.root.add(textarea)
+    await renderOnce()
+
+    renderer.selectWord(textarea.x + 1, textarea.y + 1)
+    renderer.updateSelectionWordSnap(textarea.x + 1, textarea.y)
+
+    expect(textarea.getSelectedText()).toBe("alpha\nbeta")
+  })
+
+  test("renderer.updateSelectionWordSnap works backward across wrapped textarea visual lines", async () => {
+    const textarea = new TextareaRenderable(renderer, {
+      id: "wrapped-word-snap-textarea-backward",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 6,
+      height: 4,
+      initialValue: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(textarea)
+    await renderOnce()
+
+    renderer.selectWord(textarea.x + 1, textarea.y + 1)
+    renderer.updateSelectionWordSnap(textarea.x + 1, textarea.y)
+
+    expect(textarea.getSelectedText()).toBe("alpha beta")
+  })
+
+  test("renderer.updateSelectionWordSnap works across wrapped textarea visual lines", async () => {
+    const textarea = new TextareaRenderable(renderer, {
+      id: "wrapped-word-snap-textarea",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 6,
+      height: 4,
+      initialValue: "alpha beta",
+      selectable: true,
+    })
+    renderer.root.add(textarea)
+    await renderOnce()
+
+    renderer.selectWord(textarea.x + 1, textarea.y)
+    renderer.updateSelectionWordSnap(textarea.x + 1, textarea.y + 1)
+
+    expect(textarea.getSelectedText()).toBe("alpha beta")
+  })
+
+  test("renderer.selectWord groups decomposed accented latin text in textareas", async () => {
+    const textarea = new TextareaRenderable(renderer, {
+      id: "decomposed-accented-word-textarea",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 3,
+      initialValue: "cafe\u0301 noir",
+      selectable: true,
+    })
+    renderer.root.add(textarea)
+    await renderOnce()
+
+    renderer.selectWord(textarea.x + 3, textarea.y)
+
+    expect(textarea.getSelectedText()).toBe("cafe\u0301")
+  })
+
+  test("renderer.selectWord treats the continuation cell of a wide emoji grapheme as part of the same cluster in textareas", async () => {
+    const textarea = new TextareaRenderable(renderer, {
+      id: "emoji-continuation-cell-textarea",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 3,
+      initialValue: "hi 👨‍👩‍👧‍👦 there",
+      selectable: true,
+    })
+    renderer.root.add(textarea)
+    await renderOnce()
+
+    renderer.selectWord(textarea.x + 5, textarea.y)
+
+    expect(textarea.getSelectedText()).toBe("👨‍👩‍👧‍👦")
+  })
+
+  test("renderer.selectWord works for textarea renderables", async () => {
+    const textarea = new TextareaRenderable(renderer, {
+      id: "select-word-textarea",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 3,
+      initialValue: "hello brave new world",
+      selectable: true,
+    })
+    renderer.root.add(textarea)
+    await renderOnce()
+
+    renderer.selectWord(textarea.x + 7, textarea.y)
+
+    expect(textarea.getSelectedText()).toBe("brave")
+    expect(renderer.getSelection()?.getSelectedText()).toBe("brave")
+  })
+
+  test("double-click via mouse events selects the word under the cursor", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "dbl-click-integration",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "alpha beta gamma",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    await mockMouse.doubleClick(text.x + 7, text.y)
+
+    expect(text.getSelectedText()).toBe("beta")
+    expect(renderer.getSelection()?.getSelectedText()).toBe("beta")
+  })
+
+  test("triple-click via mouse events selects the full visual line", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "triple-click-integration",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 20,
+      height: 3,
+      content: "first\nsecond\nthird",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    await mockMouse.click(text.x + 2, text.y + 1)
+    await mockMouse.click(text.x + 2, text.y + 1)
+    await mockMouse.click(text.x + 2, text.y + 1)
+
+    expect(text.getSelectedText()).toBe("second")
+    expect(renderer.getSelection()?.getSelectedText()).toBe("second")
+  })
+
+  test("double-click-drag extends selection by whole words", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "dbl-click-drag-integration",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "alpha beta gamma delta",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    // Double-click on "beta" (second down starts word selection)
+    await mockMouse.click(text.x + 7, text.y)
+    await mockMouse.pressDown(text.x + 7, text.y)
+    // Drag to "gamma"
+    await mockMouse.moveTo(text.x + 14, text.y)
+    await mockMouse.release(text.x + 14, text.y)
+
+    expect(text.getSelectedText()).toBe("beta gamma")
+  })
+
+  test("double-click-drag does not emit intermediate selection-finished events during drag", async () => {
+    const text = new TextRenderable(renderer, {
+      id: "dbl-click-drag-selection-event",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 1,
+      content: "alpha beta gamma delta",
+      selectable: true,
+    })
+    renderer.root.add(text)
+    await renderOnce()
+
+    let selectionEventCount = 0
+    renderer.on(CliRenderEvents.SELECTION, () => {
+      selectionEventCount += 1
+    })
+
+    await mockMouse.click(text.x + 7, text.y)
+    expect(selectionEventCount).toBe(1)
+
+    await mockMouse.pressDown(text.x + 7, text.y)
+    expect(selectionEventCount).toBe(2)
+
+    await mockMouse.moveTo(text.x + 14, text.y)
+    await mockMouse.moveTo(text.x + 20, text.y)
+    expect(selectionEventCount).toBe(2)
+
+    await mockMouse.release(text.x + 20, text.y)
+    expect(selectionEventCount).toBe(3)
+  })
+})


### PR DESCRIPTION
## Multi-click text selection (double-click word, triple-click line, word-snap drag)

Add standard terminal/editor selection behavior to OpenTUI: double-click selects a word, triple-click selects a line, and dragging after double-click expands by whole words.

The renderer now tracks click sequences and exposes MouseEvent.clickCount, then uses that in mouse handling to trigger word/line selection paths. Word boundaries are computed with Unicode grapheme segmentation (Intl.Segmenter) so emoji clusters, CJK, and combining marks select correctly. I also extracted the selection probing logic into shared primitives to remove duplication between text/edit buffer renderables.

One important behavioral fix included here: word-snap drag updates no longer prematurely end selection state during drag; selection finalization now happens correctly on mouse-up.

resolves #744 