### PR TITLE
core: add native split-footer commit path

### DIFF
--- a/packages/core/src/examples/index.ts
+++ b/packages/core/src/examples/index.ts
@@ -48,6 +48,7 @@ import * as mouseInteractionExample from "./mouse-interaction-demo.js"
 import * as textSelectionExample from "./text-selection-demo.js"
 import * as asciiFontSelectionExample from "./ascii-font-selection-demo.js"
 import * as splitModeExample from "./split-mode-demo.js"
+import * as splitFooterStreamingDemo from "./split-footer-streaming-demo.js"
 import * as consoleExample from "./console-demo.js"
 import * as vnodeCompositionDemo from "./vnode-composition-demo.js"
 import * as hastSyntaxHighlightingExample from "./hast-syntax-highlighting-demo.js"
@@ -232,6 +233,12 @@ const examples: Example[] = [
     description: "Markdown rendering with table alignment, syntax highlighting, and theme switching",
     run: markdownDemo.run,
     destroy: markdownDemo.destroy,
+  },
+  {
+    name: "Split Footer Streaming Demo",
+    description: "Focused split-footer surface demo for progressive text, code, and markdown scrollback",
+    run: splitFooterStreamingDemo.run,
+    destroy: splitFooterStreamingDemo.destroy,
   },
   {
     name: "Live State Management Demo",

--- a/packages/core/src/examples/split-footer-streaming-demo.ts
+++ b/packages/core/src/examples/split-footer-streaming-demo.ts
@@ -1,0 +1,767 @@
+import {
+  BoxRenderable,
+  CliRenderEvents,
+  CodeRenderable,
+  MarkdownRenderable,
+  TextTableRenderable,
+  TextRenderable,
+  createCliRenderer,
+  type CliRenderer,
+  type KeyEvent,
+  type ScrollbackSurface,
+} from "../index.js"
+import { RGBA, parseColor } from "../lib/RGBA.js"
+import { getTreeSitterClient } from "../lib/tree-sitter/index.js"
+import type { TextTableContent } from "../renderables/TextTable.js"
+import { SyntaxStyle } from "../syntax-style.js"
+import type { TextChunk } from "../text-buffer.js"
+import { setupCommonDemoKeys } from "./lib/standalone-keys.js"
+
+const FOOTER_HEIGHT = 10
+const DEFAULT_INTERVAL_MS = 180
+const MIN_INTERVAL_MS = 60
+const MAX_INTERVAL_MS = 1000
+const INTERVAL_STEP_MS = 40
+
+type StreamKind = "text" | "code" | "markdown"
+
+interface ScenarioDefinition {
+  kind: StreamKind
+  title: string
+  description: string
+  prefix: string
+  chunks: string[]
+}
+
+interface ActiveRun {
+  id: number
+  scenario: ScenarioDefinition
+  surface: ScrollbackSurface
+  renderable: TextRenderable | CodeRenderable | MarkdownRenderable
+  content: string
+  chunkIndex: number
+  committedRows: number
+  committedBlocks: number
+  cancelled: boolean
+  done: boolean
+}
+
+const PALETTE = {
+  background: "#0B1220",
+  panel: "#101A2D",
+  border: "#3B5B82",
+  title: "#F4F8FF",
+  status: "#D7E5FA",
+  detail: "#A8C0E4",
+  hint: "#8BA6CD",
+  textAccent: "#66D9EF",
+  codeAccent: "#FFD580",
+  markdownAccent: "#C7A6FF",
+  error: "#FF9B9B",
+} as const
+
+const SURFACE_SYNTAX_STYLE = SyntaxStyle.fromStyles({
+  default: { fg: RGBA.fromInts(230, 237, 243, 255) },
+  keyword: { fg: RGBA.fromInts(255, 123, 114, 255), bold: true },
+  string: { fg: RGBA.fromInts(165, 214, 255, 255) },
+  comment: { fg: RGBA.fromInts(139, 148, 158, 255), italic: true },
+  number: { fg: RGBA.fromInts(121, 192, 255, 255) },
+  function: { fg: RGBA.fromInts(210, 168, 255, 255) },
+  type: { fg: RGBA.fromInts(255, 166, 87, 255) },
+  variable: { fg: RGBA.fromInts(230, 237, 243, 255) },
+  property: { fg: RGBA.fromInts(121, 192, 255, 255) },
+  "markup.heading": { fg: RGBA.fromInts(88, 166, 255, 255), bold: true },
+  "markup.heading.1": { fg: RGBA.fromInts(0, 255, 136, 255), bold: true },
+  "markup.strong": { fg: RGBA.fromInts(244, 248, 255, 255), bold: true },
+  "markup.italic": { fg: RGBA.fromInts(200, 210, 220, 255), italic: true },
+  "markup.list": { fg: RGBA.fromInts(121, 192, 255, 255) },
+  "markup.raw": { fg: RGBA.fromInts(255, 213, 128, 255) },
+  "markup.link": { fg: RGBA.fromInts(88, 166, 255, 255), underline: true },
+  "markup.link.label": { fg: RGBA.fromInts(88, 166, 255, 255), underline: true },
+  "markup.link.url": { fg: RGBA.fromInts(88, 166, 255, 255), underline: true },
+  conceal: { fg: RGBA.fromInts(98, 114, 130, 255) },
+})
+
+const SCENARIOS: Record<StreamKind, ScenarioDefinition> = {
+  text: {
+    kind: "text",
+    title: "text",
+    prefix: "text> ",
+    description: "Chunks cut through words, spaces, newlines, long tokens, and repeated padding.",
+    chunks: [
+      "Text chunks can la",
+      "nd mid-word, mid-space, o",
+      "r mid-newline. LongTokenWithoutNatural",
+      "Breaks_1234567890_keeps_growing while previous wrap decisions stay under pressure.\n\n",
+      "Bullets can start before their content arrives:\n- first item keep",
+      "s expanding after later chunks\n- second item includes emoji 🚀 and CJK 漢",
+      "字 across chunk boundaries\n\nIndented columns: alpha    be",
+      "ta    gamma\nTrailing text lands in small fragments to expose unstable row endings.\n",
+    ],
+  },
+  code: {
+    kind: "code",
+    title: "code",
+    prefix: "code> ",
+    description: "Chunks cut through keywords, identifiers, comments, strings, and punctuation.",
+    chunks: [
+      "export as",
+      "ync function buildSurfaceRepo",
+      "rt<TRecord extends Record<string, string>>(chunks: string[]) {\n",
+      '  const longIdentifier = "LongTokenWithoutNatural',
+      'Breaks_1234567890"\n',
+      "  /* block comments can also arrive in pie",
+      "ces while highlighting is still pending */\n",
+      "  return chunks\n    .map((chunk, index) => `${index}:${chunk.trim()}-${longId",
+      'entifier}`)\n    .join("\\n")\n}\n',
+    ],
+  },
+  markdown: {
+    kind: "markdown",
+    title: "markdown",
+    prefix: "md> ",
+    description: "Chunks cut through headings, emphasis, table rows, blockquotes, and fenced code.",
+    chunks: [
+      "# Split Footer Ma",
+      "rkdown Edge Cases\n\nParag",
+      "raph with **bo",
+      "ld**, `inline c",
+      "ode`, emoji 🚀, CJK 漢",
+      "字, and a [li",
+      "nk](https://example.com/very/long/path) that arrives in pieces.\n\n",
+      "| Key | Statu",
+      "s | Notes |\n| --- | --- | --- |\n| text | partial | inline `LongTokenWithoutNatural",
+      "Breaks_1234567890` grows |\n| code | async | escaped pipe A\\|B stays in one cell |\n",
+      "| markdown | streaming | delimiter row and data rows arrived separately |\n\n| 甲 | 乙 | 丙 |\n| --- | --- | --- |\n| 漢 | 字 | 表 |\n",
+      "| 流 | 式 | 測 |\n| 邊 | 界 | 行 |\n\n| 😀 | 🚀 | 🧪 |\n| --- | --- | --- |\n| 🎯 | ✨ | 📦 |\n",
+      "| 🌊 | 🔥 | 🪄 |\n\n> Quote starts here and the rest of the block arrives",
+      ' in the next chunk. Unicode repeats: 🚀 漢字.\n\n```ts\nconst rows = ["text", "code", "markdown"]\n',
+      ".map((kind, index) => `${index}:${kind}`)\n```\n\n- list item opened",
+      " in one chunk\n- second item closes the sample\n",
+    ],
+  },
+}
+
+function getScenarioAccent(kind: StreamKind): string {
+  switch (kind) {
+    case "text":
+      return PALETTE.textAccent
+    case "code":
+      return PALETTE.codeAccent
+    case "markdown":
+      return PALETTE.markdownAccent
+  }
+}
+
+function tableCell(text: string, color: string, attributes: number = 0): TextChunk[] {
+  return [
+    {
+      __isChunk: true,
+      text,
+      fg: parseColor(color),
+      attributes,
+    },
+  ]
+}
+
+function footerRow(label: string, value: string, valueColor: string): TextTableContent[number] {
+  return [
+    tableCell(label.toUpperCase().padEnd(6, " "), PALETTE.hint, 1),
+    tableCell(":", PALETTE.border),
+    tableCell(` ${value}`, valueColor),
+  ]
+}
+
+class SplitFooterStreamingDemo {
+  private shell: BoxRenderable
+  private titleText: TextRenderable
+  private footerTable: TextTableRenderable
+
+  private readonly treeSitterClient = getTreeSitterClient()
+  private currentKind: StreamKind = "markdown"
+  private inlinePrefix = false
+  private autoAdvance = true
+  private intervalMs = DEFAULT_INTERVAL_MS
+  private destroyed = false
+  private stepping = false
+  private autoTimer: ReturnType<typeof setInterval> | null = null
+  private activeRun: ActiveRun | null = null
+  private nextRunId = 1
+  private lastStatus = "Ready. Press R to replay the current sample."
+  private pendingReplayReason: string | null = null
+  private wrote = false
+
+  constructor(private renderer: CliRenderer) {
+    if (this.renderer.screenMode !== "split-footer") {
+      this.renderer.screenMode = "split-footer"
+    }
+
+    this.renderer.footerHeight = FOOTER_HEIGHT
+
+    if (this.renderer.externalOutputMode !== "capture-stdout") {
+      this.renderer.externalOutputMode = "capture-stdout"
+    }
+
+    this.renderer.setBackgroundColor(PALETTE.background)
+
+    this.shell = new BoxRenderable(this.renderer, {
+      id: "split-footer-streaming-demo-shell",
+      width: "100%",
+      height: "100%",
+      border: ["top"],
+      borderColor: PALETTE.border,
+      backgroundColor: PALETTE.panel,
+      paddingTop: 1,
+      paddingBottom: 0,
+      paddingLeft: 1,
+      paddingRight: 1,
+      gap: 0,
+      flexDirection: "column",
+    })
+
+    this.titleText = new TextRenderable(this.renderer, {
+      id: "split-footer-streaming-demo-title",
+      width: "100%",
+      content: "Split Footer Surface Streaming Demo",
+      fg: PALETTE.title,
+      attributes: 1,
+    })
+
+    this.footerTable = new TextTableRenderable(this.renderer, {
+      id: "split-footer-streaming-demo-footer-table",
+      width: "100%",
+      wrapMode: "word",
+      columnWidthMode: "content",
+      columnFitter: "proportional",
+      cellPadding: 0,
+      selectable: false,
+      border: false,
+      outerBorder: false,
+      showBorders: false,
+      backgroundColor: "transparent",
+      fg: PALETTE.detail,
+      content: [],
+    })
+
+    this.shell.add(this.titleText)
+    this.shell.add(this.footerTable)
+    this.renderer.root.add(this.shell)
+
+    this.renderer.keyInput.on("keypress", this.handleKeyPress)
+    this.renderer.on(CliRenderEvents.RESIZE, this.handleResize)
+    this.renderer.on(CliRenderEvents.DESTROY, this.handleRendererDestroy)
+
+    this.refreshFooter()
+    this.syncAutoTimer()
+    this.requestReplay("Started markdown sample.")
+  }
+
+  private get currentScenario(): ScenarioDefinition {
+    return SCENARIOS[this.currentKind]
+  }
+
+  private refreshFooter(): void {
+    if (this.destroyed) {
+      return
+    }
+
+    const scenario = this.currentScenario
+    const run = this.activeRun
+    const runState = !run
+      ? "idle"
+      : run.done
+        ? `done ${run.chunkIndex}/${run.scenario.chunks.length}`
+        : `chunk ${run.chunkIndex}/${run.scenario.chunks.length}`
+    const committedState =
+      scenario.kind === "markdown"
+        ? `${run?.committedBlocks ?? 0} blocks committed`
+        : `${run?.committedRows ?? 0} rows committed`
+
+    this.footerTable.content = [
+      footerRow(
+        "mode",
+        `${scenario.title} · start ${this.inlinePrefix ? "inline-prefix" : "newline"} · auto ${this.autoAdvance ? `${this.intervalMs}ms` : "off"} · ${runState}`,
+        getScenarioAccent(this.currentKind),
+      ),
+      footerRow("status", this.lastStatus, this.lastStatus.startsWith("Error:") ? PALETTE.error : PALETTE.status),
+      footerRow("stats", `${run?.content.length ?? 0} bytes · ${committedState}`, PALETTE.detail),
+      footerRow("about", scenario.description, PALETTE.detail),
+      footerRow("scene", "1 text · 2 code · 3 markdown · i inline-prefix", PALETTE.hint),
+      footerRow("flow", "r replay · n next · a auto · [ slower · ] faster · resize -> r", PALETTE.hint),
+    ]
+  }
+
+  private syncAutoTimer(): void {
+    if (this.autoTimer) {
+      clearInterval(this.autoTimer)
+      this.autoTimer = null
+    }
+
+    if (!this.autoAdvance || this.destroyed) {
+      return
+    }
+
+    this.autoTimer = setInterval(() => {
+      void this.stepCurrentRun()
+    }, this.intervalMs)
+  }
+
+  private destroyActiveRun(): void {
+    if (!this.activeRun) {
+      return
+    }
+
+    this.activeRun.cancelled = true
+
+    if (!this.activeRun.surface.isDestroyed) {
+      try {
+        this.activeRun.surface.destroy()
+      } catch {
+        // Ignore teardown races while replaying.
+      }
+    }
+
+    this.activeRun = null
+  }
+
+  private requestReplay(reason: string): void {
+    this.pendingReplayReason = reason
+    this.destroyActiveRun()
+    this.lastStatus = reason
+    this.refreshFooter()
+
+    if (!this.stepping) {
+      const nextReason = this.pendingReplayReason
+      this.pendingReplayReason = null
+      if (nextReason) {
+        void this.replayCurrentScenario(nextReason)
+      }
+    }
+  }
+
+  private async replayCurrentScenario(reason: string): Promise<void> {
+    if (this.destroyed) {
+      return
+    }
+
+    this.destroyActiveRun()
+    this.lastStatus = reason
+    this.activeRun = this.createRun(this.currentScenario)
+    this.refreshFooter()
+    await this.stepCurrentRun()
+  }
+
+  private createRun(scenario: ScenarioDefinition): ActiveRun {
+    const spaced = this.wrote
+    if (spaced) {
+      this.writeSpacer()
+    }
+
+    if (this.inlinePrefix) {
+      this.writeInlinePrefix(scenario, !spaced)
+    }
+
+    const surface = this.renderer.createScrollbackSurface({
+      startOnNewLine: this.inlinePrefix ? false : !spaced,
+    })
+
+    let renderable: TextRenderable | CodeRenderable | MarkdownRenderable
+    switch (scenario.kind) {
+      case "text":
+        renderable = new TextRenderable(surface.renderContext, {
+          id: `split-footer-stream-text-${this.nextRunId}`,
+          content: "",
+          width: "100%",
+          wrapMode: "char",
+          fg: PALETTE.title,
+        })
+        break
+      case "code":
+        renderable = new CodeRenderable(surface.renderContext, {
+          id: `split-footer-stream-code-${this.nextRunId}`,
+          content: "",
+          filetype: "typescript",
+          syntaxStyle: SURFACE_SYNTAX_STYLE,
+          width: "100%",
+          wrapMode: "char",
+          drawUnstyledText: false,
+          streaming: true,
+          treeSitterClient: this.treeSitterClient,
+        })
+        break
+      case "markdown":
+        renderable = new MarkdownRenderable(surface.renderContext, {
+          id: `split-footer-stream-markdown-${this.nextRunId}`,
+          content: "",
+          syntaxStyle: SURFACE_SYNTAX_STYLE,
+          width: "100%",
+          streaming: true,
+          internalBlockMode: "top-level",
+          tableOptions: { widthMode: "content" },
+          treeSitterClient: this.treeSitterClient,
+        })
+        break
+    }
+
+    surface.root.add(renderable)
+
+    return {
+      id: this.nextRunId++,
+      scenario,
+      surface,
+      renderable,
+      content: "",
+      chunkIndex: 0,
+      committedRows: 0,
+      committedBlocks: 0,
+      cancelled: false,
+      done: false,
+    }
+  }
+
+  private writeSpacer(): void {
+    this.renderer.writeToScrollback((ctx) => {
+      const width = Math.max(1, Math.trunc(ctx.width))
+      const root = new TextRenderable(ctx.renderContext, {
+        id: `split-footer-stream-spacer-${this.nextRunId}`,
+        position: "absolute",
+        left: 0,
+        top: 0,
+        width,
+        height: 1,
+        content: "",
+      })
+
+      return {
+        root,
+        width,
+        height: 1,
+        startOnNewLine: true,
+        trailingNewline: true,
+      }
+    })
+
+    this.wrote = true
+  }
+
+  private writeInlinePrefix(scenario: ScenarioDefinition, startOnNewLine: boolean): void {
+    const prefix = scenario.prefix
+
+    this.renderer.writeToScrollback((ctx) => {
+      const root = new TextRenderable(ctx.renderContext, {
+        id: `split-footer-stream-prefix-${this.nextRunId}`,
+        position: "absolute",
+        left: 0,
+        top: 0,
+        width: prefix.length,
+        height: 1,
+        content: prefix,
+        fg: getScenarioAccent(scenario.kind),
+        attributes: 1,
+      })
+
+      return {
+        root,
+        width: prefix.length,
+        height: 1,
+        startOnNewLine,
+        trailingNewline: false,
+      }
+    })
+
+    this.wrote = true
+  }
+
+  private async stepCurrentRun(): Promise<void> {
+    if (this.destroyed || this.stepping) {
+      return
+    }
+
+    let run = this.activeRun
+    if (!run) {
+      run = this.createRun(this.currentScenario)
+      this.activeRun = run
+      this.lastStatus = `Started ${run.scenario.title} sample.`
+      this.refreshFooter()
+    }
+
+    if (run.done || run.cancelled) {
+      return
+    }
+
+    if (run.chunkIndex >= run.scenario.chunks.length) {
+      run.done = true
+      this.lastStatus = `${run.scenario.title} sample finished. Press R to replay.`
+      this.refreshFooter()
+      return
+    }
+
+    this.stepping = true
+
+    const runId = run.id
+    const chunk = run.scenario.chunks[run.chunkIndex]!
+    const isFinalChunk = run.chunkIndex === run.scenario.chunks.length - 1
+    run.chunkIndex += 1
+    run.content += chunk
+
+    try {
+      await this.flushRun(run, isFinalChunk)
+
+      if (run.cancelled || this.destroyed || this.activeRun?.id !== runId) {
+        return
+      }
+
+      if (isFinalChunk) {
+        run.done = true
+        run.surface.destroy()
+        this.lastStatus = `${run.scenario.title} sample finished. Press R to replay.`
+      } else {
+        this.lastStatus = `${run.scenario.title} chunk ${run.chunkIndex}/${run.scenario.chunks.length} committed.`
+      }
+    } catch (error) {
+      if (run.cancelled || this.destroyed) {
+        return
+      }
+
+      this.lastStatus = `Error: ${run.scenario.title} sample failed.`
+      console.error("split-footer-streaming-demo step failed", error)
+      this.destroyActiveRun()
+    } finally {
+      this.stepping = false
+      this.refreshFooter()
+
+      if (this.pendingReplayReason && !this.destroyed) {
+        const reason = this.pendingReplayReason
+        this.pendingReplayReason = null
+        void this.replayCurrentScenario(reason)
+      }
+    }
+  }
+
+  private async flushRun(run: ActiveRun, done: boolean): Promise<void> {
+    switch (run.scenario.kind) {
+      case "text":
+        await this.flushTextRun(run, done)
+        return
+      case "code":
+        await this.flushCodeRun(run, done)
+        return
+      case "markdown":
+        await this.flushMarkdownRun(run, done)
+        return
+    }
+  }
+
+  private async flushTextRun(run: ActiveRun, done: boolean): Promise<void> {
+    const renderable = run.renderable as TextRenderable
+    renderable.content = run.content
+    run.surface.render()
+
+    const targetRows = done ? run.surface.height : Math.max(run.committedRows, run.surface.height - 1)
+    if (targetRows > run.committedRows) {
+      run.surface.commitRows(run.committedRows, targetRows)
+      run.committedRows = targetRows
+      this.wrote = true
+    }
+  }
+
+  private async flushCodeRun(run: ActiveRun, done: boolean): Promise<void> {
+    const renderable = run.renderable as CodeRenderable
+    renderable.content = run.content
+    renderable.streaming = !done
+    await run.surface.settle()
+
+    const targetRows = done ? run.surface.height : Math.max(run.committedRows, run.surface.height - 1)
+    if (targetRows > run.committedRows) {
+      run.surface.commitRows(run.committedRows, targetRows)
+      run.committedRows = targetRows
+      this.wrote = true
+    }
+  }
+
+  private async flushMarkdownRun(run: ActiveRun, done: boolean): Promise<void> {
+    const renderable = run.renderable as MarkdownRenderable
+    renderable.content = run.content
+    renderable.streaming = !done
+    await run.surface.settle()
+
+    const targetBlockCount = done ? renderable._blockStates.length : renderable._stableBlockCount
+    if (targetBlockCount <= run.committedBlocks) {
+      return
+    }
+
+    const firstState = renderable._blockStates[run.committedBlocks]!
+    const lastState = renderable._blockStates[targetBlockCount - 1]!
+    const nextState = renderable._blockStates[targetBlockCount]
+    const endRow = nextState
+      ? nextState.renderable.y
+      : lastState.renderable.y + lastState.renderable.height + (lastState.marginBottom ?? 0)
+
+    run.surface.commitRows(firstState.renderable.y, endRow)
+    run.committedBlocks = targetBlockCount
+    this.wrote = true
+  }
+
+  private setScenario(kind: StreamKind): void {
+    if (this.currentKind === kind) {
+      this.requestReplay(`Replaying ${kind} sample.`)
+      return
+    }
+
+    this.currentKind = kind
+    this.requestReplay(`Switched to ${kind} sample.`)
+  }
+
+  private toggleAutoAdvance(): void {
+    this.autoAdvance = !this.autoAdvance
+    this.syncAutoTimer()
+
+    if (this.autoAdvance && (!this.activeRun || this.activeRun.done)) {
+      this.requestReplay(`Auto advance enabled at ${this.intervalMs}ms.`)
+      return
+    }
+
+    this.lastStatus = this.autoAdvance ? `Auto advance enabled at ${this.intervalMs}ms.` : "Auto advance disabled."
+    this.refreshFooter()
+  }
+
+  private toggleInlinePrefix(): void {
+    this.inlinePrefix = !this.inlinePrefix
+    this.requestReplay(this.inlinePrefix ? "Inline-prefix mode enabled." : "New-line mode enabled.")
+  }
+
+  private adjustInterval(deltaMs: number): void {
+    const next = Math.min(Math.max(this.intervalMs + deltaMs, MIN_INTERVAL_MS), MAX_INTERVAL_MS)
+    if (next === this.intervalMs) {
+      this.lastStatus = "Interval already at the limit."
+      this.refreshFooter()
+      return
+    }
+
+    this.intervalMs = next
+    this.syncAutoTimer()
+    this.lastStatus = `Auto advance interval ${next}ms.`
+    this.refreshFooter()
+  }
+
+  private handleKeyPress = (key: KeyEvent): void => {
+    if (key.ctrl || key.meta || key.option) {
+      return
+    }
+
+    switch (key.name) {
+      case "1":
+        key.preventDefault()
+        this.setScenario("text")
+        return
+      case "2":
+        key.preventDefault()
+        this.setScenario("code")
+        return
+      case "3":
+        key.preventDefault()
+        this.setScenario("markdown")
+        return
+      case "r":
+        key.preventDefault()
+        this.requestReplay(`Replaying ${this.currentKind} sample.`)
+        return
+      case "n":
+        key.preventDefault()
+        void this.stepCurrentRun()
+        return
+      case "a":
+        key.preventDefault()
+        this.toggleAutoAdvance()
+        return
+      case "i":
+        key.preventDefault()
+        this.toggleInlinePrefix()
+        return
+      case "[":
+        key.preventDefault()
+        this.adjustInterval(INTERVAL_STEP_MS)
+        return
+      case "]":
+        key.preventDefault()
+        this.adjustInterval(-INTERVAL_STEP_MS)
+        return
+    }
+  }
+
+  private handleResize = (): void => {
+    if (this.destroyed) {
+      return
+    }
+
+    this.lastStatus = "Renderer resized. Press R to replay at the new width."
+    this.destroyActiveRun()
+    this.refreshFooter()
+  }
+
+  private handleRendererDestroy = (): void => {
+    this.destroy()
+  }
+
+  public destroy(): void {
+    if (this.destroyed) {
+      return
+    }
+
+    this.destroyed = true
+
+    if (this.autoTimer) {
+      clearInterval(this.autoTimer)
+      this.autoTimer = null
+    }
+
+    this.destroyActiveRun()
+    this.renderer.keyInput.off("keypress", this.handleKeyPress)
+    this.renderer.off(CliRenderEvents.RESIZE, this.handleResize)
+    this.renderer.off(CliRenderEvents.DESTROY, this.handleRendererDestroy)
+
+    if (!this.shell.isDestroyed) {
+      this.shell.destroyRecursively()
+    }
+
+    if (!this.renderer.isDestroyed) {
+      this.renderer.externalOutputMode = "passthrough"
+      this.renderer.screenMode = "main-screen"
+    }
+  }
+}
+
+let activeDemo: SplitFooterStreamingDemo | null = null
+
+export function run(renderer: CliRenderer): void {
+  if (activeDemo) {
+    activeDemo.destroy()
+  }
+
+  activeDemo = new SplitFooterStreamingDemo(renderer)
+}
+
+export function destroy(_renderer: CliRenderer): void {
+  if (!activeDemo) {
+    return
+  }
+
+  activeDemo.destroy()
+  activeDemo = null
+}
+
+if (import.meta.main) {
+  const renderer = await createCliRenderer({
+    targetFps: 30,
+    exitOnCtrlC: true,
+    useMouse: false,
+    screenMode: "split-footer",
+    footerHeight: FOOTER_HEIGHT,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  run(renderer)
+  setupCommonDemoKeys(renderer)
+  renderer.start()
+}

--- a/packages/core/src/examples/split-mode-demo.ts
+++ b/packages/core/src/examples/split-mode-demo.ts
@@ -1,439 +1,1287 @@
-import { BoxRenderable, bold, createCliRenderer, fg, TextRenderable, t, type CliRenderer } from "../index.js"
+import {
+  BoxRenderable,
+  CliRenderEvents,
+  TextRenderable,
+  TextareaRenderable,
+  createCliRenderer,
+  type CliRenderer,
+  type KeyEvent,
+  type ScrollbackRenderContext,
+  type ScrollbackSnapshot,
+  type ScrollbackWriter,
+  type ThemeMode,
+} from "../index.js"
 import { setupCommonDemoKeys } from "./lib/standalone-keys.js"
-import { createTimeline, type JSAnimation, Timeline } from "../animation/Timeline.js"
 
-let text: TextRenderable | null = null
-let instructionsText: TextRenderable | null = null
-let keyHandler: ((key: any) => void) | null = null
-let outputTimer: Timer | null = null
-let animationSystem: SplitModeAnimations | null = null
-let testOutputInterval = 100
+const DEFAULT_FOOTER_HEIGHT = 11
+const MIN_FOOTER_HEIGHT = 8
+const MIN_MAIN_SCREEN_HEIGHT = 5
 
-class SplitModeAnimations {
-  private timeline: Timeline
-  private renderer: CliRenderer
-  private container: BoxRenderable
+const DEFAULT_STREAM_INTERVAL = 1600
+const MIN_STREAM_INTERVAL = 180
+const MAX_STREAM_INTERVAL = 2000
+const STREAM_INTERVAL_STEP = 80
+const CTRL_R_HOLD_REPEAT_MS = 45
+const CTRL_R_HOLD_DURATION_MS = 1400
+const CTRL_R_HOLD_BOOT_DELAY_MS = 600
+// Stress-mode helpers are opt-in by default. This keeps the example usable for
+// interactive/manual checks while still allowing scripted flicker repro loops.
+const DEFAULT_AUTO_EXIT_MS = 0
 
-  private systemLoadingBars: BoxRenderable[] = []
-  private movingOrbs: BoxRenderable[] = []
-  private statusCounters: TextRenderable[] = []
-  private pulsingElements: BoxRenderable[] = []
+const AUTO_CTRL_R_HOLD_ON_BOOT =
+  process.env.OTUI_SPLIT_DEMO_AUTO_CTRL_R_HOLD === "1" ||
+  process.env.OTUI_SPLIT_DEMO_AUTO_CTRL_R_HOLD?.toLowerCase() === "true"
+const AUTO_EXIT_ENV = Number.parseInt(process.env.OTUI_SPLIT_DEMO_AUTO_EXIT_MS ?? "", 10)
+const AUTO_EXIT_MS = Number.isFinite(AUTO_EXIT_ENV) && AUTO_EXIT_ENV > 0 ? AUTO_EXIT_ENV : DEFAULT_AUTO_EXIT_MS
 
-  private systemProgress = { cpu: 0, memory: 0, network: 0, disk: 0 }
-  private counters = { packets: 0, connections: 0, processes: 0, uptime: 0 }
-  private orbPositions = [
-    { x: 2, y: 2 },
-    { x: 15, y: 3 },
-    { x: 30, y: 2 },
-  ]
-  private pulseValues = [1.0, 1.0, 1.0]
+interface WallLyricPassage {
+  song: string
+  lines: string[]
+}
 
-  constructor(renderer: CliRenderer) {
-    this.renderer = renderer
-    this.timeline = createTimeline({
-      duration: 8000,
-      loop: true,
-    })
+const WALL_STREAM_PASSAGES: WallLyricPassage[] = [
+  {
+    song: "In the Flesh?",
+    lines: [
+      "So ya thought ya might like to go to the show",
+      "To feel the warm thrill of confusion",
+      "That space cadet glow",
+    ],
+  },
+  {
+    song: "Another Brick in the Wall (Part 2)",
+    lines: [
+      "We don't need no education",
+      "We don't need no thought control",
+      "No dark sarcasm in the classroom",
+      "Teacher leave us kids alone",
+    ],
+  },
+  {
+    song: "Mother",
+    lines: [
+      "Mother should I build the wall",
+      "Mother should I trust the government",
+      "Mother will they put me in the firing line",
+      "Oooh is it just a waste of time",
+    ],
+  },
+  {
+    song: "Hey You",
+    lines: [
+      "Hey you! out there in the cold",
+      "getting lonely, getting old, can you feel me",
+      "Hey you! with your ears against the wall",
+      "Waiting for someone to call out would you touch me",
+      "Together we stand, divided we fall",
+    ],
+  },
+  {
+    song: "Nobody Home",
+    lines: [
+      "I've got a little black book with my poems in",
+      "I've got thirteen channels on the TV to choose from",
+      "When I try to get through on the telephone to you there'll be nobody home",
+      "Ooooh Babe when I pick up the phone",
+      "There's still nobody home",
+    ],
+  },
+  {
+    song: "Comfortably Numb",
+    lines: [
+      "Hello, is there anybody in there",
+      "just nod if you can hear me",
+      "There is no pain, you are receding",
+      "The child is grown",
+      "The dream is gone",
+      "And I have become comfortably numb",
+    ],
+  },
+  {
+    song: "Outside the Wall",
+    lines: [
+      "All alone, or in twos",
+      "The ones who really love you walk up and down outside the wall",
+      "And when they've given you their all",
+      "Some stagger and fall after all it's not easy",
+      "Banging your heart against some mad bugger's wall",
+    ],
+  },
+]
 
-    this.container = new BoxRenderable(renderer, {
-      id: "animation-container",
-      zIndex: 5,
-    })
-    this.renderer.root.add(this.container)
+const WALL_ASSISTANT_LINES = [
+  "Hello, is there anybody in there\njust nod if you can hear me",
+  "Hey you! with your ears against the wall",
+  "The show must go on",
+  "All in all you're just another brick in the wall",
+  "All alone, or in twos",
+]
 
-    this.setupUI()
-    this.setupAnimations()
-    this.timeline.play()
+type DemoMode = "split-footer" | "fullscreen"
+type MessageRole = "user" | "assistant" | "system" | "stream"
+
+interface DemoPalette {
+  appBackground: string
+  shellBackground: string
+  shellBorder: string
+  titleText: string
+  modeText: string
+  helpText: string
+  statusText: string
+  streamHeadingText: string
+  streamText: string
+  composerBorder: string
+  composerBackground: string
+  composerHint: string
+  inputPlaceholder: string
+  inputText: string
+  inputFocusedText: string
+  inputFocusedBackground: string
+  inputCursor: string
+  controlText: string
+  messageText: string
+  userBorder: string
+  assistantBorder: string
+  systemBorder: string
+  streamBorder: string
+}
+
+const DARK_PALETTE: DemoPalette = {
+  appBackground: "#0A1222",
+  shellBackground: "#0F1F39",
+  shellBorder: "#4C6D94",
+  titleText: "#F6FAFF",
+  modeText: "#A7D4FF",
+  helpText: "#C3D9F0",
+  statusText: "#D5E7FA",
+  streamHeadingText: "#66CCFF",
+  streamText: "#CBE9FF",
+  composerBorder: "#6A89AD",
+  composerBackground: "#112642",
+  composerHint: "#8CB6DF",
+  inputPlaceholder: "#5F7FA0",
+  inputText: "#E7F2FF",
+  inputFocusedText: "#FFFFFF",
+  inputFocusedBackground: "#153153",
+  inputCursor: "#FFFFFF",
+  controlText: "#A5C9EC",
+  messageText: "#EDF6FF",
+  userBorder: "#68C79E",
+  assistantBorder: "#78A8DA",
+  systemBorder: "#D9A568",
+  streamBorder: "#4FB8F5",
+}
+
+const LIGHT_PALETTE: DemoPalette = {
+  appBackground: "#EEF4FB",
+  shellBackground: "#FBFDFF",
+  shellBorder: "#90A8C1",
+  titleText: "#17324F",
+  modeText: "#245D93",
+  helpText: "#395B7D",
+  statusText: "#23435F",
+  streamHeadingText: "#1F5F97",
+  streamText: "#2D5D87",
+  composerBorder: "#A5B8CB",
+  composerBackground: "#FFFFFF",
+  composerHint: "#4B6784",
+  inputPlaceholder: "#7A93AB",
+  inputText: "#1A334D",
+  inputFocusedText: "#13293F",
+  inputFocusedBackground: "#F3F8FF",
+  inputCursor: "#1B3550",
+  controlText: "#4A6481",
+  messageText: "#19334F",
+  userBorder: "#1F9968",
+  assistantBorder: "#356FA8",
+  systemBorder: "#B37F2D",
+  streamBorder: "#2E73AF",
+}
+
+function resolveDemoPalette(themeMode: ThemeMode | null): DemoPalette {
+  return themeMode === "light" ? LIGHT_PALETTE : DARK_PALETTE
+}
+
+interface BoxMessageEntry {
+  role: MessageRole
+  text: string
+  timestamp: Date
+  palette: DemoPalette
+}
+
+let snapshotNodeCounter = 0
+
+function formatTimestamp(timestamp: Date): string {
+  const hh = timestamp.getHours().toString().padStart(2, "0")
+  const mm = timestamp.getMinutes().toString().padStart(2, "0")
+  const ss = timestamp.getSeconds().toString().padStart(2, "0")
+  return `${hh}:${mm}:${ss}`
+}
+
+function truncateToWidth(text: string, width: number): string {
+  if (width <= 0) {
+    return ""
   }
 
-  private setupUI(): void {
-    const statusPanel = new BoxRenderable(this.renderer, {
-      id: "status-panel",
-      position: "absolute",
-      left: 2,
-      top: 5,
-      width: this.renderer.width - 6,
-      height: 8,
-      backgroundColor: "#1a1a2e",
-      zIndex: 1,
-      borderStyle: "double",
-      borderColor: "#4a4a6a",
-      title: "◆ SYSTEM MONITOR ◆",
-      titleAlignment: "center",
-      border: true,
-    })
-    this.container.add(statusPanel)
-
-    this.systemLoadingBars = []
-    const systems = [
-      { name: "CPU", color: "#6a5acd", y: 6 },
-      { name: "MEM", color: "#4682b4", y: 7 },
-      { name: "NET", color: "#20b2aa", y: 8 },
-      { name: "DSK", color: "#daa520", y: 9 },
-    ]
-
-    systems.forEach((system, index) => {
-      const label = new TextRenderable(this.renderer, {
-        id: `${system.name.toLowerCase()}-label`,
-        content: `${system.name}:`,
-        position: "absolute",
-        left: 4,
-        top: system.y,
-        fg: system.color,
-        zIndex: 2,
-      })
-      this.container.add(label)
-
-      const bgBar = new BoxRenderable(this.renderer, {
-        id: `${system.name.toLowerCase()}-bg`,
-        position: "absolute",
-        left: 9,
-        top: system.y,
-        width: this.renderer.width - 16,
-        height: 1,
-        backgroundColor: "#333333",
-        zIndex: 1,
-      })
-      this.container.add(bgBar)
-
-      const progressBar = new BoxRenderable(this.renderer, {
-        id: `${system.name.toLowerCase()}-progress`,
-        position: "absolute",
-        left: 9,
-        top: system.y,
-        width: 1,
-        height: 1,
-        backgroundColor: system.color,
-        zIndex: 2,
-      })
-      this.container.add(progressBar)
-      this.systemLoadingBars.push(progressBar)
-    })
-
-    const statsPanel = new BoxRenderable(this.renderer, {
-      id: "stats-panel",
-      position: "absolute",
-      left: 2,
-      top: 14,
-      width: this.renderer.width - 6,
-      height: 4,
-      backgroundColor: "#2d1b2e",
-      zIndex: 1,
-      borderStyle: "single",
-      borderColor: "#8a4a8a",
-      title: "◇ REAL-TIME STATS ◇",
-      titleAlignment: "center",
-      border: true,
-    })
-    this.container.add(statsPanel)
-
-    this.statusCounters = []
-    const counterLabels = ["PACKETS", "CONNECTIONS", "PROCESSES", "UPTIME"]
-    counterLabels.forEach((label, index) => {
-      const counter = new TextRenderable(this.renderer, {
-        id: `counter-${index}`,
-        content: `${label}: 0`,
-        position: "absolute",
-        left: 4 + index * 15,
-        top: 15,
-        fg: "#9a9acd",
-        zIndex: 2,
-      })
-      this.container.add(counter)
-      this.statusCounters.push(counter)
-    })
-
-    this.movingOrbs = []
-    const orbColors = ["#ff6b9d", "#4ecdc4", "#ffe66d"]
-    orbColors.forEach((color, index) => {
-      const orb = new BoxRenderable(this.renderer, {
-        id: `orb-${index}`,
-        position: "absolute",
-        left: 2,
-        top: 2,
-        width: 3,
-        height: 1,
-        backgroundColor: color,
-        zIndex: 3,
-      })
-      this.container.add(orb)
-      this.movingOrbs.push(orb)
-    })
-
-    this.pulsingElements = []
-    const pulseColors = ["#ff8a80", "#80cbc4", "#fff176"]
-    pulseColors.forEach((color, index) => {
-      const pulse = new BoxRenderable(this.renderer, {
-        id: `pulse-${index}`,
-        position: "absolute",
-        left: this.renderer.width - 8 + index * 2,
-        top: 1,
-        width: 1,
-        height: 1,
-        backgroundColor: color,
-        zIndex: 3,
-      })
-      this.container.add(pulse)
-      this.pulsingElements.push(pulse)
-    })
+  if (text.length <= width) {
+    return text
   }
 
-  private setupAnimations(): void {
-    this.timeline.add(
-      this.systemProgress,
-      {
-        cpu: 85,
-        memory: 70,
-        network: 95,
-        disk: 60,
-        duration: 3000,
-        ease: "inOutQuad",
-        onUpdate: (values: JSAnimation) => {
-          const progress = values.targets[0]
-          const maxWidth = this.renderer.width - 16
-
-          this.systemLoadingBars[0].width = Math.max(1, Math.floor((progress.cpu / 100) * maxWidth))
-          this.systemLoadingBars[1].width = Math.max(1, Math.floor((progress.memory / 100) * maxWidth))
-          this.systemLoadingBars[2].width = Math.max(1, Math.floor((progress.network / 100) * maxWidth))
-          this.systemLoadingBars[3].width = Math.max(1, Math.floor((progress.disk / 100) * maxWidth))
-        },
-      },
-      0,
-    )
-
-    this.timeline.add(
-      this.systemProgress,
-      {
-        cpu: 20,
-        memory: 30,
-        network: 15,
-        disk: 25,
-        duration: 2000,
-        ease: "inOutSine",
-        onUpdate: (values: JSAnimation) => {
-          const progress = values.targets[0]
-          const maxWidth = this.renderer.width - 16
-
-          this.systemLoadingBars[0].width = Math.max(1, Math.floor((progress.cpu / 100) * maxWidth))
-          this.systemLoadingBars[1].width = Math.max(1, Math.floor((progress.memory / 100) * maxWidth))
-          this.systemLoadingBars[2].width = Math.max(1, Math.floor((progress.network / 100) * maxWidth))
-          this.systemLoadingBars[3].width = Math.max(1, Math.floor((progress.disk / 100) * maxWidth))
-        },
-      },
-      4000,
-    )
-
-    this.timeline.add(
-      this.counters,
-      {
-        packets: 12847,
-        connections: 234,
-        processes: 187,
-        uptime: 86400,
-        duration: 8000,
-        ease: "linear",
-        onUpdate: (values: JSAnimation) => {
-          const counters = values.targets[0]
-          this.statusCounters[0].content = `PACKETS: ${Math.floor(counters.packets)}`
-          this.statusCounters[1].content = `CONN: ${Math.floor(counters.connections)}`
-          this.statusCounters[2].content = `PROC: ${Math.floor(counters.processes)}`
-          this.statusCounters[3].content = `UP: ${Math.floor(counters.uptime)}s`
-        },
-      },
-      0,
-    )
-
-    this.orbPositions.forEach((orbPos, index) => {
-      this.timeline.add(
-        orbPos,
-        {
-          x: this.renderer.width - 10,
-          duration: 2000 + index * 400,
-          ease: "inOutSine",
-          onUpdate: (values: JSAnimation) => {
-            const pos = values.targets[0]
-            this.movingOrbs[index].x = Math.floor(pos.x)
-          },
-        },
-        index * 800,
-      )
-
-      this.timeline.add(
-        orbPos,
-        {
-          x: 2,
-          duration: 2000 + index * 400,
-          ease: "inOutSine",
-          onUpdate: (values: JSAnimation) => {
-            const pos = values.targets[0]
-            this.movingOrbs[index].x = Math.floor(pos.x)
-          },
-        },
-        4000 + index * 800,
-      )
-    })
-
-    this.pulseValues.forEach((pulseVal, index) => {
-      const pulseData = { intensity: 1.0 }
-      this.timeline.add(
-        pulseData,
-        {
-          intensity: 3.0,
-          duration: 1000,
-          ease: "inOutQuad",
-          loop: 8,
-          alternate: true,
-          onUpdate: (values: JSAnimation) => {
-            const intensity = values.targets[0].intensity
-            const height = Math.max(1, Math.floor(intensity))
-            this.pulsingElements[index].height = Math.min(3, height)
-          },
-        },
-        index * 300,
-      )
-    })
+  if (width <= 3) {
+    return text.slice(0, width)
   }
 
-  public update(deltaTime: number): void {
-    this.timeline.update(deltaTime)
+  return `${text.slice(0, width - 3)}...`
+}
+
+function splitLongToken(token: string, width: number): string[] {
+  const clampedWidth = Math.max(1, width)
+  const segments: string[] = []
+
+  for (let offset = 0; offset < token.length; offset += clampedWidth) {
+    segments.push(token.slice(offset, offset + clampedWidth))
+  }
+
+  return segments
+}
+
+function wrapText(text: string, width: number): string[] {
+  const clampedWidth = Math.max(1, width)
+  const normalized = text.replace(/\r/g, "")
+  const paragraphs = normalized.split("\n")
+  const wrapped: string[] = []
+
+  for (const paragraph of paragraphs) {
+    if (paragraph.length === 0) {
+      wrapped.push("")
+      continue
+    }
+
+    const words = paragraph.split(/\s+/)
+    let current = ""
+
+    for (const word of words) {
+      if (word.length === 0) {
+        continue
+      }
+
+      if (current.length === 0) {
+        if (word.length <= clampedWidth) {
+          current = word
+        } else {
+          const segments = splitLongToken(word, clampedWidth)
+          current = segments.pop() ?? ""
+          wrapped.push(...segments)
+        }
+        continue
+      }
+
+      const candidate = `${current} ${word}`
+      if (candidate.length <= clampedWidth) {
+        current = candidate
+        continue
+      }
+
+      wrapped.push(current)
+
+      if (word.length <= clampedWidth) {
+        current = word
+      } else {
+        const segments = splitLongToken(word, clampedWidth)
+        current = segments.pop() ?? ""
+        wrapped.push(...segments)
+      }
+    }
+
+    wrapped.push(current)
+  }
+
+  return wrapped.length > 0 ? wrapped : [""]
+}
+
+function roleBorderColor(role: MessageRole, palette: DemoPalette): string {
+  switch (role) {
+    case "user":
+      return palette.userBorder
+    case "assistant":
+      return palette.assistantBorder
+    case "system":
+      return palette.systemBorder
+    case "stream":
+      return palette.streamBorder
+  }
+}
+
+function roleLabel(role: MessageRole): string {
+  switch (role) {
+    case "user":
+      return "YOU"
+    case "assistant":
+      return "ASSISTANT"
+    case "system":
+      return "SYSTEM"
+    case "stream":
+      return "STREAM LIVE"
+  }
+}
+
+function roleHeadingColor(role: MessageRole, palette: DemoPalette): string {
+  switch (role) {
+    case "user":
+      return palette.userBorder
+    case "assistant":
+      return palette.assistantBorder
+    case "system":
+      return palette.systemBorder
+    case "stream":
+      return palette.streamHeadingText
+  }
+}
+
+function roleHeadingAttributes(role: MessageRole): number {
+  if (role === "stream") {
+    return 5
+  }
+
+  return 1
+}
+
+function roleBodyColor(role: MessageRole, palette: DemoPalette): string {
+  switch (role) {
+    case "system":
+      return palette.helpText
+    case "stream":
+      return palette.streamText
+    default:
+      return palette.messageText
+  }
+}
+
+function buildSimpleTextBoxSnapshot(entry: BoxMessageEntry, ctx: ScrollbackRenderContext): ScrollbackSnapshot {
+  const maxTextWidth = Math.max(18, Math.min(ctx.width - 4, 90))
+  const headingCore = truncateToWidth(
+    `${roleLabel(entry.role)} | ${formatTimestamp(entry.timestamp)}`,
+    Math.max(1, maxTextWidth - 2),
+  )
+  const headingLine = ` ${headingCore}`
+  const bodyIndent = entry.role === "stream" ? " > " : " "
+  const bodyWrapWidth = Math.max(1, maxTextWidth - bodyIndent.length)
+  const bodyLines = wrapText(entry.text, bodyWrapWidth).map((line) => `${bodyIndent}${line}`)
+  const longestBody = bodyLines.reduce((maxWidth, line) => Math.max(maxWidth, line.length), 1)
+  const longestLine = Math.max(headingLine.length, longestBody)
+
+  const textWidth = Math.min(maxTextWidth, Math.max(2, longestLine + 1))
+  const boxWidth = Math.min(ctx.width, Math.max(4, textWidth + 1))
+  const boxHeight = Math.max(4, bodyLines.length + 3)
+
+  const box = new BoxRenderable(ctx.renderContext, {
+    id: `split-simple-box-${snapshotNodeCounter++}`,
+    position: "absolute",
+    left: 0,
+    top: 0,
+    width: boxWidth,
+    height: boxHeight,
+    border: ["left"],
+    borderStyle: "double",
+    borderColor: roleBorderColor(entry.role, entry.palette),
+    backgroundColor: "transparent",
+  })
+
+  const headingText = new TextRenderable(ctx.renderContext, {
+    id: `split-simple-heading-${snapshotNodeCounter++}`,
+    position: "absolute",
+    left: 1,
+    top: 1,
+    width: Math.max(1, boxWidth - 1),
+    height: 1,
+    content: headingLine,
+    fg: roleHeadingColor(entry.role, entry.palette),
+    attributes: roleHeadingAttributes(entry.role),
+  })
+
+  const bodyText = new TextRenderable(ctx.renderContext, {
+    id: `split-simple-body-${snapshotNodeCounter++}`,
+    position: "absolute",
+    left: 1,
+    top: 2,
+    width: Math.max(1, boxWidth - 1),
+    height: Math.max(1, boxHeight - 3),
+    content: bodyLines.join("\n"),
+    fg: roleBodyColor(entry.role, entry.palette),
+  })
+
+  box.add(headingText)
+  box.add(bodyText)
+
+  return {
+    root: box,
+    width: boxWidth,
+    height: boxHeight,
+  }
+}
+
+class SplitFooterDemo {
+  private shell: BoxRenderable
+  private headerRow: BoxRenderable
+  private titleText: TextRenderable
+  private modeText: TextRenderable
+  private composerBox: BoxRenderable
+  private composer: TextareaRenderable
+  private statusRow: BoxRenderable
+  private statusText: TextRenderable
+  private metaText: TextRenderable
+  private controlsRow: BoxRenderable
+  private controlsText: TextRenderable
+
+  private palette: DemoPalette
+  private mode: DemoMode = "split-footer"
+  private desiredFooterHeight = DEFAULT_FOOTER_HEIGHT
+  private pendingAssistantReply: ReturnType<typeof setTimeout> | null = null
+  private streamTimer: ReturnType<typeof setInterval> | null = null
+  private ctrlRHoldTimer: ReturnType<typeof setInterval> | null = null
+  private ctrlRBootTimer: ReturnType<typeof setTimeout> | null = null
+  private ctrlRHoldDeadlineMs = 0
+  private streamEnabled = true
+  private streamIntervalMs = DEFAULT_STREAM_INTERVAL
+  private streamCount = 0
+  private commitCount = 0
+  private messageCount = 0
+  private assistantTyping = false
+  private statusMessage = "Ready"
+  private destroyed = false
+
+  constructor(private renderer: CliRenderer) {
+    this.palette = resolveDemoPalette(this.renderer.themeMode)
+    this.desiredFooterHeight = this.clampFooterHeight(this.desiredFooterHeight)
+
+    if (this.renderer.screenMode !== "split-footer") {
+      this.renderer.screenMode = "split-footer"
+    }
+
+    this.renderer.footerHeight = this.desiredFooterHeight
+
+    if (this.renderer.externalOutputMode !== "capture-stdout") {
+      this.renderer.externalOutputMode = "capture-stdout"
+    }
+
+    this.mode = "split-footer"
+    this.renderer.setBackgroundColor(this.palette.appBackground)
+
+    this.shell = new BoxRenderable(this.renderer, {
+      id: "split-footer-shell",
+      width: "100%",
+      height: "100%",
+      border: false,
+      backgroundColor: this.palette.shellBackground,
+      padding: 0,
+      gap: 0,
+      flexDirection: "column",
+      zIndex: 10,
+    })
+
+    this.headerRow = new BoxRenderable(this.renderer, {
+      id: "split-footer-header-row",
+      width: "100%",
+      height: 1,
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+    })
+
+    this.titleText = new TextRenderable(this.renderer, {
+      id: "split-footer-title",
+      content: "Split Footer Demo",
+      fg: this.palette.titleText,
+    })
+
+    this.modeText = new TextRenderable(this.renderer, {
+      id: "split-footer-mode",
+      content: "",
+      fg: this.palette.modeText,
+    })
+
+    this.composerBox = new BoxRenderable(this.renderer, {
+      id: "split-footer-composer-frame",
+      width: "100%",
+      minHeight: 4,
+      flexGrow: 1,
+      border: false,
+      backgroundColor: this.palette.composerBackground,
+      padding: 0,
+      gap: 0,
+      flexDirection: "column",
+    })
+
+    this.composer = new TextareaRenderable(this.renderer, {
+      id: "split-footer-composer",
+      width: "100%",
+      minHeight: 3,
+      flexGrow: 1,
+      wrapMode: "word",
+      showCursor: true,
+      placeholder: "Type message or /command... (Enter = new line, Ctrl+Enter = send)",
+      placeholderColor: this.palette.inputPlaceholder,
+      textColor: this.palette.inputText,
+      focusedTextColor: this.palette.inputFocusedText,
+      backgroundColor: this.palette.composerBackground,
+      focusedBackgroundColor: this.palette.inputFocusedBackground,
+      cursorColor: this.palette.inputCursor,
+      onSubmit: this.handleComposerSubmit,
+      keyBindings: [
+        { name: "return", ctrl: true, action: "submit" },
+        { name: "linefeed", ctrl: true, action: "submit" },
+      ],
+    })
+
+    this.statusRow = new BoxRenderable(this.renderer, {
+      id: "split-footer-status-row",
+      width: "100%",
+      height: 1,
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+    })
+
+    this.statusText = new TextRenderable(this.renderer, {
+      id: "split-footer-status",
+      content: "",
+      fg: this.palette.statusText,
+    })
+
+    this.metaText = new TextRenderable(this.renderer, {
+      id: "split-footer-meta",
+      content: "",
+      fg: this.palette.streamText,
+    })
+
+    this.controlsRow = new BoxRenderable(this.renderer, {
+      id: "split-footer-controls-row",
+      width: "100%",
+      height: 1,
+      flexDirection: "row",
+      justifyContent: "flex-start",
+      alignItems: "center",
+    })
+
+    this.controlsText = new TextRenderable(this.renderer, {
+      id: "split-footer-controls",
+      content: "",
+      width: "100%",
+      height: 1,
+      fg: this.palette.controlText,
+    })
+
+    this.headerRow.add(this.titleText)
+    this.headerRow.add(this.modeText)
+
+    this.composerBox.add(this.composer)
+
+    this.statusRow.add(this.statusText)
+    this.statusRow.add(this.metaText)
+
+    this.controlsRow.add(this.controlsText)
+
+    this.shell.add(this.headerRow)
+    this.shell.add(this.composerBox)
+    this.shell.add(this.statusRow)
+    this.shell.add(this.controlsRow)
+    this.renderer.root.add(this.shell)
+
+    this.composer.on("line-info-change", this.handleDraftChanged)
+    this.renderer.keyInput.on("keypress", this.handleKeyPress)
+    this.renderer.on("resize", this.handleResize)
+    this.renderer.on(CliRenderEvents.THEME_MODE, this.handleThemeMode)
+    this.renderer.on(CliRenderEvents.DESTROY, this.handleRendererDestroy)
+
+    this.applyPalette()
+    this.refreshStatus("ready")
+    this.publishWelcomeMessages()
+    if (AUTO_CTRL_R_HOLD_ON_BOOT) {
+      this.scheduleCtrlRHoldBootSimulation()
+    }
+    this.syncStreamLoop()
+    this.composer.focus()
+  }
+
+  private get draftLength(): number {
+    if (this.destroyed || this.composer.isDestroyed) {
+      return 0
+    }
+
+    return this.composer.plainText.length
+  }
+
+  private isSplitCaptureMode(): boolean {
+    return this.renderer.screenMode === "split-footer" && this.renderer.externalOutputMode === "capture-stdout"
+  }
+
+  private clampFooterHeight(requestedHeight: number): number {
+    const maxFooterHeight = Math.max(1, this.renderer.terminalHeight - MIN_MAIN_SCREEN_HEIGHT)
+    const minFooterHeight = Math.min(MIN_FOOTER_HEIGHT, maxFooterHeight)
+    return Math.min(Math.max(requestedHeight, minFooterHeight), maxFooterHeight)
+  }
+
+  private applyPalette(): void {
+    this.renderer.setBackgroundColor(this.palette.appBackground)
+    this.shell.backgroundColor = this.palette.shellBackground
+    this.shell.borderColor = this.palette.shellBorder
+    this.titleText.fg = this.palette.titleText
+    this.modeText.fg = this.palette.modeText
+    this.statusText.fg = this.palette.statusText
+    this.metaText.fg = this.palette.streamText
+    this.composerBox.borderColor = this.palette.composerBorder
+    this.composerBox.backgroundColor = this.palette.composerBackground
+    this.composer.placeholderColor = this.palette.inputPlaceholder
+    this.composer.textColor = this.palette.inputText
+    this.composer.focusedTextColor = this.palette.inputFocusedText
+    this.composer.backgroundColor = this.palette.composerBackground
+    this.composer.focusedBackgroundColor = this.palette.inputFocusedBackground
+    this.composer.cursorColor = this.palette.inputCursor
+    this.controlsText.fg = this.palette.controlText
+  }
+
+  private refreshStatus(message?: string): void {
+    if (this.destroyed) {
+      return
+    }
+
+    if (message) {
+      this.statusMessage = message
+    }
+
+    const modeLabel = this.mode === "split-footer" ? `split:${this.renderer.footerHeight}` : "fullscreen"
+    const streamLabel = this.streamEnabled ? `${this.streamIntervalMs}ms` : "off"
+    const mouseLabel = this.renderer.useMouse ? "mouse:on" : "mouse:off"
+    const typingLabel = this.assistantTyping ? "typing" : "idle"
+
+    this.modeText.content = modeLabel
+    this.statusText.content = `msg ${this.messageCount} draft ${this.draftLength} ${typingLabel} | ${this.statusMessage}`
+    this.metaText.content = `${mouseLabel} stream:${streamLabel} commits:${this.commitCount} lines:${this.streamCount}`
+    this.controlsText.content =
+      "Ctrl+Enter send · Enter newline · Shift+U mouse · Ctrl+S stream · Ctrl+0 mode · Ctrl+R hold-demo · /help"
+  }
+
+  private activateSplitFooterMode(announce: boolean = true): void {
+    this.desiredFooterHeight = this.clampFooterHeight(this.desiredFooterHeight)
+
+    if (this.renderer.screenMode !== "split-footer") {
+      this.renderer.screenMode = "split-footer"
+    }
+
+    this.renderer.footerHeight = this.desiredFooterHeight
+
+    if (this.renderer.externalOutputMode !== "capture-stdout") {
+      this.renderer.externalOutputMode = "capture-stdout"
+    }
+
+    this.mode = "split-footer"
+    this.syncStreamLoop()
+    this.refreshStatus("split-footer mode")
+
+    if (announce) {
+      this.publishMessage(
+        "system",
+        `Switched to split-footer mode (height ${this.renderer.footerHeight}). Stream capture is active.`,
+        false,
+      )
+    }
+  }
+
+  private activateFullscreenMode(): void {
+    if (this.renderer.externalOutputMode !== "passthrough") {
+      this.renderer.externalOutputMode = "passthrough"
+    }
+
+    if (this.renderer.screenMode !== "main-screen") {
+      this.renderer.screenMode = "main-screen"
+    }
+
+    this.mode = "fullscreen"
+    this.syncStreamLoop()
+    this.refreshStatus("fullscreen mode")
+  }
+
+  private toggleMode(): void {
+    if (this.mode === "split-footer") {
+      this.activateFullscreenMode()
+    } else {
+      this.activateSplitFooterMode(true)
+    }
+  }
+
+  private enqueueScrollback(write: ScrollbackWriter, failureStatus: string): void {
+    if (!this.isSplitCaptureMode()) {
+      this.refreshStatus("output paused in fullscreen")
+      return
+    }
+
+    if (this.destroyed || !this.isSplitCaptureMode()) {
+      return
+    }
+
+    try {
+      this.renderer.writeToScrollback(write)
+
+      if (this.destroyed) {
+        return
+      }
+
+      this.commitCount += 1
+      this.refreshStatus()
+    } catch (error) {
+      if (!this.destroyed) {
+        this.refreshStatus(failureStatus)
+        console.error("split-mode-demo publish failed", error)
+      }
+    }
+  }
+
+  private publishMessage(role: MessageRole, text: string, countAsMessage: boolean = true): void {
+    if (countAsMessage) {
+      this.messageCount += 1
+    }
+
+    const paletteSnapshot: DemoPalette = { ...this.palette }
+
+    this.enqueueScrollback(
+      (ctx) =>
+        buildSimpleTextBoxSnapshot(
+          {
+            role,
+            text,
+            timestamp: new Date(),
+            palette: paletteSnapshot,
+          },
+          ctx,
+        ),
+      "failed to publish text box",
+    )
+  }
+
+  private getPassage(index: number): WallLyricPassage {
+    const total = WALL_STREAM_PASSAGES.length
+    const safeIndex = ((index % total) + total) % total
+    return WALL_STREAM_PASSAGES[safeIndex]!
+  }
+
+  private passageText(passage: WallLyricPassage): string {
+    return `${passage.song}\n${passage.lines.join("\n")}`
+  }
+
+  private publishWelcomeMessages(): void {
+    this.publishMessage(
+      "system",
+      `Lyric cue pack loaded. Width ${this.renderer.width}. Use /demo for a guided mini medley.`,
+      false,
+    )
+
+    this.publishMessage("system", "Stream mode rotates through a short ordered setlist.", false)
+  }
+
+  private syncStreamLoop(): void {
+    const shouldRun = this.streamEnabled && this.isSplitCaptureMode() && !this.destroyed
+
+    if (!shouldRun) {
+      if (this.streamTimer) {
+        clearInterval(this.streamTimer)
+        this.streamTimer = null
+      }
+      return
+    }
+
+    if (this.streamTimer) {
+      return
+    }
+
+    this.streamTimer = setInterval(this.emitStreamTick, this.streamIntervalMs)
+  }
+
+  private setStreamEnabled(enabled: boolean): void {
+    this.streamEnabled = enabled
+    if (!enabled && this.streamTimer) {
+      clearInterval(this.streamTimer)
+      this.streamTimer = null
+    }
+    if (enabled) {
+      this.syncStreamLoop()
+    }
+    this.refreshStatus(`stream ${enabled ? "enabled" : "disabled"}`)
+  }
+
+  private setStreamInterval(requestedInterval: number): void {
+    const clampedInterval = Math.min(Math.max(requestedInterval, MIN_STREAM_INTERVAL), MAX_STREAM_INTERVAL)
+    if (clampedInterval === this.streamIntervalMs) {
+      this.refreshStatus("stream speed unchanged")
+      return
+    }
+
+    this.streamIntervalMs = clampedInterval
+
+    if (this.streamTimer) {
+      clearInterval(this.streamTimer)
+      this.streamTimer = null
+    }
+
+    this.syncStreamLoop()
+    this.refreshStatus(`stream interval ${clampedInterval}ms`)
+  }
+
+  private emitStreamTick = (): void => {
+    if (this.destroyed || !this.streamEnabled || !this.isSplitCaptureMode()) {
+      return
+    }
+
+    const nextPassage = this.getPassage(this.streamCount)
+    this.streamCount += 1
+    this.publishMessage("stream", this.passageText(nextPassage), false)
+    this.refreshStatus()
+  }
+
+  private publishCommandHelp(): void {
+    this.publishMessage(
+      "system",
+      [
+        "Commands:",
+        "/help - show this command guide",
+        "/demo - append a compact lyric medley",
+        "/mouse on|off|toggle - toggle mouse handling",
+        "/stream on|off|toggle - control stream output",
+        "/speed <ms> - set stream interval",
+        "/mode split|full|toggle - switch split/footer mode",
+        "/footer <n> - set split footer height",
+        "keys: Ctrl+Enter send, Enter newline, Shift+U mouse, Ctrl+S stream, Ctrl+R held demo burst",
+      ].join("\n"),
+      false,
+    )
+  }
+
+  private publishDemoTranscript(): void {
+    const medleySequence = [0, 1, 2, 3, 4, 5, 6]
+
+    this.publishMessage("system", "Mini medley:", false)
+    medleySequence.forEach((index) => {
+      this.publishMessage("assistant", this.passageText(this.getPassage(index)))
+    })
+
+    this.publishMessage(
+      "system",
+      "All alone, or in twos, the ones who really love you walk up and down outside the wall.",
+      false,
+    )
+    this.refreshStatus("demo transcript queued")
+  }
+
+  private scheduleCtrlRHoldBootSimulation(): void {
+    if (this.ctrlRBootTimer || this.destroyed) {
+      return
+    }
+
+    this.ctrlRBootTimer = setTimeout(() => {
+      this.ctrlRBootTimer = null
+      if (this.destroyed) {
+        return
+      }
+
+      this.startCtrlRHoldSimulation(CTRL_R_HOLD_DURATION_MS)
+    }, CTRL_R_HOLD_BOOT_DELAY_MS)
+  }
+
+  private runCtrlRHoldTick = (): void => {
+    if (this.destroyed || !this.isSplitCaptureMode()) {
+      this.stopCtrlRHoldSimulation(false)
+      return
+    }
+
+    if (Date.now() >= this.ctrlRHoldDeadlineMs) {
+      this.stopCtrlRHoldSimulation(true)
+      return
+    }
+
+    this.publishDemoTranscript()
+  }
+
+  private startCtrlRHoldSimulation(durationMs: number = CTRL_R_HOLD_DURATION_MS): void {
+    if (this.destroyed || !this.isSplitCaptureMode()) {
+      return
+    }
+
+    this.ctrlRHoldDeadlineMs = Math.max(this.ctrlRHoldDeadlineMs, Date.now() + durationMs)
+
+    if (this.ctrlRHoldTimer) {
+      return
+    }
+
+    this.publishDemoTranscript()
+    this.ctrlRHoldTimer = setInterval(this.runCtrlRHoldTick, CTRL_R_HOLD_REPEAT_MS)
+    this.refreshStatus("simulating Ctrl+R hold")
+  }
+
+  private stopCtrlRHoldSimulation(announceDone: boolean): void {
+    if (this.ctrlRHoldTimer) {
+      clearInterval(this.ctrlRHoldTimer)
+      this.ctrlRHoldTimer = null
+    }
+
+    this.ctrlRHoldDeadlineMs = 0
+
+    if (!announceDone || this.destroyed) {
+      return
+    }
+
+    this.refreshStatus("Ctrl+R hold simulation complete")
+  }
+
+  private handleCommand(commandLine: string): void {
+    const [command, ...args] = commandLine.trim().split(/\s+/)
+
+    switch (command.toLowerCase()) {
+      case "/help": {
+        this.publishCommandHelp()
+        this.refreshStatus("help published")
+        return
+      }
+
+      case "/demo": {
+        this.publishDemoTranscript()
+        return
+      }
+
+      case "/mouse": {
+        const option = (args[0] ?? "toggle").toLowerCase()
+
+        if (option === "on") {
+          this.renderer.useMouse = true
+        } else if (option === "off") {
+          this.renderer.useMouse = false
+        } else {
+          this.renderer.useMouse = !this.renderer.useMouse
+        }
+
+        this.refreshStatus(`mouse ${this.renderer.useMouse ? "enabled" : "disabled"}`)
+        return
+      }
+
+      case "/stream": {
+        const option = (args[0] ?? "toggle").toLowerCase()
+        if (option === "on") {
+          this.setStreamEnabled(true)
+        } else if (option === "off") {
+          this.setStreamEnabled(false)
+        } else {
+          this.setStreamEnabled(!this.streamEnabled)
+        }
+        return
+      }
+
+      case "/speed": {
+        if (args.length === 0) {
+          this.publishMessage("system", `Current stream interval is ${this.streamIntervalMs}ms.`, false)
+          return
+        }
+
+        const requested = Number.parseInt(args[0], 10)
+        if (!Number.isFinite(requested)) {
+          this.publishMessage("system", `Invalid speed value: ${args[0]}`, false)
+          this.refreshStatus("invalid speed value")
+          return
+        }
+
+        this.setStreamInterval(requested)
+        return
+      }
+
+      case "/mode": {
+        const option = (args[0] ?? "toggle").toLowerCase()
+        if (option === "split" || option === "footer") {
+          this.activateSplitFooterMode(true)
+        } else if (option === "full" || option === "fullscreen" || option === "main") {
+          this.activateFullscreenMode()
+        } else {
+          this.toggleMode()
+        }
+        return
+      }
+
+      case "/footer": {
+        if (args.length === 0) {
+          this.publishMessage("system", "usage: /footer <height>", false)
+          return
+        }
+
+        const requested = Number.parseInt(args[0], 10)
+        if (!Number.isFinite(requested)) {
+          this.publishMessage("system", `Invalid footer height: ${args[0]}`, false)
+          this.refreshStatus("invalid footer height")
+          return
+        }
+
+        this.desiredFooterHeight = this.clampFooterHeight(requested)
+        if (this.mode === "split-footer") {
+          this.renderer.footerHeight = this.desiredFooterHeight
+          this.publishMessage("system", `footer height set to ${this.desiredFooterHeight}`, false)
+        }
+        this.refreshStatus(`footer target ${this.desiredFooterHeight}`)
+        return
+      }
+
+      default: {
+        this.publishMessage("system", `Unknown command: ${command}`, false)
+        this.refreshStatus("unknown command")
+      }
+    }
+  }
+
+  private handleComposerSubmit = (): void => {
+    const value = this.composer.plainText
+    const trimmed = value.trim()
+
+    if (trimmed.length === 0) {
+      this.refreshStatus("empty draft ignored")
+      return
+    }
+
+    this.composer.setText("")
+    this.composer.focus()
+
+    if (trimmed.startsWith("/")) {
+      this.handleCommand(trimmed)
+      return
+    }
+
+    this.publishMessage("user", trimmed)
+    this.scheduleAssistantReply(trimmed)
+  }
+
+  private scheduleAssistantReply(userText: string): void {
+    if (this.pendingAssistantReply) {
+      clearTimeout(this.pendingAssistantReply)
+      this.pendingAssistantReply = null
+    }
+
+    this.assistantTyping = true
+    this.refreshStatus("assistant composing")
+
+    const delayMs = Math.min(1100, 250 + userText.length * 10)
+    this.pendingAssistantReply = setTimeout(() => {
+      this.pendingAssistantReply = null
+      if (this.destroyed) {
+        return
+      }
+
+      this.publishMessage("assistant", this.buildAssistantReply(userText))
+      this.assistantTyping = false
+      this.refreshStatus("assistant reply queued")
+    }, delayMs)
+  }
+
+  private buildAssistantReply(userText: string): string {
+    const normalized = userText.toLowerCase()
+
+    if (normalized.includes("wall")) {
+      return "All in all you're just another brick in the wall"
+    }
+
+    if (normalized.includes("home")) {
+      return "Open your heart, I'm coming home"
+    }
+
+    if (normalized.includes("show")) {
+      return "The show must go on"
+    }
+
+    if (normalized.includes("hello") || normalized.includes("anybody")) {
+      return "Hello, is there anybody in there"
+    }
+
+    if (normalized.includes("goodbye")) {
+      return "Goodbye cruel world, I'm leaving you today"
+    }
+
+    if (normalized.includes("more") || normalized.includes("next")) {
+      return this.passageText(this.getPassage(this.streamCount))
+    }
+
+    return WALL_ASSISTANT_LINES[(this.messageCount + userText.length) % WALL_ASSISTANT_LINES.length]!
+  }
+
+  private adjustFooterHeight(delta: number): void {
+    if (this.mode !== "split-footer") {
+      this.refreshStatus("footer height can only change in split mode")
+      return
+    }
+
+    const nextHeight = this.clampFooterHeight(this.renderer.footerHeight + delta)
+    if (nextHeight === this.renderer.footerHeight) {
+      this.refreshStatus("footer already at limit")
+      return
+    }
+
+    this.desiredFooterHeight = nextHeight
+    this.renderer.footerHeight = nextHeight
+    this.refreshStatus(`footer height ${nextHeight}`)
+    this.publishMessage("system", `footer height adjusted to ${nextHeight}`, false)
+  }
+
+  private handleDraftChanged = (): void => {
+    this.refreshStatus()
+  }
+
+  private isModeToggleKey(key: KeyEvent): boolean {
+    if (!key.ctrl) {
+      return false
+    }
+
+    if (key.baseCode === 48) {
+      return true
+    }
+
+    if (key.name === "0" || key.name === "kp0" || key.name === ")") {
+      return true
+    }
+
+    return key.raw === "\u001b[27;5;48~" || key.raw === "\u001b[27;6;48~"
+  }
+
+  private handleKeyPress = (key: KeyEvent): void => {
+    if (!key.ctrl && !key.meta && key.shift && key.name === "u") {
+      key.preventDefault()
+      this.renderer.useMouse = !this.renderer.useMouse
+      this.refreshStatus(`mouse ${this.renderer.useMouse ? "enabled" : "disabled"}`)
+      return
+    }
+
+    if (key.ctrl && key.name === "s") {
+      key.preventDefault()
+      this.setStreamEnabled(!this.streamEnabled)
+      return
+    }
+
+    if (this.isModeToggleKey(key)) {
+      key.preventDefault()
+      this.toggleMode()
+      return
+    }
+
+    if (key.ctrl && key.name === "r") {
+      key.preventDefault()
+      this.startCtrlRHoldSimulation(CTRL_R_HOLD_DURATION_MS)
+      return
+    }
+
+    if (key.ctrl && key.name === "l") {
+      key.preventDefault()
+      this.composer.setText("")
+      this.refreshStatus("draft cleared")
+      return
+    }
+
+    if (key.ctrl && key.name === "up") {
+      key.preventDefault()
+      this.adjustFooterHeight(1)
+      return
+    }
+
+    if (key.ctrl && key.name === "down") {
+      key.preventDefault()
+      this.adjustFooterHeight(-1)
+      return
+    }
+
+    if (key.ctrl && key.name === "]") {
+      key.preventDefault()
+      this.setStreamInterval(this.streamIntervalMs - STREAM_INTERVAL_STEP)
+      return
+    }
+
+    if (key.ctrl && key.name === "[") {
+      key.preventDefault()
+      this.setStreamInterval(this.streamIntervalMs + STREAM_INTERVAL_STEP)
+      return
+    }
+
+    if (key.name === "escape") {
+      this.composer.focus()
+      this.refreshStatus("composer focused")
+    }
+  }
+
+  private handleThemeMode = (mode: ThemeMode): void => {
+    this.palette = resolveDemoPalette(mode)
+    this.applyPalette()
+    this.refreshStatus(`theme ${mode}`)
+  }
+
+  private handleResize = (): void => {
+    this.desiredFooterHeight = this.clampFooterHeight(this.desiredFooterHeight)
+    if (this.mode === "split-footer" && this.renderer.footerHeight !== this.desiredFooterHeight) {
+      this.renderer.footerHeight = this.desiredFooterHeight
+    }
+
+    this.refreshStatus("layout resized")
+  }
+
+  private handleRendererDestroy = (): void => {
+    this.destroy()
   }
 
   public destroy(): void {
-    this.timeline.pause()
-    this.renderer.root.remove("animation-container")
+    if (this.destroyed) {
+      return
+    }
+
+    this.destroyed = true
+    this.streamEnabled = false
+
+    if (this.pendingAssistantReply) {
+      clearTimeout(this.pendingAssistantReply)
+      this.pendingAssistantReply = null
+    }
+
+    if (this.ctrlRBootTimer) {
+      clearTimeout(this.ctrlRBootTimer)
+      this.ctrlRBootTimer = null
+    }
+
+    this.stopCtrlRHoldSimulation(false)
+
+    if (this.streamTimer) {
+      clearInterval(this.streamTimer)
+      this.streamTimer = null
+    }
+
+    this.composer.off("line-info-change", this.handleDraftChanged)
+    this.composer.onSubmit = undefined
+    this.renderer.keyInput.off("keypress", this.handleKeyPress)
+    this.renderer.off("resize", this.handleResize)
+    this.renderer.off(CliRenderEvents.THEME_MODE, this.handleThemeMode)
+    this.renderer.off(CliRenderEvents.DESTROY, this.handleRendererDestroy)
+
+    this.renderer.root.remove(this.shell.id)
+
+    if (!this.renderer.isDestroyed) {
+      this.renderer.externalOutputMode = "passthrough"
+      this.renderer.screenMode = "main-screen"
+    }
   }
 }
+
+let activeDemo: SplitFooterDemo | null = null
 
 export function run(rendererInstance: CliRenderer): void {
-  rendererInstance.setBackgroundColor("#001122")
-  rendererInstance.footerHeight = 20
-  rendererInstance.screenMode = "split-footer"
-  rendererInstance.externalOutputMode = "capture-stdout"
-
-  animationSystem = new SplitModeAnimations(rendererInstance)
-
-  text = new TextRenderable(rendererInstance, {
-    id: "demo-text",
-    position: "absolute",
-    left: 2,
-    top: 0,
-    width: rendererInstance.width - 4,
-    height: 2,
-    zIndex: 10,
-    content: t`${bold(fg("#00ffff")("◆ SPLIT MODE DEMO - ANIMATED DASHBOARD ◆"))}`,
-  })
-
-  instructionsText = new TextRenderable(rendererInstance, {
-    id: "split-mode-instructions",
-    position: "absolute",
-    left: 2,
-    top: 19,
-    width: rendererInstance.width - 4,
-    height: 2,
-    zIndex: 10,
-    content: t`${bold(fg("#cccccc")("[+/-] Split height | [0] Toggle fullscreen | [M/L] Output speed | [U] Toggle mouse"))}`,
-  })
-
-  rendererInstance.root.add(text)
-  rendererInstance.root.add(instructionsText)
-
-  rendererInstance.setFrameCallback(async (deltaTime: number) => {
-    if (animationSystem) {
-      animationSystem.update(deltaTime)
-    }
-  })
-
-  console.log("=== Split Mode Demo ===")
-  console.log(`Terminal size: ${rendererInstance.terminalWidth}x${rendererInstance.terminalHeight}`)
-  console.log(`Renderer split height: ${rendererInstance.footerHeight}`)
-  console.log(`Renderer offset: ${rendererInstance.terminalHeight - rendererInstance.footerHeight}`)
-  console.log("Console output should appear here and scroll naturally")
-  console.log("The renderer should stay fixed at the bottom as a footer")
-  console.log(`Test output running at ${testOutputInterval}ms intervals (use M/L to adjust speed)`)
-  console.log(`Mouse functionality: ${rendererInstance.useMouse ? "enabled" : "disabled"} (use U to toggle)`)
-
-  let messageCount = 0
-
-  const startTestOutput = () => {
-    if (outputTimer) {
-      clearInterval(outputTimer)
-    }
-    outputTimer = setInterval(() => {
-      messageCount++
-      console.log(`Test output ${messageCount}: This should appear above the renderer and scroll naturally`)
-    }, testOutputInterval)
+  if (activeDemo) {
+    activeDemo.destroy()
   }
 
-  startTestOutput()
-
-  keyHandler = (key) => {
-    if (key.name === "+") {
-      const currentHeight = rendererInstance.footerHeight
-      const newHeight = Math.min(currentHeight + 1, rendererInstance.terminalHeight - 5)
-      rendererInstance.footerHeight = newHeight
-      console.log(`Split height increased to ${newHeight}`)
-    } else if (key.name === "-") {
-      const currentHeight = rendererInstance.footerHeight
-      const newHeight = Math.max(currentHeight - 1, 5)
-      rendererInstance.footerHeight = newHeight
-      console.log(`Split height decreased to ${newHeight}`)
-    } else if (key.name === "0") {
-      if (rendererInstance.screenMode === "split-footer") {
-        rendererInstance.externalOutputMode = "passthrough"
-        rendererInstance.screenMode = "main-screen"
-        console.log("Switched to main-screen mode")
-      } else {
-        rendererInstance.footerHeight = 20
-        rendererInstance.screenMode = "split-footer"
-        rendererInstance.externalOutputMode = "capture-stdout"
-        console.log("Switched to split-footer mode (height 20)")
-      }
-    } else if (key.name === "m") {
-      testOutputInterval = Math.max(5, testOutputInterval - 5)
-      startTestOutput()
-      console.log(`Test output speed increased (interval: ${testOutputInterval}ms)`)
-    } else if (key.name === "l") {
-      testOutputInterval = Math.min(1000, testOutputInterval + 5)
-      startTestOutput()
-      console.log(`Test output speed decreased (interval: ${testOutputInterval}ms)`)
-    } else if (key.name === "u") {
-      rendererInstance.useMouse = !rendererInstance.useMouse
-      console.log(`Mouse functionality ${rendererInstance.useMouse ? "enabled" : "disabled"}`)
-    }
-  }
-
-  rendererInstance.keyInput.on("keypress", keyHandler)
+  activeDemo = new SplitFooterDemo(rendererInstance)
 }
 
-export function destroy(rendererInstance: CliRenderer): void {
-  if (keyHandler) {
-    rendererInstance.keyInput.off("keypress", keyHandler)
-    keyHandler = null
+export function destroy(_rendererInstance: CliRenderer): void {
+  if (!activeDemo) {
+    return
   }
 
-  if (outputTimer) {
-    clearInterval(outputTimer)
-    outputTimer = null
-  }
-
-  if (animationSystem) {
-    animationSystem.destroy()
-    animationSystem = null
-  }
-
-  if (text) {
-    rendererInstance.root.remove(text.id)
-    text = null
-  }
-
-  if (instructionsText) {
-    rendererInstance.root.remove(instructionsText.id)
-    instructionsText = null
-  }
-
-  rendererInstance.clearFrameCallbacks()
-  rendererInstance.externalOutputMode = "passthrough"
-  rendererInstance.screenMode = "main-screen"
+  activeDemo.destroy()
+  activeDemo = null
 }
 
 if (import.meta.main) {
@@ -442,7 +1290,7 @@ if (import.meta.main) {
     exitOnCtrlC: true,
     useMouse: true,
     screenMode: "split-footer",
-    footerHeight: 20,
+    footerHeight: DEFAULT_FOOTER_HEIGHT,
     externalOutputMode: "capture-stdout",
     consoleMode: "disabled",
   })
@@ -450,4 +1298,13 @@ if (import.meta.main) {
   run(renderer)
   setupCommonDemoKeys(renderer)
   renderer.start()
+
+  // Used by capture scripts to bound each run to a fixed duration.
+  if (AUTO_EXIT_MS > 0) {
+    setTimeout(() => {
+      if (!renderer.isDestroyed) {
+        renderer.destroy()
+      }
+    }, AUTO_EXIT_MS)
+  }
 }

--- a/packages/core/src/lib/render-geometry.ts
+++ b/packages/core/src/lib/render-geometry.ts
@@ -1,0 +1,36 @@
+export type RenderGeometryScreenMode = "alternate-screen" | "main-screen" | "split-footer"
+
+export interface RenderGeometry {
+  effectiveFooterHeight: number
+  renderOffset: number
+  renderWidth: number
+  renderHeight: number
+}
+
+export function calculateRenderGeometry(
+  screenMode: RenderGeometryScreenMode,
+  terminalWidth: number,
+  terminalHeight: number,
+  footerHeight: number,
+): RenderGeometry {
+  const safeTerminalWidth = Math.max(terminalWidth, 0)
+  const safeTerminalHeight = Math.max(terminalHeight, 0)
+
+  if (screenMode !== "split-footer") {
+    return {
+      effectiveFooterHeight: 0,
+      renderOffset: 0,
+      renderWidth: safeTerminalWidth,
+      renderHeight: safeTerminalHeight,
+    }
+  }
+
+  const effectiveFooterHeight = Math.min(footerHeight, safeTerminalHeight)
+
+  return {
+    effectiveFooterHeight,
+    renderOffset: safeTerminalHeight - effectiveFooterHeight,
+    renderWidth: safeTerminalWidth,
+    renderHeight: effectiveFooterHeight,
+  }
+}

--- a/packages/core/src/lib/stdin-parser.test.ts
+++ b/packages/core/src/lib/stdin-parser.test.ts
@@ -868,7 +868,7 @@ describe("StdinParser", () => {
       // DA (Device Attributes)
       ["DA1", "\x1b[?62;1;2;6;7;8;9;15;22c", [resp("csi", "\x1b[?62;1;2;6;7;8;9;15;22c")]],
       // CPR (Cursor Position Report)
-      ["CPR", "\x1b[24;80R", [resp("csi", "\x1b[24;80R")]],
+      ["CPR", "\x1b[24;80R", [resp("cpr", "\x1b[24;80R")]],
       // Window/cell size
       ["window size", "\x1b[4;600;800t", [resp("csi", "\x1b[4;600;800t")]],
       // Mode report
@@ -1228,7 +1228,7 @@ describe("StdinParser", () => {
         expect(snap(parser)).toEqual([])
 
         parser.push(Buffer.from("R"))
-        expect(snap(parser)).toEqual([resp("csi", "\x1b[1;2R")])
+        expect(snap(parser)).toEqual([resp("cpr", "\x1b[1;2R")])
       } finally {
         parser.destroy()
       }
@@ -1366,6 +1366,24 @@ describe("StdinParser", () => {
 
         parser.push(Buffer.from("R"))
         expect(snap(parser)).toEqual([k("r", { raw: "R", shift: true })])
+      } finally {
+        parser.destroy()
+      }
+    })
+
+    test("generic row/col CPR stays pending after timeout while startup cursor probe is active", () => {
+      const { parser, clock } = createTimedParser({
+        protocolContext: { startupCursorCprActive: true },
+      })
+
+      try {
+        parser.push(Buffer.from("\x1b[24;80"))
+        expect(snap(parser)).toEqual([])
+        clock.advance(10)
+        expect(snap(parser)).toEqual([])
+
+        parser.push(Buffer.from("R"))
+        expect(snap(parser)).toEqual([resp("cpr", "\x1b[24;80R")])
       } finally {
         parser.destroy()
       }

--- a/packages/core/src/lib/stdin-parser.ts
+++ b/packages/core/src/lib/stdin-parser.ts
@@ -13,7 +13,7 @@ import type { PasteMetadata } from "./paste.js"
 
 export { SystemClock, type Clock, type TimerHandle } from "./clock.js"
 
-export type StdinResponseProtocol = "csi" | "osc" | "dcs" | "apc" | "unknown"
+export type StdinResponseProtocol = "csi" | "cpr" | "osc" | "dcs" | "apc" | "unknown"
 
 // The four event types the parser produces. Everything stdin sends becomes
 // exactly one of these.
@@ -45,6 +45,7 @@ export interface StdinParserProtocolContext {
   privateCapabilityRepliesActive: boolean
   pixelResolutionQueryActive: boolean
   explicitWidthCprActive: boolean
+  startupCursorCprActive: boolean
 }
 
 export interface StdinParserOptions {
@@ -112,6 +113,7 @@ const DEFAULT_PROTOCOL_CONTEXT: StdinParserProtocolContext = {
   privateCapabilityRepliesActive: false,
   pixelResolutionQueryActive: false,
   explicitWidthCprActive: false,
+  startupCursorCprActive: false,
 }
 // rxvt uses $-terminated CSI sequences for shifted function keys (e.g. ESC[2$).
 // Standard CSI treats $ as an intermediate byte, not a final, so we match these
@@ -370,6 +372,10 @@ function canStillBeExplicitWidthCpr(state: ParametricCsiLike): boolean {
   return state.firstParamValue === 1 && state.semicolons === 1
 }
 
+function canStillBeStartupCursorCpr(state: ParametricCsiLike): boolean {
+  return state.semicolons === 1
+}
+
 function canStillBePixelResolution(state: ParametricCsiLike): boolean {
   return state.firstParamValue === 4 && state.semicolons === 2
 }
@@ -378,6 +384,7 @@ function canDeferParametricCsi(state: ParametricCsiLike, context: StdinParserPro
   return (
     (context.kittyKeyboardEnabled && (canStillBeKittyU(state) || canStillBeKittySpecial(state))) ||
     (context.explicitWidthCprActive && canStillBeExplicitWidthCpr(state)) ||
+    (context.startupCursorCprActive && canStillBeStartupCursorCpr(state)) ||
     (context.pixelResolutionQueryActive && canStillBePixelResolution(state))
   )
 }
@@ -409,6 +416,10 @@ function canCompleteDeferredParametricCsi(
     return true
   }
 
+  if (context.startupCursorCprActive && state.hasDigit && state.semicolons === 1 && byte === 0x52) {
+    return true
+  }
+
   if (
     context.pixelResolutionQueryActive &&
     state.hasDigit &&
@@ -420,6 +431,14 @@ function canCompleteDeferredParametricCsi(
   }
 
   return false
+}
+
+function classifyParametricCsiProtocol(state: ParametricCsiLike, finalByte: number): StdinResponseProtocol {
+  if (finalByte === 0x52 && state.semicolons === 1 && state.segments === 1 && state.hasDigit) {
+    return "cpr"
+  }
+
+  return "csi"
 }
 
 function canDeferPrivateReplyCsi(context: StdinParserProtocolContext): boolean {
@@ -567,6 +586,7 @@ export class StdinParser {
       privateCapabilityRepliesActive: options.protocolContext?.privateCapabilityRepliesActive ?? false,
       pixelResolutionQueryActive: options.protocolContext?.pixelResolutionQueryActive ?? false,
       explicitWidthCprActive: options.protocolContext?.explicitWidthCprActive ?? false,
+      startupCursorCprActive: options.protocolContext?.startupCursorCprActive ?? false,
     }
   }
 
@@ -1223,7 +1243,8 @@ export class StdinParser {
 
           if (byte >= 0x40 && byte <= 0x7e) {
             const end = this.cursor + 1
-            this.emitKeyOrResponse("csi", decodeUtf8(bytes.subarray(this.unitStart, end)))
+            const protocol = classifyParametricCsiProtocol(this.state, byte)
+            this.emitKeyOrResponse(protocol, decodeUtf8(bytes.subarray(this.unitStart, end)))
             this.state = { tag: "ground" }
             this.consumePrefix(end)
             continue

--- a/packages/core/src/renderables/TextBufferRenderable.ts
+++ b/packages/core/src/renderables/TextBufferRenderable.ts
@@ -37,6 +37,7 @@ export abstract class TextBufferRenderable extends Renderable implements LineInf
   protected _scrollX: number = 0
   protected _scrollY: number = 0
   protected _truncate: boolean = false
+  protected _firstLineOffset: number = 0
 
   protected textBuffer: TextBuffer
   protected textBufferView: TextBufferView
@@ -73,11 +74,13 @@ export abstract class TextBufferRenderable extends Renderable implements LineInf
 
     this.textBuffer = TextBuffer.create(this._ctx.widthMethod)
     this.textBufferView = TextBufferView.create(this.textBuffer)
+    this._firstLineOffset = ctx.claimFirstLineOffset?.(this) ?? 0
 
     this._textBufferSyntaxStyle = SyntaxStyle.create()
     this.textBuffer.setSyntaxStyle(this._textBufferSyntaxStyle)
 
     this.textBufferView.setWrapMode(this._wrapMode)
+    this.textBufferView.setFirstLineOffset(this._firstLineOffset)
     this.setupMeasureFunc()
 
     this.textBuffer.setDefaultFg(this._defaultFg)

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1,5 +1,8 @@
 import { ANSI } from "./ansi.js"
 import { Renderable, RootRenderable } from "./Renderable.js"
+import { BoxRenderable } from "./renderables/Box.js"
+import { CodeRenderable } from "./renderables/Code.js"
+import { TextRenderable } from "./renderables/Text.js"
 import {
   DebugOverlayCorner,
   type CursorStyleOptions,
@@ -30,6 +33,7 @@ import {
   type TerminalColors,
   type GetPaletteOptions,
 } from "./lib/terminal-palette.js"
+import { calculateRenderGeometry } from "./lib/render-geometry.js"
 import {
   isCapabilityResponse,
   isPixelResolutionResponse,
@@ -130,6 +134,9 @@ export interface CliRendererConfig {
 
   // Clean up on these signals. Defaults to the common termination signals.
   exitSignals?: NodeJS.Signals[]
+
+  // Clear owned screen regions on suspend/destroy. Defaults to true.
+  clearOnShutdown?: boolean
 
   // Forward these env var names to native terminal detection.
   forwardEnvKeys?: string[]
@@ -234,7 +241,52 @@ export type PixelResolution = {
   height: number
 }
 
+export interface ScrollbackRenderContext {
+  width: number
+  widthMethod: WidthMethod
+  tailColumn: number
+  renderContext: RenderContext
+}
+
+export interface ScrollbackSnapshot {
+  root: Renderable
+  width?: number
+  height?: number
+  rowColumns?: number
+  startOnNewLine?: boolean
+  trailingNewline?: boolean
+  teardown?: () => void
+}
+
+export type ScrollbackWriter = (ctx: ScrollbackRenderContext) => ScrollbackSnapshot
+
+export interface ScrollbackSurfaceOptions {
+  startOnNewLine?: boolean
+}
+
+export interface ScrollbackSurfaceCommitOptions {
+  rowColumns?: number
+  trailingNewline?: boolean
+}
+
+export interface ScrollbackSurface {
+  readonly renderContext: RenderContext
+  readonly root: Renderable
+  readonly width: number
+  readonly height: number
+  readonly isDestroyed: boolean
+
+  render(): void
+  settle(timeoutMs?: number): Promise<void>
+  commitRows(startRow: number, endRowExclusive: number, options?: ScrollbackSurfaceCommitOptions): void
+  destroy(): void
+}
+
 const DEFAULT_FOOTER_HEIGHT = 12
+const MAX_SCROLLBACK_SURFACE_HEIGHT_PASSES = 4
+const TRANSPARENT_RGBA = RGBA.fromValues(0, 0, 0, 0)
+
+let scrollbackSurfaceCounter = 0
 
 function normalizeFooterHeight(footerHeight: number | undefined): number {
   if (footerHeight === undefined) {
@@ -281,6 +333,133 @@ function resolveModes(config: CliRendererConfig): {
     footerHeight,
     externalOutputMode,
   }
+}
+
+type ExternalOutputCommit = {
+  snapshot: OptimizedBuffer
+  rowColumns: number
+  startOnNewLine: boolean
+  trailingNewline: boolean
+}
+
+type PendingSplitFooterTransition = {
+  mode: "viewport-scroll" | "clear-stale-rows"
+  sourceTopLine: number
+  sourceHeight: number
+  targetTopLine: number
+  targetHeight: number
+}
+
+class ExternalOutputQueue {
+  private commits: ExternalOutputCommit[] = []
+
+  get size(): number {
+    return this.commits.length
+  }
+
+  writeSnapshot(commit: ExternalOutputCommit): void {
+    this.commits.push(commit)
+  }
+
+  claim(limit: number = Number.POSITIVE_INFINITY): ExternalOutputCommit[] {
+    if (this.commits.length === 0) {
+      return []
+    }
+
+    // Split-footer capture can enqueue many tiny commits in a burst (for example,
+    // simulated Ctrl+R hold). Taking everything at once creates very large native
+    // frames that increase visible churn. We keep claim() bounded so one render tick
+    // produces one modest frame and schedules another tick if work remains.
+    const clampedLimit = Number.isFinite(limit) ? Math.max(1, Math.trunc(limit)) : this.commits.length
+    if (clampedLimit >= this.commits.length) {
+      const output = this.commits
+      this.commits = []
+      return output
+    }
+
+    const output = this.commits.slice(0, clampedLimit)
+    this.commits = this.commits.slice(clampedLimit)
+    return output
+  }
+
+  clear(): void {
+    for (const commit of this.commits) {
+      commit.snapshot.destroy()
+    }
+    this.commits = []
+  }
+}
+
+const CHAR_FLAG_CONTINUATION = 0xc0000000 >>> 0
+const CHAR_FLAG_MASK = 0xc0000000 >>> 0
+
+class ScrollbackSnapshotRenderContext extends EventEmitter implements RenderContext {
+  public width: number
+  public height: number
+  public frameId = 0
+  public widthMethod: WidthMethod
+  public capabilities: any | null = null
+  public hasSelection: boolean = false
+  public currentFocusedRenderable: Renderable | null = null
+  public keyInput: KeyHandler
+  public _internalKeyInput: InternalKeyHandler
+
+  private lifecyclePasses: Set<Renderable> = new Set()
+
+  constructor(width: number, height: number, widthMethod: WidthMethod) {
+    super()
+    this.width = width
+    this.height = height
+    this.widthMethod = widthMethod
+    this.keyInput = new KeyHandler()
+    this._internalKeyInput = new InternalKeyHandler()
+  }
+
+  public addToHitGrid(_x: number, _y: number, _width: number, _height: number, _id: number): void {}
+  public pushHitGridScissorRect(_x: number, _y: number, _width: number, _height: number): void {}
+  public popHitGridScissorRect(): void {}
+  public clearHitGridScissorRects(): void {}
+  public requestRender(): void {}
+  public setCursorPosition(_x: number, _y: number, _visible: boolean): void {}
+  public setCursorStyle(_options: CursorStyleOptions): void {}
+  public setCursorColor(_color: RGBA): void {}
+  public setMousePointer(_shape: MousePointerStyle): void {}
+  public requestLive(): void {}
+  public dropLive(): void {}
+  public getSelection(): Selection | null {
+    return null
+  }
+  public get currentFocusedEditor(): EditBufferRenderable | null {
+    if (!this.currentFocusedRenderable) return null
+    if (!isEditBufferRenderable(this.currentFocusedRenderable)) return null
+    return this.currentFocusedRenderable
+  }
+  public requestSelectionUpdate(): void {}
+  public focusRenderable(renderable: Renderable): void {
+    this.currentFocusedRenderable = renderable
+  }
+  public blurRenderable(renderable: Renderable): void {
+    if (this.currentFocusedRenderable === renderable) {
+      this.currentFocusedRenderable = null
+    }
+  }
+  public registerLifecyclePass(renderable: Renderable): void {
+    this.lifecyclePasses.add(renderable)
+  }
+  public unregisterLifecyclePass(renderable: Renderable): void {
+    this.lifecyclePasses.delete(renderable)
+  }
+  public getLifecyclePasses(): Set<Renderable> {
+    return this.lifecyclePasses
+  }
+  public clearSelection(): void {}
+  public startSelection(_renderable: Renderable, _x: number, _y: number): void {}
+  public updateSelection(
+    _currentRenderable: Renderable | undefined,
+    _x: number,
+    _y: number,
+    _options?: { finishDragging?: boolean },
+  ): void {}
 }
 
 const DEFAULT_FORWARDED_ENV_KEYS = [
@@ -458,10 +637,10 @@ export async function createCliRenderer(config: CliRendererConfig = {}): Promise
 
   const width = stdout.columns || 80
   const height = stdout.rows || 24
-  const renderHeight = screenMode === "split-footer" ? footerHeight : height
+  const geometry = calculateRenderGeometry(screenMode, width, height, footerHeight)
 
   const ziglib = resolveRenderLib()
-  const rendererPtr = ziglib.createRenderer(width, renderHeight, {
+  const rendererPtr = ziglib.createRenderer(geometry.renderWidth, geometry.renderHeight, {
     remote: config.remote ?? false,
     testing: config.testing ?? false,
   })
@@ -600,6 +779,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private resizeTimeoutId: TimerHandle | null = null
   private capabilityTimeoutId: TimerHandle | null = null
+  private splitStartupSeedTimeoutId: TimerHandle | null = null
+  private pendingSplitStartupCursorSeed: boolean = false
   private resizeDebounceDelay: number = 100
 
   private enableMouseMovement: boolean = false
@@ -608,6 +789,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private _screenMode: ScreenMode = "alternate-screen"
   private _footerHeight: number = DEFAULT_FOOTER_HEIGHT
   private _externalOutputMode: ExternalOutputMode = "passthrough"
+  private clearOnShutdown: boolean = true
   private _suspendedMouseEnabled: boolean = false
   private _previousControlState: RendererControlState = RendererControlState.IDLE
   private capturedRenderable?: Renderable
@@ -620,17 +802,22 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private _splitHeight: number = 0
   private renderOffset: number = 0
+  private splitTailColumn: number = 0
+  private pendingSplitFooterTransition: PendingSplitFooterTransition | null = null
+  // One-shot latch used to request a full split repaint after transitions
+  // (resize/mode/output-path changes). Cleared on first renderNative tick.
+  private forceFullRepaintRequested: boolean = false
+  // Upper bound for captured stdout commits consumed per native frame.
+  // This is a visual smoothness control: smaller batches reduce frame envelope
+  // churn and keep render latency predictable under heavy scrollback append load.
+  private readonly maxSplitCommitsPerFrame: number = 8
 
   private _terminalWidth: number = 0
   private _terminalHeight: number = 0
   private _terminalIsSetup: boolean = false
 
+  private externalOutputQueue = new ExternalOutputQueue()
   private realStdoutWrite: (chunk: any, encoding?: any, callback?: any) => boolean
-  private captureCallback: () => void = () => {
-    if (this._splitHeight > 0) {
-      this.requestRender()
-    }
-  }
 
   private _useConsole: boolean = true
   private sigwinchHandler: () => void = (() => {
@@ -681,9 +868,16 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private dumpOutputCache(optionalMessage: string = ""): void {
     const cachedLogs = this.console.getCachedLogs()
-    const capturedOutput = capture.claimOutput()
+    const capturedConsoleOutput = capture.claimOutput()
+    const capturedExternalOutputCommits = this.externalOutputQueue.claim()
 
-    if (capturedOutput.length > 0 || cachedLogs.length > 0) {
+    let capturedExternalOutput = ""
+    for (const commit of capturedExternalOutputCommits) {
+      capturedExternalOutput += `[snapshot ${commit.snapshot.width}x${commit.snapshot.height}]\n`
+      commit.snapshot.destroy()
+    }
+
+    if (capturedConsoleOutput.length > 0 || capturedExternalOutput.length > 0 || cachedLogs.length > 0) {
       this.realStdoutWrite.call(this.stdout, optionalMessage)
     }
 
@@ -692,9 +886,14 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.realStdoutWrite.call(this.stdout, cachedLogs)
     }
 
-    if (capturedOutput.length > 0) {
-      this.realStdoutWrite.call(this.stdout, "\nCaptured output:\n")
-      this.realStdoutWrite.call(this.stdout, capturedOutput + "\n")
+    if (capturedConsoleOutput.length > 0) {
+      this.realStdoutWrite.call(this.stdout, "\nCaptured console output:\n")
+      this.realStdoutWrite.call(this.stdout, capturedConsoleOutput + "\n")
+    }
+
+    if (capturedExternalOutput.length > 0) {
+      this.realStdoutWrite.call(this.stdout, "\nCaptured external output:\n")
+      this.realStdoutWrite.call(this.stdout, capturedExternalOutput + "\n")
     }
 
     this.realStdoutWrite.call(this.stdout, ANSI.reset)
@@ -736,15 +935,22 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.lib = lib
     this._terminalWidth = stdout.columns ?? width
     this._terminalHeight = stdout.rows ?? height
-    this.width = width
-    this.height = height
     this._useThread = config.useThread === undefined ? false : config.useThread
     const { screenMode, footerHeight, externalOutputMode } = resolveModes(config)
+    this._externalOutputMode = externalOutputMode
+
+    const initialGeometry = calculateRenderGeometry(screenMode, this._terminalWidth, this._terminalHeight, footerHeight)
+
+    this.width = initialGeometry.renderWidth
+    this.height = initialGeometry.renderHeight
+    this._splitHeight = initialGeometry.effectiveFooterHeight
+    this.renderOffset = screenMode === "split-footer" ? 0 : initialGeometry.renderOffset
 
     this._footerHeight = footerHeight
-    this._screenMode = screenMode
 
     this.rendererPtr = rendererPtr
+    this.clearOnShutdown = config.clearOnShutdown ?? true
+    this.lib.setClearOnShutdown(this.rendererPtr, this.clearOnShutdown)
 
     const forwardEnvKeys = config.forwardEnvKeys ?? [...DEFAULT_FORWARDED_ENV_KEYS]
     for (const key of forwardEnvKeys) {
@@ -826,6 +1032,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
         privateCapabilityRepliesActive: false,
         pixelResolutionQueryActive: false,
         explicitWidthCprActive: false,
+        startupCursorCprActive: false,
       },
       clock: this.clock,
     })
@@ -836,7 +1043,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     })
     this.consoleMode = config.consoleMode ?? "console-overlay"
     this.applyScreenMode(screenMode, false, false)
-    this.externalOutputMode = externalOutputMode
+    this.stdout.write = externalOutputMode === "capture-stdout" ? this.interceptStdoutWrite : this.realStdoutWrite
     this._openConsoleOnError = config.openConsoleOnError ?? process.env.NODE_ENV !== "production"
     this._onDestroy = config.onDestroy
 
@@ -1184,8 +1391,35 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       throw new Error('externalOutputMode "capture-stdout" requires screenMode "split-footer"')
     }
 
+    const previousMode = this._externalOutputMode
+    if (previousMode === mode) {
+      return
+    }
+
+    if (previousMode === "capture-stdout" && mode === "passthrough" && this._splitHeight > 0) {
+      this.flushPendingSplitOutputBeforeTransition()
+    }
+
     this._externalOutputMode = mode
     this.stdout.write = mode === "capture-stdout" ? this.interceptStdoutWrite : this.realStdoutWrite
+
+    if (this._screenMode === "split-footer" && this._splitHeight > 0 && mode === "capture-stdout") {
+      this.clearPendingSplitFooterTransition()
+      this.resetSplitScrollback(this.getSplitCursorSeedRows())
+      return
+    }
+
+    if (
+      this._screenMode === "split-footer" &&
+      this._splitHeight > 0 &&
+      previousMode === "capture-stdout" &&
+      mode === "passthrough"
+    ) {
+      this.clearPendingSplitFooterTransition()
+      return
+    }
+
+    this.syncSplitFooterState()
   }
 
   public get liveRequestCount(): number {
@@ -1258,25 +1492,852 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.lib.setKittyKeyboardFlags(this.rendererPtr, flags)
   }
 
-  private interceptStdoutWrite = (chunk: any, encoding?: any, callback?: any): boolean => {
-    const text = chunk.toString()
-
-    capture.write("stdout", text)
-    if (this._splitHeight > 0) {
-      this.requestRender()
+  public createScrollbackSurface(options: ScrollbackSurfaceOptions = {}): ScrollbackSurface {
+    if (this._screenMode !== "split-footer" || this._externalOutputMode !== "capture-stdout") {
+      throw new Error(
+        'createScrollbackSurface requires screenMode "split-footer" and externalOutputMode "capture-stdout"',
+      )
     }
 
-    if (typeof callback === "function") {
-      process.nextTick(callback)
+    const renderer = this
+    const surfaceId = scrollbackSurfaceCounter++
+    const startOnNewLine = options.startOnNewLine ?? true
+    const firstLineOffset =
+      !startOnNewLine && renderer.splitTailColumn > 0 && renderer.splitTailColumn < renderer.width
+        ? renderer.splitTailColumn
+        : 0
+
+    const snapshotContext = new ScrollbackSnapshotRenderContext(renderer.width, 1, renderer.widthMethod)
+    let firstLineOffsetOwner: Renderable | null = null
+    const renderContext = Object.create(snapshotContext) as RenderContext
+    Object.defineProperty(renderContext, "claimFirstLineOffset", {
+      value: (renderable?: Renderable): number => {
+        if (firstLineOffsetOwner?.isDestroyed) {
+          firstLineOffsetOwner = null
+        }
+
+        if (firstLineOffsetOwner) {
+          return 0
+        }
+
+        firstLineOffsetOwner = renderable ?? null
+        return firstLineOffset
+      },
+      enumerable: true,
+      configurable: true,
+    })
+
+    const internalRoot = new RootRenderable(renderContext)
+    const publicRoot = new BoxRenderable(renderContext, {
+      id: `scrollback-surface-root-${surfaceId}`,
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width: renderer.width,
+      height: "auto",
+      border: false,
+      backgroundColor: "transparent",
+      shouldFill: false,
+      flexDirection: "column",
+    })
+    internalRoot.add(publicRoot)
+
+    let surfaceWidth = renderer.width
+    let surfaceHeight = 1
+    let surfaceWidthMethod = renderer.widthMethod
+    let surfaceDestroyed = false
+    let hasRendered = false
+    let nextCommitStartOnNewLine = startOnNewLine
+    let backingBuffer = OptimizedBuffer.create(surfaceWidth, surfaceHeight, surfaceWidthMethod, {
+      id: `scrollback-surface-buffer-${surfaceId}`,
+    })
+
+    const destroyListener = (): void => {
+      destroySurface()
+    }
+
+    const assertNotDestroyed = (): void => {
+      if (surfaceDestroyed) {
+        throw new Error("ScrollbackSurface is destroyed")
+      }
+    }
+
+    const assertRendered = (): void => {
+      if (!hasRendered) {
+        throw new Error("ScrollbackSurface.commitRows requires render() before commitRows()")
+      }
+    }
+
+    const assertGeometryStillCurrent = (): void => {
+      if (renderer.width !== surfaceWidth || renderer.widthMethod !== surfaceWidthMethod) {
+        throw new Error("ScrollbackSurface.commitRows requires render() after renderer geometry changes")
+      }
+    }
+
+    const assertRowRange = (startRow: number, endRowExclusive: number): void => {
+      if (!Number.isInteger(startRow) || !Number.isInteger(endRowExclusive)) {
+        throw new Error("ScrollbackSurface.commitRows requires finite integer row bounds")
+      }
+
+      if (startRow < 0) {
+        throw new Error("ScrollbackSurface.commitRows requires startRow >= 0")
+      }
+
+      if (endRowExclusive < startRow) {
+        throw new Error("ScrollbackSurface.commitRows requires endRowExclusive >= startRow")
+      }
+
+      if (endRowExclusive > surfaceHeight) {
+        throw new Error("ScrollbackSurface.commitRows row range exceeds rendered surface height")
+      }
+    }
+
+    const collectPendingCodeRenderables = (node: Renderable): CodeRenderable[] => {
+      const pending: CodeRenderable[] = []
+
+      if (node instanceof CodeRenderable && node.isHighlighting) {
+        pending.push(node)
+      }
+
+      for (const child of node.getChildren()) {
+        pending.push(...collectPendingCodeRenderables(child))
+      }
+
+      return pending
+    }
+
+    const waitForPendingHighlights = async (pending: CodeRenderable[], timeoutMs: number): Promise<void> => {
+      await new Promise<void>((resolve, reject) => {
+        let settled = false
+        const timeoutHandle = renderer.clock.setTimeout(() => {
+          if (settled) {
+            return
+          }
+
+          settled = true
+          reject(new Error("ScrollbackSurface.settle timed out waiting for CodeRenderable highlighting"))
+        }, timeoutMs)
+
+        Promise.all(pending.map((renderable) => renderable.highlightingDone)).then(
+          () => {
+            if (settled) {
+              return
+            }
+
+            settled = true
+            renderer.clock.clearTimeout(timeoutHandle)
+            resolve()
+          },
+          (error) => {
+            if (settled) {
+              return
+            }
+
+            settled = true
+            renderer.clock.clearTimeout(timeoutHandle)
+            reject(error)
+          },
+        )
+      })
+    }
+
+    const renderSurface = (): void => {
+      assertNotDestroyed()
+
+      const width = renderer.width
+      const widthMethod = renderer.widthMethod
+
+      snapshotContext.width = width
+      snapshotContext.widthMethod = widthMethod
+      publicRoot.width = width
+
+      const renderPass = (height: number): void => {
+        snapshotContext.height = height
+        internalRoot.resize(width, height)
+        backingBuffer.resize(width, height)
+        backingBuffer.clear(TRANSPARENT_RGBA)
+        snapshotContext.frameId += 1
+        internalRoot.render(backingBuffer, 0)
+      }
+
+      let targetHeight = Math.max(1, surfaceHeight)
+
+      if (surfaceWidthMethod !== widthMethod) {
+        backingBuffer.destroy()
+        backingBuffer = OptimizedBuffer.create(width, targetHeight, widthMethod, {
+          id: `scrollback-surface-buffer-${surfaceId}`,
+        })
+      } else {
+        backingBuffer.resize(width, targetHeight)
+      }
+
+      for (let pass = 0; pass < MAX_SCROLLBACK_SURFACE_HEIGHT_PASSES; pass += 1) {
+        renderPass(targetHeight)
+
+        const measuredHeight = Math.max(1, publicRoot.height)
+        if (measuredHeight === targetHeight) {
+          surfaceWidth = width
+          surfaceHeight = measuredHeight
+          surfaceWidthMethod = widthMethod
+          hasRendered = true
+          return
+        }
+
+        targetHeight = measuredHeight
+      }
+
+      renderPass(targetHeight)
+
+      surfaceWidth = width
+      surfaceHeight = targetHeight
+      surfaceWidthMethod = widthMethod
+      hasRendered = true
+    }
+
+    const settleSurface = async (timeoutMs: number = 2000): Promise<void> => {
+      assertNotDestroyed()
+
+      const startedAt = renderer.clock.now()
+      renderSurface()
+
+      while (true) {
+        assertNotDestroyed()
+
+        const pending = collectPendingCodeRenderables(publicRoot)
+        if (pending.length === 0) {
+          return
+        }
+
+        const remainingMs = timeoutMs - (renderer.clock.now() - startedAt)
+        if (remainingMs <= 0) {
+          throw new Error("ScrollbackSurface.settle timed out waiting for CodeRenderable highlighting")
+        }
+
+        await waitForPendingHighlights(pending, remainingMs)
+        assertNotDestroyed()
+        renderSurface()
+      }
+    }
+
+    const commitRows = (
+      startRow: number,
+      endRowExclusive: number,
+      commitOptions: ScrollbackSurfaceCommitOptions = {},
+    ): void => {
+      assertNotDestroyed()
+      assertRendered()
+      assertGeometryStillCurrent()
+      assertRowRange(startRow, endRowExclusive)
+
+      if (startRow === endRowExclusive) {
+        return
+      }
+
+      const rowCount = endRowExclusive - startRow
+      const commitBuffer = OptimizedBuffer.create(surfaceWidth, rowCount, surfaceWidthMethod, {
+        id: `scrollback-surface-commit-${surfaceId}`,
+      })
+
+      try {
+        commitBuffer.drawFrameBuffer(0, 0, backingBuffer, 0, startRow, surfaceWidth, rowCount)
+
+        renderer.enqueueRenderedScrollbackCommit({
+          snapshot: commitBuffer,
+          rowColumns: commitOptions.rowColumns,
+          startOnNewLine: nextCommitStartOnNewLine,
+          trailingNewline: commitOptions.trailingNewline ?? false,
+        })
+
+        nextCommitStartOnNewLine = false
+      } catch (error) {
+        commitBuffer.destroy()
+        throw error
+      }
+    }
+
+    const destroySurface = (): void => {
+      if (surfaceDestroyed) {
+        return
+      }
+
+      surfaceDestroyed = true
+      renderer.off(CliRenderEvents.DESTROY, destroyListener)
+
+      let destroyError: unknown = null
+
+      try {
+        internalRoot.destroyRecursively()
+      } catch (error) {
+        destroyError = error
+      }
+
+      try {
+        backingBuffer.destroy()
+      } catch (error) {
+        if (destroyError === null) {
+          destroyError = error
+        }
+      }
+
+      renderContext.removeAllListeners()
+      snapshotContext.removeAllListeners()
+
+      if (destroyError !== null) {
+        throw destroyError
+      }
+    }
+
+    renderer.on(CliRenderEvents.DESTROY, destroyListener)
+
+    return {
+      get renderContext(): RenderContext {
+        return renderContext
+      },
+      get root(): Renderable {
+        return publicRoot
+      },
+      get width(): number {
+        return surfaceWidth
+      },
+      get height(): number {
+        return surfaceHeight
+      },
+      get isDestroyed(): boolean {
+        return surfaceDestroyed
+      },
+      render: renderSurface,
+      settle: settleSurface,
+      commitRows,
+      destroy: destroySurface,
+    }
+  }
+
+  // writeToScrollback is a "render to scrollback commit" API, not a direct stdout
+  // write. The callback returns a renderable tree, we render that tree into an
+  // off-screen OptimizedBuffer, then enqueue the result as one ExternalOutputCommit.
+  //
+  // Why this shape exists:
+  // - It keeps app-authored scrollback output in the same FIFO queue as captured
+  //   stdout, so ordering is deterministic even when both sources interleave.
+  // - It lets the render loop batch multiple queued commits into one native frame,
+  //   which is the key mechanism that avoids repeated sync/cursor toggles (flicker).
+  // - It reuses the normal renderable pipeline (layout, styling, grapheme shaping),
+  //   so scrollback payloads match what users see in the live UI.
+  //
+  // startOnNewLine and trailingNewline preserve newline intent when one logical
+  // write spans multiple commits. startOnNewLine adds a newline before this commit
+  // if the previous commit ended mid-row. trailingNewline adds a newline after this
+  // commit's final row.
+  //
+  // Native split append uses these flags to avoid glued rows (missing newline), and
+  // double-advance gaps (extra newline), while still appending payload and repainting
+  // footer in the same frame.
+  //
+  // Side effects: throws if split-footer capture mode is not active, transfers
+  // snapshot buffer ownership to the queue on success, triggers async render,
+  // and invokes snapshot teardown when cleanup runs.
+  public writeToScrollback(write: ScrollbackWriter): void {
+    if (this._screenMode !== "split-footer" || this._externalOutputMode !== "capture-stdout") {
+      throw new Error('writeToScrollback requires screenMode "split-footer" and externalOutputMode "capture-stdout"')
+    }
+
+    const snapshotContext = new ScrollbackSnapshotRenderContext(this.width, this.height, this.widthMethod)
+    const snapshot = write({
+      width: this.width,
+      widthMethod: this.widthMethod,
+      tailColumn: this.splitTailColumn,
+      renderContext: snapshotContext,
+    })
+
+    if (!snapshot || !snapshot.root) {
+      throw new Error("writeToScrollback must return a snapshot root renderable")
+    }
+
+    let renderFailed = false
+    let snapshotRoot: RootRenderable | null = null
+    let snapshotBuffer: OptimizedBuffer | null = null
+
+    try {
+      const rootRenderable = snapshot.root
+      const snapshotWidth = this.getSnapshotWidth(snapshot.width, rootRenderable.width)
+      const snapshotHeight = this.getSnapshotHeight(snapshot.height, rootRenderable.height)
+
+      snapshotContext.width = snapshotWidth
+      snapshotContext.height = snapshotHeight
+      snapshotContext.widthMethod = this.widthMethod
+
+      snapshotRoot = new RootRenderable(snapshotContext)
+      snapshotBuffer = OptimizedBuffer.create(snapshotWidth, snapshotHeight, this.widthMethod, {
+        id: "scrollback-snapshot-commit",
+      })
+
+      // Render through normal renderables so split scrollback output uses the same
+      // text shaping/styling pipeline as the rest of the renderer.
+      snapshotRoot.add(rootRenderable)
+      snapshotRoot.render(snapshotBuffer, 0)
+      this.enqueueRenderedScrollbackCommit({
+        snapshot: snapshotBuffer,
+        rowColumns: snapshot.rowColumns,
+        startOnNewLine: snapshot.startOnNewLine,
+        trailingNewline: snapshot.trailingNewline,
+      })
+    } catch (error) {
+      renderFailed = true
+      snapshotBuffer?.destroy()
+      throw error
+    } finally {
+      let cleanupError: unknown | null = null
+
+      try {
+        if (snapshotRoot) {
+          snapshotRoot.destroyRecursively()
+        } else {
+          snapshot.root.destroyRecursively()
+        }
+      } catch (error) {
+        cleanupError = error
+      }
+
+      try {
+        snapshot.teardown?.()
+      } catch (error) {
+        if (cleanupError === null) {
+          cleanupError = error
+        }
+      }
+
+      if (!renderFailed && cleanupError) {
+        throw cleanupError
+      }
+    }
+  }
+
+  private getSnapshotWidth(value: number | undefined, fallback: number): number {
+    const rawValue = value ?? fallback
+
+    if (!Number.isFinite(rawValue)) {
+      throw new Error("writeToScrollback produced a non-finite width")
+    }
+
+    return Math.min(Math.max(Math.trunc(rawValue), 1), Math.max(this.width, 1))
+  }
+
+  private getSnapshotHeight(value: number | undefined, fallback: number): number {
+    const rawValue = value ?? fallback
+
+    if (!Number.isFinite(rawValue)) {
+      throw new Error("writeToScrollback produced a non-finite height")
+    }
+
+    return Math.max(Math.trunc(rawValue), 1)
+  }
+
+  private getSnapshotRowWidths(snapshot: OptimizedBuffer, rowColumns: number): number[] {
+    const widths: number[] = []
+    const limit = Math.min(Math.max(Math.trunc(rowColumns), 0), snapshot.width)
+    const chars = snapshot.buffers.char
+
+    for (let y = 0; y < snapshot.height; y += 1) {
+      let x = limit
+
+      while (x > 0) {
+        const cp = chars[y * snapshot.width + x - 1]
+        if (cp === 0 || (cp & CHAR_FLAG_MASK) === CHAR_FLAG_CONTINUATION) {
+          x -= 1
+          continue
+        }
+
+        break
+      }
+
+      widths.push(x)
+    }
+
+    return widths
+  }
+
+  private publishSplitTailColumns(columns: number): void {
+    if (columns <= 0) {
+      return
+    }
+
+    const width = Math.max(this.width, 1)
+    let tail = this.splitTailColumn
+    let remaining = columns
+
+    while (remaining > 0) {
+      if (tail >= width) {
+        tail = 0
+      }
+
+      const step = Math.min(remaining, width - tail)
+      tail += step
+      remaining -= step
+
+      if (remaining > 0 && tail >= width) {
+        tail = 0
+      }
+    }
+
+    this.splitTailColumn = tail
+  }
+
+  private recordSplitCommit(commit: ExternalOutputCommit): void {
+    if (commit.startOnNewLine && this.splitTailColumn > 0) {
+      this.splitTailColumn = 0
+    }
+
+    const rowWidths = this.getSnapshotRowWidths(commit.snapshot, commit.rowColumns)
+    for (const [index, rowWidth] of rowWidths.entries()) {
+      this.publishSplitTailColumns(rowWidth)
+      if (index < rowWidths.length - 1 || commit.trailingNewline) {
+        this.splitTailColumn = 0
+      }
+    }
+  }
+
+  private enqueueRenderedScrollbackCommit(options: {
+    snapshot: OptimizedBuffer
+    rowColumns?: number
+    startOnNewLine?: boolean
+    trailingNewline?: boolean
+  }): void {
+    if (this._screenMode !== "split-footer" || this._externalOutputMode !== "capture-stdout") {
+      throw new Error('scrollback commit requires screenMode "split-footer" and externalOutputMode "capture-stdout"')
+    }
+
+    const rowColumns = Math.min(
+      Math.max(Math.trunc(options.rowColumns ?? options.snapshot.width), 0),
+      options.snapshot.width,
+    )
+
+    this.enqueueSplitCommit({
+      snapshot: options.snapshot,
+      rowColumns,
+      startOnNewLine: options.startOnNewLine ?? true,
+      trailingNewline: options.trailingNewline ?? true,
+    })
+
+    this.requestRender()
+  }
+
+  private enqueueSplitCommit(commit: ExternalOutputCommit): void {
+    this.recordSplitCommit(commit)
+    this.externalOutputQueue.writeSnapshot(commit)
+  }
+
+  private createStdoutSnapshotCommit(line: string, trailingNewline: boolean): ExternalOutputCommit {
+    // Convert captured stdout into the same commit shape used by writeToScrollback.
+    // One commit format keeps split append behavior consistent across both sources.
+    const snapshotContext = new ScrollbackSnapshotRenderContext(this.width, 1, this.widthMethod)
+    const maxWidth = Math.max(1, this.width)
+    const lineCells = [...line]
+    const rowColumns = Math.min(lineCells.length, maxWidth)
+    const renderedLine = lineCells.slice(0, maxWidth).join("")
+    const snapshotRoot = new RootRenderable(snapshotContext)
+    const snapshotRenderable = new TextRenderable(snapshotContext, {
+      id: "captured-stdout-snapshot",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width: Math.max(1, rowColumns),
+      height: 1,
+      content: renderedLine,
+    })
+    const snapshotBuffer = OptimizedBuffer.create(Math.max(1, rowColumns), 1, this.widthMethod, {
+      id: "captured-stdout-snapshot",
+    })
+
+    try {
+      snapshotRoot.add(snapshotRenderable)
+      snapshotRoot.render(snapshotBuffer, 0)
+      return {
+        snapshot: snapshotBuffer,
+        rowColumns,
+        startOnNewLine: false,
+        trailingNewline,
+      }
+    } catch (error) {
+      snapshotBuffer.destroy()
+      throw error
+    } finally {
+      snapshotRoot.destroyRecursively()
+    }
+  }
+
+  private splitStdoutRows(text: string): Array<{ line: string; trailingNewline: boolean }> {
+    // Captured stdout arrives as an arbitrary byte stream, but split append commits
+    // are row-based (line text + whether that row ended with '\n'). We normalize
+    // here because native split append expects already-decoded row intent, not raw
+    // control characters.
+    //
+    // '\r' must restart the in-progress row so in-place status updates (progress
+    // bars/spinners) do not accumulate stale prefixes in scrollback. '\n' commits
+    // the row and marks newline intent for the final chunk of that logical row.
+    const rows: Array<{ line: string; trailingNewline: boolean }> = []
+    let current = ""
+
+    for (const char of text) {
+      if (char === "\r") {
+        current = ""
+        continue
+      }
+
+      if (char === "\n") {
+        rows.push({ line: current, trailingNewline: true })
+        current = ""
+        continue
+      }
+
+      current += char
+    }
+
+    if (current.length > 0) {
+      rows.push({ line: current, trailingNewline: false })
+    }
+
+    return rows
+  }
+
+  private createStdoutSnapshotCommits(text: string): ExternalOutputCommit[] {
+    if (text.length === 0) {
+      return []
+    }
+
+    // Chunk captured stdout into width-bounded row commits so each commit is a
+    // small, deterministic append step. This keeps bursty output smooth while
+    // preserving newline ownership on the final chunk of each logical row.
+    const commits: ExternalOutputCommit[] = []
+    // Split commits are row-oriented snapshots. We chunk by renderer width so each
+    // commit maps to a single logical terminal row append operation.
+    const chunkWidth = Math.max(1, this.width)
+    for (const row of this.splitStdoutRows(text)) {
+      const rowCells = [...row.line]
+      if (rowCells.length === 0) {
+        // Preserve empty-line writes: newline-only chunks still need a commit so
+        // split scrollback state advances correctly in native code.
+        commits.push(this.createStdoutSnapshotCommit("", row.trailingNewline))
+        continue
+      }
+
+      let offset = 0
+      while (offset < rowCells.length) {
+        const chunk = rowCells.slice(offset, offset + chunkWidth).join("")
+        offset += chunkWidth
+        const isLastChunk = offset >= rowCells.length
+        // Only the final wrapped chunk carries newline intent.
+        commits.push(this.createStdoutSnapshotCommit(chunk, isLastChunk ? row.trailingNewline : false))
+      }
+    }
+
+    return commits
+  }
+
+  private flushPendingSplitCommits(forceFooterRepaint: boolean = false): void {
+    // Drain only a bounded prefix so one JS render pass maps to one native frame.
+    // Remaining commits are intentionally left queued and rendered on subsequent
+    // ticks to avoid giant multi-thousand-cell frames that can flicker.
+    const commits = this.externalOutputQueue.claim(this.maxSplitCommitsPerFrame)
+    let hasCommittedOutput = false
+    const lastCommitIndex = commits.length - 1
+
+    for (const [index, commit] of commits.entries()) {
+      // Force repaint only on the last commit in a frame. Repainting after every
+      // chunk negates batching and reintroduces duplicate clear/move traffic.
+      const forceCommit = forceFooterRepaint && index === lastCommitIndex
+      // beginFrame/finalizeFrame tell native code whether this commit opens or
+      // closes the shared frame envelope. Intermediate commits append payload only.
+      const beginFrame = index === 0
+      const finalizeFrame = index === lastCommitIndex
+
+      try {
+        // Keep split append policy in native code so every producer (captured stdout
+        // and writeToScrollback) shares the same cursor/scrollback invariants.
+        this.renderOffset = this.lib.commitSplitFooterSnapshot(
+          this.rendererPtr,
+          commit.snapshot,
+          commit.rowColumns,
+          commit.startOnNewLine,
+          commit.trailingNewline,
+          this.getSplitPinnedRenderOffset(),
+          forceCommit,
+          beginFrame,
+          finalizeFrame,
+        )
+        hasCommittedOutput = true
+      } finally {
+        commit.snapshot.destroy()
+      }
+    }
+
+    if (!hasCommittedOutput) {
+      this.renderOffset = this.lib.repaintSplitFooter(
+        this.rendererPtr,
+        this.getSplitPinnedRenderOffset(),
+        forceFooterRepaint,
+      )
+    }
+
+    this.pendingSplitFooterTransition = null
+
+    if (this.externalOutputQueue.size > 0) {
+      // Preserve FIFO ordering without doing unbounded work in one tick.
+      // This keeps sustained stdout bursts smooth instead of blocking on one frame.
+      this.requestRender()
+    }
+  }
+
+  private interceptStdoutWrite = (chunk: any, encoding?: any, callback?: any): boolean => {
+    const resolvedCallback = typeof encoding === "function" ? encoding : callback
+    const resolvedEncoding = typeof encoding === "string" ? encoding : undefined
+    const text = typeof chunk === "string" ? chunk : (chunk?.toString(resolvedEncoding) ?? "")
+
+    if (this._externalOutputMode === "capture-stdout" && this._screenMode === "split-footer" && this._splitHeight > 0) {
+      // Capture mode intentionally diverts stdout into split commit snapshots
+      // instead of writing directly to process stdout. Native flushing will append
+      // and repaint in one controlled frame, which is what avoids footer flicker.
+      const commits = this.createStdoutSnapshotCommits(text)
+      for (const commit of commits) {
+        this.enqueueSplitCommit(commit)
+      }
+
+      if (commits.length > 0) {
+        // Defer actual terminal writes to the render loop so commits can be batched.
+        this.requestRender()
+      }
+    }
+
+    if (typeof resolvedCallback === "function") {
+      process.nextTick(resolvedCallback)
     }
 
     return true
   }
 
+  private getSplitPinnedRenderOffset(): number {
+    return this._screenMode === "split-footer" ? Math.max(this._terminalHeight - this._splitHeight, 0) : 0
+  }
+
+  private getSplitCursorSeedRows(): number {
+    const cursorState = this.lib.getCursorState(this.rendererPtr)
+    const cursorRow = Number.isFinite(cursorState.y) ? Math.max(Math.trunc(cursorState.y), 1) : 1
+    return Math.min(cursorRow, Math.max(this._terminalHeight, 1))
+  }
+
+  private flushPendingSplitOutputBeforeTransition(forceFooterRepaint: boolean = false): void {
+    if (
+      this._screenMode !== "split-footer" ||
+      this._splitHeight <= 0 ||
+      this._externalOutputMode !== "capture-stdout"
+    ) {
+      return
+    }
+
+    if (this.externalOutputQueue.size === 0 && !forceFooterRepaint) {
+      return
+    }
+
+    this.flushPendingSplitCommits(forceFooterRepaint)
+  }
+
+  private resetSplitScrollback(seedRows: number = 0): void {
+    this.splitTailColumn = 0
+    this.renderOffset = this.lib.resetSplitScrollback(this.rendererPtr, seedRows, this.getSplitPinnedRenderOffset())
+  }
+
+  private syncSplitScrollback(): void {
+    this.renderOffset = this.lib.syncSplitScrollback(this.rendererPtr, this.getSplitPinnedRenderOffset())
+  }
+
+  private clearPendingSplitFooterTransition(): void {
+    if (this.pendingSplitFooterTransition === null) {
+      return
+    }
+
+    this.pendingSplitFooterTransition = null
+    this.lib.clearPendingSplitFooterTransition(this.rendererPtr)
+  }
+
+  private setPendingSplitFooterTransition(transition: PendingSplitFooterTransition): void {
+    this.pendingSplitFooterTransition = transition
+    this.lib.setPendingSplitFooterTransition(
+      this.rendererPtr,
+      transition.mode === "viewport-scroll" ? 1 : 2,
+      transition.sourceTopLine,
+      transition.sourceHeight,
+      transition.targetTopLine,
+      transition.targetHeight,
+    )
+  }
+
+  private syncSplitFooterState(): void {
+    const splitActive = this._screenMode === "split-footer" && this._splitHeight > 0
+
+    if (!splitActive) {
+      this.clearPendingSplitFooterTransition()
+      this.splitTailColumn = 0
+      this.lib.resetSplitScrollback(this.rendererPtr, 0, 0)
+      this.renderOffset = 0
+      this.lib.setRenderOffset(this.rendererPtr, this.renderOffset)
+      return
+    }
+
+    if (this._externalOutputMode === "capture-stdout") {
+      this.syncSplitScrollback()
+    } else {
+      this.clearPendingSplitFooterTransition()
+      this.splitTailColumn = 0
+      this.lib.resetSplitScrollback(this.rendererPtr, 0, 0)
+      this.renderOffset = this.getSplitPinnedRenderOffset()
+      this.lib.setRenderOffset(this.rendererPtr, this.renderOffset)
+    }
+  }
+
+  private clearStaleSplitSurfaceRows(
+    previousTopLine: number,
+    previousHeight: number,
+    nextTopLine: number,
+    nextHeight: number,
+  ): void {
+    if (!this._terminalIsSetup || previousHeight <= 0 || this._terminalHeight <= 0) {
+      return
+    }
+
+    const terminalBottom = this._terminalHeight
+    const previousStart = Math.max(1, previousTopLine)
+    const previousEnd = Math.min(terminalBottom, previousTopLine + previousHeight - 1)
+
+    if (previousEnd < previousStart) {
+      return
+    }
+
+    const nextStart = Math.max(1, nextTopLine)
+    const nextEnd = Math.min(terminalBottom, nextTopLine + Math.max(nextHeight, 0) - 1)
+
+    let clear = ""
+    for (let line = previousStart; line <= previousEnd; line += 1) {
+      if (line >= nextStart && line <= nextEnd) {
+        continue
+      }
+
+      clear += `${ANSI.moveCursor(line, 1)}\x1b[2K`
+    }
+
+    if (clear.length > 0) {
+      this.writeOut(clear)
+    }
+  }
+
   private applyScreenMode(screenMode: ScreenMode, emitResize: boolean = true, requestRender: boolean = true): void {
     const prevScreenMode = this._screenMode
     const prevSplitHeight = this._splitHeight
-    const nextSplitHeight = screenMode === "split-footer" ? this._footerHeight : 0
+    const nextGeometry = calculateRenderGeometry(
+      screenMode,
+      this._terminalWidth,
+      this._terminalHeight,
+      this._footerHeight,
+    )
+    const nextSplitHeight = nextGeometry.effectiveFooterHeight
 
     if (prevScreenMode === screenMode && prevSplitHeight === nextSplitHeight) {
       return
@@ -1287,11 +2348,41 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     const terminalScreenModeChanged = this._terminalIsSetup && prevUseAlternateScreen !== nextUseAlternateScreen
     const leavingSplitFooter = prevSplitHeight > 0 && nextSplitHeight === 0
 
-    if (this._terminalIsSetup && leavingSplitFooter) {
-      this.flushStdoutCache(this._terminalHeight, true)
+    if (this._terminalIsSetup && prevSplitHeight > 0) {
+      this.flushPendingSplitOutputBeforeTransition()
     }
 
-    if (this._terminalIsSetup && !terminalScreenModeChanged) {
+    const previousSurfaceTopLine = this.renderOffset + 1
+    const previousPinnedRenderOffset = Math.max(this._terminalHeight - prevSplitHeight, 0)
+    const splitWasSettled = prevSplitHeight === 0 || this.renderOffset >= previousPinnedRenderOffset
+    const shouldUseViewportScrollTransitions = this._externalOutputMode !== "capture-stdout" || splitWasSettled
+    const shouldDeferSplitFooterResizeTransition =
+      this._terminalIsSetup &&
+      prevScreenMode === "split-footer" &&
+      screenMode === "split-footer" &&
+      this._externalOutputMode === "capture-stdout" &&
+      prevSplitHeight > 0 &&
+      nextSplitHeight > 0 &&
+      !terminalScreenModeChanged
+    const splitStartupSeedBlocksFirstNativeFrame =
+      this.pendingSplitStartupCursorSeed && this.splitStartupSeedTimeoutId !== null
+    const splitTransitionSourceTopLine = this.pendingSplitFooterTransition?.sourceTopLine ?? previousSurfaceTopLine
+    const splitTransitionSourceHeight = this.pendingSplitFooterTransition?.sourceHeight ?? prevSplitHeight
+    const splitTransitionMode =
+      this.pendingSplitFooterTransition?.mode ?? (splitWasSettled ? "viewport-scroll" : "clear-stale-rows")
+
+    if (this._terminalIsSetup && leavingSplitFooter) {
+      this.clearPendingSplitFooterTransition()
+      this.renderOffset = 0
+      this.lib.setRenderOffset(this.rendererPtr, 0)
+    }
+
+    if (
+      this._terminalIsSetup &&
+      !terminalScreenModeChanged &&
+      shouldUseViewportScrollTransitions &&
+      !shouldDeferSplitFooterResizeTransition
+    ) {
       if (prevSplitHeight === 0 && nextSplitHeight > 0) {
         const freedLines = this._terminalHeight - nextSplitHeight
         const scrollDown = ANSI.scrollDown(freedLines)
@@ -1307,20 +2398,43 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       }
     }
 
-    if (prevSplitHeight === 0 && nextSplitHeight > 0) {
-      capture.on("write", this.captureCallback)
-    } else if (prevSplitHeight > 0 && nextSplitHeight === 0) {
-      capture.off("write", this.captureCallback)
-    }
-
     this._screenMode = screenMode
     this._splitHeight = nextSplitHeight
-    this.renderOffset = nextSplitHeight > 0 ? this._terminalHeight - nextSplitHeight : 0
-    this.width = this._terminalWidth
-    this.height = nextSplitHeight > 0 ? nextSplitHeight : this._terminalHeight
+    this.width = nextGeometry.renderWidth
+    this.height = nextGeometry.renderHeight
 
-    this.lib.setRenderOffset(this.rendererPtr, this.renderOffset)
     this.lib.resizeRenderer(this.rendererPtr, this.width, this.height)
+
+    if (this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout") {
+      if (prevScreenMode !== "split-footer") {
+        this.resetSplitScrollback(this.getSplitCursorSeedRows())
+      } else {
+        this.syncSplitScrollback()
+      }
+
+      if (shouldDeferSplitFooterResizeTransition) {
+        if (splitStartupSeedBlocksFirstNativeFrame) {
+          this.clearPendingSplitFooterTransition()
+        } else {
+          this.setPendingSplitFooterTransition({
+            mode: splitTransitionMode,
+            sourceTopLine: splitTransitionSourceTopLine,
+            sourceHeight: splitTransitionSourceHeight,
+            targetTopLine: this.renderOffset + 1,
+            targetHeight: nextSplitHeight,
+          })
+        }
+        this.forceFullRepaintRequested = true
+      } else if (!shouldUseViewportScrollTransitions && prevSplitHeight > 0 && nextSplitHeight > 0) {
+        this.clearPendingSplitFooterTransition()
+        this.clearStaleSplitSurfaceRows(previousSurfaceTopLine, prevSplitHeight, this.renderOffset + 1, nextSplitHeight)
+      } else {
+        this.clearPendingSplitFooterTransition()
+      }
+    } else {
+      this.syncSplitFooterState()
+    }
+
     this.nextRenderBuffer = this.lib.getNextBuffer(this.rendererPtr)
     this.currentRenderBuffer = this.lib.getCurrentBuffer(this.rendererPtr)
 
@@ -1347,14 +2461,19 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   // TODO: Move this to native
   private flushStdoutCache(space: number, force: boolean = false): boolean {
-    if (capture.size === 0 && !force) return false
+    if (this.externalOutputQueue.size === 0 && !force) return false
 
-    const output = capture.claimOutput()
+    const outputCommits = this.externalOutputQueue.claim()
+    let output = ""
+    for (const commit of outputCommits) {
+      output += `[snapshot ${commit.snapshot.width}x${commit.snapshot.height}]\n`
+      commit.snapshot.destroy()
+    }
 
-    const rendererStartLine = this._terminalHeight - this._splitHeight
+    const rendererStartLine = this.renderOffset + 1
     const flush = ANSI.moveCursorAndClear(rendererStartLine, 1)
 
-    const outputLine = this._terminalHeight - this._splitHeight
+    const outputLine = this.renderOffset + 1
     const move = ANSI.moveCursor(outputLine, 1)
 
     let clear = ""
@@ -1410,9 +2529,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     if (this._terminalIsSetup) return
     this._terminalIsSetup = true
 
+    const startupCursorCprActive = this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout"
     this.updateStdinParserProtocolContext({
       privateCapabilityRepliesActive: true,
       explicitWidthCprActive: true,
+      startupCursorCprActive,
     })
     this.lib.setupTerminal(this.rendererPtr, this._screenMode === "alternate-screen")
     this._capabilities = this.lib.getTerminalCapabilities(this.rendererPtr)
@@ -1428,11 +2549,23 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this.capabilityTimeoutId = this.clock.setTimeout(() => {
       this.capabilityTimeoutId = null
+      this.pendingSplitStartupCursorSeed = false
+
+      if (this.splitStartupSeedTimeoutId !== null) {
+        this.clock.clearTimeout(this.splitStartupSeedTimeoutId)
+        this.splitStartupSeedTimeoutId = null
+      }
+
+      if (this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout") {
+        this.requestRender()
+      }
+
       this.removeInputHandler(this.capabilityHandler)
       this.updateStdinParserProtocolContext(
         {
           privateCapabilityRepliesActive: false,
           explicitWidthCprActive: false,
+          startupCursorCprActive: false,
         },
         true,
       )
@@ -1440,6 +2573,28 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     if (this._useMouse) {
       this.enableMouse()
+    }
+
+    if (this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout") {
+      this.pendingSplitStartupCursorSeed = true
+
+      if (this.splitStartupSeedTimeoutId !== null) {
+        this.clock.clearTimeout(this.splitStartupSeedTimeoutId)
+      }
+
+      this.splitStartupSeedTimeoutId = this.clock.setTimeout(() => {
+        this.splitStartupSeedTimeoutId = null
+
+        if (!this.pendingSplitStartupCursorSeed) {
+          return
+        }
+
+        this.updateStdinParserProtocolContext({ startupCursorCprActive: false })
+
+        if (this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout") {
+          this.requestRender()
+        }
+      }, 120)
     }
 
     this.queryPixelResolution()
@@ -1482,14 +2637,48 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
   }
 
-  private capabilityHandler: (sequence: string) => boolean = ((sequence: string) => {
-    if (isCapabilityResponse(sequence)) {
-      this.lib.processCapabilityResponse(this.rendererPtr, sequence)
-      this._capabilities = this.lib.getTerminalCapabilities(this.rendererPtr)
-      this.emit(CliRenderEvents.CAPABILITIES, this._capabilities)
-      return true
+  private processCapabilitySequence(sequence: string, hasCursorReport: boolean): boolean {
+    const hasStandardCapabilitySignature = isCapabilityResponse(sequence)
+    const shouldProcessAsCapability =
+      hasStandardCapabilitySignature || (hasCursorReport && this.capabilityTimeoutId !== null)
+
+    if (!shouldProcessAsCapability) {
+      return false
     }
-    return false
+
+    this.lib.processCapabilityResponse(this.rendererPtr, sequence)
+    this._capabilities = this.lib.getTerminalCapabilities(this.rendererPtr)
+    this.emit(CliRenderEvents.CAPABILITIES, this._capabilities)
+
+    const hadPendingSplitStartupCursorSeed = this.pendingSplitStartupCursorSeed
+
+    if (
+      hadPendingSplitStartupCursorSeed &&
+      hasCursorReport &&
+      this._screenMode === "split-footer" &&
+      this._externalOutputMode === "capture-stdout"
+    ) {
+      this.resetSplitScrollback(this.getSplitCursorSeedRows())
+      this.clearPendingSplitFooterTransition()
+      this.pendingSplitStartupCursorSeed = false
+      this.updateStdinParserProtocolContext({ startupCursorCprActive: false })
+
+      if (this.splitStartupSeedTimeoutId !== null) {
+        this.clock.clearTimeout(this.splitStartupSeedTimeoutId)
+        this.splitStartupSeedTimeoutId = null
+      }
+
+      this.requestRender()
+    }
+
+    const consumeStartupCursorReport =
+      hadPendingSplitStartupCursorSeed && hasCursorReport && this.splitStartupSeedTimeoutId !== null
+
+    return hasStandardCapabilitySignature || consumeStartupCursorReport
+  }
+
+  private capabilityHandler: (sequence: string) => boolean = ((sequence: string) => {
+    return this.processCapabilitySequence(sequence, false)
   }).bind(this)
 
   private focusHandler: (sequence: string) => boolean = ((sequence: string) => {
@@ -1626,6 +2815,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
           for (const subscriber of this.oscSubscribers) {
             subscriber(event.sequence)
           }
+        }
+
+        if (event.protocol === "cpr" && this.processCapabilitySequence(event.sequence, true)) {
+          return
         }
 
         this.dispatchSequenceHandlers(event.sequence)
@@ -2002,7 +3195,21 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private processResize(width: number, height: number): void {
     if (width === this._terminalWidth && height === this._terminalHeight) return
 
+    if (this._terminalIsSetup && this._controlState !== RendererControlState.EXPLICIT_SUSPENDED) {
+      this.flushPendingSplitOutputBeforeTransition()
+    }
+
+    const pendingSplitFooterTransition = this.pendingSplitFooterTransition
+    const previousGeometry = calculateRenderGeometry(
+      this._screenMode,
+      this._terminalWidth,
+      this._terminalHeight,
+      this._footerHeight,
+    )
     const prevWidth = this._terminalWidth
+    const previousTerminalHeight = this._terminalHeight
+    const visiblePreviousSplitHeight =
+      pendingSplitFooterTransition?.sourceHeight ?? previousGeometry.effectiveFooterHeight
 
     this._terminalWidth = width
     this._terminalHeight = height
@@ -2011,24 +3218,52 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.setCapturedRenderable(undefined)
     this.stdinParser?.resetMouseState()
 
-    if (this._splitHeight > 0) {
-      // TODO: Handle resizing split mode properly
-      if (width < prevWidth) {
-        const start = this._terminalHeight - this._splitHeight * 2
-        const flush = ANSI.moveCursorAndClear(start, 1)
+    const nextGeometry = calculateRenderGeometry(
+      this._screenMode,
+      this._terminalWidth,
+      this._terminalHeight,
+      this._footerHeight,
+    )
+    const splitFooterActive = this._screenMode === "split-footer"
+
+    if (splitFooterActive) {
+      // Width shrink historically needs a broader scrub band, but if resize interrupts
+      // a deferred footer transition we also need to clear from that visible source surface.
+      let clearStart: number | null = null
+
+      if (width < prevWidth && visiblePreviousSplitHeight > 0) {
+        clearStart = Math.max(previousTerminalHeight - visiblePreviousSplitHeight * 2, 1)
+      }
+
+      if (pendingSplitFooterTransition !== null) {
+        clearStart =
+          clearStart === null
+            ? pendingSplitFooterTransition.sourceTopLine
+            : Math.min(clearStart, pendingSplitFooterTransition.sourceTopLine)
+      }
+
+      if (clearStart !== null) {
+        const flush = ANSI.moveCursorAndClear(clearStart, 1)
         this.writeOut(flush)
       }
-      this.renderOffset = height - this._splitHeight
-      this.width = width
-      this.height = this._splitHeight
+
       this.currentRenderBuffer.clear(this.backgroundColor)
-      this.lib.setRenderOffset(this.rendererPtr, this.renderOffset)
-    } else {
-      this.width = width
-      this.height = height
     }
 
+    this.clearPendingSplitFooterTransition()
+
+    this._splitHeight = nextGeometry.effectiveFooterHeight
+    this.width = nextGeometry.renderWidth
+    this.height = nextGeometry.renderHeight
+
     this.lib.resizeRenderer(this.rendererPtr, this.width, this.height)
+
+    if (this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout") {
+      this.syncSplitScrollback()
+    } else {
+      this.syncSplitFooterState()
+    }
+
     this.nextRenderBuffer = this.lib.getNextBuffer(this.rendererPtr)
     this.currentRenderBuffer = this.lib.getCurrentBuffer(this.rendererPtr)
     this._console.resize(this.width, this.height)
@@ -2224,6 +3459,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this._controlState = RendererControlState.EXPLICIT_SUSPENDED
     this.internalPause()
 
+    if (this._terminalIsSetup) {
+      this.flushPendingSplitOutputBeforeTransition(true)
+    }
+
     this._suspendedMouseEnabled = this._useMouse
 
     this.disableMouse()
@@ -2233,9 +3472,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       privateCapabilityRepliesActive: false,
       pixelResolutionQueryActive: false,
       explicitWidthCprActive: false,
+      startupCursorCprActive: false,
     })
     this.stdinParser?.reset()
     this.stdin.removeListener("data", this.stdinListener)
+
     this.lib.suspendRenderer(this.rendererPtr)
 
     if (this.stdin.setRawMode) {
@@ -2260,6 +3501,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.addExitListeners()
 
     this.lib.resumeRenderer(this.rendererPtr)
+    if (this._screenMode === "split-footer" && this._splitHeight > 0) {
+      this.syncSplitFooterState()
+    }
 
     if (this._suspendedMouseEnabled) {
       this.enableMouse()
@@ -2341,7 +3585,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     process.removeListener("unhandledRejection", this.handleError)
     process.removeListener("warning", this.warningHandler)
     process.removeListener("beforeExit", this.exitHandler)
-    capture.removeListener("write", this.captureCallback)
     this.removeExitListeners()
 
     if (this.resizeTimeoutId !== null) {
@@ -2352,6 +3595,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     if (this.capabilityTimeoutId !== null) {
       this.clock.clearTimeout(this.capabilityTimeoutId)
       this.capabilityTimeoutId = null
+    }
+
+    if (this.splitStartupSeedTimeoutId !== null) {
+      this.clock.clearTimeout(this.splitStartupSeedTimeoutId)
+      this.splitStartupSeedTimeoutId = null
     }
 
     if (this.memorySnapshotTimer) {
@@ -2371,6 +3619,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
         privateCapabilityRepliesActive: false,
         pixelResolutionQueryActive: false,
         explicitWidthCprActive: false,
+        startupCursorCprActive: false,
       },
       true,
     )
@@ -2422,6 +3671,22 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.stdinParser = null
     this.oscSubscribers.clear()
     this._console.destroy()
+
+    if (
+      this._splitHeight > 0 &&
+      this._terminalIsSetup &&
+      this._controlState !== RendererControlState.EXPLICIT_SUSPENDED
+    ) {
+      this.flushPendingSplitOutputBeforeTransition(true)
+      this.renderOffset = 0
+      if (this.clearOnShutdown) {
+        this.lib.setRenderOffset(this.rendererPtr, 0)
+      }
+    }
+
+    this._externalOutputMode = "passthrough"
+    this.stdout.write = this.realStdoutWrite
+    this.externalOutputQueue.clear()
 
     this.lib.destroyRenderer(this.rendererPtr)
     rendererTracker.removeRenderer(this)
@@ -2564,15 +3829,31 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       throw new Error("Rendering called concurrently")
     }
 
-    let force = false
-    if (this._splitHeight > 0) {
-      // TODO: Flickering could maybe be even more reduced by moving the flush to the native layer,
-      // to output the flush with the buffered writer, after the render is done.
-      force = this.flushStdoutCache(this._splitHeight)
+    this.renderingNative = true
+
+    if (
+      this.pendingSplitStartupCursorSeed &&
+      this.splitStartupSeedTimeoutId !== null &&
+      this._splitHeight > 0 &&
+      this._externalOutputMode === "capture-stdout"
+    ) {
+      this.renderingNative = false
+      return
     }
 
-    this.renderingNative = true
-    this.lib.render(this.rendererPtr, force)
+    if (this._splitHeight > 0 && this._externalOutputMode === "capture-stdout") {
+      // forceFullRepaintRequested is a one-shot latch used when mode/geometry
+      // transitions need a complete footer refresh. Consume it once so steady-state
+      // capture path keeps using diff-based repainting.
+      const forceSplitRepaint = this.forceFullRepaintRequested
+      this.forceFullRepaintRequested = false
+      this.flushPendingSplitCommits(forceSplitRepaint)
+      this.pendingSplitFooterTransition = null
+    } else {
+      this.forceFullRepaintRequested = false
+      this.pendingSplitFooterTransition = null
+      this.lib.render(this.rendererPtr, false)
+    }
     // this.dumpStdoutBuffer(Date.now())
     this.renderingNative = false
   }

--- a/packages/core/src/testing/test-renderer.ts
+++ b/packages/core/src/testing/test-renderer.ts
@@ -1,5 +1,6 @@
 import { Readable, Writable } from "stream"
 import { CliRenderer, type CliRendererConfig } from "../renderer.js"
+import { calculateRenderGeometry } from "../lib/render-geometry.js"
 import { resolveRenderLib } from "../zig.js"
 import { createMockKeys } from "./mock-keys.js"
 import { createMockMouse } from "./mock-mouse.js"
@@ -102,10 +103,12 @@ async function setupTestRenderer(config: TestRendererOptions) {
   const width = config.width || config.stdout?.columns || process.stdout.columns || 80
   const height = config.height || config.stdout?.rows || process.stdout.rows || 24
   const stdout = config.stdout || (new TestWriteStream(width, height) as unknown as NodeJS.WriteStream)
-  const renderHeight = config.screenMode === "split-footer" ? (config.footerHeight ?? 12) : height
+  const screenMode = config.screenMode ?? "alternate-screen"
+  const footerHeight = config.footerHeight ?? 12
+  const geometry = calculateRenderGeometry(screenMode, width, height, footerHeight)
 
   const ziglib = resolveRenderLib()
-  const rendererPtr = ziglib.createRenderer(width, renderHeight, {
+  const rendererPtr = ziglib.createRenderer(geometry.renderWidth, geometry.renderHeight, {
     testing: true,
     remote: config.remote ?? false,
   })

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -1,22 +1,61 @@
-import { afterEach, beforeEach, expect, test } from "bun:test"
+import { afterEach, beforeEach, expect, spyOn, test } from "bun:test"
 
+import { ANSI } from "../ansi.ts"
 import { capture } from "../console.ts"
 import { clearEnvCache } from "../lib/env.ts"
 import { createTestRenderer, type TestRenderer } from "../testing/test-renderer.js"
 import { ManualClock } from "../testing/manual-clock.js"
+import { TextRenderable, type ScrollbackRenderContext } from "../index.js"
 
 let renderer: TestRenderer | null = null
 let previousShowConsole: string | undefined
 let previousUseAlternateScreen: string | undefined
 let previousOverrideStdout: string | undefined
+let previousUseConsole: string | undefined
+
+function textScrollbackWrite(data: string) {
+  return (ctx: ScrollbackRenderContext) => {
+    const lines = data.replace(/\r/g, "").split("\n")
+    if (lines.length > 0 && lines[lines.length - 1] === "") {
+      lines.pop()
+    }
+
+    const normalizedLines = lines.length > 0 ? lines : [""]
+    const width = Math.max(
+      1,
+      Math.min(
+        ctx.width,
+        normalizedLines.reduce((max, line) => Math.max(max, line.length), 1),
+      ),
+    )
+    const height = Math.max(1, normalizedLines.length)
+    const root = new TextRenderable(ctx.renderContext, {
+      id: "scrollback-test-text",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width,
+      height,
+      content: normalizedLines.map((line) => line.slice(0, width)).join("\n"),
+    })
+
+    return {
+      root,
+      width,
+      height,
+    }
+  }
+}
 
 beforeEach(() => {
   previousShowConsole = process.env.SHOW_CONSOLE
   previousUseAlternateScreen = process.env.OTUI_USE_ALTERNATE_SCREEN
   previousOverrideStdout = process.env.OTUI_OVERRIDE_STDOUT
+  previousUseConsole = process.env.OTUI_USE_CONSOLE
   delete process.env.SHOW_CONSOLE
   delete process.env.OTUI_USE_ALTERNATE_SCREEN
   delete process.env.OTUI_OVERRIDE_STDOUT
+  delete process.env.OTUI_USE_CONSOLE
   clearEnvCache()
 })
 
@@ -41,6 +80,12 @@ afterEach(() => {
     delete process.env.OTUI_OVERRIDE_STDOUT
   } else {
     process.env.OTUI_OVERRIDE_STDOUT = previousOverrideStdout
+  }
+
+  if (previousUseConsole === undefined) {
+    delete process.env.OTUI_USE_CONSOLE
+  } else {
+    process.env.OTUI_USE_CONSOLE = previousUseConsole
   }
 
   clearEnvCache()
@@ -100,6 +145,42 @@ test("CliRenderer applies explicit screen and output modes", async () => {
   expect(renderer.consoleMode).toBe("disabled")
 })
 
+test("CliRenderer consoleMode disabled restores the original console", async () => {
+  process.env.OTUI_USE_CONSOLE = "true"
+  clearEnvCache()
+
+  const originalConsole = global.console
+
+  const result = await createTestRenderer({
+    consoleMode: "console-overlay",
+  })
+
+  renderer = result.renderer
+
+  expect(global.console).not.toBe(originalConsole)
+
+  renderer.consoleMode = "disabled"
+
+  expect(global.console).toBe(originalConsole)
+})
+
+test("CliRenderer clamps split footer height to terminal height at startup", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 5,
+    screenMode: "split-footer",
+    footerHeight: 12,
+    externalOutputMode: "capture-stdout",
+  })
+
+  renderer = result.renderer
+
+  expect(renderer.footerHeight).toBe(12)
+  expect(renderer.height).toBe(5)
+  expect((renderer as any)._splitHeight).toBe(5)
+  expect((renderer as any).renderOffset).toBe(0)
+})
+
 test("CliRenderer rejects captured output outside split-footer mode", async () => {
   await expect(
     createTestRenderer({
@@ -107,6 +188,1236 @@ test("CliRenderer rejects captured output outside split-footer mode", async () =
       externalOutputMode: "capture-stdout",
     }),
   ).rejects.toThrow('externalOutputMode "capture-stdout" requires screenMode "split-footer"')
+})
+
+test("CliRenderer writeToScrollback throws when screen mode is not split-footer", async () => {
+  const result = await createTestRenderer({
+    screenMode: "main-screen",
+    externalOutputMode: "passthrough",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+
+  expect(() => renderer!.writeToScrollback(textScrollbackWrite("ignored\n"))).toThrow(
+    'writeToScrollback requires screenMode "split-footer" and externalOutputMode "capture-stdout"',
+  )
+})
+
+test("CliRenderer writeToScrollback throws when external output mode is passthrough", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "passthrough",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+
+  expect(() => renderer!.writeToScrollback(textScrollbackWrite("ignored\n"))).toThrow(
+    'writeToScrollback requires screenMode "split-footer" and externalOutputMode "capture-stdout"',
+  )
+})
+
+test("CliRenderer writeToScrollback enqueues snapshot commits to native", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  const lib = (renderer as any).lib
+  const snapshotCommitSpy = spyOn(lib, "commitSplitFooterSnapshot")
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+  let decodedOutput = ""
+
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    const snapshotBuffer = args[1]
+    decodedOutput = new TextDecoder().decode(snapshotBuffer.getRealCharBytes(true))
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+
+  renderer.writeToScrollback(textScrollbackWrite("api-line-1\napi-line-2\n"))
+
+  expect((renderer as any).externalOutputQueue.size).toBe(1)
+
+  await result.renderOnce()
+
+  expect(snapshotCommitSpy).toHaveBeenCalledTimes(1)
+  expect(decodedOutput).toContain("api-line-1")
+  expect(decodedOutput).toContain("api-line-2")
+
+  lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+  snapshotCommitSpy.mockRestore()
+})
+
+test("CliRenderer writeToScrollback passes width and widthMethod to the scrollback writer", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  let receivedContext: ScrollbackRenderContext | null = null
+
+  renderer.writeToScrollback((ctx) => {
+    receivedContext = ctx
+
+    const root = new TextRenderable(ctx.renderContext, {
+      id: "scrollback-context-test",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width: 3,
+      height: 1,
+      content: "ctx",
+    })
+
+    return {
+      root,
+      width: 3,
+      height: 1,
+    }
+  })
+
+  expect(receivedContext).not.toBeNull()
+
+  if (receivedContext === null) {
+    throw new Error("expected writeToScrollback to provide context")
+  }
+
+  const writeContext = receivedContext as ScrollbackRenderContext
+  expect(writeContext.width).toBe(result.renderer.width)
+  expect(writeContext.widthMethod).toBe(result.renderer.widthMethod)
+})
+
+test("CliRenderer writeToScrollback runs snapshot teardown after enqueueing", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  let teardownCalls = 0
+  let snapshotRoot: TextRenderable | null = null
+
+  renderer.writeToScrollback((ctx) => {
+    const root = new TextRenderable(ctx.renderContext, {
+      id: "scrollback-teardown-success",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width: 4,
+      height: 1,
+      content: "done",
+    })
+    snapshotRoot = root
+
+    return {
+      root,
+      width: 4,
+      height: 1,
+      teardown: () => {
+        teardownCalls += 1
+      },
+    }
+  })
+
+  expect(teardownCalls).toBe(1)
+  expect(snapshotRoot?.isDestroyed).toBe(true)
+  expect((renderer as any).externalOutputQueue.size).toBe(1)
+})
+
+test("CliRenderer writeToScrollback runs snapshot teardown when snapshot validation fails", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  let teardownCalls = 0
+  let snapshotRoot: TextRenderable | null = null
+
+  expect(() => {
+    renderer.writeToScrollback((ctx) => {
+      const root = new TextRenderable(ctx.renderContext, {
+        id: "scrollback-teardown-failure",
+        position: "absolute",
+        left: 0,
+        top: 0,
+        width: 4,
+        height: 1,
+        content: "fail",
+      })
+      snapshotRoot = root
+
+      return {
+        root,
+        width: Number.NaN,
+        height: 1,
+        teardown: () => {
+          teardownCalls += 1
+        },
+      }
+    })
+  }).toThrow("writeToScrollback produced a non-finite width")
+
+  expect(teardownCalls).toBe(1)
+  expect(snapshotRoot?.isDestroyed).toBe(true)
+})
+
+test("CliRenderer preserves append order when writeToScrollback and stdout capture are interleaved", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  const order: string[] = []
+  const lib = (renderer as any).lib
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    const snapshotBuffer = args[1]
+    const content = new TextDecoder().decode(snapshotBuffer.getRealCharBytes(true)).trim()
+    const startOnNewLine = args[3] as boolean
+    order.push(`${startOnNewLine ? "api" : "stdout"}:${content}`)
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+
+  renderer.writeToScrollback(textScrollbackWrite("api-1\n"))
+  ;(renderer as any).stdout.write("stdout-1\n")
+  renderer.writeToScrollback(textScrollbackWrite("api-2\n"))
+
+  await result.renderOnce()
+
+  expect(order).toHaveLength(3)
+  expect(order[0]).toContain("api:api-1")
+  expect(order[1]).toContain("stdout:stdout-1")
+  expect(order[2]).toContain("api:api-2")
+
+  lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+})
+
+test("CliRenderer writeToScrollback bypasses global console capture singleton", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  capture.claimOutput()
+
+  renderer.writeToScrollback(textScrollbackWrite("api-only\n"))
+  await result.renderOnce()
+
+  expect(capture.size).toBe(0)
+  expect(capture.claimOutput()).toBe("")
+})
+
+test("CliRenderer flushes captured output before switching to passthrough in split-footer", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  const lib = (renderer as any).lib
+  const splitCommitSpy = spyOn(lib, "commitSplitFooterSnapshot")
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+  let committedOutput = ""
+
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    committedOutput = new TextDecoder().decode(args[1].getRealCharBytes(true))
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+
+  ;(renderer as any).stdout.write("pending output\n")
+
+  expect((renderer as any).externalOutputQueue.size).toBe(1)
+
+  renderer.externalOutputMode = "passthrough"
+
+  expect(splitCommitSpy).toHaveBeenCalledTimes(1)
+  expect(committedOutput).toContain("pending output")
+  expect((renderer as any).externalOutputQueue.size).toBe(0)
+  lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+  splitCommitSpy.mockRestore()
+})
+
+test("CliRenderer preserves split render offset when switching to passthrough", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any).stdout.write("seed\n")
+  await result.renderOnce()
+
+  const before = (renderer as any).renderOffset
+  const pinned = (renderer as any)._terminalHeight - (renderer as any)._splitHeight
+
+  renderer.externalOutputMode = "passthrough"
+
+  expect(before).toBeGreaterThan(0)
+  expect(before).toBeLessThanOrEqual(pinned)
+  expect((renderer as any).renderOffset).toBe(before)
+})
+
+test("CliRenderer does not force split repaint when switching to passthrough with no pending output", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  const lib = (renderer as any).lib
+  const repaintSpy = spyOn(lib, "repaintSplitFooter")
+
+  expect((renderer as any).externalOutputQueue.size).toBe(0)
+
+  renderer.externalOutputMode = "passthrough"
+
+  expect(repaintSpy).toHaveBeenCalledTimes(0)
+  repaintSpy.mockRestore()
+})
+
+test("CliRenderer flushes pending split output before resize applies new geometry", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  ;(renderer as any).stdout.write("before-resize\n")
+
+  const order: string[] = []
+  const lib = (renderer as any).lib
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+  const originalResizeRenderer = lib.resizeRenderer.bind(lib)
+
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    order.push("split-commit")
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+  lib.resizeRenderer = (...args: any[]) => {
+    order.push("resize")
+    return originalResizeRenderer(...args)
+  }
+
+  ;(renderer as any).processResize(60, 16)
+
+  expect(order.indexOf("split-commit")).toBeGreaterThanOrEqual(0)
+  expect(order.indexOf("resize")).toBeGreaterThanOrEqual(0)
+  expect(order.indexOf("split-commit")).toBeLessThan(order.indexOf("resize"))
+
+  lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+  lib.resizeRenderer = originalResizeRenderer
+})
+
+test("CliRenderer flushes pending writeToScrollback output before resize applies new geometry", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  renderer.writeToScrollback(textScrollbackWrite("before-resize\n"))
+
+  const order: string[] = []
+  const lib = (renderer as any).lib
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+  const originalResizeRenderer = lib.resizeRenderer.bind(lib)
+
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    order.push("split-commit")
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+  lib.resizeRenderer = (...args: any[]) => {
+    order.push("resize")
+    return originalResizeRenderer(...args)
+  }
+
+  ;(renderer as any).processResize(60, 16)
+
+  expect(order.indexOf("split-commit")).toBeGreaterThanOrEqual(0)
+  expect(order.indexOf("resize")).toBeGreaterThanOrEqual(0)
+  expect(order.indexOf("split-commit")).toBeLessThan(order.indexOf("resize"))
+
+  lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+  lib.resizeRenderer = originalResizeRenderer
+})
+
+test("CliRenderer reuses generic suspend/resume native helpers in split-footer mode", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const suspendGenericSpy = spyOn((renderer as any).lib, "suspendRenderer")
+  const resumeGenericSpy = spyOn((renderer as any).lib, "resumeRenderer")
+
+  renderer.suspend()
+  renderer.resume()
+
+  expect(suspendGenericSpy).toHaveBeenCalledTimes(1)
+  expect(resumeGenericSpy).toHaveBeenCalledTimes(1)
+
+  suspendGenericSpy.mockRestore()
+  resumeGenericSpy.mockRestore()
+})
+
+test("CliRenderer does not flush captured split output during resize while suspended", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const splitCommitSpy = spyOn((renderer as any).lib, "commitSplitFooterSnapshot")
+
+  renderer.suspend()
+  ;(renderer as any).stdout.write("during-suspend\n")
+  ;(renderer as any).processResize(60, 16)
+
+  expect(splitCommitSpy).toHaveBeenCalledTimes(0)
+
+  splitCommitSpy.mockRestore()
+})
+
+test("CliRenderer flushes pending writeToScrollback output before suspend", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  renderer.writeToScrollback(textScrollbackWrite("before-suspend\n"))
+
+  const order: string[] = []
+  const lib = (renderer as any).lib
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+  const originalSuspendRenderer = lib.suspendRenderer.bind(lib)
+
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    order.push("split-commit")
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+  lib.suspendRenderer = (...args: any[]) => {
+    order.push("suspend")
+    return originalSuspendRenderer(...args)
+  }
+
+  renderer.suspend()
+
+  expect(order.indexOf("split-commit")).toBeGreaterThanOrEqual(0)
+  expect(order.indexOf("suspend")).toBeGreaterThanOrEqual(0)
+  expect(order.indexOf("split-commit")).toBeLessThan(order.indexOf("suspend"))
+
+  lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+  lib.suspendRenderer = originalSuspendRenderer
+})
+
+test("CliRenderer clears split footer surface when leaving split-footer mode", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "passthrough",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  const clearCalls: number[] = []
+  const lib = (renderer as any).lib
+  const originalSetRenderOffset = lib.setRenderOffset.bind(lib)
+
+  lib.setRenderOffset = (...args: any[]) => {
+    if (args[1] === 0) {
+      clearCalls.push(args[1])
+    }
+    return originalSetRenderOffset(...args)
+  }
+
+  renderer.screenMode = "main-screen"
+
+  expect(clearCalls.length).toBeGreaterThanOrEqual(1)
+
+  lib.setRenderOffset = originalSetRenderOffset
+})
+
+test("CliRenderer destroy flushes split output before clearing split footer surface", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  ;(renderer as any).stdout.write("before-destroy\n")
+
+  const order: string[] = []
+  const lib = (renderer as any).lib
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+  const originalSetRenderOffset = lib.setRenderOffset.bind(lib)
+  const originalDestroyRenderer = lib.destroyRenderer.bind(lib)
+
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    order.push("split-commit")
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+  lib.setRenderOffset = (...args: any[]) => {
+    if (args[1] === 0) {
+      order.push("clear")
+    }
+    return originalSetRenderOffset(...args)
+  }
+  lib.destroyRenderer = (...args: any[]) => {
+    order.push("destroy")
+    return originalDestroyRenderer(...args)
+  }
+
+  renderer.destroy()
+
+  expect(order).toEqual(["split-commit", "clear", "destroy"])
+
+  lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+  lib.setRenderOffset = originalSetRenderOffset
+  lib.destroyRenderer = originalDestroyRenderer
+})
+
+test("CliRenderer destroy flushes writeToScrollback output before clearing split footer surface", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  renderer.writeToScrollback(textScrollbackWrite("before-destroy\n"))
+
+  const order: string[] = []
+  const lib = (renderer as any).lib
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+  const originalSetRenderOffset = lib.setRenderOffset.bind(lib)
+  const originalDestroyRenderer = lib.destroyRenderer.bind(lib)
+
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    order.push("split-commit")
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+  lib.setRenderOffset = (...args: any[]) => {
+    if (args[1] === 0) {
+      order.push("clear")
+    }
+    return originalSetRenderOffset(...args)
+  }
+  lib.destroyRenderer = (...args: any[]) => {
+    order.push("destroy")
+    return originalDestroyRenderer(...args)
+  }
+
+  renderer.destroy()
+
+  expect(order).toEqual(["split-commit", "clear", "destroy"])
+
+  lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+  lib.setRenderOffset = originalSetRenderOffset
+  lib.destroyRenderer = originalDestroyRenderer
+})
+
+test("CliRenderer destroy does not clear split footer surface when clearOnShutdown is false", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+    clearOnShutdown: false,
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  ;(renderer as any).stdout.write("before-destroy\n")
+
+  const order: string[] = []
+  const lib = (renderer as any).lib
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+  const originalSetRenderOffset = lib.setRenderOffset.bind(lib)
+  const originalDestroyRenderer = lib.destroyRenderer.bind(lib)
+
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    order.push("split-commit")
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+  lib.setRenderOffset = (...args: any[]) => {
+    if (args[1] === 0) {
+      order.push("clear")
+    }
+    return originalSetRenderOffset(...args)
+  }
+  lib.destroyRenderer = (...args: any[]) => {
+    order.push("destroy")
+    return originalDestroyRenderer(...args)
+  }
+
+  renderer.destroy()
+
+  expect(order).toEqual(["split-commit", "destroy"])
+
+  lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+  lib.setRenderOffset = originalSetRenderOffset
+  lib.destroyRenderer = originalDestroyRenderer
+})
+
+test("CliRenderer split-footer passthrough ignores console capture writes", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "passthrough",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  const requestRenderSpy = spyOn(renderer, "requestRender")
+
+  capture.write("stdout", "from console capture\n")
+
+  expect(requestRenderSpy).toHaveBeenCalledTimes(0)
+  expect((renderer as any).externalOutputQueue.size).toBe(0)
+  requestRenderSpy.mockRestore()
+})
+
+test("CliRenderer split-footer captures direct console writes when console mode is disabled", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+
+  ;(renderer as any).stdout.write("direct write\n")
+
+  const commits = (renderer as any).externalOutputQueue.claim()
+  expect(commits.length).toBe(1)
+  expect(commits[0]?.startOnNewLine).toBe(false)
+  expect(commits[0]?.trailingNewline).toBe(true)
+  expect(commits[0]?.rowColumns).toBe(12)
+  const rendered = new TextDecoder().decode(commits[0]?.snapshot.getRealCharBytes(true))
+  expect(rendered).toContain("direct write")
+  commits[0]?.snapshot.destroy()
+  expect(capture.size).toBe(0)
+})
+
+test("CliRenderer split-footer renderNative does not call TypeScript flush path", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  const flushSpy = spyOn(renderer as any, "flushStdoutCache")
+
+  ;(renderer as any).stdout.write("pending output\n")
+  await result.renderOnce()
+
+  expect(flushSpy).toHaveBeenCalledTimes(0)
+  flushSpy.mockRestore()
+})
+
+test("CliRenderer split-footer renderNative repaints footer frame with no pending commits", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  const splitCommitSpy = spyOn((renderer as any).lib, "repaintSplitFooter")
+
+  await result.renderOnce()
+
+  expect(splitCommitSpy).toHaveBeenCalledTimes(1)
+  expect(splitCommitSpy.mock.calls[0]?.[2]).toBe(false)
+
+  splitCommitSpy.mockRestore()
+})
+
+test("CliRenderer split-footer forwards forced repaint flag to final pending commit", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  const lib = (renderer as any).lib
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+  const forceFlags: boolean[] = []
+
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    forceFlags.push(args[6] as boolean)
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+
+  ;(renderer as any).stdout.write("line-1\nline-2\n")
+  ;(renderer as any).forceFullRepaintRequested = true
+
+  await result.renderOnce()
+
+  expect(forceFlags).toEqual([false, true])
+
+  lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+})
+
+test("CliRenderer split-footer defers first native frame while startup cursor seed is pending", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any).pendingSplitStartupCursorSeed = true
+  ;(renderer as any).splitStartupSeedTimeoutId = setTimeout(() => {}, 10)
+
+  const repaintSpy = spyOn((renderer as any).lib, "repaintSplitFooter")
+  const commitSpy = spyOn((renderer as any).lib, "commitSplitFooterSnapshot")
+
+  await result.renderOnce()
+
+  expect(repaintSpy).toHaveBeenCalledTimes(0)
+  expect(commitSpy).toHaveBeenCalledTimes(0)
+
+  clearTimeout((renderer as any).splitStartupSeedTimeoutId)
+  ;(renderer as any).splitStartupSeedTimeoutId = null
+
+  repaintSpy.mockRestore()
+  commitSpy.mockRestore()
+})
+
+test("CliRenderer split-footer starts in settling phase and then pins as output grows", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+
+  expect((renderer as any).renderOffset).toBe(1)
+
+  ;(renderer as any).stdout.write("a\n")
+  await result.renderOnce()
+  expect((renderer as any).renderOffset).toBe(2)
+
+  ;(renderer as any).stdout.write("b\n")
+  await result.renderOnce()
+  expect((renderer as any).renderOffset).toBe(3)
+
+  ;(renderer as any).stdout.write("c\n")
+  await result.renderOnce()
+  expect((renderer as any).renderOffset).toBe(4)
+
+  for (let i = 0; i < 8; i++) {
+    ;(renderer as any).stdout.write(`line-${i}\n`)
+    await result.renderOnce()
+  }
+
+  expect((renderer as any).renderOffset).toBe(6)
+})
+
+test("CliRenderer split-footer footerHeight changes defer settling cleanup to the next native frame", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const writeOutSpy = spyOn(renderer as any, "writeOut")
+  const repaintSpy = spyOn((renderer as any).lib, "repaintSplitFooter")
+
+  renderer.footerHeight = 8
+  renderer.footerHeight = 3
+
+  expect((renderer as any).renderOffset).toBe(1)
+  expect(writeOutSpy).toHaveBeenCalledTimes(0)
+
+  await result.renderOnce()
+
+  expect(repaintSpy).toHaveBeenCalledTimes(1)
+  expect(repaintSpy.mock.calls[0]?.[2]).toBe(true)
+
+  writeOutSpy.mockRestore()
+  repaintSpy.mockRestore()
+})
+
+test("CliRenderer split-footer footerHeight changes coalesce while settling before the next frame", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const repaintSpy = spyOn((renderer as any).lib, "repaintSplitFooter")
+
+  renderer.footerHeight = 8
+  renderer.footerHeight = 3
+
+  await result.renderOnce()
+
+  expect(repaintSpy).toHaveBeenCalledTimes(1)
+  expect(repaintSpy.mock.calls[0]?.[1]).toBe(7)
+  expect(repaintSpy.mock.calls[0]?.[2]).toBe(true)
+
+  repaintSpy.mockRestore()
+})
+
+test("CliRenderer split-footer footerHeight changes defer pinned viewport transitions to the next native frame", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  for (let i = 0; i < 12; i += 1) {
+    ;(renderer as any).stdout.write(`line-${i}\n`)
+    await result.renderOnce()
+  }
+
+  expect((renderer as any).renderOffset).toBe(6)
+
+  const writeOutSpy = spyOn(renderer as any, "writeOut")
+  const repaintSpy = spyOn((renderer as any).lib, "repaintSplitFooter")
+
+  renderer.footerHeight = 3
+
+  expect(writeOutSpy).toHaveBeenCalledTimes(0)
+
+  await result.renderOnce()
+
+  expect(repaintSpy).toHaveBeenCalledTimes(1)
+  expect(repaintSpy.mock.calls[0]?.[1]).toBe(7)
+  expect(repaintSpy.mock.calls[0]?.[2]).toBe(true)
+
+  writeOutSpy.mockRestore()
+  repaintSpy.mockRestore()
+})
+
+test("CliRenderer split-footer resize cleanup uses the visible footer surface while a deferred footer transition is pending", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const writeOutSpy = spyOn(renderer as any, "writeOut")
+
+  renderer.footerHeight = 3
+
+  expect((renderer as any).pendingSplitFooterTransition).toEqual({
+    mode: "clear-stale-rows",
+    sourceTopLine: 2,
+    sourceHeight: 4,
+    targetTopLine: 2,
+    targetHeight: 3,
+  })
+
+  result.resize(20, 10)
+
+  expect(writeOutSpy).toHaveBeenCalledTimes(1)
+  expect(writeOutSpy.mock.calls[0]?.[0]).toBe(ANSI.moveCursorAndClear(2, 1))
+  expect((renderer as any).pendingSplitFooterTransition).toBeNull()
+
+  writeOutSpy.mockRestore()
+})
+
+test("CliRenderer split-footer resize cleanup uses the visible source top line across width and height resize while a deferred footer transition is pending", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const writeOutSpy = spyOn(renderer as any, "writeOut")
+
+  renderer.footerHeight = 3
+
+  expect((renderer as any).pendingSplitFooterTransition).toEqual({
+    mode: "clear-stale-rows",
+    sourceTopLine: 2,
+    sourceHeight: 4,
+    targetTopLine: 2,
+    targetHeight: 3,
+  })
+
+  result.resize(20, 12)
+
+  expect(writeOutSpy).toHaveBeenCalledTimes(1)
+  expect(writeOutSpy.mock.calls[0]?.[0]).toBe(ANSI.moveCursorAndClear(2, 1))
+
+  writeOutSpy.mockRestore()
+})
+
+test("CliRenderer split-footer resize cleanup still clears the visible source surface when only height changes while a deferred footer transition is pending", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const writeOutSpy = spyOn(renderer as any, "writeOut")
+
+  renderer.footerHeight = 3
+
+  result.resize(40, 12)
+
+  expect(writeOutSpy).toHaveBeenCalledTimes(1)
+  expect(writeOutSpy.mock.calls[0]?.[0]).toBe(ANSI.moveCursorAndClear(2, 1))
+
+  writeOutSpy.mockRestore()
+})
+
+test("CliRenderer split-footer footerHeight changes do not queue deferred transitions while startup cursor seeding blocks the first frame", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  ;(renderer as any).pendingSplitStartupCursorSeed = true
+  ;(renderer as any).splitStartupSeedTimeoutId = setTimeout(() => {}, 10)
+
+  const setPendingTransitionSpy = spyOn((renderer as any).lib, "setPendingSplitFooterTransition")
+
+  try {
+    renderer.footerHeight = 3
+
+    expect(setPendingTransitionSpy).toHaveBeenCalledTimes(0)
+    expect((renderer as any).pendingSplitFooterTransition).toBeNull()
+    expect((renderer as any).forceFullRepaintRequested).toBe(true)
+  } finally {
+    clearTimeout((renderer as any).splitStartupSeedTimeoutId)
+    ;(renderer as any).splitStartupSeedTimeoutId = null
+    setPendingTransitionSpy.mockRestore()
+  }
+})
+
+test("CliRenderer entering split capture seeds from current terminal cursor row", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 20,
+    screenMode: "main-screen",
+    externalOutputMode: "passthrough",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  renderer.footerHeight = 6
+  renderer.setCursorPosition(1, 4, true)
+
+  renderer.screenMode = "split-footer"
+  renderer.externalOutputMode = "capture-stdout"
+
+  expect((renderer as any).renderOffset).toBe(4)
+})
+
+test("CliRenderer reseeds split startup offset from non-home CPR capability response", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 20,
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  expect((renderer as any).renderOffset).toBe(1)
+
+  const lib = (renderer as any).lib
+  const originalGetCursorState = lib.getCursorState.bind(lib)
+  ;(renderer as any).pendingSplitStartupCursorSeed = true
+  ;(renderer as any).capabilityTimeoutId = setTimeout(() => {}, 10)
+  ;(renderer as any).setPendingSplitFooterTransition({
+    mode: "clear-stale-rows",
+    sourceTopLine: 2,
+    sourceHeight: 6,
+    targetTopLine: 2,
+    targetHeight: 4,
+  })
+
+  try {
+    lib.getCursorState = () => ({
+      ...originalGetCursorState((renderer as any).rendererPtr),
+      y: 5,
+    })
+
+    const handled = (renderer as any).processCapabilitySequence("\x1b[5;1R", true)
+
+    expect(handled).toBe(false)
+    expect((renderer as any).renderOffset).toBe(5)
+    expect((renderer as any).pendingSplitStartupCursorSeed).toBe(false)
+    expect((renderer as any).pendingSplitFooterTransition).toBeNull()
+  } finally {
+    clearTimeout((renderer as any).capabilityTimeoutId)
+    ;(renderer as any).capabilityTimeoutId = null
+    lib.getCursorState = originalGetCursorState
+  }
+})
+
+test("CliRenderer does not consume standalone CPR replies during capability window", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 20,
+    screenMode: "main-screen",
+    externalOutputMode: "passthrough",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any).pendingSplitStartupCursorSeed = false
+  ;(renderer as any).capabilityTimeoutId = setTimeout(() => {}, 10)
+
+  const handled = (renderer as any).processCapabilitySequence("\x1b[7;11R", true)
+  expect(handled).toBe(false)
+
+  clearTimeout((renderer as any).capabilityTimeoutId)
+  ;(renderer as any).capabilityTimeoutId = null
+})
+
+test("CliRenderer preserves cursor seed rows when split starts with zero pinned offset", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 12,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+
+  expect((renderer as any).renderOffset).toBe(0)
+
+  renderer.footerHeight = 4
+
+  expect((renderer as any).renderOffset).toBe(1)
+})
+
+test("CliRenderer split-footer commits only unpublished captured output chunks", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  const lib = (renderer as any).lib
+  const snapshotCommitSpy = spyOn(lib, "commitSplitFooterSnapshot")
+  const fullRenderSpy = spyOn(lib, "repaintSplitFooter")
+
+  const committedPayloads: string[] = []
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    committedPayloads.push(new TextDecoder().decode(args[1].getRealCharBytes(true)).trim())
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+
+  ;(renderer as any).stdout.write("first\n")
+  await result.renderOnce()
+
+  ;(renderer as any).stdout.write("second\n")
+  await result.renderOnce()
+
+  await result.renderOnce()
+
+  expect(snapshotCommitSpy).toHaveBeenCalledTimes(2)
+  expect(committedPayloads[0]).toContain("first")
+  expect(committedPayloads[1]).toContain("second")
+
+  expect(fullRenderSpy).toHaveBeenCalledTimes(1)
+  expect(fullRenderSpy.mock.calls[0]?.[2]).toBe(false)
+
+  lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+  snapshotCommitSpy.mockRestore()
+  fullRenderSpy.mockRestore()
+})
+
+test("CliRenderer split-footer routes captured output through snapshot native commit path", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  const lib = (renderer as any).lib
+  const splitCommitSpy = spyOn(lib, "commitSplitFooterSnapshot")
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+  const payloads: string[] = []
+
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    payloads.push(new TextDecoder().decode(args[1].getRealCharBytes(true)).trim())
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+
+  ;(renderer as any).stdout.write("line-1\nline-2\n")
+  await result.renderOnce()
+
+  expect(splitCommitSpy).toHaveBeenCalledTimes(2)
+  expect(payloads[0]).toContain("line-1")
+  expect(payloads[1]).toContain("line-2")
+  expect((renderer as any).renderOffset).toBe(3)
+
+  lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+  splitCommitSpy.mockRestore()
+})
+
+test("CliRenderer split-footer native scrollback tracks wrapped tail state across commits", async () => {
+  const result = await createTestRenderer({
+    width: 4,
+    height: 6,
+    screenMode: "split-footer",
+    footerHeight: 2,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+
+  ;(renderer as any).stdout.write("abcd")
+  await result.renderOnce()
+
+  expect((renderer as any).renderOffset).toBe(1)
+
+  ;(renderer as any).stdout.write("e")
+  await result.renderOnce()
+
+  expect((renderer as any).renderOffset).toBe(2)
 })
 
 test("CliRenderer flushes captured output when leaving split-footer for alternate-screen", async () => {
@@ -123,11 +1434,11 @@ test("CliRenderer flushes captured output when leaving split-footer for alternat
   ;(renderer as any).lib.suspendRenderer = () => {}
   ;(renderer as any).lib.setupTerminal = () => {}
 
-  capture.write("stdout", "pending output\n")
+  ;(renderer as any).stdout.write("pending output\n")
   renderer.externalOutputMode = "passthrough"
   renderer.screenMode = "alternate-screen"
 
-  expect(capture.size).toBe(0)
+  expect((renderer as any).externalOutputQueue.size).toBe(0)
 })
 
 test("CliRenderer allows env to force main-screen mode", async () => {

--- a/packages/core/src/tests/renderer.mouse.test.ts
+++ b/packages/core/src/tests/renderer.mouse.test.ts
@@ -1251,6 +1251,47 @@ describe("renderer handleMouseData split height", () => {
     }
   })
 
+  test("split height clamps to terminal height before applying mouse offsets", async () => {
+    const requestedFooterHeight = 8
+    const terminalHeight = 5
+    const setup = await createTestRenderer({
+      width: 40,
+      height: terminalHeight,
+      screenMode: "split-footer",
+      footerHeight: requestedFooterHeight,
+    })
+
+    const clampedRenderer = setup.renderer
+    const clampedMouse = setup.mockMouse
+
+    try {
+      const target = new TestRenderable(clampedRenderer, {
+        id: "split-clamped-target",
+        position: "absolute",
+        left: 2,
+        top: 1,
+        width: 6,
+        height: 3,
+      })
+      clampedRenderer.root.add(target)
+      await setup.renderOnce()
+
+      let downEvent: MouseEvent | null = null
+      target.onMouseDown = (event) => {
+        downEvent = event
+      }
+
+      await clampedMouse.click(target.x + 1, target.y + 1)
+
+      expect((clampedRenderer as any)._splitHeight).toBe(terminalHeight)
+      expect((clampedRenderer as any).renderOffset).toBe(0)
+      expect(downEvent).not.toBeNull()
+      expect(downEvent!.y).toBe(target.y + 1)
+    } finally {
+      clampedRenderer.destroy()
+    }
+  })
+
   test("split height returns false for input above render area", async () => {
     try {
       const sequences: string[] = []

--- a/packages/core/src/tests/renderer.scrollback-surface.test.ts
+++ b/packages/core/src/tests/renderer.scrollback-surface.test.ts
@@ -1,0 +1,418 @@
+import { afterEach, expect, test } from "bun:test"
+
+import { RGBA } from "../lib/RGBA.js"
+import { Renderable, type RenderableOptions } from "../Renderable.js"
+import { CodeRenderable } from "../renderables/Code.js"
+import { MarkdownRenderable } from "../renderables/Markdown.js"
+import { TextRenderable } from "../renderables/Text.js"
+import { SyntaxStyle } from "../syntax-style.js"
+import { createTestRenderer, MockTreeSitterClient, type TestRenderer } from "../testing.js"
+import type { RenderContext } from "../types.js"
+
+type ClaimedCommit = {
+  snapshot: {
+    height: number
+    getRealCharBytes(addLineBreaks?: boolean): Uint8Array
+    destroy(): void
+  }
+  rowColumns: number
+  startOnNewLine: boolean
+  trailingNewline: boolean
+}
+
+const decoder = new TextDecoder()
+const syntaxStyle = SyntaxStyle.fromStyles({
+  default: { fg: RGBA.fromValues(1, 1, 1, 1) },
+})
+
+class CountingRenderable extends Renderable {
+  public renderCount = 0
+
+  constructor(ctx: RenderContext, options: RenderableOptions) {
+    super(ctx, options)
+  }
+
+  protected renderSelf(): void {
+    this.renderCount += 1
+  }
+}
+
+const activeRenderers: TestRenderer[] = []
+
+afterEach(() => {
+  for (const renderer of activeRenderers.splice(0)) {
+    renderer.destroy()
+  }
+})
+
+async function createSplitFooterRenderer(options: Parameters<typeof createTestRenderer>[0] = {}) {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+    ...options,
+  })
+
+  activeRenderers.push(result.renderer)
+  return result
+}
+
+function claimCommits(renderer: TestRenderer): ClaimedCommit[] {
+  return (renderer as any).externalOutputQueue.claim() as ClaimedCommit[]
+}
+
+function destroyClaimedCommits(commits: ClaimedCommit[]): void {
+  for (const commit of commits) {
+    commit.snapshot.destroy()
+  }
+}
+
+test("ScrollbackSurface.commitRows reuses the last rendered buffer", async () => {
+  const { renderer } = await createSplitFooterRenderer()
+  const surface = renderer.createScrollbackSurface()
+
+  const counter = new CountingRenderable(surface.renderContext, {
+    id: "surface-counter",
+    width: 5,
+    height: 1,
+  })
+  const text = new TextRenderable(surface.renderContext, {
+    id: "surface-text",
+    content: "hello",
+    width: 5,
+    height: 1,
+  })
+
+  counter.add(text)
+  surface.root.add(counter)
+  surface.render()
+
+  expect(counter.renderCount).toBe(1)
+
+  surface.commitRows(0, surface.height)
+
+  expect(counter.renderCount).toBe(1)
+
+  const commits = claimCommits(renderer)
+
+  try {
+    expect(commits).toHaveLength(1)
+    expect(decoder.decode(commits[0]!.snapshot.getRealCharBytes(true))).toContain("hello")
+  } finally {
+    destroyClaimedCommits(commits)
+  }
+})
+
+test("ScrollbackSurface.settle waits for code highlighting before commit", async () => {
+  const { renderer } = await createSplitFooterRenderer()
+  const surface = renderer.createScrollbackSurface({ startOnNewLine: true })
+  const mockTreeSitterClient = new MockTreeSitterClient()
+  mockTreeSitterClient.setMockResult({ highlights: [] })
+
+  const code = new CodeRenderable(surface.renderContext, {
+    id: "surface-code",
+    content: "const x = 1",
+    filetype: "typescript",
+    syntaxStyle,
+    drawUnstyledText: false,
+    treeSitterClient: mockTreeSitterClient,
+    width: "100%",
+  })
+
+  surface.root.add(code)
+
+  const settlePromise = surface.settle()
+
+  expect(code.isHighlighting).toBe(true)
+
+  mockTreeSitterClient.resolveAllHighlightOnce()
+  await settlePromise
+
+  expect(code.isHighlighting).toBe(false)
+
+  surface.commitRows(code.y, code.y + code.height)
+
+  const commits = claimCommits(renderer)
+
+  try {
+    expect(commits).toHaveLength(1)
+    expect(decoder.decode(commits[0]!.snapshot.getRealCharBytes(true))).toContain("const x = 1")
+  } finally {
+    destroyClaimedCommits(commits)
+  }
+})
+
+test("ScrollbackSurface works with MarkdownRenderable top-level blocks", async () => {
+  const { renderer } = await createSplitFooterRenderer()
+  const surface = renderer.createScrollbackSurface({ startOnNewLine: true })
+  const mockTreeSitterClient = new MockTreeSitterClient({ autoResolveTimeout: 0 })
+  mockTreeSitterClient.setMockResult({ highlights: [] })
+
+  const md = new MarkdownRenderable(surface.renderContext, {
+    id: "surface-markdown",
+    content: "# Title\n\nPara 1\n\n",
+    syntaxStyle,
+    streaming: true,
+    internalBlockMode: "top-level",
+    treeSitterClient: mockTreeSitterClient,
+  })
+
+  surface.root.add(md)
+  await surface.settle()
+
+  md.content = "# Title\n\nPara 1\n\nPara 2"
+  await surface.settle()
+
+  expect(md._stableBlockCount).toBe(1)
+
+  const stableBlock = md._blockStates[0]!
+  const nextBlock = md._blockStates[1]
+  const stableEnd = nextBlock
+    ? nextBlock.renderable.y
+    : stableBlock.renderable.y + stableBlock.renderable.height + (stableBlock.marginBottom ?? 0)
+
+  surface.commitRows(stableBlock.renderable.y, stableEnd, { trailingNewline: false })
+
+  const commits = claimCommits(renderer)
+
+  try {
+    expect(commits).toHaveLength(1)
+
+    const rendered = decoder.decode(commits[0]!.snapshot.getRealCharBytes(true))
+    expect(rendered).toContain("Title")
+    expect(rendered).not.toContain("Para 1")
+  } finally {
+    destroyClaimedCommits(commits)
+  }
+})
+
+test("ScrollbackSurface commitRows respects top-level block margins from custom renderNode blocks", async () => {
+  const { renderer } = await createSplitFooterRenderer()
+  const surface = renderer.createScrollbackSurface({ startOnNewLine: true })
+  const mockTreeSitterClient = new MockTreeSitterClient({ autoResolveTimeout: 0 })
+  mockTreeSitterClient.setMockResult({ highlights: [] })
+
+  const md = new MarkdownRenderable(surface.renderContext, {
+    id: "surface-markdown-custom-scrollback",
+    content: "# Title\n\nPara 1\n\n",
+    syntaxStyle,
+    streaming: true,
+    internalBlockMode: "top-level",
+    treeSitterClient: mockTreeSitterClient,
+    renderNode: (node, ctx) => {
+      if (node.type === "heading") {
+        return new TextRenderable(surface.renderContext, {
+          id: "surface-markdown-custom-heading",
+          content: "CUSTOM",
+          width: "100%",
+        })
+      }
+
+      return ctx.defaultRender()
+    },
+  })
+
+  surface.root.add(md)
+  await surface.settle()
+
+  md.content = "# Title\n\nPara 1\n\nPara 2"
+  await surface.settle()
+
+  expect(md._stableBlockCount).toBe(1)
+
+  const stableBlock = md._blockStates[0]!
+  const nextBlock = md._blockStates[1]
+  const stableEnd = nextBlock
+    ? nextBlock.renderable.y
+    : stableBlock.renderable.y + stableBlock.renderable.height + (stableBlock.marginBottom ?? 0)
+
+  expect(nextBlock!.renderable.y).toBe(stableEnd)
+
+  surface.commitRows(stableBlock.renderable.y, stableEnd, { trailingNewline: false })
+
+  const commits = claimCommits(renderer)
+
+  try {
+    expect(commits).toHaveLength(1)
+
+    const rendered = decoder.decode(commits[0]!.snapshot.getRealCharBytes(true))
+    expect(rendered).toContain("CUSTOM")
+    expect(rendered).not.toContain("Para 1")
+  } finally {
+    destroyClaimedCommits(commits)
+  }
+})
+
+test("ScrollbackSurface captures inline first-line offset at creation", async () => {
+  const { renderer } = await createSplitFooterRenderer({
+    width: 10,
+    height: 6,
+    footerHeight: 3,
+  })
+
+  renderer.writeToScrollback((ctx) => {
+    const root = new TextRenderable(ctx.renderContext, {
+      id: "seed-tail",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width: 5,
+      height: 1,
+      content: "12345",
+    })
+
+    return {
+      root,
+      width: 5,
+      height: 1,
+      startOnNewLine: false,
+      trailingNewline: false,
+    }
+  })
+
+  const seededCommits = claimCommits(renderer)
+  destroyClaimedCommits(seededCommits)
+
+  const surface = renderer.createScrollbackSurface({ startOnNewLine: false })
+  const text = new TextRenderable(surface.renderContext, {
+    id: "surface-inline-text",
+    content: "abcdef",
+    width: "100%",
+    wrapMode: "char",
+  })
+
+  surface.root.add(text)
+  surface.render()
+
+  expect(text.height).toBe(2)
+})
+
+test("ScrollbackSurface preserves inline first-line offset when the first markdown block is replaced", async () => {
+  const { renderer } = await createSplitFooterRenderer({
+    width: 10,
+    height: 6,
+    footerHeight: 3,
+  })
+
+  renderer.writeToScrollback((ctx) => {
+    const root = new TextRenderable(ctx.renderContext, {
+      id: "seed-tail-replacement",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width: 5,
+      height: 1,
+      content: "12345",
+    })
+
+    return {
+      root,
+      width: 5,
+      height: 1,
+      startOnNewLine: false,
+      trailingNewline: false,
+    }
+  })
+
+  destroyClaimedCommits(claimCommits(renderer))
+
+  const surface = renderer.createScrollbackSurface({ startOnNewLine: false })
+  const mockTreeSitterClient = new MockTreeSitterClient({ autoResolveTimeout: 0 })
+  mockTreeSitterClient.setMockResult({ highlights: [] })
+
+  const md = new MarkdownRenderable(surface.renderContext, {
+    id: "surface-inline-markdown",
+    content: "abcdef",
+    syntaxStyle,
+    streaming: true,
+    internalBlockMode: "top-level",
+    treeSitterClient: mockTreeSitterClient,
+  })
+
+  surface.root.add(md)
+  await surface.settle()
+
+  const initialRenderable = md._blockStates[0]!.renderable
+  expect(initialRenderable.height).toBe(2)
+
+  md.content = "# abcdef"
+  await surface.settle()
+
+  const replacementRenderable = md._blockStates[0]!.renderable
+  expect(replacementRenderable).not.toBe(initialRenderable)
+  expect(replacementRenderable.height).toBe(2)
+})
+
+test("ScrollbackSurface.commitRows rejects stale geometry after resize", async () => {
+  const { renderer, resize } = await createSplitFooterRenderer({
+    width: 40,
+    height: 10,
+    footerHeight: 4,
+  })
+
+  const surface = renderer.createScrollbackSurface()
+  const text = new TextRenderable(surface.renderContext, {
+    id: "surface-resize",
+    content: "resize me",
+    width: "100%",
+  })
+
+  surface.root.add(text)
+  surface.render()
+
+  resize(60, 16)
+
+  expect(() => {
+    surface.commitRows(0, surface.height)
+  }).toThrow("ScrollbackSurface.commitRows requires render() after renderer geometry changes")
+
+  surface.render()
+
+  expect(() => {
+    surface.commitRows(0, surface.height)
+  }).not.toThrow()
+
+  const commits = claimCommits(renderer)
+  destroyClaimedCommits(commits)
+})
+
+test("CliRenderer writeToScrollback lays out tall snapshots against the resolved snapshot height", async () => {
+  const { renderer } = await createSplitFooterRenderer({
+    width: 20,
+    height: 6,
+    footerHeight: 3,
+  })
+
+  renderer.writeToScrollback((ctx) => {
+    const root = new TextRenderable(ctx.renderContext, {
+      id: "tall-snapshot",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width: 1,
+      height: "100%",
+      content: "1\n2\n3\n4\n5\n6\n7\n8",
+    })
+
+    return {
+      root,
+      width: 1,
+      height: 8,
+      trailingNewline: false,
+    }
+  })
+
+  const commits = claimCommits(renderer)
+
+  try {
+    expect(commits).toHaveLength(1)
+    expect(commits[0]!.snapshot.height).toBe(8)
+    expect(commits[0]!.snapshot.height).toBeGreaterThan(renderer.height)
+
+    const lines = decoder.decode(commits[0]!.snapshot.getRealCharBytes(true)).split("\n")
+    expect(lines.slice(0, 8)).toEqual(["1", "2", "3", "4", "5", "6", "7", "8"])
+  } finally {
+    destroyClaimedCommits(commits)
+  }
+})

--- a/packages/core/src/text-buffer-view.ts
+++ b/packages/core/src/text-buffer-view.ts
@@ -111,6 +111,11 @@ export class TextBufferView {
     this.lib.textBufferViewSetWrapMode(this.viewPtr, mode)
   }
 
+  public setFirstLineOffset(offset: number): void {
+    this.guard()
+    this.lib.textBufferViewSetFirstLineOffset(this.viewPtr, offset)
+  }
+
   public setViewportSize(width: number, height: number): void {
     this.guard()
     this.lib.textBufferViewSetViewportSize(this.viewPtr, width, height)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -92,6 +92,7 @@ export interface RenderContext extends EventEmitter {
   currentFocusedEditor: EditBufferRenderable | null
   focusRenderable: (renderable: Renderable) => void
   blurRenderable: (renderable: Renderable) => void
+  claimFirstLineOffset?: (renderable?: Renderable) => number
   registerLifecyclePass: (renderable: Renderable) => void
   unregisterLifecyclePass: (renderable: Renderable) => void
   getLifecyclePasses: () => Set<Renderable>

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -150,12 +150,32 @@ function getOpenTUILib(libPath?: string) {
       args: ["ptr", "bool"],
       returns: "void",
     },
+    setClearOnShutdown: {
+      args: ["ptr", "bool"],
+      returns: "void",
+    },
     setBackgroundColor: {
       args: ["ptr", "ptr"],
       returns: "void",
     },
     setRenderOffset: {
       args: ["ptr", "u32"],
+      returns: "void",
+    },
+    resetSplitScrollback: {
+      args: ["ptr", "u32", "u32"],
+      returns: "u32",
+    },
+    syncSplitScrollback: {
+      args: ["ptr", "u32"],
+      returns: "u32",
+    },
+    setPendingSplitFooterTransition: {
+      args: ["ptr", "u8", "u32", "u32", "u32", "u32"],
+      returns: "void",
+    },
+    clearPendingSplitFooterTransition: {
+      args: ["ptr"],
       returns: "void",
     },
     updateStats: {
@@ -169,6 +189,17 @@ function getOpenTUILib(libPath?: string) {
     render: {
       args: ["ptr", "bool"],
       returns: "void",
+    },
+    repaintSplitFooter: {
+      args: ["ptr", "u32", "bool"],
+      returns: "u32",
+    },
+    // Single FFI entrypoint for split commit append. beginFrame/finalizeFrame let
+    // native code decide whether this call is a standalone commit or part of a
+    // larger batched frame envelope.
+    commitSplitFooterSnapshot: {
+      args: ["ptr", "ptr", "u32", "bool", "bool", "u32", "bool", "bool", "bool"],
+      returns: "u32",
     },
     getNextBuffer: {
       args: ["ptr"],
@@ -662,6 +693,10 @@ function getOpenTUILib(libPath?: string) {
     },
     textBufferViewSetWrapMode: {
       args: ["ptr", "u8"],
+      returns: "void",
+    },
+    textBufferViewSetFirstLineOffset: {
+      args: ["ptr", "u32"],
       returns: "void",
     },
     textBufferViewSetViewportSize: {
@@ -1383,11 +1418,37 @@ export interface RenderLib {
   setTerminalEnvVar: (renderer: Pointer, key: string, value: string) => boolean
   destroyRenderer: (renderer: Pointer) => void
   setUseThread: (renderer: Pointer, useThread: boolean) => void
+  setClearOnShutdown: (renderer: Pointer, clear: boolean) => void
   setBackgroundColor: (renderer: Pointer, color: RGBA) => void
   setRenderOffset: (renderer: Pointer, offset: number) => void
+  resetSplitScrollback: (renderer: Pointer, seedRows: number, pinnedRenderOffset: number) => number
+  syncSplitScrollback: (renderer: Pointer, pinnedRenderOffset: number) => number
+  setPendingSplitFooterTransition: (
+    renderer: Pointer,
+    mode: number,
+    sourceTopLine: number,
+    sourceHeight: number,
+    targetTopLine: number,
+    targetHeight: number,
+  ) => void
+  clearPendingSplitFooterTransition: (renderer: Pointer) => void
   updateStats: (renderer: Pointer, time: number, fps: number, frameCallbackTime: number) => void
   updateMemoryStats: (renderer: Pointer, heapUsed: number, heapTotal: number, arrayBuffers: number) => void
   render: (renderer: Pointer, force: boolean) => void
+  repaintSplitFooter: (renderer: Pointer, pinnedRenderOffset: number, force: boolean) => number
+  commitSplitFooterSnapshot: (
+    renderer: Pointer,
+    snapshot: OptimizedBuffer,
+    rowColumns: number,
+    startOnNewLine: boolean,
+    trailingNewline: boolean,
+    pinnedRenderOffset: number,
+    force: boolean,
+    // beginFrame/finalizeFrame mark commit boundaries when one JS flush contains
+    // multiple stdout snapshots. Defaults preserve old one-call behavior.
+    beginFrame?: boolean,
+    finalizeFrame?: boolean,
+  ) => number
   getNextBuffer: (renderer: Pointer) => OptimizedBuffer
   getCurrentBuffer: (renderer: Pointer) => OptimizedBuffer
   createOptimizedBuffer: (
@@ -1637,6 +1698,7 @@ export interface RenderLib {
   textBufferViewResetLocalSelection: (view: Pointer) => void
   textBufferViewSetWrapWidth: (view: Pointer, width: number) => void
   textBufferViewSetWrapMode: (view: Pointer, mode: "none" | "char" | "word") => void
+  textBufferViewSetFirstLineOffset: (view: Pointer, offset: number) => void
   textBufferViewSetViewportSize: (view: Pointer, width: number, height: number) => void
   textBufferViewSetViewport: (view: Pointer, x: number, y: number, width: number, height: number) => void
   textBufferViewGetLineInfo: (view: Pointer) => LineInfo
@@ -2020,12 +2082,46 @@ class FFIRenderLib implements RenderLib {
     this.opentui.symbols.setUseThread(renderer, useThread)
   }
 
+  public setClearOnShutdown(renderer: Pointer, clear: boolean) {
+    this.opentui.symbols.setClearOnShutdown(renderer, clear)
+  }
+
   public setBackgroundColor(renderer: Pointer, color: RGBA) {
     this.opentui.symbols.setBackgroundColor(renderer, color.buffer)
   }
 
   public setRenderOffset(renderer: Pointer, offset: number) {
     this.opentui.symbols.setRenderOffset(renderer, offset)
+  }
+
+  public resetSplitScrollback(renderer: Pointer, seedRows: number, pinnedRenderOffset: number): number {
+    return this.opentui.symbols.resetSplitScrollback(renderer, seedRows, pinnedRenderOffset)
+  }
+
+  public syncSplitScrollback(renderer: Pointer, pinnedRenderOffset: number): number {
+    return this.opentui.symbols.syncSplitScrollback(renderer, pinnedRenderOffset)
+  }
+
+  public setPendingSplitFooterTransition(
+    renderer: Pointer,
+    mode: number,
+    sourceTopLine: number,
+    sourceHeight: number,
+    targetTopLine: number,
+    targetHeight: number,
+  ): void {
+    this.opentui.symbols.setPendingSplitFooterTransition(
+      renderer,
+      mode,
+      sourceTopLine,
+      sourceHeight,
+      targetTopLine,
+      targetHeight,
+    )
+  }
+
+  public clearPendingSplitFooterTransition(renderer: Pointer): void {
+    this.opentui.symbols.clearPendingSplitFooterTransition(renderer)
   }
 
   public updateStats(renderer: Pointer, time: number, fps: number, frameCallbackTime: number) {
@@ -2417,6 +2513,34 @@ class FFIRenderLib implements RenderLib {
 
   public render(renderer: Pointer, force: boolean) {
     this.opentui.symbols.render(renderer, force)
+  }
+
+  public repaintSplitFooter(renderer: Pointer, pinnedRenderOffset: number, force: boolean): number {
+    return this.opentui.symbols.repaintSplitFooter(renderer, pinnedRenderOffset, force)
+  }
+
+  public commitSplitFooterSnapshot(
+    renderer: Pointer,
+    snapshot: OptimizedBuffer,
+    rowColumns: number,
+    startOnNewLine: boolean,
+    trailingNewline: boolean,
+    pinnedRenderOffset: number,
+    force: boolean,
+    beginFrame: boolean = true,
+    finalizeFrame: boolean = true,
+  ): number {
+    return this.opentui.symbols.commitSplitFooterSnapshot(
+      renderer,
+      snapshot.ptr,
+      rowColumns,
+      startOnNewLine,
+      trailingNewline,
+      pinnedRenderOffset,
+      force,
+      beginFrame,
+      finalizeFrame,
+    )
   }
 
   public createOptimizedBuffer(
@@ -2874,6 +2998,10 @@ class FFIRenderLib implements RenderLib {
   public textBufferViewSetWrapMode(view: Pointer, mode: "none" | "char" | "word"): void {
     const modeValue = mode === "none" ? 0 : mode === "char" ? 1 : 2
     this.opentui.symbols.textBufferViewSetWrapMode(view, modeValue)
+  }
+
+  public textBufferViewSetFirstLineOffset(view: Pointer, offset: number): void {
+    this.opentui.symbols.textBufferViewSetFirstLineOffset(view, offset)
   }
 
   public textBufferViewSetViewportSize(view: Pointer, width: number, height: number): void {

--- a/packages/core/src/zig/ansi.zig
+++ b/packages/core/src/zig/ansi.zig
@@ -13,6 +13,7 @@ pub const ANSI = struct {
     pub const clear = "\x1b[2J";
     pub const home = "\x1b[H";
     pub const clearAndHome = "\x1b[H\x1b[2J";
+    pub const eraseToEndOfLine = "\x1b[K";
     pub const hideCursor = "\x1b[?25l";
     pub const showCursor = "\x1b[?25h";
     pub const defaultCursorStyle = "\x1b[0 q";

--- a/packages/core/src/zig/buffer.zig
+++ b/packages/core/src/zig/buffer.zig
@@ -702,7 +702,7 @@ pub const OptimizedBuffer = struct {
             } else {
                 const codepoint = char_code;
 
-                if (codepoint > 0x10FFFF) {
+                if (codepoint == 0 or codepoint > 0x10FFFF) {
                     if (bytes_written + 1 > output_buffer.len) {
                         return BufferError.BufferTooSmall;
                     }

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -209,6 +209,10 @@ export fn setUseThread(rendererPtr: *renderer.CliRenderer, useThread: bool) void
     rendererPtr.setUseThread(useThread);
 }
 
+export fn setClearOnShutdown(rendererPtr: *renderer.CliRenderer, clear: bool) void {
+    rendererPtr.setClearOnShutdown(clear);
+}
+
 export fn destroyRenderer(rendererPtr: *renderer.CliRenderer) void {
     rendererPtr.destroy();
 }
@@ -219,6 +223,35 @@ export fn setBackgroundColor(rendererPtr: *renderer.CliRenderer, color: [*]const
 
 export fn setRenderOffset(rendererPtr: *renderer.CliRenderer, offset: u32) void {
     rendererPtr.setRenderOffset(offset);
+}
+
+export fn resetSplitScrollback(rendererPtr: *renderer.CliRenderer, seedRows: u32, pinnedRenderOffset: u32) u32 {
+    return rendererPtr.resetSplitScrollback(seedRows, pinnedRenderOffset);
+}
+
+export fn syncSplitScrollback(rendererPtr: *renderer.CliRenderer, pinnedRenderOffset: u32) u32 {
+    return rendererPtr.syncSplitScrollback(pinnedRenderOffset);
+}
+
+export fn setPendingSplitFooterTransition(
+    rendererPtr: *renderer.CliRenderer,
+    mode: u8,
+    sourceTopLine: u32,
+    sourceHeight: u32,
+    targetTopLine: u32,
+    targetHeight: u32,
+) void {
+    rendererPtr.setPendingSplitFooterTransition(
+        @enumFromInt(mode),
+        sourceTopLine,
+        sourceHeight,
+        targetTopLine,
+        targetHeight,
+    );
+}
+
+export fn clearPendingSplitFooterTransition(rendererPtr: *renderer.CliRenderer) void {
+    rendererPtr.clearPendingSplitFooterTransition();
 }
 
 export fn updateStats(rendererPtr: *renderer.CliRenderer, time: f64, fps: u32, frameCallbackTime: f64) void {
@@ -266,6 +299,55 @@ export fn getBufferHeight(bufferPtr: *buffer.OptimizedBuffer) u32 {
 
 export fn render(rendererPtr: *renderer.CliRenderer, force: bool) void {
     rendererPtr.render(force);
+}
+
+export fn repaintSplitFooter(
+    rendererPtr: *renderer.CliRenderer,
+    pinnedRenderOffset: u32,
+    force: bool,
+) u32 {
+    return rendererPtr.repaintSplitFooter(pinnedRenderOffset, force);
+}
+
+export fn commitSplitFooterSnapshot(
+    rendererPtr: *renderer.CliRenderer,
+    snapshotBufferPtr: *buffer.OptimizedBuffer,
+    rowColumns: u32,
+    startOnNewLine: bool,
+    trailingNewline: bool,
+    pinnedRenderOffset: u32,
+    force: bool,
+    beginFrame: bool,
+    finalizeFrame: bool,
+) u32 {
+    // JS passes rowColumns/startOnNewLine/trailingNewline per commit from
+    // writeToScrollback or captured stdout chunking. This entrypoint is the ABI
+    // boundary where that metadata enters the native split append algorithm.
+    // Route all commits through the batched renderer path so sync/cursor framing
+    // happens exactly once per JS flush cycle.
+    if (beginFrame and finalizeFrame) {
+        return rendererPtr.commitSplitFooterSnapshotBatched(
+            snapshotBufferPtr,
+            rowColumns,
+            startOnNewLine,
+            trailingNewline,
+            pinnedRenderOffset,
+            force,
+            true,
+            true,
+        );
+    }
+
+    return rendererPtr.commitSplitFooterSnapshotBatched(
+        snapshotBufferPtr,
+        rowColumns,
+        startOnNewLine,
+        trailingNewline,
+        pinnedRenderOffset,
+        force,
+        beginFrame,
+        finalizeFrame,
+    );
 }
 
 export fn createOptimizedBuffer(width: u32, height: u32, respectAlpha: bool, widthMethod: u8, idPtr: [*]const u8, idLen: usize) ?*buffer.OptimizedBuffer {
@@ -971,6 +1053,10 @@ export fn textBufferViewSetWrapMode(view: *text_buffer_view.UnifiedTextBufferVie
         else => .none,
     };
     view.setWrapMode(wrapMode);
+}
+
+export fn textBufferViewSetFirstLineOffset(view: *text_buffer_view.UnifiedTextBufferView, offset: u32) void {
+    view.setFirstLineOffset(offset);
 }
 
 export fn textBufferViewSetViewportSize(view: *text_buffer_view.UnifiedTextBufferView, width: u32, height: u32) void {

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -4,6 +4,7 @@ const ansi = @import("ansi.zig");
 const buf = @import("buffer.zig");
 const gp = @import("grapheme.zig");
 const link = @import("link.zig");
+const split_scrollback = @import("split-scrollback.zig");
 const Terminal = @import("terminal.zig");
 const logger = @import("logger.zig");
 
@@ -40,6 +41,54 @@ pub const DebugOverlayCorner = enum {
     bottomRight,
 };
 
+fn moveToSplitOutputCursor(writer: anytype, render_offset: u32, output_column: u32, width: u32) void {
+    const safe_width = @max(width, @as(u32, 1));
+    const row: u32 = if (render_offset > 0) render_offset else 1;
+    const column: u32 = if (render_offset == 0 or output_column == 0)
+        1
+    else
+        @min(output_column + 1, safe_width);
+
+    ansi.ANSI.moveToOutput(writer, column, row) catch {};
+}
+
+fn snapshotRowEnd(snapshot: *const OptimizedBuffer, row: u32, limit: u32) u32 {
+    var x = limit;
+    while (x > 0) {
+        const cell = snapshot.get(x - 1, row) orelse {
+            x -= 1;
+            continue;
+        };
+
+        if (cell.char == 0 or gp.isContinuationChar(cell.char)) {
+            x -= 1;
+            continue;
+        }
+
+        return x;
+    }
+
+    return 0;
+}
+
+pub const SplitFooterTransitionMode = enum(u8) {
+    none = 0,
+    viewport_scroll = 1,
+    clear_stale_rows = 2,
+};
+
+const SplitFooterTransition = struct {
+    mode: SplitFooterTransitionMode = .none,
+    source_top_line: u32 = 0,
+    source_height: u32 = 0,
+    target_top_line: u32 = 0,
+    target_height: u32 = 0,
+
+    fn clear(self: *SplitFooterTransition) void {
+        self.* = .{};
+    }
+};
+
 pub const CliRenderer = struct {
     width: u32,
     height: u32,
@@ -52,6 +101,7 @@ pub const CliRenderer = struct {
     testing: bool = false,
     useAlternateScreen: bool = true,
     terminalSetup: bool = false,
+    clearOnShutdown: bool = true,
 
     renderStats: struct {
         lastFrameTime: f64,
@@ -98,6 +148,14 @@ pub const CliRenderer = struct {
     renderInProgress: bool = false,
     currentOutputBuffer: []u8 = &[_]u8{},
     currentOutputLen: usize = 0,
+    splitScrollback: split_scrollback.SplitScrollback = .{},
+    // Batch state for split-footer commit flushing. A single JS render tick can
+    // enqueue multiple stdout snapshots; batching keeps all of them inside one
+    // sync frame so terminals do not repeatedly enter/exit synchronized update.
+    splitBatchActive: bool = false,
+    splitBatchRedrawFooter: bool = false,
+    splitBatchDeltaTime: f64 = 0,
+    pendingSplitFooterTransition: SplitFooterTransition = .{},
 
     // Hit grid for mouse event dispatch.
     //
@@ -127,6 +185,11 @@ pub const CliRenderer = struct {
     lastCursorStyleTag: ?u8 = null,
     lastCursorBlinking: ?bool = null,
     lastCursorColorRGB: ?[3]u8 = null,
+    // Cursor diff cache. If nothing changed we avoid emitting cursor restore/show
+    // sequences for no-op frames, which removes a major source of visible flicker.
+    lastCursorX: ?u32 = null,
+    lastCursorY: ?u32 = null,
+    lastCursorVisible: ?bool = null,
     lastMousePointerStyle: Terminal.MousePointerStyle = .default,
 
     // Preallocated output buffer
@@ -317,10 +380,10 @@ pub const CliRenderer = struct {
         };
         writer.flush() catch {};
 
-        self.setupTerminalWithoutDetection(useAlternateScreen);
+        self.setupTerminalWithoutDetection(useAlternateScreen, true);
     }
 
-    fn setupTerminalWithoutDetection(self: *CliRenderer, useAlternateScreen: bool) void {
+    fn setupTerminalWithoutDetection(self: *CliRenderer, useAlternateScreen: bool, reserve_non_alt_surface: bool) void {
         var stdoutWriter = std.fs.File.stdout().writer(&self.stdoutBuffer);
         const writer = &stdoutWriter.interface;
 
@@ -328,7 +391,7 @@ pub const CliRenderer = struct {
 
         if (useAlternateScreen) {
             self.terminal.enterAltScreen(writer) catch {};
-        } else {
+        } else if (reserve_non_alt_surface) {
             ansi.ANSI.makeRoomForRendererOutput(writer, @max(self.height, 1)) catch {};
         }
 
@@ -344,9 +407,23 @@ pub const CliRenderer = struct {
         self.performShutdownSequence();
     }
 
+    pub fn setClearOnShutdown(self: *CliRenderer, clear: bool) void {
+        self.clearOnShutdown = clear;
+    }
+
     pub fn resumeRenderer(self: *CliRenderer) void {
         if (!self.terminalSetup) return;
-        self.setupTerminalWithoutDetection(self.useAlternateScreen);
+        self.setupTerminalWithoutDetection(self.useAlternateScreen, self.renderOffset == 0);
+    }
+
+    fn clearSplitFooterSurface(self: *CliRenderer, writer: anytype) void {
+        if (self.renderOffset == 0) return;
+
+        const footer_top_line = @max(self.renderOffset + 1, @as(u32, 1));
+        writer.writeAll("\x1b[r") catch {};
+        ansi.ANSI.moveToOutput(writer, 1, footer_top_line) catch {};
+        writer.writeAll(ansi.ANSI.eraseBelowCursor) catch {};
+        ansi.ANSI.moveToOutput(writer, 1, footer_top_line) catch {};
     }
 
     pub fn performShutdownSequence(self: *CliRenderer) void {
@@ -360,13 +437,12 @@ pub const CliRenderer = struct {
 
         if (self.useAlternateScreen) {
             direct.flush() catch {};
-        } else if (self.renderOffset == 0) {
+        } else if (self.clearOnShutdown and self.renderOffset == 0) {
             direct.writeAll("\x1b[H\x1b[J") catch {};
             direct.flush() catch {};
-        } else if (self.renderOffset > 0) {
-            // Currently still handled in typescript
-            // const consoleEndLine = self.height - self.renderOffset;
-            // ansi.ANSI.moveToOutput(direct, 1, consoleEndLine) catch {};
+        } else if (self.clearOnShutdown and self.renderOffset > 0) {
+            self.clearSplitFooterSurface(direct);
+            direct.flush() catch {};
         }
 
         // NOTE: This messes up state after shutdown, but might be necessary for windows?
@@ -515,7 +591,94 @@ pub const CliRenderer = struct {
     }
 
     pub fn setRenderOffset(self: *CliRenderer, offset: u32) void {
+        if (self.terminalSetup and !self.useAlternateScreen and self.renderOffset > 0 and offset == 0) {
+            var stdoutWriter = std.fs.File.stdout().writer(&self.stdoutBuffer);
+            const writer = &stdoutWriter.interface;
+            self.clearSplitFooterSurface(writer);
+            writer.flush() catch {};
+        }
+
         self.renderOffset = offset;
+    }
+
+    pub fn resetSplitScrollback(self: *CliRenderer, seed_rows: u32, pinned_render_offset: u32) u32 {
+        self.splitScrollback.reset(seed_rows);
+        self.renderOffset = self.splitScrollback.renderOffset(pinned_render_offset);
+        return self.renderOffset;
+    }
+
+    pub fn syncSplitScrollback(self: *CliRenderer, pinned_render_offset: u32) u32 {
+        self.renderOffset = self.splitScrollback.renderOffset(pinned_render_offset);
+        return self.renderOffset;
+    }
+
+    pub fn setPendingSplitFooterTransition(
+        self: *CliRenderer,
+        mode: SplitFooterTransitionMode,
+        source_top_line: u32,
+        source_height: u32,
+        target_top_line: u32,
+        target_height: u32,
+    ) void {
+        self.pendingSplitFooterTransition = .{
+            .mode = mode,
+            .source_top_line = source_top_line,
+            .source_height = source_height,
+            .target_top_line = target_top_line,
+            .target_height = target_height,
+        };
+    }
+
+    pub fn clearPendingSplitFooterTransition(self: *CliRenderer) void {
+        self.pendingSplitFooterTransition.clear();
+    }
+
+    fn applyPendingSplitFooterTransition(self: *CliRenderer, writer: anytype, frame_started: *bool) void {
+        const transition = self.pendingSplitFooterTransition;
+        defer self.pendingSplitFooterTransition.clear();
+
+        if (transition.mode == .none or transition.source_height == 0 or transition.target_height == 0) {
+            return;
+        }
+
+        if (!frame_started.*) {
+            beginRenderFrame(writer);
+            frame_started.* = true;
+        }
+
+        switch (transition.mode) {
+            .viewport_scroll => {
+                if (transition.source_height > transition.target_height) {
+                    writer.print("\x1b[{d}T", .{transition.source_height - transition.target_height}) catch {};
+                } else if (transition.source_height < transition.target_height) {
+                    writer.print("\x1b[{d}S", .{transition.target_height - transition.source_height}) catch {};
+                }
+            },
+            .clear_stale_rows => {
+                const source_end = transition.source_top_line + transition.source_height - 1;
+                const target_end = transition.target_top_line + transition.target_height - 1;
+                var line = transition.source_top_line;
+                while (line <= source_end) : (line += 1) {
+                    if (line >= transition.target_top_line and line <= target_end) {
+                        continue;
+                    }
+
+                    ansi.ANSI.moveToOutput(writer, 1, line) catch {};
+                    writer.writeAll("\x1b[2K") catch {};
+                }
+            },
+            .none => {},
+        }
+    }
+
+    fn resetActiveOutputBuffer() void {
+        // TODO: check if we need to guard this with a mutex when threading is enabled. It should be safe as long as the
+        // render thread only reads from the current buffer after the main thread has finished writing and signaled
+        if (activeBuffer == .A) {
+            outputBufferLen = 0;
+        } else {
+            outputBufferBLen = 0;
+        }
     }
 
     fn renderThreadFn(self: *CliRenderer) void {
@@ -561,8 +724,128 @@ pub const CliRenderer = struct {
         self.lastRenderTime = now;
         self.renderDebugOverlay();
 
-        self.prepareRenderFrame(force);
+        self.prepareRenderFrame(force, true, false);
 
+        self.finalizeRender(deltaTime);
+    }
+
+    pub fn repaintSplitFooter(
+        self: *CliRenderer,
+        pinned_render_offset: u32,
+        force: bool,
+    ) u32 {
+        const now = std.time.microTimestamp();
+        const deltaTimeMs = @as(f64, @floatFromInt(now - self.lastRenderTime));
+        const deltaTime = deltaTimeMs / 1000.0; // Convert to seconds
+
+        self.lastRenderTime = now;
+        self.renderDebugOverlay();
+
+        self.prepareSplitFooterRepaintFrame(pinned_render_offset, force);
+
+        self.finalizeRender(deltaTime);
+
+        return self.renderOffset;
+    }
+
+    pub fn commitSplitFooterSnapshotBatched(
+        self: *CliRenderer,
+        snapshot: *const OptimizedBuffer,
+        row_columns: u32,
+        start_on_new_line: bool,
+        trailing_newline: bool,
+        pinned_render_offset: u32,
+        force: bool,
+        begin_frame: bool,
+        finalize_frame: bool,
+    ) u32 {
+        // Batched commit protocol:
+        // - first call starts frame and appends payload
+        // - middle calls append payload only
+        // - final call renders footer diff/cursor and closes frame
+        // This avoids repeated syncSet/syncReset and cursor toggles per chunk.
+        if (begin_frame) {
+            const now = std.time.microTimestamp();
+            const deltaTimeMs = @as(f64, @floatFromInt(now - self.lastRenderTime));
+            const deltaTime = deltaTimeMs / 1000.0;
+
+            self.lastRenderTime = now;
+            self.renderDebugOverlay();
+
+            resetActiveOutputBuffer();
+            const writer = OutputBufferWriter.writer();
+            beginRenderFrame(writer);
+            var frame_started = true;
+            self.applyPendingSplitFooterTransition(writer, &frame_started);
+
+            // Track batch lifetime so subsequent calls can append into the same
+            // output buffer without restarting frame state.
+            self.splitBatchActive = !finalize_frame;
+            self.splitBatchRedrawFooter = false;
+            self.splitBatchDeltaTime = deltaTime;
+
+            const redraw_footer = self.appendSplitFooterSnapshotCommit(
+                writer,
+                snapshot,
+                row_columns,
+                start_on_new_line,
+                trailing_newline,
+                pinned_render_offset,
+                force,
+            );
+
+            if (finalize_frame) {
+                self.prepareRenderFrame(redraw_footer, false, true);
+                self.finalizeRender(deltaTime);
+                self.splitBatchActive = false;
+                self.splitBatchRedrawFooter = false;
+                self.splitBatchDeltaTime = 0;
+            } else {
+                self.splitBatchRedrawFooter = redraw_footer;
+            }
+
+            return self.renderOffset;
+        }
+
+        // Defensive fallback: if caller forgot begin_frame, execute through a
+        // single-call frame instead of appending into undefined batch state.
+        if (!self.splitBatchActive) {
+            return self.commitSplitFooterSnapshotBatched(
+                snapshot,
+                row_columns,
+                start_on_new_line,
+                trailing_newline,
+                pinned_render_offset,
+                force,
+                true,
+                true,
+            );
+        }
+
+        const writer = OutputBufferWriter.writer();
+        const redraw_footer = self.appendSplitFooterSnapshotCommit(
+            writer,
+            snapshot,
+            row_columns,
+            start_on_new_line,
+            trailing_newline,
+            pinned_render_offset,
+            force,
+        );
+        self.splitBatchRedrawFooter = self.splitBatchRedrawFooter or redraw_footer;
+
+        if (finalize_frame) {
+            self.prepareRenderFrame(self.splitBatchRedrawFooter, false, true);
+            self.finalizeRender(self.splitBatchDeltaTime);
+            self.splitBatchActive = false;
+            self.splitBatchRedrawFooter = false;
+            self.splitBatchDeltaTime = 0;
+        }
+
+        return self.renderOffset;
+    }
+
+    fn finalizeRender(self: *CliRenderer, deltaTime: f64) void {
         if (self.useThread) {
             self.renderMutex.lock();
             while (self.renderInProgress) {
@@ -585,10 +868,11 @@ pub const CliRenderer = struct {
             self.renderMutex.unlock();
         } else {
             const writeStart = std.time.microTimestamp();
+            const output = if (activeBuffer == .A) outputBuffer[0..outputBufferLen] else outputBufferB[0..outputBufferBLen];
             if (!self.testing) {
                 var stdoutWriter = std.fs.File.stdout().writer(&self.stdoutBuffer);
                 const w = &stdoutWriter.interface;
-                w.writeAll(outputBuffer[0..outputBufferLen]) catch {};
+                w.writeAll(output) catch {};
                 w.flush() catch {};
             }
             self.renderStats.stdoutWriteTime = @as(f64, @floatFromInt(std.time.microTimestamp() - writeStart));
@@ -610,6 +894,265 @@ pub const CliRenderer = struct {
         self.addStatSample(u32, &self.statSamples.cellsUpdated, self.renderStats.cellsUpdated);
     }
 
+    fn prepareSplitFooterRepaintFrame(
+        self: *CliRenderer,
+        pinned_render_offset: u32,
+        force: bool,
+    ) void {
+        const previousRenderOffset = self.renderOffset;
+        const next_render_offset = self.splitScrollback.renderOffset(pinned_render_offset);
+        const redraw_footer = force or previousRenderOffset != next_render_offset;
+
+        self.renderOffset = next_render_offset;
+        // Do not pre-start sync frame here. prepareRenderFrame now lazily starts
+        // frame output only when something actually changes; this prevents no-op
+        // repaint ticks from emitting hide/show cursor and sync envelopes.
+        self.prepareRenderFrame(redraw_footer, true, false);
+    }
+
+    /// Serialization for one split append payload.
+    ///
+    /// This function intentionally does not emit syncSet/syncReset or footer
+    /// repaint sequences. It only writes snapshot text rows at the current output
+    /// cursor. Frame boundaries are controlled by commitSplitFooterSnapshot*
+    /// callers so multiple payloads can share one frame.
+    ///
+    /// row_columns limits the per-row emitted width. Caller may provide a
+    /// wider buffer but a smaller logical row width for wrapped stdout chunks.
+    ///
+    /// trailing_newline mirrors stdout semantics: only payloads that logically
+    /// ended with '\n' advance and clear the next row after the final row.
+    fn writeSnapshotCommit(
+        self: *CliRenderer,
+        writer: anytype,
+        snapshot: *const OptimizedBuffer,
+        row_columns: u32,
+        trailing_newline: bool,
+    ) void {
+        var currentFg: ?RGBA = null;
+        var currentBg: ?RGBA = null;
+        var currentAttributes: i32 = -1;
+        var currentLinkId: u32 = 0;
+        var utf8Buf: [4]u8 = undefined;
+
+        const colorEpsilon: f32 = COLOR_EPSILON_DEFAULT;
+        const hyperlinksEnabled = self.terminal.getCapabilities().hyperlinks;
+        const render_columns = @min(row_columns, snapshot.width);
+
+        for (0..snapshot.height) |uy| {
+            const y = @as(u32, @intCast(uy));
+            const row_end = snapshotRowEnd(snapshot, y, render_columns);
+
+            for (0..row_end) |ux| {
+                const x = @as(u32, @intCast(ux));
+                const cell = snapshot.get(x, y) orelse continue;
+
+                const fgMatch = currentFg != null and buf.rgbaEqual(currentFg.?, cell.fg, colorEpsilon);
+                const bgMatch = currentBg != null and buf.rgbaEqual(currentBg.?, cell.bg, colorEpsilon);
+                const sameAttributes = fgMatch and bgMatch and @as(i32, @intCast(cell.attributes)) == currentAttributes;
+
+                const linkId = if (hyperlinksEnabled) ansi.TextAttributes.getLinkId(cell.attributes) else 0;
+                if (hyperlinksEnabled and linkId != currentLinkId) {
+                    if (currentLinkId != 0) {
+                        writer.writeAll("\x1b]8;;\x1b\\") catch {};
+                    }
+                    currentLinkId = linkId;
+                    if (currentLinkId != 0) {
+                        const lp = link.initGlobalLinkPool(self.allocator);
+                        if (lp.get(currentLinkId)) |url_bytes| {
+                            writer.print("\x1b]8;id={d};{s}\x1b\\", .{ currentLinkId, url_bytes }) catch {};
+                        } else |_| {
+                            currentLinkId = 0;
+                        }
+                    }
+                }
+
+                if (!sameAttributes) {
+                    writer.writeAll(ansi.ANSI.reset) catch {};
+
+                    currentFg = cell.fg;
+                    currentBg = cell.bg;
+                    currentAttributes = @as(i32, @intCast(cell.attributes));
+
+                    const fgR = rgbaComponentToU8(cell.fg[0]);
+                    const fgG = rgbaComponentToU8(cell.fg[1]);
+                    const fgB = rgbaComponentToU8(cell.fg[2]);
+
+                    const bgR = rgbaComponentToU8(cell.bg[0]);
+                    const bgG = rgbaComponentToU8(cell.bg[1]);
+                    const bgB = rgbaComponentToU8(cell.bg[2]);
+                    const bgA = cell.bg[3];
+
+                    ansi.ANSI.fgColorOutput(writer, fgR, fgG, fgB) catch {};
+                    if (bgA < 0.001) {
+                        writer.writeAll("\x1b[49m") catch {};
+                    } else {
+                        ansi.ANSI.bgColorOutput(writer, bgR, bgG, bgB) catch {};
+                    }
+
+                    ansi.TextAttributes.applyAttributesOutputWriter(writer, cell.attributes) catch {};
+                }
+
+                if (cell.char == 0) {
+                    writer.writeByte(' ') catch {};
+                } else if (gp.isGraphemeChar(cell.char)) {
+                    const gid: u32 = gp.graphemeIdFromChar(cell.char);
+                    const bytes = self.pool.get(gid) catch {
+                        writer.writeByte(' ') catch {};
+                        continue;
+                    };
+
+                    if (bytes.len > 0) {
+                        const capabilities = self.terminal.getCapabilities();
+                        const graphemeWidth = gp.charRightExtent(cell.char) + 1;
+                        if (capabilities.explicit_width) {
+                            ansi.ANSI.explicitWidthOutput(writer, graphemeWidth, bytes) catch {};
+                        } else {
+                            writer.writeAll(bytes) catch {};
+                        }
+                    }
+                } else if (gp.isContinuationChar(cell.char)) {
+                    // Keep split scrollback payload behavior aligned with the live
+                    // frame renderer: continuation cells must not serialize as
+                    // spaces, or wide graphemes become one extra column wider in
+                    // terminal output and table rows can autowrap unexpectedly.
+                } else {
+                    const len = std.unicode.utf8Encode(@intCast(cell.char), &utf8Buf) catch 1;
+                    writer.writeAll(utf8Buf[0..len]) catch {};
+                }
+            }
+
+            if (hyperlinksEnabled and currentLinkId != 0) {
+                writer.writeAll("\x1b]8;;\x1b\\") catch {};
+                currentLinkId = 0;
+            }
+
+            writer.writeAll(ansi.ANSI.reset) catch {};
+            // Guarantee short rows do not leave stale content from prior frame data.
+            writer.writeAll(ansi.ANSI.eraseToEndOfLine) catch {};
+
+            const is_last_row = @as(u32, @intCast(uy + 1)) >= snapshot.height;
+            if (!is_last_row or trailing_newline) {
+                writer.writeAll("\r\n") catch {};
+            }
+
+            if (is_last_row and trailing_newline) {
+                // After a trailing newline, clear the destination row that becomes
+                // current so old footer text cannot flash through.
+                writer.writeAll(ansi.ANSI.reset) catch {};
+                writer.writeAll(ansi.ANSI.eraseToEndOfLine) catch {};
+            }
+
+            currentFg = null;
+            currentBg = null;
+            currentAttributes = -1;
+        }
+    }
+
+    /// Shared append path for all split payload sources.
+    ///
+    /// Contract: append payload first, then position for footer repaint in the
+    /// same frame. Returning redraw_footer lets caller skip full diff work when
+    /// footer position did not actually change.
+    fn appendSplitFooterSnapshotCommit(
+        self: *CliRenderer,
+        writer: anytype,
+        snapshot: *const OptimizedBuffer,
+        row_columns: u32,
+        start_on_new_line: bool,
+        trailing_newline: bool,
+        pinned_render_offset: u32,
+        force: bool,
+    ) bool {
+        const previousRenderOffset = self.renderOffset;
+        const previousOutputColumn = self.splitScrollback.tail_column;
+        const snapshot_has_content = snapshot.width > 0 and snapshot.height > 0;
+        const normalized_row_columns = @min(row_columns, snapshot.width);
+        const starts_mid_line = previousOutputColumn > 0 and start_on_new_line;
+        const starts_wrapped_line = previousOutputColumn >= self.width;
+        const previousFooterTopLine: u32 = @max(previousRenderOffset + 1, @as(u32, 1));
+
+        if (snapshot_has_content) {
+            // First update logical split scrollback state, then emit terminal I/O.
+            // Keeping model state authoritative makes repaint decisions deterministic.
+            if (starts_mid_line) {
+                self.splitScrollback.noteNewline();
+            }
+
+            var row: u32 = 0;
+            while (row < snapshot.height) : (row += 1) {
+                self.splitScrollback.publishRow(
+                    snapshotRowEnd(snapshot, row, normalized_row_columns),
+                    self.width,
+                    row + 1 < snapshot.height or trailing_newline,
+                );
+            }
+        }
+
+        const next_render_offset = self.splitScrollback.renderOffset(pinned_render_offset);
+        const targetFooterTopLine: u32 = @max(next_render_offset + 1, @as(u32, 1));
+        // Footer redraw is only needed when offset changes (settling/pinning) or
+        // when an explicit force was requested by the caller.
+        const redraw_footer = force or previousRenderOffset != next_render_offset;
+        // When split scrollback is settled at the pinned boundary, newlines/wraps from
+        // appended output must scroll only the upper pane. Without a temporary DECSTBM
+        // region, terminals advance into the footer rows and overwrite them in place.
+        const use_bounded_scroll_region = snapshot_has_content and
+            pinned_render_offset > 0 and
+            next_render_offset == pinned_render_offset;
+
+        if (snapshot_has_content or force) {
+            if (snapshot_has_content) {
+                // Clear rows that are transitioning from "footer surface" to scrollback before
+                // writing appended rows. If this happens after append, the clear itself is what
+                // gets scrolled and manifests as extra blank lines in history.
+                if (targetFooterTopLine > previousFooterTopLine) {
+                    var clear_line = previousFooterTopLine;
+                    while (clear_line < targetFooterTopLine) : (clear_line += 1) {
+                        ansi.ANSI.moveToOutput(writer, 1, clear_line) catch {};
+                        writer.writeAll("\x1b[2K") catch {};
+                    }
+                }
+
+                if (use_bounded_scroll_region) {
+                    // Temporarily bound scrolling to the upper pane so newline/wrap
+                    // from appended payload pushes history upward instead of stepping
+                    // through footer rows.
+                    writer.print("\x1b[1;{d}r", .{pinned_render_offset}) catch {};
+                }
+
+                moveToSplitOutputCursor(writer, previousRenderOffset, previousOutputColumn, self.width);
+                if (starts_mid_line or starts_wrapped_line) {
+                    // The prior commit left output cursor mid-row and caller asked
+                    // for newline anchoring. When the prior commit exactly filled the
+                    // row, we also need a CRLF here because moving the cursor back to
+                    // the last column loses the terminal's pending autowrap state.
+                    // Emit CRLF before payload to preserve logical row boundaries
+                    // across commit chunks.
+                    writer.writeAll("\r\n") catch {};
+                }
+
+                // Serialize payload rows at current output cursor.
+                self.writeSnapshotCommit(writer, snapshot, normalized_row_columns, trailing_newline);
+
+                if (use_bounded_scroll_region) {
+                    // Restore default full-height scroll region for regular repaint
+                    // and cursor operations after append is complete.
+                    writer.writeAll("\x1b[r") catch {};
+                }
+            }
+
+            self.renderOffset = next_render_offset;
+            if (redraw_footer) {
+                ansi.ANSI.moveToOutput(writer, 1, targetFooterTopLine) catch {};
+            }
+        } else {
+            self.renderOffset = next_render_offset;
+        }
+
+        return redraw_footer;
+    }
+
     pub fn getNextBuffer(self: *CliRenderer) *OptimizedBuffer {
         return self.nextRenderBuffer;
     }
@@ -618,20 +1161,25 @@ pub const CliRenderer = struct {
         return self.currentRenderBuffer;
     }
 
-    fn prepareRenderFrame(self: *CliRenderer, force: bool) void {
+    fn beginRenderFrame(writer: anytype) void {
+        writer.writeAll(ansi.ANSI.syncSet) catch {};
+        writer.writeAll(ansi.ANSI.hideCursor) catch {};
+    }
+
+    fn prepareRenderFrame(self: *CliRenderer, force: bool, reset_output_buffer: bool, sync_started: bool) void {
         const renderStartTime = std.time.microTimestamp();
         var cellsUpdated: u32 = 0;
 
-        if (activeBuffer == .A) {
-            outputBufferLen = 0;
-        } else {
-            outputBufferBLen = 0;
+        if (reset_output_buffer) {
+            resetActiveOutputBuffer();
         }
 
         var writer = OutputBufferWriter.writer();
-
-        writer.writeAll(ansi.ANSI.syncSet) catch {};
-        writer.writeAll(ansi.ANSI.hideCursor) catch {};
+        // Lazy frame start is the core no-op suppression mechanism. If diffing,
+        // cursor state, and pointer state are unchanged, frame_started stays false
+        // and we emit nothing at all for this tick.
+        var frame_started = sync_started;
+        self.applyPendingSplitFooterTransition(writer, &frame_started);
 
         var currentFg: ?RGBA = null;
         var currentBg: ?RGBA = null;
@@ -673,6 +1221,11 @@ pub const CliRenderer = struct {
                 }
 
                 const cell = nextCell.?;
+
+                if (!frame_started) {
+                    beginRenderFrame(writer);
+                    frame_started = true;
+                }
 
                 const fgMatch = currentFg != null and buf.rgbaEqual(currentFg.?, cell.fg, colorEpsilon);
                 const bgMatch = currentBg != null and buf.rgbaEqual(currentBg.?, cell.bg, colorEpsilon);
@@ -776,10 +1329,16 @@ pub const CliRenderer = struct {
         }
 
         if (hyperlinksEnabled and currentLinkId != 0) {
+            if (!frame_started) {
+                beginRenderFrame(writer);
+                frame_started = true;
+            }
             writer.writeAll("\x1b]8;;\x1b\\") catch {};
         }
 
-        writer.writeAll(ansi.ANSI.reset) catch {};
+        if (frame_started) {
+            writer.writeAll(ansi.ANSI.reset) catch {};
+        }
 
         const cursorPos = self.terminal.getCursorPosition();
         const cursorStyle = self.terminal.getCursorStyle();
@@ -820,32 +1379,67 @@ pub const CliRenderer = struct {
             const styleChanged = (self.lastCursorStyleTag == null or self.lastCursorStyleTag.? != styleTag) or
                 (self.lastCursorBlinking == null or self.lastCursorBlinking.? != cursorStyle.blinking);
             const colorChanged = (self.lastCursorColorRGB == null or self.lastCursorColorRGB.?[0] != cursorR or self.lastCursorColorRGB.?[1] != cursorG or self.lastCursorColorRGB.?[2] != cursorB);
+            const cursorX = cursorPos.x;
+            const cursorY = cursorPos.y + self.renderOffset;
+            const positionChanged = self.lastCursorX == null or self.lastCursorY == null or self.lastCursorX.? != cursorX or self.lastCursorY.? != cursorY;
+            const visibilityChanged = self.lastCursorVisible == null or !self.lastCursorVisible.?;
+            // If any visual output was produced this frame, we must restore cursor
+            // state (position + visibility). If frame is otherwise empty, only emit
+            // cursor sequences when some cursor property actually changed.
+            const needsCursorRestore = frame_started or styleChanged or colorChanged or positionChanged or visibilityChanged;
 
-            if (colorChanged) {
-                ansi.ANSI.cursorColorOutputWriter(writer, cursorR, cursorG, cursorB) catch {};
-                self.lastCursorColorRGB = .{ cursorR, cursorG, cursorB };
+            if (needsCursorRestore) {
+                if (!frame_started) {
+                    beginRenderFrame(writer);
+                    frame_started = true;
+                }
+
+                if (colorChanged) {
+                    ansi.ANSI.cursorColorOutputWriter(writer, cursorR, cursorG, cursorB) catch {};
+                    self.lastCursorColorRGB = .{ cursorR, cursorG, cursorB };
+                }
+                if (styleChanged) {
+                    writer.writeAll(cursorStyleCode) catch {};
+                    self.lastCursorStyleTag = styleTag;
+                    self.lastCursorBlinking = cursorStyle.blinking;
+                }
+
+                ansi.ANSI.moveToOutput(writer, cursorX, cursorY) catch {};
+                writer.writeAll(ansi.ANSI.showCursor) catch {};
             }
-            if (styleChanged) {
-                writer.writeAll(cursorStyleCode) catch {};
-                self.lastCursorStyleTag = styleTag;
-                self.lastCursorBlinking = cursorStyle.blinking;
-            }
-            ansi.ANSI.moveToOutput(writer, cursorPos.x, cursorPos.y + self.renderOffset) catch {};
-            writer.writeAll(ansi.ANSI.showCursor) catch {};
+
+            self.lastCursorX = cursorX;
+            self.lastCursorY = cursorY;
+            self.lastCursorVisible = true;
         } else {
-            writer.writeAll(ansi.ANSI.hideCursor) catch {};
+            if (!frame_started and (self.lastCursorVisible == null or self.lastCursorVisible.?)) {
+                beginRenderFrame(writer);
+                frame_started = true;
+                writer.writeAll(ansi.ANSI.hideCursor) catch {};
+            }
+
             self.lastCursorStyleTag = null;
             self.lastCursorBlinking = null;
             self.lastCursorColorRGB = null;
+            self.lastCursorX = null;
+            self.lastCursorY = null;
+            self.lastCursorVisible = false;
         }
 
         const mousePointer = self.terminal.getMousePointer();
         if (mousePointer != self.lastMousePointerStyle) {
+            if (!frame_started) {
+                beginRenderFrame(writer);
+                frame_started = true;
+            }
             ansi.ANSI.setMousePointerOutput(writer, mousePointer.toName()) catch {};
             self.lastMousePointerStyle = mousePointer;
         }
 
-        writer.writeAll(ansi.ANSI.syncReset) catch {};
+        // Only close sync if we opened it. This keeps true no-op frames empty.
+        if (frame_started) {
+            writer.writeAll(ansi.ANSI.syncReset) catch {};
+        }
 
         const renderEndTime = std.time.microTimestamp();
         const renderTime = @as(f64, @floatFromInt(renderEndTime - renderStartTime));

--- a/packages/core/src/zig/split-scrollback.zig
+++ b/packages/core/src/zig/split-scrollback.zig
@@ -1,0 +1,81 @@
+pub const SplitScrollback = struct {
+    published_rows: u32 = 0,
+    tail_column: u32 = 0,
+
+    pub fn reset(self: *SplitScrollback, seed_rows: u32) void {
+        self.published_rows = seed_rows;
+        self.tail_column = 0;
+    }
+
+    pub fn renderOffset(self: *const SplitScrollback, pinned_render_offset: u32) u32 {
+        if (pinned_render_offset == 0) {
+            return 0;
+        }
+
+        return @min(self.published_rows, pinned_render_offset);
+    }
+
+    pub fn noteNewline(self: *SplitScrollback) void {
+        if (self.published_rows == 0) {
+            self.published_rows = 1;
+        }
+
+        self.published_rows += 1;
+        self.tail_column = 0;
+    }
+
+    pub fn publishSnapshotRows(
+        self: *SplitScrollback,
+        row_count: u32,
+        row_columns: u32,
+        terminal_width: u32,
+        trailing_newline: bool,
+    ) void {
+        if (row_count == 0) {
+            return;
+        }
+
+        var row: u32 = 0;
+        while (row < row_count) : (row += 1) {
+            self.publishRow(row_columns, terminal_width, row + 1 < row_count or trailing_newline);
+        }
+    }
+
+    pub fn publishRow(self: *SplitScrollback, columns: u32, width: u32, trailing_newline: bool) void {
+        self.publishColumns(columns, width);
+        if (trailing_newline) {
+            self.noteNewline();
+        }
+    }
+
+    fn publishColumns(self: *SplitScrollback, columns: u32, width: u32) void {
+        if (columns == 0) {
+            return;
+        }
+
+        const safe_width = @max(width, @as(u32, 1));
+        var remaining = columns;
+
+        while (remaining > 0) {
+            if (self.published_rows == 0) {
+                self.published_rows = 1;
+            }
+
+            if (self.tail_column >= safe_width) {
+                self.published_rows += 1;
+                self.tail_column = 0;
+            }
+
+            const available_width = safe_width - self.tail_column;
+            const step = @min(remaining, available_width);
+
+            self.tail_column += step;
+            remaining -= step;
+
+            if (remaining > 0 and self.tail_column >= safe_width) {
+                self.published_rows += 1;
+                self.tail_column = 0;
+            }
+        }
+    }
+};

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -107,6 +107,8 @@ skip_explicit_width_query: bool = false,
 graphics_query_pending: bool = false,
 capability_queries_pending: bool = false,
 theme_queries_pending: bool = false,
+startup_cursor_query_pending: bool = false,
+startup_cursor_query_captured: bool = false,
 
 state: struct {
     alt_screen: bool = false,
@@ -231,6 +233,8 @@ pub fn queryTerminalSend(self: *Terminal, tty: anytype) !void {
     self.graphics_query_pending = !self.skip_graphics_query;
     self.capability_queries_pending = false;
     self.theme_queries_pending = false;
+    self.startup_cursor_query_pending = true;
+    self.startup_cursor_query_captured = false;
 
     try self.setColorSchemeUpdates(tty, true);
     try tty.writeAll(ansi.ANSI.colorSchemeRequest);
@@ -247,6 +251,9 @@ pub fn queryTerminalSend(self: *Terminal, tty: anytype) !void {
     try tty.writeAll(ansi.ANSI.xtversion ++
         ansi.ANSI.hideCursor ++
         ansi.ANSI.saveCursorState);
+
+    // Capture the current cursor position before temporary home-position queries.
+    try tty.writeAll(ansi.ANSI.cursorPositionRequest);
 
     if (self.in_tmux) {
         try tty.writeAll(ansi.ANSI.capabilityQueriesTmux);
@@ -714,24 +721,55 @@ pub fn processCapabilityResponse(self: *Terminal, response: []const u8) void {
         self.caps.bracketed_paste = true;
     }
 
-    // Explicit width detection - cursor position report [1;NR where N >= 2 means explicit width supported
-    // We look for ESC[1; followed by a digit >= 2
-    // This handles cases where the cursor isn't at exact home position when queries are sent
-    if (std.mem.indexOf(u8, response, "\x1b[1;")) |pos| {
-        const after = response[pos + 4 ..];
-        if (after.len > 0) {
-            var end: usize = 0;
-            while (end < after.len and after[end] >= '0' and after[end] <= '9') : (end += 1) {}
-            if (end > 0 and end < after.len and after[end] == 'R') {
-                const col = std.fmt.parseInt(u16, after[0..end], 10) catch 0;
-                if (col >= 2) {
-                    self.caps.explicit_width = true;
-                }
-                if (col >= 3) {
-                    self.caps.scaled_text = true;
-                }
+    // Parse cursor position reports: ESC[row;colR
+    // The first report after queryTerminalSend is the pre-home cursor position.
+    var scan_pos: usize = 0;
+    while (scan_pos < response.len) {
+        const esc_rel = std.mem.indexOf(u8, response[scan_pos..], "\x1b[") orelse break;
+        const esc = scan_pos + esc_rel;
+        var pos = esc + 2;
+
+        const row_start = pos;
+        while (pos < response.len and response[pos] >= '0' and response[pos] <= '9') : (pos += 1) {}
+        if (pos == row_start or pos >= response.len or response[pos] != ';') {
+            scan_pos = esc + 2;
+            continue;
+        }
+
+        const row = std.fmt.parseInt(u16, response[row_start..pos], 10) catch {
+            scan_pos = pos + 1;
+            continue;
+        };
+
+        pos += 1;
+        const col_start = pos;
+        while (pos < response.len and response[pos] >= '0' and response[pos] <= '9') : (pos += 1) {}
+        if (pos == col_start or pos >= response.len or response[pos] != 'R') {
+            scan_pos = col_start;
+            continue;
+        }
+
+        const col = std.fmt.parseInt(u16, response[col_start..pos], 10) catch {
+            scan_pos = pos + 1;
+            continue;
+        };
+
+        if (self.startup_cursor_query_pending and !self.startup_cursor_query_captured and row >= 1 and col >= 1) {
+            self.setCursorPosition(col, row, self.state.cursor.visible);
+            self.startup_cursor_query_captured = true;
+            self.startup_cursor_query_pending = false;
+        }
+
+        if (row == 1) {
+            if (col >= 2) {
+                self.caps.explicit_width = true;
+            }
+            if (col >= 3) {
+                self.caps.scaled_text = true;
             }
         }
+
+        scan_pos = pos + 1;
     }
 
     // Parse xtversion response: ESC P > | name version ESC \

--- a/packages/core/src/zig/test.zig
+++ b/packages/core/src/zig/test.zig
@@ -32,6 +32,7 @@ const memory_leak_regression_tests = @import("tests/memory_leak_regression_test.
 const wrap_cache_perf_tests = @import("tests/wrap-cache-perf_test.zig");
 const native_span_feed_tests = @import("tests/native-span-feed_test.zig");
 const buffer_methods_tests = @import("tests/buffer-methods_test.zig");
+const split_scrollback_tests = @import("tests/split-scrollback_test.zig");
 // const example_tests = @import("example_test.zig");
 
 // Re-export test declarations from individual test files
@@ -68,5 +69,6 @@ comptime {
     _ = wrap_cache_perf_tests;
     _ = native_span_feed_tests;
     _ = buffer_methods_tests;
+    _ = split_scrollback_tests;
     // _ = example_tests;
 }

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -1015,3 +1015,656 @@ test "renderer - explicit_cursor_positioning with CJK characters" {
 
     try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[1;3H") != null);
 }
+
+test "renderer - commitSplitFooterSnapshot writes append before footer repaint in one output" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        12,
+        3,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    _ = cli_renderer.resetSplitScrollback(2, 2);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    const fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try next_buffer.drawText("FOOT", 0, 0, fg, bg, 0);
+
+    var snapshot = try OptimizedBuffer.init(
+        std.testing.allocator,
+        11,
+        1,
+        .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
+    );
+    defer snapshot.deinit();
+
+    try snapshot.clear(.{ 0.0, 0.0, 0.0, 0.0 }, 32);
+    try snapshot.drawText("append-line", 0, 0, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+
+    const appended = "append-line";
+    // This test documents the critical ordering contract:
+    // 1) append payload is emitted in the same sync frame as repaint
+    // 2) DECSTBM is active only during append when pinned
+    // 3) footer repaint cursor move happens after append payload
+    _ = cli_renderer.commitSplitFooterSnapshotBatched(snapshot, 11, false, true, 2, false, true, true);
+
+    const output = cli_renderer.getLastOutputForTest();
+    const append_index = std.mem.indexOf(u8, output, appended);
+    const scroll_region_set_index = std.mem.indexOf(u8, output, "\x1b[1;2r");
+    const scroll_region_reset_index = std.mem.indexOf(u8, output, "\x1b[r");
+    const sync_index = std.mem.indexOf(u8, output, ansi.ANSI.syncSet);
+    const footer_move_after_sync = if (sync_index) |sync_start|
+        std.mem.indexOf(u8, output[sync_start + ansi.ANSI.syncSet.len ..], "\x1b[3;1H")
+    else
+        null;
+
+    try std.testing.expect(append_index != null);
+    try std.testing.expect(scroll_region_set_index != null);
+    try std.testing.expect(scroll_region_reset_index != null);
+    try std.testing.expect(sync_index != null);
+    try std.testing.expect(footer_move_after_sync != null);
+    try std.testing.expect(sync_index.? < append_index.?);
+    try std.testing.expect(scroll_region_set_index.? < append_index.?);
+    try std.testing.expect(append_index.? < scroll_region_reset_index.?);
+
+    var sync_count: usize = 0;
+    var pos: usize = 0;
+    while (std.mem.indexOf(u8, output[pos..], ansi.ANSI.syncSet)) |found| {
+        sync_count += 1;
+        pos += found + ansi.ANSI.syncSet.len;
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), sync_count);
+}
+
+test "renderer - commitSplitFooterSnapshot settling phase moves footer downward" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        12,
+        3,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    _ = cli_renderer.resetSplitScrollback(0, 3);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    const fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try next_buffer.drawText("FOOT", 0, 0, fg, bg, 0);
+
+    var snapshot = try OptimizedBuffer.init(
+        std.testing.allocator,
+        6,
+        1,
+        .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
+    );
+    defer snapshot.deinit();
+
+    try snapshot.clear(.{ 0.0, 0.0, 0.0, 0.0 }, 32);
+    try snapshot.drawText("settle", 0, 0, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+
+    const appended = "settle";
+    // During settling we intentionally avoid bounded DECSTBM and instead clear rows
+    // that transition from footer surface to scrollback before append.
+    _ = cli_renderer.commitSplitFooterSnapshotBatched(snapshot, 6, false, true, 3, false, true, true);
+
+    const output = cli_renderer.getLastOutputForTest();
+    const settling_clear_index = std.mem.indexOf(u8, output, "\x1b[1;1H\x1b[J");
+    const stale_footer_clear_top_index = std.mem.indexOf(u8, output, "\x1b[1;1H\x1b[2K");
+    const stale_footer_clear_next_index = std.mem.indexOf(u8, output, "\x1b[2;1H\x1b[2K");
+    const append_index = std.mem.indexOf(u8, output, appended);
+    const scroll_region_reset_index = std.mem.indexOf(u8, output, "\x1b[r");
+    const footer_clear_index = std.mem.indexOf(u8, output, "\x1b[3;1H\x1b[2K");
+    const footer_erase_below_index = std.mem.indexOf(u8, output, "\x1b[3;1H\x1b[J");
+    const sync_index = std.mem.indexOf(u8, output, ansi.ANSI.syncSet);
+
+    try std.testing.expectEqual(@as(u32, 2), cli_renderer.renderOffset);
+    try std.testing.expect(settling_clear_index == null);
+    try std.testing.expect(stale_footer_clear_top_index != null);
+    try std.testing.expect(stale_footer_clear_next_index != null);
+    try std.testing.expect(append_index != null);
+    try std.testing.expect(scroll_region_reset_index == null);
+    try std.testing.expect(footer_clear_index == null);
+    try std.testing.expect(footer_erase_below_index == null);
+    try std.testing.expect(sync_index != null);
+    try std.testing.expect(sync_index.? < append_index.?);
+    try std.testing.expect(stale_footer_clear_top_index.? < append_index.?);
+}
+
+test "renderer - commitSplitFooterSnapshot multiline settling enables bounded scroll at pin" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        12,
+        3,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    _ = cli_renderer.resetSplitScrollback(1, 3);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    const fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try next_buffer.drawText("FOOT", 0, 0, fg, bg, 0);
+
+    var snapshot = try OptimizedBuffer.init(
+        std.testing.allocator,
+        6,
+        2,
+        .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
+    );
+    defer snapshot.deinit();
+
+    try snapshot.clear(.{ 0.0, 0.0, 0.0, 0.0 }, 32);
+    try snapshot.drawText("line-a", 0, 0, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+    try snapshot.drawText("line-b", 0, 1, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+
+    _ = cli_renderer.commitSplitFooterSnapshotBatched(snapshot, 6, false, true, 3, false, true, true);
+
+    const output = cli_renderer.getLastOutputForTest();
+    const expanded_region_index = std.mem.indexOf(u8, output, "\x1b[1;3r");
+    const collapsed_region_index = std.mem.indexOf(u8, output, "\x1b[r");
+
+    try std.testing.expectEqual(@as(u32, 3), cli_renderer.renderOffset);
+    try std.testing.expect(expanded_region_index != null);
+    try std.testing.expect(collapsed_region_index != null);
+    try std.testing.expect(expanded_region_index.? < collapsed_region_index.?);
+}
+
+test "renderer - commitSplitFooterSnapshot multiline short final row keeps continuation column" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        20,
+        4,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    _ = cli_renderer.resetSplitScrollback(2, 2);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    const fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try next_buffer.drawText("FOOT", 0, 0, fg, bg, 0);
+
+    var first_snapshot = try OptimizedBuffer.init(
+        std.testing.allocator,
+        16,
+        3,
+        .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
+    );
+    defer first_snapshot.deinit();
+
+    try first_snapshot.clear(.{ 0.0, 0.0, 0.0, 0.0 }, 0);
+    try first_snapshot.drawText("1234567890123456", 0, 0, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+    try first_snapshot.drawText("short", 0, 2, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+
+    _ = cli_renderer.commitSplitFooterSnapshotBatched(first_snapshot, 16, false, false, 2, false, true, true);
+
+    try std.testing.expectEqual(@as(u32, 5), cli_renderer.splitScrollback.tail_column);
+
+    var second_snapshot = try OptimizedBuffer.init(
+        std.testing.allocator,
+        1,
+        1,
+        .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
+    );
+    defer second_snapshot.deinit();
+
+    try second_snapshot.clear(.{ 0.0, 0.0, 0.0, 0.0 }, 0);
+    try second_snapshot.drawText(",", 0, 0, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+
+    _ = cli_renderer.commitSplitFooterSnapshotBatched(second_snapshot, 1, false, false, 2, false, true, true);
+
+    const output = cli_renderer.getLastOutputForTest();
+    const move_index = std.mem.indexOf(u8, output, "\x1b[2;6H");
+    const comma_index = std.mem.indexOf(u8, output, ",");
+
+    try std.testing.expect(move_index != null);
+    try std.testing.expect(comma_index != null);
+    try std.testing.expect(move_index.? < comma_index.?);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[2;17H") == null);
+}
+
+test "renderer - commitSplitFooterSnapshot exact-width continuation preserves autowrap" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        20,
+        4,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    _ = cli_renderer.resetSplitScrollback(2, 2);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    const fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try next_buffer.drawText("FOOT", 0, 0, fg, bg, 0);
+
+    var first_snapshot = try OptimizedBuffer.init(
+        std.testing.allocator,
+        20,
+        1,
+        .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
+    );
+    defer first_snapshot.deinit();
+
+    try first_snapshot.clear(.{ 0.0, 0.0, 0.0, 0.0 }, 0);
+    try first_snapshot.drawText("12345678901234567890", 0, 0, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+
+    _ = cli_renderer.commitSplitFooterSnapshotBatched(first_snapshot, 20, false, false, 2, false, true, true);
+
+    var second_snapshot = try OptimizedBuffer.init(
+        std.testing.allocator,
+        8,
+        1,
+        .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
+    );
+    defer second_snapshot.deinit();
+
+    try second_snapshot.clear(.{ 0.0, 0.0, 0.0, 0.0 }, 0);
+    try second_snapshot.drawText(" letters", 0, 0, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+
+    _ = cli_renderer.commitSplitFooterSnapshotBatched(second_snapshot, 8, false, false, 2, false, true, true);
+
+    const output = cli_renderer.getLastOutputForTest();
+    const wrap_index = std.mem.indexOf(u8, output, "\x1b[2;20H\r\n");
+    const text_index = std.mem.indexOf(u8, output, " letters");
+
+    try std.testing.expectEqual(@as(u32, 8), cli_renderer.splitScrollback.tail_column);
+    try std.testing.expect(wrap_index != null);
+    try std.testing.expect(text_index != null);
+    try std.testing.expect(wrap_index.? < text_index.?);
+}
+
+test "renderer - commitSplitFooterSnapshot does not emit continuation spaces for wide graphemes" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        12,
+        4,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    _ = cli_renderer.resetSplitScrollback(2, 2);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    const fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try next_buffer.drawText("FOOT", 0, 0, fg, bg, 0);
+
+    var snapshot = try OptimizedBuffer.init(
+        std.testing.allocator,
+        10,
+        2,
+        .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
+    );
+    defer snapshot.deinit();
+
+    try snapshot.clear(.{ 0.0, 0.0, 0.0, 0.0 }, 0);
+    try snapshot.drawText("│甲│乙│丙│", 0, 0, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+    try snapshot.drawText("│😀│🚀│🧪│", 0, 1, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+
+    _ = cli_renderer.commitSplitFooterSnapshotBatched(snapshot, 10, false, false, 2, false, true, true);
+
+    const output = cli_renderer.getLastOutputForTest();
+
+    try std.testing.expect(std.mem.indexOf(u8, output, "│甲│乙│丙│") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "│😀│🚀│🧪│") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "甲 ") == null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "乙 ") == null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "丙 ") == null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "😀 ") == null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "🚀 ") == null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "🧪 ") == null);
+}
+
+test "renderer - repaintSplitFooter repaints footer without append payload" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        12,
+        3,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    _ = cli_renderer.resetSplitScrollback(2, 2);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    const fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try next_buffer.drawText("FOOT", 0, 0, fg, bg, 0);
+
+    _ = cli_renderer.repaintSplitFooter(2, true);
+
+    const output = cli_renderer.getLastOutputForTest();
+    const footer_text_index = std.mem.indexOf(u8, output, "FOOT");
+    const footer_clear_index = std.mem.indexOf(u8, output, "\x1b[3;1H\x1b[2K");
+    const footer_erase_below_index = std.mem.indexOf(u8, output, "\x1b[3;1H\x1b[J");
+    const sync_index = std.mem.indexOf(u8, output, ansi.ANSI.syncSet);
+
+    try std.testing.expect(footer_text_index != null);
+    try std.testing.expect(footer_clear_index == null);
+    try std.testing.expect(footer_erase_below_index == null);
+    try std.testing.expect(sync_index != null);
+    try std.testing.expect(sync_index.? < footer_text_index.?);
+}
+
+test "renderer - repaintSplitFooter applies pending viewport scroll transition in one frame" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        12,
+        1,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    _ = cli_renderer.resetSplitScrollback(4, 4);
+    cli_renderer.setRenderOffset(3);
+    cli_renderer.setPendingSplitFooterTransition(.viewport_scroll, 4, 2, 5, 1);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    const fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try next_buffer.drawText("FOOT", 0, 0, fg, bg, 0);
+
+    _ = cli_renderer.repaintSplitFooter(4, true);
+
+    const output = cli_renderer.getLastOutputForTest();
+    const sync_index = std.mem.indexOf(u8, output, ansi.ANSI.syncSet);
+    const scroll_index = std.mem.indexOf(u8, output, "\x1b[1T");
+    const footer_move_index = std.mem.indexOf(u8, output, "\x1b[5;1H");
+    const footer_text_index = std.mem.indexOf(u8, output, "FOOT");
+
+    try std.testing.expect(sync_index != null);
+    try std.testing.expect(scroll_index != null);
+    try std.testing.expect(footer_move_index != null);
+    try std.testing.expect(footer_text_index != null);
+    try std.testing.expect(sync_index.? < scroll_index.?);
+    try std.testing.expect(scroll_index.? < footer_move_index.?);
+    try std.testing.expect(footer_move_index.? < footer_text_index.?);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, ansi.ANSI.syncSet));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, ansi.ANSI.syncReset));
+}
+
+test "renderer - repaintSplitFooter applies pending stale row clear transition in one frame" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        12,
+        3,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    _ = cli_renderer.resetSplitScrollback(1, 7);
+    cli_renderer.setPendingSplitFooterTransition(.clear_stale_rows, 2, 4, 2, 3);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    const fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try next_buffer.drawText("FOOT", 0, 0, fg, bg, 0);
+
+    _ = cli_renderer.repaintSplitFooter(7, true);
+
+    const output = cli_renderer.getLastOutputForTest();
+    const sync_index = std.mem.indexOf(u8, output, ansi.ANSI.syncSet);
+    const clear_index = std.mem.indexOf(u8, output, "\x1b[5;1H\x1b[2K");
+    const footer_text_index = std.mem.indexOf(u8, output, "FOOT");
+
+    try std.testing.expect(sync_index != null);
+    try std.testing.expect(clear_index != null);
+    try std.testing.expect(footer_text_index != null);
+    try std.testing.expect(sync_index.? < clear_index.?);
+    try std.testing.expect(clear_index.? < footer_text_index.?);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, ansi.ANSI.syncSet));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, ansi.ANSI.syncReset));
+}
+
+test "renderer - commitSplitFooterSnapshot appends styled snapshot before footer repaint" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        16,
+        4,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    _ = cli_renderer.resetSplitScrollback(2, 2);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    const fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try next_buffer.drawText("FOOT", 0, 0, fg, bg, 0);
+
+    var snapshot = try OptimizedBuffer.init(
+        std.testing.allocator,
+        8,
+        2,
+        .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
+    );
+    defer snapshot.deinit();
+
+    try snapshot.clear(.{ 0.0, 0.0, 0.0, 0.0 }, 32);
+    try snapshot.drawText("SNAP", 0, 0, .{ 1.0, 0.5, 0.0, 1.0 }, .{ 0.0, 0.0, 0.0, 0.0 }, ansi.TextAttributes.BOLD);
+    try snapshot.drawText("SHOT", 0, 1, .{ 0.2, 0.8, 0.9, 1.0 }, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+
+    _ = cli_renderer.commitSplitFooterSnapshotBatched(snapshot, 8, true, true, 2, false, true, true);
+
+    const output = cli_renderer.getLastOutputForTest();
+    const snapshot_text_index = std.mem.indexOf(u8, output, "SNAP");
+    const orange_fg_index = std.mem.indexOf(u8, output, "\x1b[38;2;255;128;0m");
+    const bold_index = std.mem.indexOf(u8, output, "\x1b[1m");
+    const sync_index = std.mem.indexOf(u8, output, ansi.ANSI.syncSet);
+    const footer_clear_index = std.mem.indexOf(u8, output, "\x1b[3;1H\x1b[2K");
+
+    try std.testing.expect(snapshot_text_index != null);
+    try std.testing.expect(orange_fg_index != null);
+    try std.testing.expect(bold_index != null);
+    try std.testing.expect(sync_index != null);
+    try std.testing.expect(sync_index.? < snapshot_text_index.?);
+    try std.testing.expect(footer_clear_index == null);
+}
+
+test "renderer - commitSplitFooterSnapshot does not emit NUL padding for short rows" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        20,
+        4,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    _ = cli_renderer.resetSplitScrollback(2, 2);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    const fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try next_buffer.drawText("FOOT", 0, 0, fg, bg, 0);
+
+    var snapshot = try OptimizedBuffer.init(
+        std.testing.allocator,
+        16,
+        2,
+        .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
+    );
+    defer snapshot.deinit();
+
+    try snapshot.clear(.{ 0.0, 0.0, 0.0, 0.0 }, 32);
+    try snapshot.drawText("[tool:bash] Shell", 0, 0, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+    try snapshot.drawText("$ pwd", 0, 1, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+
+    _ = cli_renderer.commitSplitFooterSnapshotBatched(snapshot, 16, true, true, 2, false, true, true);
+
+    const output = cli_renderer.getLastOutputForTest();
+    try std.testing.expect(std.mem.indexOfScalar(u8, output, 0) == null);
+    try std.testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.eraseToEndOfLine) != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\r\n\x1b[0m\x1b[K") != null);
+}
+
+test "renderer - batched split commits share single sync frame" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        16,
+        4,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    _ = cli_renderer.resetSplitScrollback(2, 2);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    const fg = RGBA{ 1.0, 1.0, 1.0, 1.0 };
+    const bg = RGBA{ 0.0, 0.0, 0.0, 1.0 };
+    try next_buffer.drawText("FOOT", 0, 0, fg, bg, 0);
+
+    var first_snapshot = try OptimizedBuffer.init(
+        std.testing.allocator,
+        10,
+        1,
+        .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
+    );
+    defer first_snapshot.deinit();
+    try first_snapshot.clear(.{ 0.0, 0.0, 0.0, 0.0 }, 32);
+    try first_snapshot.drawText("FIRST", 0, 0, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+
+    var second_snapshot = try OptimizedBuffer.init(
+        std.testing.allocator,
+        10,
+        1,
+        .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
+    );
+    defer second_snapshot.deinit();
+    try second_snapshot.clear(.{ 0.0, 0.0, 0.0, 0.0 }, 32);
+    try second_snapshot.drawText("SECOND", 0, 0, fg, .{ 0.0, 0.0, 0.0, 0.0 }, 0);
+
+    _ = cli_renderer.commitSplitFooterSnapshotBatched(
+        first_snapshot,
+        10,
+        true,
+        true,
+        2,
+        false,
+        true,
+        false,
+    );
+
+    _ = cli_renderer.commitSplitFooterSnapshotBatched(
+        second_snapshot,
+        10,
+        true,
+        true,
+        2,
+        false,
+        false,
+        true,
+    );
+
+    const output = cli_renderer.getLastOutputForTest();
+    // Batching should keep both commits inside one synchronized update envelope.
+    try std.testing.expect(std.mem.indexOf(u8, output, "FIRST") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "SECOND") != null);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, ansi.ANSI.syncSet));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, ansi.ANSI.syncReset));
+}
+
+test "renderer - unchanged frame with unchanged cursor emits no output" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        12,
+        4,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    cli_renderer.terminal.setCursorPosition(3, 2, true);
+    cli_renderer.render(false);
+
+    cli_renderer.render(false);
+    const output = cli_renderer.getLastOutputForTest();
+
+    // No-op frames must be byte-empty; otherwise repeated sync/cursor toggles can
+    // produce visible shimmer in terminals that animate cursor or repaint eagerly.
+    try std.testing.expectEqual(@as(usize, 0), output.len);
+}

--- a/packages/core/src/zig/tests/split-scrollback_test.zig
+++ b/packages/core/src/zig/tests/split-scrollback_test.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+const split_scrollback = @import("../split-scrollback.zig");
+
+test "split scrollback starts empty" {
+    var scrollback = split_scrollback.SplitScrollback{};
+
+    try std.testing.expectEqual(@as(u32, 0), scrollback.published_rows);
+    try std.testing.expectEqual(@as(u32, 0), scrollback.tail_column);
+    try std.testing.expectEqual(@as(u32, 0), scrollback.renderOffset(6));
+}
+
+test "split scrollback reset seeds pinned rows" {
+    var scrollback = split_scrollback.SplitScrollback{};
+
+    scrollback.reset(6);
+    try std.testing.expectEqual(@as(u32, 6), scrollback.published_rows);
+    try std.testing.expectEqual(@as(u32, 0), scrollback.tail_column);
+    try std.testing.expectEqual(@as(u32, 6), scrollback.renderOffset(6));
+
+    scrollback.publishSnapshotRows(1, 1, 40, false);
+    try std.testing.expectEqual(@as(u32, 6), scrollback.renderOffset(6));
+    try std.testing.expectEqual(@as(u32, 1), scrollback.tail_column);
+}
+
+test "split scrollback snapshot rows start at line boundary" {
+    var scrollback = split_scrollback.SplitScrollback{};
+
+    scrollback.publishSnapshotRows(1, 4, 20, false);
+    try std.testing.expectEqual(@as(u32, 1), scrollback.published_rows);
+    try std.testing.expectEqual(@as(u32, 4), scrollback.tail_column);
+
+    scrollback.noteNewline();
+    scrollback.publishSnapshotRows(2, 8, 20, true);
+
+    try std.testing.expectEqual(@as(u32, 4), scrollback.published_rows);
+    try std.testing.expectEqual(@as(u32, 0), scrollback.tail_column);
+}
+
+test "split scrollback snapshot rows wrap visible columns against terminal width" {
+    var scrollback = split_scrollback.SplitScrollback{};
+
+    scrollback.publishSnapshotRows(1, 6, 4, true);
+
+    try std.testing.expectEqual(@as(u32, 3), scrollback.published_rows);
+    try std.testing.expectEqual(@as(u32, 0), scrollback.tail_column);
+}
+
+test "split scrollback snapshot rows can omit trailing newline" {
+    var scrollback = split_scrollback.SplitScrollback{};
+
+    scrollback.publishSnapshotRows(1, 6, 4, false);
+
+    try std.testing.expectEqual(@as(u32, 2), scrollback.published_rows);
+    try std.testing.expectEqual(@as(u32, 2), scrollback.tail_column);
+}

--- a/packages/core/src/zig/tests/terminal_test.zig
+++ b/packages/core/src/zig/tests/terminal_test.zig
@@ -71,6 +71,22 @@ test "parseXtversion - full ghostty response" {
     try testing.expect(term.term_info.from_xtversion);
 }
 
+test "processCapabilityResponse captures startup cursor report before home probes" {
+    var term = Terminal.init(.{});
+    term.startup_cursor_query_pending = true;
+    term.startup_cursor_query_captured = false;
+
+    term.processCapabilityResponse("\x1b[7;11R\x1b[1;2R\x1b[1;3R");
+
+    const cursor = term.getCursorPosition();
+    try testing.expectEqual(@as(u32, 11), cursor.x);
+    try testing.expectEqual(@as(u32, 7), cursor.y);
+    try testing.expect(term.startup_cursor_query_captured);
+    try testing.expect(!term.startup_cursor_query_pending);
+    try testing.expect(term.caps.explicit_width);
+    try testing.expect(term.caps.scaled_text);
+}
+
 test "environment variables - should be overridden by xtversion" {
     var term = Terminal.init(.{});
 

--- a/packages/core/src/zig/tests/text-buffer-view_test.zig
+++ b/packages/core/src/zig/tests/text-buffer-view_test.zig
@@ -708,7 +708,6 @@ test "TextBufferView word wrapping - CJK boundary width" {
     try std.testing.expectEqual(@as(u32, 2), vlines[1].width_cols);
 }
 
-
 test "TextBufferView word wrapping - compare char vs word mode" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
@@ -2341,6 +2340,30 @@ test "TextBufferView measureForDimensions - word wrap" {
     // Should wrap at word boundaries
     try std.testing.expect(result.line_count >= 2);
     try std.testing.expect(result.width_cols_max <= 10);
+}
+
+test "TextBufferView word wrap - first line offset reduces initial line width" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    try tb.setText(" located");
+    view.setWrapMode(.word);
+    view.setWrapWidth(20);
+    view.setFirstLineOffset(17);
+
+    const vlines = view.getVirtualLines();
+
+    try std.testing.expectEqual(@as(usize, 2), vlines.len);
+    try std.testing.expectEqual(@as(u32, 1), vlines[0].width_cols);
+    try std.testing.expectEqual(@as(u32, 7), vlines[1].width_cols);
 }
 
 test "TextBufferView measureForDimensions - empty buffer" {

--- a/packages/core/src/zig/text-buffer-view.zig
+++ b/packages/core/src/zig/text-buffer-view.zig
@@ -120,6 +120,7 @@ pub const UnifiedTextBufferView = struct {
     viewport: ?Viewport,
     wrap_width: ?u32,
     wrap_mode: WrapMode,
+    first_line_offset: u32,
     virtual_lines: std.ArrayListUnmanaged(VirtualLine),
     virtual_lines_dirty: bool,
     cached_line_starts: std.ArrayListUnmanaged(u32),
@@ -145,6 +146,7 @@ pub const UnifiedTextBufferView = struct {
     // code paths clear dirty (e.g., updateVirtualLines).
     cached_measure_width: ?u32,
     cached_measure_wrap_mode: WrapMode,
+    cached_measure_first_line_offset: u32,
     cached_measure_result: ?MeasureResult,
     cached_measure_epoch: u64,
     cached_measure_buffer: ?*UnifiedTextBuffer,
@@ -176,6 +178,7 @@ pub const UnifiedTextBufferView = struct {
             .viewport = null,
             .wrap_width = null,
             .wrap_mode = .none,
+            .first_line_offset = 0,
             .virtual_lines = .{},
             .virtual_lines_dirty = true,
             .cached_line_starts = .{},
@@ -194,6 +197,7 @@ pub const UnifiedTextBufferView = struct {
             .ellipsis_mem_id = ellipsis_mem_id,
             .cached_measure_width = null,
             .cached_measure_wrap_mode = .none,
+            .cached_measure_first_line_offset = 0,
             .cached_measure_result = null,
             .cached_measure_epoch = 0,
             .cached_measure_buffer = null,
@@ -265,6 +269,14 @@ pub const UnifiedTextBufferView = struct {
     pub fn setWrapMode(self: *Self, mode: WrapMode) void {
         if (self.wrap_mode != mode) {
             self.wrap_mode = mode;
+            self.virtual_lines_dirty = true;
+            self.truncation_applied = false;
+        }
+    }
+
+    pub fn setFirstLineOffset(self: *Self, offset: u32) void {
+        if (self.first_line_offset != offset) {
+            self.first_line_offset = offset;
             self.virtual_lines_dirty = true;
             self.truncation_applied = false;
         }
@@ -344,6 +356,7 @@ pub const UnifiedTextBufferView = struct {
             self.text_buffer,
             self.wrap_mode,
             self.wrap_width,
+            self.first_line_offset,
             virtual_allocator,
             output,
         );
@@ -885,7 +898,10 @@ pub const UnifiedTextBufferView = struct {
         if (self.cached_measure_result) |result| {
             if (self.cached_measure_epoch == epoch and self.cached_measure_buffer == self.text_buffer) {
                 if (self.cached_measure_width) |cached_width| {
-                    if (cached_width == width and self.cached_measure_wrap_mode == self.wrap_mode) {
+                    if (cached_width == width and
+                        self.cached_measure_wrap_mode == self.wrap_mode and
+                        self.cached_measure_first_line_offset == self.first_line_offset)
+                    {
                         return result;
                     }
                 }
@@ -908,6 +924,7 @@ pub const UnifiedTextBufferView = struct {
 
             self.cached_measure_width = width;
             self.cached_measure_wrap_mode = self.wrap_mode;
+            self.cached_measure_first_line_offset = self.first_line_offset;
             self.cached_measure_result = result;
             self.cached_measure_epoch = epoch;
             self.cached_measure_buffer = self.text_buffer;
@@ -946,6 +963,7 @@ pub const UnifiedTextBufferView = struct {
             self.text_buffer,
             self.wrap_mode,
             wrap_width_for_measure,
+            self.first_line_offset,
             measure_allocator,
             output,
         );
@@ -963,6 +981,7 @@ pub const UnifiedTextBufferView = struct {
 
         self.cached_measure_width = width;
         self.cached_measure_wrap_mode = self.wrap_mode;
+        self.cached_measure_first_line_offset = self.first_line_offset;
         self.cached_measure_result = result;
         self.cached_measure_epoch = epoch;
         self.cached_measure_buffer = self.text_buffer;
@@ -975,6 +994,7 @@ pub const UnifiedTextBufferView = struct {
         text_buffer: *UnifiedTextBuffer,
         wrap_mode: WrapMode,
         wrap_width: ?u32,
+        first_line_offset: u32,
         allocator: Allocator,
         output: VirtualLineOutput,
     ) void {
@@ -1039,6 +1059,8 @@ pub const UnifiedTextBufferView = struct {
                 output: VirtualLineOutput,
                 wrap_mode: WrapMode,
                 wrap_w: u32,
+                first_line_offset: u32,
+                first_line_pending: bool,
                 global_char_offset: u32 = 0,
                 line_idx: u32 = 0,
                 line_col_offset: u32 = 0,
@@ -1051,6 +1073,14 @@ pub const UnifiedTextBufferView = struct {
                 last_wrap_chunk_count: u32 = 0,
                 last_wrap_line_position: u32 = 0,
                 last_wrap_global_offset: u32 = 0,
+
+                fn lineWrapWidth(wctx: *@This()) u32 {
+                    if (!wctx.first_line_pending or wctx.first_line_offset == 0 or wctx.first_line_offset >= wctx.wrap_w) {
+                        return wctx.wrap_w;
+                    }
+
+                    return wctx.wrap_w - wctx.first_line_offset;
+                }
 
                 fn commitVirtualLine(wctx: *@This()) void {
                     wctx.current_vline.width_cols = wctx.line_position;
@@ -1068,6 +1098,7 @@ pub const UnifiedTextBufferView = struct {
                     wctx.current_vline = VirtualLine.init();
                     wctx.current_vline.col_offset = wctx.global_char_offset;
                     wctx.line_position = 0;
+                    wctx.first_line_pending = false;
 
                     wctx.last_wrap_chunk_count = 0;
                     wctx.last_wrap_line_position = 0;
@@ -1106,8 +1137,9 @@ pub const UnifiedTextBufferView = struct {
                         var wrap_idx: usize = 0;
 
                         while (char_offset < chunk.width) {
+                            const line_wrap_w = wctx.lineWrapWidth();
                             const remaining_in_chunk = chunk.width - char_offset;
-                            const remaining_on_line = if (wctx.line_position < wctx.wrap_w) wctx.wrap_w - wctx.line_position else 0;
+                            const remaining_on_line = if (wctx.line_position < line_wrap_w) line_wrap_w - wctx.line_position else 0;
 
                             var last_wrap_that_fits: ?u32 = null;
                             var saved_wrap_idx = wrap_idx;
@@ -1138,7 +1170,7 @@ pub const UnifiedTextBufferView = struct {
 
                             if (remaining_in_chunk <= remaining_on_line) {
                                 if (last_wrap_that_fits) |boundary_w| {
-                                    const would_fill_line = wctx.line_position + remaining_in_chunk >= wctx.wrap_w;
+                                    const would_fill_line = wctx.line_position + remaining_in_chunk >= line_wrap_w;
                                     if (would_fill_line and boundary_w < remaining_in_chunk) {
                                         to_add = boundary_w;
                                         has_wrap_after = true;
@@ -1225,7 +1257,7 @@ pub const UnifiedTextBufferView = struct {
                                     byte_offset = pos_result.byte_offset;
                                 }
                                 const remaining_bytes = chunk_bytes[byte_offset..];
-                                const wrap_result = utf8.findWrapPosByWidth(remaining_bytes, wctx.wrap_w, wctx.text_buffer.tabWidth(), is_ascii_only, wctx.text_buffer.widthMethod());
+                                const wrap_result = utf8.findWrapPosByWidth(remaining_bytes, wctx.lineWrapWidth(), wctx.text_buffer.tabWidth(), is_ascii_only, wctx.text_buffer.widthMethod());
                                 to_add = wrap_result.columns_used;
                                 byte_offset += wrap_result.byte_offset;
                                 if (to_add == 0) {
@@ -1253,7 +1285,7 @@ pub const UnifiedTextBufferView = struct {
                                     wctx.last_wrap_global_offset = offset_before_add + wrap_pos_in_added;
                                 }
 
-                                if (wctx.line_position >= wctx.wrap_w and char_offset < chunk.width) {
+                                if (wctx.line_position >= line_wrap_w and char_offset < chunk.width) {
                                     if (has_wrap_after or wctx.last_wrap_chunk_count > 0) {
                                         commitVirtualLine(wctx);
                                     }
@@ -1267,7 +1299,8 @@ pub const UnifiedTextBufferView = struct {
                         var char_offset: u32 = 0;
 
                         while (char_offset < chunk.width) {
-                            const remaining_width = if (wctx.line_position < wctx.wrap_w) wctx.wrap_w - wctx.line_position else 0;
+                            const line_wrap_w = wctx.lineWrapWidth();
+                            const remaining_width = if (wctx.line_position < line_wrap_w) line_wrap_w - wctx.line_position else 0;
 
                             if (remaining_width == 0) {
                                 if (wctx.line_position > 0) {
@@ -1316,7 +1349,7 @@ pub const UnifiedTextBufferView = struct {
                             char_offset += wrap_result.columns_used;
                             byte_offset += wrap_result.byte_offset;
 
-                            if (wctx.line_position >= wctx.wrap_w and char_offset < chunk.width) {
+                            if (wctx.line_position >= line_wrap_w and char_offset < chunk.width) {
                                 commitVirtualLine(wctx);
                             }
                         }
@@ -1346,6 +1379,7 @@ pub const UnifiedTextBufferView = struct {
                     wctx.line_idx += 1;
                     wctx.line_col_offset = 0;
                     wctx.line_position = 0;
+                    wctx.first_line_pending = false;
                     wctx.current_vline = VirtualLine.init();
                     wctx.current_vline.col_offset = wctx.global_char_offset;
                     wctx.last_wrap_chunk_count = 0;
@@ -1363,6 +1397,8 @@ pub const UnifiedTextBufferView = struct {
                 .output = output,
                 .wrap_mode = wrap_mode,
                 .wrap_w = wrap_w,
+                .first_line_offset = first_line_offset,
+                .first_line_pending = first_line_offset > 0,
             };
 
             text_buffer.walkLinesAndSegments(&wrap_ctx, WrapContext.segment_callback, WrapContext.line_end_callback);

--- a/packages/solid/index.ts
+++ b/packages/solid/index.ts
@@ -98,6 +98,7 @@ export const testRender = async (node: () => JSX.Element, renderConfig: TestRend
 
 export * from "./src/reconciler.js"
 export * from "./src/elements/index.js"
+export * from "./src/scrollback.js"
 export * from "./src/time-to-first-draw.js"
 export * from "./src/plugins/slot.js"
 export * from "./src/types/elements.js"

--- a/packages/solid/src/scrollback.ts
+++ b/packages/solid/src/scrollback.ts
@@ -1,0 +1,227 @@
+import {
+  BoxRenderable,
+  RootRenderable,
+  type CliRenderer,
+  type Renderable,
+  type ScrollbackRenderContext,
+  type ScrollbackSnapshot,
+  type ScrollbackWriter,
+} from "@opentui/core"
+import { createSignal, type JSX } from "solid-js"
+import { RendererContext } from "./elements/index.js"
+import { _render as renderInternal, createComponent } from "./reconciler.js"
+
+type DisposeFn = () => void
+
+interface SnapshotRendererBinding {
+  renderer: CliRenderer
+  getHeight: () => number
+  setHeight: (height: number) => void
+}
+
+let solidScrollbackRootCounter = 0
+const MAX_AUTO_HEIGHT_PASSES = 4
+
+export interface SolidScrollbackWriterOptions {
+  width?: number
+  height?: number
+  rowColumns?: number
+  startOnNewLine?: boolean
+  trailingNewline?: boolean
+}
+
+export type SolidScrollbackNode = (ctx: ScrollbackRenderContext) => JSX.Element
+
+function normalizeSnapshotDimension(value: number | undefined, axis: "width" | "height"): number | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (!Number.isFinite(value)) {
+    throw new Error(`createScrollbackWriter requires a finite ${axis}`)
+  }
+
+  return Math.max(1, Math.trunc(value))
+}
+
+function createSnapshotRendererValue(
+  renderContext: ScrollbackRenderContext["renderContext"],
+  root: BoxRenderable,
+  width: number,
+  height: number,
+  firstLineOffset: number,
+): SnapshotRendererBinding {
+  const [snapshotWidth] = createSignal(width)
+  const [snapshotHeight, setSnapshotHeight] = createSignal(height)
+  const renderer = Object.create(renderContext) as CliRenderer
+  let offset = firstLineOffset
+
+  Object.defineProperties(renderer, {
+    root: {
+      value: root,
+      enumerable: true,
+      configurable: true,
+    },
+    width: {
+      get: snapshotWidth,
+      enumerable: true,
+      configurable: true,
+    },
+    height: {
+      get: snapshotHeight,
+      enumerable: true,
+      configurable: true,
+    },
+    claimFirstLineOffset: {
+      value: () => {
+        const out = offset
+        offset = 0
+        return out
+      },
+      enumerable: true,
+      configurable: true,
+    },
+  })
+
+  return {
+    renderer,
+    getHeight: snapshotHeight,
+    setHeight(nextHeight: number): void {
+      setSnapshotHeight(nextHeight)
+      renderer.emit("resize", snapshotWidth(), nextHeight)
+    },
+  }
+}
+
+function runLifecyclePasses(renderContext: ScrollbackRenderContext["renderContext"]): void {
+  for (const renderable of renderContext.getLifecyclePasses()) {
+    renderable.onLifecyclePass?.call(renderable)
+  }
+}
+
+function clearLifecyclePasses(renderContext: ScrollbackRenderContext["renderContext"]): void {
+  for (const renderable of [...renderContext.getLifecyclePasses()]) {
+    renderContext.unregisterLifecyclePass(renderable)
+  }
+}
+
+function measureSnapshotHeight(renderContext: ScrollbackRenderContext["renderContext"], root: Renderable): number {
+  const measureRoot = new RootRenderable(renderContext)
+
+  try {
+    measureRoot.add(root)
+    runLifecyclePasses(renderContext)
+    measureRoot.calculateLayout()
+    return Math.max(1, Math.trunc(root.getLayoutNode().getComputedLayout().height))
+  } finally {
+    if (root.parent === measureRoot) {
+      measureRoot.remove(root.id)
+    }
+    measureRoot.destroyRecursively()
+  }
+}
+
+function resolveSnapshotHeight(
+  renderContext: ScrollbackRenderContext["renderContext"],
+  root: Renderable,
+  snapshotRenderer: SnapshotRendererBinding,
+): number {
+  for (let pass = 0; pass < MAX_AUTO_HEIGHT_PASSES; pass++) {
+    const measuredHeight = measureSnapshotHeight(renderContext, root)
+
+    if (measuredHeight === snapshotRenderer.getHeight()) {
+      clearLifecyclePasses(renderContext)
+      return measuredHeight
+    }
+
+    snapshotRenderer.setHeight(measuredHeight)
+  }
+
+  // Give up on converging the synthetic height and let the final render rerun
+  // lifecycle passes against the last consistent tree state.
+  return measureSnapshotHeight(renderContext, root)
+}
+
+export function createScrollbackWriter(
+  node: SolidScrollbackNode,
+  options: SolidScrollbackWriterOptions = {},
+): ScrollbackWriter {
+  return (ctx: ScrollbackRenderContext): ScrollbackSnapshot => {
+    const width = normalizeSnapshotDimension(options.width, "width") ?? Math.max(1, Math.trunc(ctx.width))
+    const height = normalizeSnapshotDimension(options.height, "height")
+    const startOnNewLine = options.startOnNewLine ?? true
+    const firstLineWidth =
+      !startOnNewLine && ctx.tailColumn > 0 && ctx.tailColumn < ctx.width
+        ? Math.min(width, ctx.width - ctx.tailColumn)
+        : width
+    const firstLineOffset = width - firstLineWidth
+    const root = new BoxRenderable(ctx.renderContext, {
+      id: `solid-scrollback-root-${solidScrollbackRootCounter++}`,
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width,
+      height: height ?? "auto",
+      border: false,
+      backgroundColor: "transparent",
+      shouldFill: false,
+      flexDirection: "column",
+    })
+    const snapshotRenderer = createSnapshotRendererValue(
+      ctx.renderContext,
+      root,
+      width,
+      height ?? Math.max(1, ctx.renderContext.height),
+      firstLineOffset,
+    )
+
+    let dispose: DisposeFn | undefined
+    let disposed = false
+
+    const teardown = () => {
+      if (disposed) {
+        return
+      }
+
+      disposed = true
+      dispose?.()
+    }
+
+    try {
+      dispose = renderInternal(
+        () =>
+          createComponent(RendererContext.Provider, {
+            get value() {
+              return snapshotRenderer.renderer
+            },
+            get children() {
+              return node(ctx)
+            },
+          }),
+        root,
+      )
+
+      return {
+        root,
+        width,
+        height: height ?? resolveSnapshotHeight(ctx.renderContext, root, snapshotRenderer),
+        rowColumns: options.rowColumns,
+        startOnNewLine,
+        trailingNewline: options.trailingNewline,
+        teardown,
+      }
+    } catch (error) {
+      teardown()
+      root.destroyRecursively()
+      throw error
+    }
+  }
+}
+
+export function writeSolidToScrollback(
+  renderer: CliRenderer,
+  node: SolidScrollbackNode,
+  options: SolidScrollbackWriterOptions = {},
+): void {
+  renderer.writeToScrollback(createScrollbackWriter(node, options))
+}

--- a/packages/solid/tests/scrollback-writer.test.tsx
+++ b/packages/solid/tests/scrollback-writer.test.tsx
@@ -1,0 +1,274 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { TextAttributes, TextRenderable, getLinkId, parseColor, type RenderContext } from "@opentui/core"
+import { createTestRenderer } from "@opentui/core/testing"
+import { onCleanup } from "solid-js"
+import { createScrollbackWriter, useRenderer, useTerminalDimensions, writeSolidToScrollback } from "../index.js"
+
+let testSetup: Awaited<ReturnType<typeof createTestRenderer>> | null = null
+const decoder = new TextDecoder()
+
+type QueuedSnapshotCommit = {
+  snapshot: {
+    height: number
+    getRealCharBytes: (addLineBreaks?: boolean) => Uint8Array
+    getSpanLines: () => Array<{
+      spans: Array<{ text: string; attributes: number; fg: ReturnType<typeof parseColor> }>
+    }>
+    destroy: () => void
+    buffers: {
+      attributes: Uint32Array
+    }
+  }
+  rowColumns: number
+  startOnNewLine: boolean
+  trailingNewline: boolean
+}
+
+class UpdateProbeRenderable extends TextRenderable {
+  private updates = 0
+
+  constructor(ctx: RenderContext) {
+    super(ctx, {
+      id: "update-probe",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width: 1,
+      height: 1,
+      content: "0",
+    })
+  }
+
+  protected override onUpdate(_deltaTime: number): void {
+    this.updates += 1
+    this.content = `${this.updates}`
+  }
+}
+
+function claimSingleCommit(renderer: Awaited<ReturnType<typeof createTestRenderer>>["renderer"]): QueuedSnapshotCommit {
+  const commits = (renderer as any).externalOutputQueue.claim() as QueuedSnapshotCommit[]
+  expect(commits).toHaveLength(1)
+
+  const commit = commits[0]
+  if (!commit) {
+    throw new Error("expected a queued scrollback commit")
+  }
+
+  return commit
+}
+
+function claimCommits(renderer: Awaited<ReturnType<typeof createTestRenderer>>["renderer"]): QueuedSnapshotCommit[] {
+  return (renderer as any).externalOutputQueue.claim() as QueuedSnapshotCommit[]
+}
+
+afterEach(() => {
+  if (testSetup) {
+    testSetup.renderer.destroy()
+    testSetup = null
+  }
+})
+
+describe("createScrollbackWriter", () => {
+  it("creates styled snapshot commits from Solid JSX", async () => {
+    const setup = await createTestRenderer({
+      width: 40,
+      height: 10,
+      screenMode: "split-footer",
+      footerHeight: 4,
+      externalOutputMode: "capture-stdout",
+      consoleMode: "disabled",
+    })
+    testSetup = setup
+
+    setup.renderer.writeToScrollback(
+      createScrollbackWriter(
+        () => (
+          <text>
+            <span style={{ fg: "red", bold: true }}>Alert</span> <a href="https://example.com/docs">Docs</a>
+          </text>
+        ),
+        { width: 20 },
+      ),
+    )
+
+    const commit = claimSingleCommit(setup.renderer)
+
+    try {
+      const committedText = decoder.decode(commit.snapshot.getRealCharBytes(true))
+      const committedSpans = commit.snapshot.getSpanLines().flatMap((line) => line.spans)
+
+      expect(committedText).toContain("Alert Docs")
+
+      const alertSpan = committedSpans.find((span) => span.text.includes("Alert"))
+      expect(alertSpan).toBeDefined()
+      expect(alertSpan?.fg.equals(parseColor("red"))).toBe(true)
+      expect((alertSpan?.attributes ?? 0) & TextAttributes.BOLD).toBe(TextAttributes.BOLD)
+
+      const hasLinkAttributes = [...commit.snapshot.buffers.attributes].some((attributes) => getLinkId(attributes) > 0)
+      expect(hasLinkAttributes).toBe(true)
+    } finally {
+      commit.snapshot.destroy()
+    }
+  })
+
+  it("uses snapshot dimensions for renderer hooks during auto-height measurement", async () => {
+    const setup = await createTestRenderer({
+      width: 40,
+      height: 10,
+      screenMode: "split-footer",
+      footerHeight: 4,
+      externalOutputMode: "capture-stdout",
+      consoleMode: "disabled",
+    })
+    testSetup = setup
+
+    setup.renderer.writeToScrollback(
+      createScrollbackWriter(
+        () => {
+          const renderer = useRenderer()
+          const terminalDimensions = useTerminalDimensions()
+
+          return (
+            <text>
+              {renderer.width}x{renderer.height}
+              <br />
+              {terminalDimensions().width}x{terminalDimensions().height}
+            </text>
+          )
+        },
+        { width: 12 },
+      ),
+    )
+
+    const commit = claimSingleCommit(setup.renderer)
+
+    try {
+      const committedText = decoder.decode(commit.snapshot.getRealCharBytes(true))
+      expect(commit.snapshot.height).toBe(2)
+      expect(committedText).toContain("12x2")
+    } finally {
+      commit.snapshot.destroy()
+    }
+  })
+
+  it("does not run renderable onUpdate during auto-height measurement", async () => {
+    const setup = await createTestRenderer({
+      width: 40,
+      height: 10,
+      screenMode: "split-footer",
+      footerHeight: 4,
+      externalOutputMode: "capture-stdout",
+      consoleMode: "disabled",
+    })
+    testSetup = setup
+
+    setup.renderer.writeToScrollback(
+      createScrollbackWriter(() => new UpdateProbeRenderable(useRenderer()), { width: 1 }),
+    )
+
+    const commit = claimSingleCommit(setup.renderer)
+
+    try {
+      expect(decoder.decode(commit.snapshot.getRealCharBytes(true)).trim()).toBe("1")
+    } finally {
+      commit.snapshot.destroy()
+    }
+  })
+
+  it("writeSolidToScrollback wraps writer creation and keeps cleanup behavior", async () => {
+    const setup = await createTestRenderer({
+      width: 40,
+      height: 10,
+      screenMode: "split-footer",
+      footerHeight: 4,
+      externalOutputMode: "capture-stdout",
+      consoleMode: "disabled",
+    })
+    testSetup = setup
+
+    let cleanupCalls = 0
+
+    writeSolidToScrollback(
+      setup.renderer,
+      () => {
+        onCleanup(() => {
+          cleanupCalls += 1
+        })
+
+        return <text>wrapper output</text>
+      },
+      {
+        width: 20,
+        rowColumns: 7,
+        startOnNewLine: false,
+        trailingNewline: false,
+      },
+    )
+
+    expect(cleanupCalls).toBe(1)
+
+    const commit = claimSingleCommit(setup.renderer)
+
+    try {
+      expect(decoder.decode(commit.snapshot.getRealCharBytes(true))).toContain("wrapper output")
+      expect(commit.rowColumns).toBe(7)
+      expect(commit.startOnNewLine).toBe(false)
+      expect(commit.trailingNewline).toBe(false)
+    } finally {
+      commit.snapshot.destroy()
+    }
+  })
+
+  it("wraps a continued first line using the queued tail column", async () => {
+    const setup = await createTestRenderer({
+      width: 20,
+      height: 10,
+      screenMode: "split-footer",
+      footerHeight: 4,
+      externalOutputMode: "capture-stdout",
+      consoleMode: "disabled",
+    })
+    testSetup = setup
+
+    writeSolidToScrollback(setup.renderer, () => <text>12345678901234567</text>, {
+      width: 20,
+      startOnNewLine: false,
+      trailingNewline: false,
+    })
+
+    writeSolidToScrollback(
+      setup.renderer,
+      (ctx) => {
+        expect(ctx.tailColumn).toBe(17)
+        return <text> located</text>
+      },
+      {
+        width: 20,
+        startOnNewLine: false,
+        trailingNewline: false,
+      },
+    )
+
+    const commits = claimCommits(setup.renderer)
+    expect(commits).toHaveLength(2)
+
+    for (const commit of commits) {
+      expect(commit).toBeDefined()
+    }
+
+    const second = commits[1]
+    if (!second) {
+      throw new Error("expected second queued scrollback commit")
+    }
+
+    try {
+      const text = decoder.decode(second.snapshot.getRealCharBytes(true))
+      expect(second.snapshot.height).toBe(2)
+      expect(text).toContain("located")
+    } finally {
+      for (const commit of commits) {
+        commit?.snapshot.destroy()
+      }
+    }
+  })
+})

--- a/packages/web/src/content/docs/core-concepts/renderer.mdx
+++ b/packages/web/src/content/docs/core-concepts/renderer.mdx
@@ -41,6 +41,7 @@ This page covers the options that most apps set directly.
 | `consoleMode`         | `ConsoleMode`                  | `"console-overlay"`  | How the built-in console overlay behaves ([details](#console-mode))                     |
 | `exitOnCtrlC`         | `boolean`                      | `true`               | Call `renderer.destroy()` when Ctrl+C is pressed                                        |
 | `exitSignals`         | `NodeJS.Signals[]`             | see below            | Signals that trigger cleanup ([details](/docs/core-concepts/lifecycle#signal-handling)) |
+| `clearOnShutdown`     | `boolean`                      | `true`               | Clear the renderer-owned region on `suspend()` and `destroy()`                          |
 | `targetFps`           | `number`                       | `30`                 | Target frames per second for the render loop                                            |
 | `maxFps`              | `number`                       | `60`                 | Maximum FPS cap for immediate re-renders                                                |
 | `useMouse`            | `boolean`                      | `true`               | Enable mouse input                                                                      |
@@ -193,6 +194,16 @@ renderer.pause() // Pause rendering (use start() or requestLive() to run it agai
 
 renderer.suspend() // Fully suspend (disables mouse, input, and raw mode)
 renderer.resume() // Resume from suspended state
+```
+
+By default, suspending or destroying clears the region OpenTUI owns on the main screen. If you want to keep that
+content visible after shutdown, set `clearOnShutdown: false`:
+
+```typescript
+const renderer = await createCliRenderer({
+  screenMode: "split-footer",
+  clearOnShutdown: false,
+})
 ```
 
 ## Key properties


### PR DESCRIPTION
Split-footer mode on main flushes captured stdout in TypeScript
before the native frame, producing a two-phase clear/repaint
flicker. The capture queue is coupled to the global console
singleton, so footer routing reacts to console writes even in
passthrough mode. And a bunch of TODO since this was mostly
a proof of concept.

Move split-footer ownership into native. A new SplitScrollback
model tracks published rows and tail column; the footer settles
downward as scrollback grows and pins at the bottom boundary.
Captured stdout and a new writeToScrollback() API both produce
OptimizedBuffer snapshots that the native side emits as styled
ANSI in one atomic output buffer alongside the footer repaint.

Centralize geometry clamping so footerHeight > terminalHeight
cannot produce negative renderOffset. Flush pending output
before resize, suspend, mode transitions, and destroy. Detect
the real cursor row at startup via CPR so the footer starts at
the actual position rather than row 1.