### PR TITLE
fix: pressTab({ shift: true }) sends correct ANSI back-tab sequence

### DIFF
--- a/packages/core/src/testing/mock-keys.test.ts
+++ b/packages/core/src/testing/mock-keys.test.ts
@@ -381,6 +381,28 @@ describe("mock-keys", () => {
 
     mockKeys.pressTab({ shift: true })
 
+    expect(mockRenderer.getEmittedData()).toBe("\x1b[Z")
+  })
+
+  test("pressTab with shift modifier parses as shift+tab", async () => {
+    const { parseKeypress } = await import("../lib/parse.keypress")
+    const mockRenderer = new MockRenderer()
+    const mockKeys = createMockKeys(mockRenderer as any)
+
+    mockKeys.pressTab({ shift: true })
+
+    const result = parseKeypress(mockRenderer.getEmittedData())
+    expect(result).not.toBeNull()
+    expect(result?.name).toBe("tab")
+    expect(result?.shift).toBe(true)
+  })
+
+  test("pressTab without modifiers still sends raw tab", () => {
+    const mockRenderer = new MockRenderer()
+    const mockKeys = createMockKeys(mockRenderer as any)
+
+    mockKeys.pressTab()
+
     expect(mockRenderer.getEmittedData()).toBe("\t")
   })
 

--- a/packages/core/src/testing/mock-keys.ts
+++ b/packages/core/src/testing/mock-keys.ts
@@ -298,6 +298,14 @@ export function createMockKeys(renderer: CliRenderer, options?: MockKeysOptions)
         // For regular characters and single-char control codes with modifiers
         let char = keyCode
 
+        // Shift+Tab produces the back-tab escape sequence \x1b[Z in standard ANSI terminals
+        if (char === "\t" && modifiers.shift) {
+          // Build the base as \x1b[Z, then apply meta prefix if also pressed
+          keyCode = modifiers.meta ? "\x1b\x1b[Z" : "\x1b[Z"
+          renderer.stdin.emit("data", Buffer.from(keyCode))
+          return
+        }
+
         // Special handling for backspace with modifiers - use modifyOtherKeys format
         // Terminals send Ctrl+Backspace as CSI 27;5;127~ (or CSI 27;5;8~)
         // Only use modifyOtherKeys for ctrl, super, or hyper (not shift or meta alone)


### PR DESCRIPTION
## Summary

- Fix `pressTab({ shift: true })` in standard ANSI mode to emit `\x1b[Z` (back-tab / CBT) instead of silently dropping the shift modifier and sending raw `\t`
- Add round-trip test verifying the emitted sequence parses back as `{ name: "tab", shift: true }`
- Add regression test confirming unmodified `pressTab()` still sends `\t`

## Test plan

- [x] All 115 existing mock-keys tests pass
- [x] New round-trip test: `pressTab({ shift: true })` output is parsed by `parseKeypress` as shift+tab
- [x] Regression test: `pressTab()` without modifiers still sends `\t`