### PR TITLE
fix: full repaint on resume to fix transparency artifacts in Kitty

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -2111,6 +2111,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     this.currentRenderBuffer.clear(this.backgroundColor)
+
+    // Normal diff skips unchanged cells leaving transparency visible. force=true repaints all.
+    this.lib.render(this.rendererPtr, true)
+
     this._controlState = this._previousControlState
 
     if (

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -2110,8 +2110,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.enableMouse()
     }
 
-    this.currentRenderBuffer.clear(this.backgroundColor)
-
     // Normal diff skips unchanged cells leaving transparency visible. force=true repaints all.
     this.lib.render(this.rendererPtr, true)
 

--- a/packages/core/src/tests/renderer.control.test.ts
+++ b/packages/core/src/tests/renderer.control.test.ts
@@ -116,6 +116,27 @@ test("resume() restores previous AUTO_STARTED state and restarts rendering", () 
   expect(renderer.isRunning).toBe(true)
 })
 
+test("resume() triggers a force render to fix transparency artifacts", () => {
+  renderer.start()
+  renderer.suspend()
+
+  let forceRenderCalled = false
+
+  // @ts-expect-error - lib is private
+  const originalRender = renderer.lib.render.bind(renderer.lib)
+  // @ts-expect-error - lib is private
+  renderer.lib.render = (ptr: any, force: boolean) => {
+    if (force) forceRenderCalled = true
+  return originalRender(ptr, force)
+  }
+
+  renderer.resume()
+  expect(forceRenderCalled).toBe(true)
+
+  // @ts-expect-error - lib is private
+  renderer.lib.render = originalRender
+})
+
 test("stop() transitions to EXPLICIT_STOPPED and stops rendering", () => {
   renderer.start()
   expect(renderer.isRunning).toBe(true)


### PR DESCRIPTION
Fixes #922

When Kitty resumes after `SIGCONT`, it restores the alternate screen buffer with transparency compositing applied. The diff render then skips cells that haven't changed, so the transparency persists since nothing in the UI actually changed during suspension.

The fix is to call `lib.render` with `force=true` right after `currentRenderBuffer.clear()` in `resume()`. This bypasses the diff and repaints every cell immediately, overwriting whatever Kitty had in its restored buffer.

This is also why resizing fixes it, `buffer.resize()` clears both buffers which makes the diff see everything as dirty and forces a full repaint as a side effect.

```ts
this.currentRenderBuffer.clear(this.backgroundColor)
// Normal diff skips unchanged cells leaving transparency visible. force=true repaints all.
this.lib.render(this.rendererPtr, true)
```