### PR TITLE
workaround windows terminal bug when sending XTVERSION before alt screen

### DIFF
--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -309,6 +309,8 @@ pub const CliRenderer = struct {
         self.useAlternateScreen = useAlternateScreen;
         self.terminalSetup = true;
 
+        self.setupTerminalWithoutDetection(useAlternateScreen);
+
         var stdoutWriter = std.fs.File.stdout().writer(&self.stdoutBuffer);
         const writer = &stdoutWriter.interface;
 
@@ -316,8 +318,6 @@ pub const CliRenderer = struct {
             logger.warn("Failed to query terminal capabilities", .{});
         };
         writer.flush() catch {};
-
-        self.setupTerminalWithoutDetection(useAlternateScreen);
     }
 
     fn setupTerminalWithoutDetection(self: *CliRenderer, useAlternateScreen: bool) void {


### PR DESCRIPTION
## Summary
- move startup terminal queries to run after alternate-screen setup
- avoid the Windows Terminal stall caused by sending `XTVERSION` before entering alt-screen
- keep the existing startup detection logic intact and only change ordering

## Testing
- bun run build:native
- verified locally against the OpenTUI textarea harness, example selector, and OpenCode after loading the patched native build

Closes #933