### PR TITLE
core: compact keypress debug output and add IME repro

### DIFF
--- a/packages/core/src/console.test.ts
+++ b/packages/core/src/console.test.ts
@@ -315,6 +315,23 @@ describe("TerminalConsole", () => {
       expect(onCopy).toHaveBeenCalledWith("Hello")
     })
 
+    test("should use baseCode for Ctrl+Shift+C from alternate layouts", () => {
+      const onCopy = mock(() => {})
+      terminalConsole = new TerminalConsole(mockRenderer as any, {
+        position: ConsolePosition.BOTTOM,
+        sizePercent: 30,
+        onCopySelection: onCopy,
+      })
+
+      terminalConsole["_displayLines"] = [{ text: "Hello World", level: "LOG" as any, indent: false }]
+      terminalConsole["_selectionStart"] = { line: 0, col: 0 }
+      terminalConsole["_selectionEnd"] = { line: 0, col: 5 }
+
+      terminalConsole["handleKeyPress"]({ name: "ㅊ", baseCode: 99, ctrl: true, shift: true, meta: false } as any)
+
+      expect(onCopy).toHaveBeenCalledWith("Hello")
+    })
+
     test("should not trigger when no selection", () => {
       const onCopy = mock(() => {})
       terminalConsole = new TerminalConsole(mockRenderer as any, {

--- a/packages/core/src/console.ts
+++ b/packages/core/src/console.ts
@@ -15,8 +15,8 @@ import type { KeyEvent } from "./lib/KeyHandler.js"
 import {
   type KeyBinding as BaseKeyBinding,
   mergeKeyBindings,
-  getKeyBindingKey,
   buildKeyBindingsMap,
+  getKeyBindingAction,
   type KeyAliasMap,
   defaultKeyAliases,
   mergeKeyAliases,
@@ -516,16 +516,7 @@ export class TerminalConsole extends EventEmitter {
       return
     }
 
-    const bindingKey = getKeyBindingKey({
-      name: event.name,
-      ctrl: event.ctrl,
-      shift: event.shift,
-      meta: event.meta,
-      super: event.super,
-      action: "scroll-up" as ConsoleAction,
-    })
-
-    const action = this._keyBindingsMap.get(bindingKey)
+    const action = getKeyBindingAction(this._keyBindingsMap, event)
 
     if (action) {
       const handler = this._actionHandlers.get(action)

--- a/packages/core/src/examples/keypress-debug-demo.ts
+++ b/packages/core/src/examples/keypress-debug-demo.ts
@@ -10,34 +10,451 @@ import {
   decodePasteBytes,
 } from "../index.js"
 import { ScrollBoxRenderable } from "../renderables/ScrollBox.js"
-import { TextNodeRenderable } from "../renderables/TextNode.js"
 import { setupCommonDemoKeys } from "./lib/standalone-keys.js"
 import { env, registerEnvVar } from "../lib/env.js"
 
 registerEnvVar({
   name: "OTUI_KEYPRESS_DEBUG_SHOW_JSON",
-  description: "Show full JSON alongside formatted output in keypress debug tool",
+  description: "Show full JSON for the latest parsed event in the keypress debug tool",
   type: "boolean",
   default: false,
 })
 
-let scrollBox: ScrollBoxRenderable | null = null
-let eventCount = 0
+const MAX_VISIBLE_EVENTS = 120
+
+type DebugEventType = "keypress" | "keyrelease" | "paste"
+
+interface RawInputRecord {
+  timestamp: string
+  sequence: string
+}
+
+interface KeySnapshot {
+  name: string
+  ctrl: boolean
+  meta: boolean
+  shift: boolean
+  option: boolean
+  sequence: string
+  raw: string
+  eventType: string
+  source: string
+  number: boolean
+  code?: string
+  super?: boolean
+  hyper?: boolean
+  capsLock?: boolean
+  numLock?: boolean
+  baseCode?: number
+  repeated?: boolean
+}
+
+interface PasteSnapshot {
+  byteLength: number
+  bytes: number[]
+  text: string
+  metadata?: unknown
+}
+
+type DebugSnapshot = KeySnapshot | PasteSnapshot
+
+interface DebugEntry {
+  id: number
+  timestamp: string
+  type: DebugEventType
+  snapshot: DebugSnapshot
+}
+
+interface SavedEventRecord {
+  timestamp: string
+  type: DebugEventType
+  event: DebugSnapshot
+}
+
+let mainContainer: BoxRenderable | null = null
+let statusText: TextRenderable | null = null
+let footerText: TextRenderable | null = null
+let eventFeed: ScrollBoxRenderable | null = null
+let eventListText: TextRenderable | null = null
+let detailFeed: ScrollBoxRenderable | null = null
+let detailText: TextRenderable | null = null
 let helpModal: BoxRenderable | null = null
 let helpContent: TextRenderable | null = null
-let scrollHint: TextRenderable | null = null
+
 let showingHelp = false
 let showJson = false
+let eventCount = 0
+let lastSavedFile: string | null = null
+let lastSaveError: string | null = null
+
 let inputHandler: ((sequence: string) => boolean) | null = null
 let keypressHandler: ((event: KeyEvent) => void) | null = null
 let keyreleaseHandler: ((event: KeyEvent) => void) | null = null
 let pasteHandler: ((event: PasteEvent) => void) | null = null
 
-// Storage for all captured data
-let allRawInputs: Array<{ timestamp: string; sequence: string }> = []
-let allKeyEvents: Array<{ timestamp: string; type: string; event: any }> = []
+let allRawInputs: RawInputRecord[] = []
+let allKeyEvents: SavedEventRecord[] = []
+let visibleEvents: DebugEntry[] = []
+let lastRawInput: RawInputRecord | null = null
 
-function saveToFile(capabilities: CliRenderer["capabilities"]) {
+function truncate(text: string, maxLength: number): string {
+  if (maxLength <= 3 || text.length <= maxLength) {
+    return text
+  }
+
+  return `${text.slice(0, maxLength - 3)}...`
+}
+
+function pad(text: string, width: number): string {
+  return text.length >= width ? text : text.padEnd(width, " ")
+}
+
+function formatClock(timestamp: string): string {
+  const date = new Date(timestamp)
+  const hours = `${date.getHours()}`.padStart(2, "0")
+  const minutes = `${date.getMinutes()}`.padStart(2, "0")
+  const seconds = `${date.getSeconds()}`.padStart(2, "0")
+  const millis = `${date.getMilliseconds()}`.padStart(3, "0")
+  return `${hours}:${minutes}:${seconds}.${millis}`
+}
+
+function safeJson(value: unknown, indent = 0): string {
+  try {
+    return JSON.stringify(value, null, indent) ?? String(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function formatScalar(value: unknown): string {
+  if (value === undefined) return "-"
+  if (typeof value === "string") return JSON.stringify(value)
+  if (typeof value === "number" || typeof value === "boolean" || value === null) return String(value)
+  return safeJson(value)
+}
+
+function formatCharName(name: string): string {
+  if (name === " ") return "Space"
+
+  const codePoint = name.codePointAt(0)
+  if (codePoint !== undefined && (codePoint < 32 || codePoint === 127)) {
+    return `U+${codePoint.toString(16).toUpperCase().padStart(4, "0")}`
+  }
+
+  switch (name) {
+    case "escape":
+      return "Escape"
+    case "return":
+      return "Return"
+    case "linefeed":
+      return "Linefeed"
+    case "backspace":
+      return "Backspace"
+    case "space":
+      return "Space"
+    case "tab":
+      return "Tab"
+    default:
+      return name
+  }
+}
+
+function formatModifiers(snapshot: KeySnapshot): string {
+  const modifiers: string[] = []
+  if (snapshot.ctrl) modifiers.push("Ctrl")
+  if (snapshot.meta) modifiers.push("Meta")
+  if (snapshot.shift) modifiers.push("Shift")
+  if (snapshot.option) modifiers.push("Option")
+  if (snapshot.super) modifiers.push("Super")
+  if (snapshot.hyper) modifiers.push("Hyper")
+  return modifiers.length > 0 ? modifiers.join("+") : "-"
+}
+
+function formatCombo(snapshot: KeySnapshot): string {
+  const modifiers = formatModifiers(snapshot)
+  const name = snapshot.name ? formatCharName(snapshot.name) : "-"
+  if (modifiers === "-") return name
+  if (name === "-") return modifiers
+  return `${modifiers}+${name}`
+}
+
+function formatBaseCode(baseCode: number | undefined): string {
+  if (baseCode === undefined) return "-"
+
+  let rendered = `U+${baseCode.toString(16).toUpperCase().padStart(4, "0")}`
+  if (baseCode >= 32 && baseCode !== 127) {
+    try {
+      rendered = JSON.stringify(String.fromCodePoint(baseCode))
+    } catch {
+      rendered = `U+${baseCode.toString(16).toUpperCase().padStart(4, "0")}`
+    }
+  }
+
+  return `${baseCode} (${rendered})`
+}
+
+function formatBaseCodeBrief(baseCode: number | undefined): string {
+  if (baseCode === undefined) return "-"
+
+  if (baseCode >= 32 && baseCode !== 127) {
+    try {
+      return JSON.stringify(String.fromCodePoint(baseCode))
+    } catch {
+      // Fall back to the codepoint form below.
+    }
+  }
+
+  return `U+${baseCode.toString(16).toUpperCase().padStart(4, "0")}`
+}
+
+function formatInline(text: string | undefined, maxLength: number): string {
+  return truncate(formatScalar(text), maxLength)
+}
+
+function snapshotKeyEvent(event: KeyEvent): KeySnapshot {
+  return {
+    name: event.name,
+    ctrl: event.ctrl,
+    meta: event.meta,
+    shift: event.shift,
+    option: event.option,
+    sequence: event.sequence,
+    raw: event.raw,
+    eventType: event.eventType,
+    source: event.source,
+    number: event.number,
+    code: event.code,
+    super: event.super,
+    hyper: event.hyper,
+    capsLock: event.capsLock,
+    numLock: event.numLock,
+    baseCode: event.baseCode,
+    repeated: event.repeated,
+  }
+}
+
+function snapshotPasteEvent(event: PasteEvent): PasteSnapshot {
+  return {
+    byteLength: event.bytes.length,
+    bytes: Array.from(event.bytes),
+    text: decodePasteBytes(event.bytes),
+    metadata: event.metadata,
+  }
+}
+
+function pushVisibleEvent(entry: DebugEntry): void {
+  visibleEvents.push(entry)
+  if (visibleEvents.length > MAX_VISIBLE_EVENTS) {
+    visibleEvents.shift()
+  }
+}
+
+function terminalSummary(renderer: CliRenderer): string {
+  const terminalName = renderer.capabilities?.terminal?.name ?? "unknown"
+  const terminalVersion = renderer.capabilities?.terminal?.version
+  return terminalVersion ? `${terminalName} ${terminalVersion}` : terminalName
+}
+
+function latestEventSummary(): string {
+  const latest = visibleEvents[visibleEvents.length - 1]
+  if (!latest) {
+    return "none"
+  }
+
+  if (latest.type === "paste") {
+    const snapshot = latest.snapshot as PasteSnapshot
+    return `paste ${snapshot.byteLength}B`
+  }
+
+  return formatCombo(latest.snapshot as KeySnapshot)
+}
+
+function createStatusText(renderer: CliRenderer): string {
+  const summary = [
+    "Keypress Debug",
+    `events ${allKeyEvents.length}`,
+    `visible ${visibleEvents.length}`,
+    `raw ${allRawInputs.length}`,
+    `kitty ${renderer.useKittyKeyboard ? "on" : "off"}`,
+    `json ${showJson ? "on" : "off"}`,
+  ].join(" | ")
+
+  let feedback = "capture is centered on parsed events; raw input stays in the session detail and export"
+  if (lastSaveError) {
+    feedback = `save failed: ${truncate(lastSaveError, 64)}`
+  } else if (lastSavedFile) {
+    feedback = `saved ${truncate(lastSavedFile, 64)}`
+  }
+
+  return [summary, `latest ${latestEventSummary()} | terminal ${terminalSummary(renderer)} | ${feedback}`].join("\n")
+}
+
+function createEventRow(entry: DebugEntry, isLatest: boolean): string {
+  const prefix = isLatest ? ">" : " "
+  const id = String(entry.id).padStart(3, "0")
+  const time = formatClock(entry.timestamp)
+
+  if (entry.type === "paste") {
+    const snapshot = entry.snapshot as PasteSnapshot
+    const preview = truncate(JSON.stringify(snapshot.text), 30)
+    const note = `bytes=${snapshot.byteLength} text=${preview}`
+    return `${prefix} ${id} ${time} ${pad("paste", 6)} ${pad("Paste", 18)} ${note}`
+  }
+
+  const snapshot = entry.snapshot as KeySnapshot
+  const eventLabel = entry.type === "keypress" ? "down" : "up"
+  const noteParts = [`src=${snapshot.source}`]
+
+  if (snapshot.baseCode !== undefined) {
+    noteParts.push(`base=${formatBaseCodeBrief(snapshot.baseCode)}`)
+  }
+
+  if (snapshot.raw && snapshot.raw !== snapshot.sequence) {
+    noteParts.push(`raw=${formatInline(snapshot.raw, 20)}`)
+  } else if (snapshot.sequence) {
+    noteParts.push(`seq=${formatInline(snapshot.sequence, 20)}`)
+  }
+
+  if (snapshot.repeated) {
+    noteParts.push("repeat")
+  }
+
+  return `${prefix} ${id} ${time} ${pad(eventLabel, 6)} ${pad(truncate(formatCombo(snapshot), 18), 18)} ${noteParts.join(" ")}`
+}
+
+function createEventListText(): string {
+  const lines = [
+    "  ID  TIME         TYPE   KEY                NOTES",
+    "  --- ------------ ------ ------------------ ----------------------------------------",
+  ]
+
+  if (visibleEvents.length === 0) {
+    lines.push("  --  waiting for parsed input events --")
+    return lines.join("\n")
+  }
+
+  for (let index = 0; index < visibleEvents.length; index += 1) {
+    const entry = visibleEvents[index]!
+    lines.push(createEventRow(entry, index === visibleEvents.length - 1))
+  }
+
+  return lines.join("\n")
+}
+
+function createDetailText(renderer: CliRenderer): string {
+  const latest = visibleEvents[visibleEvents.length - 1] ?? null
+  const lines = [
+    "Session",
+    `terminal      ${terminalSummary(renderer)}`,
+    `kitty kb      ${renderer.useKittyKeyboard ? "on" : "off"}`,
+    `raw inputs    ${allRawInputs.length}`,
+    `parsed events ${allKeyEvents.length}`,
+    `last raw      ${formatInline(lastRawInput?.sequence, 56)}`,
+  ]
+
+  if (!latest) {
+    lines.push("", "Latest Event", "no parsed event yet")
+    return lines.join("\n")
+  }
+
+  lines.push(
+    "",
+    "Latest Event",
+    `index         #${latest.id}`,
+    `type          ${latest.type}`,
+    `time          ${latest.timestamp}`,
+  )
+
+  if (latest.type === "paste") {
+    const snapshot = latest.snapshot as PasteSnapshot
+    lines.push(
+      `bytes         ${snapshot.byteLength}`,
+      `text          ${formatScalar(snapshot.text)}`,
+      `metadata      ${formatScalar(snapshot.metadata)}`,
+    )
+  } else {
+    const snapshot = latest.snapshot as KeySnapshot
+    const flagParts = [
+      `repeated=${snapshot.repeated ? "yes" : "no"}`,
+      `caps=${snapshot.capsLock ? "on" : "off"}`,
+      `num=${snapshot.numLock ? "on" : "off"}`,
+      `number=${snapshot.number ? "yes" : "no"}`,
+    ]
+
+    lines.push(
+      `combo         ${formatCombo(snapshot)}`,
+      `name          ${formatScalar(snapshot.name)}`,
+      `sequence      ${formatScalar(snapshot.sequence)}`,
+      `raw           ${formatScalar(snapshot.raw)}`,
+      `source        ${snapshot.source}`,
+      `event type    ${snapshot.eventType}`,
+      `modifiers     ${formatModifiers(snapshot)}`,
+      `code          ${formatScalar(snapshot.code)}`,
+      `base code     ${formatBaseCode(snapshot.baseCode)}`,
+      `flags         ${flagParts.join(" ")}`,
+    )
+  }
+
+  if (showJson) {
+    lines.push("", "JSON", safeJson(latest.snapshot, 2))
+  }
+
+  return lines.join("\n")
+}
+
+function createHelpText(): string {
+  return [
+    "Keypress Debug",
+    "",
+    "This demo now keeps the feed compact and centers the parsed key events.",
+    "Raw input is still captured, but it lives in the session detail and the saved JSON instead of duplicating every row.",
+    "",
+    "Controls",
+    "  ?       toggle help",
+    "  Shift+J toggle JSON for the latest parsed event",
+    "  Shift+S save the current capture to keypress-debug-*.json",
+    "  Shift+L clear the current session",
+    "  Ctrl+C  quit",
+    "",
+    "Tips",
+    "  baseCode is shown in the detail pane for Kitty alternate-key events.",
+    "  That makes layout and IME issues easier to inspect.",
+  ].join("\n")
+}
+
+function refreshUi(renderer: CliRenderer): void {
+  if (statusText) {
+    statusText.content = createStatusText(renderer)
+  }
+
+  if (eventListText) {
+    eventListText.content = createEventListText()
+  }
+
+  if (detailText) {
+    detailText.content = createDetailText(renderer)
+  }
+
+  if (footerText) {
+    footerText.content = "Controls: ?:help  Shift+J:json  Shift+S:save  Shift+L:clear  Ctrl+C:quit"
+  }
+
+  if (helpModal) {
+    helpModal.visible = showingHelp
+  }
+
+  if (helpContent) {
+    helpContent.content = createHelpText()
+  }
+
+  if (detailFeed) {
+    detailFeed.scrollTop = 0
+  }
+
+  renderer.requestRender()
+}
+
+async function saveToFile(renderer: CliRenderer): Promise<void> {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
   const filename = `keypress-debug-${timestamp}.json`
 
@@ -48,360 +465,248 @@ function saveToFile(capabilities: CliRenderer["capabilities"]) {
     summary: {
       totalRawInputs: allRawInputs.length,
       totalKeyEvents: allKeyEvents.length,
+      visibleEventWindow: visibleEvents.length,
     },
-    capabilities,
+    capabilities: renderer.capabilities,
   }
 
   try {
-    Bun.write(filename, JSON.stringify(data, null, 2))
-    console.log(`Saved debug data to ${filename}`)
+    await Bun.write(filename, JSON.stringify(data, null, 2))
+    lastSavedFile = filename
+    lastSaveError = null
   } catch (error) {
-    console.error(`Failed to save file: ${error}`)
+    lastSavedFile = null
+    lastSaveError = error instanceof Error ? error.message : String(error)
   }
+
+  refreshUi(renderer)
 }
 
-function formatEventAsText(renderer: CliRenderer, eventType: string, event: any): TextRenderable {
-  const eventText = new TextRenderable(renderer, {
-    id: `event-text-${eventCount}`,
-  })
-
-  // Event type header with icon
-  let icon = "⌨️ "
-  let typeColor = "#A5D6FF"
-  if (eventType === "keypress") {
-    icon = "↓ "
-    typeColor = "#7EE787"
-  } else if (eventType === "keyrelease") {
-    icon = "↑ "
-    typeColor = "#FFA657"
-  } else if (eventType === "paste") {
-    icon = "📋 "
-    typeColor = "#D2A8FF"
-  } else if (eventType === "capabilities") {
-    icon = "ℹ️  "
-    typeColor = "#79C0FF"
-  }
-
-  const typeNode = TextNodeRenderable.fromString(`${icon}${eventType.toUpperCase()}`, {
-    fg: typeColor,
-    attributes: 1, // bold
-  })
-  eventText.textNode.add(typeNode)
-
-  // Key name (if available)
-  if (event.name) {
-    const keyNode = TextNodeRenderable.fromString(` ${event.name}`, {
-      fg: "#FFA657",
-      attributes: 1,
-    })
-    eventText.textNode.add(keyNode)
-  }
-
-  // Modifiers
-  const modifiers: string[] = []
-  if (event.ctrl) modifiers.push("Ctrl")
-  if (event.meta) modifiers.push("Meta")
-  if (event.shift) modifiers.push("Shift")
-  if (event.option) modifiers.push("Option")
-  if (event.super) modifiers.push("Super")
-  if (event.hyper) modifiers.push("Hyper")
-
-  if (modifiers.length > 0) {
-    const modNode = TextNodeRenderable.fromString(` [${modifiers.join("+")}]`, {
-      fg: "#D2A8FF",
-    })
-    eventText.textNode.add(modNode)
-  }
-
-  // Sequence/Raw
-  if (event.raw || event.sequence) {
-    const raw = event.raw || event.sequence
-    const displayRaw = JSON.stringify(raw)
-    const rawNode = TextNodeRenderable.fromString(` ${displayRaw}`, {
-      fg: "#79C0FF",
-    })
-    eventText.textNode.add(rawNode)
-  }
-
-  // Source
-  if (event.source) {
-    const sourceNode = TextNodeRenderable.fromString(` (${event.source})`, {
-      fg: "#8B949E",
-    })
-    eventText.textNode.add(sourceNode)
-  }
-
-  // Paste text
-  if (eventType === "paste") {
-    const pasteText = decodePasteBytes(event.bytes)
-    const textPreview = pasteText.length > 50 ? pasteText.substring(0, 47) + "..." : pasteText
-    const pasteNode = TextNodeRenderable.fromString(`\n  "${textPreview}"`, {
-      fg: "#A5D6FF",
-    })
-    eventText.textNode.add(pasteNode)
-  }
-
-  // Capabilities info - show full details
-  if (eventType === "capabilities") {
-    const capsText = JSON.stringify(event, null, 2)
-    const capsNode = TextNodeRenderable.fromString(`\n${capsText}`, {
-      fg: "#8B949E",
-    })
-    eventText.textNode.add(capsNode)
-  }
-
-  // Timestamp
-  const time = new Date().toLocaleTimeString()
-  const timeNode = TextNodeRenderable.fromString(`\n  ${time}`, {
-    fg: "#6E7681",
-  })
-  eventText.textNode.add(timeNode)
-
-  // Show full JSON if enabled
-  if (showJson && eventType !== "capabilities") {
-    const jsonText = JSON.stringify({ type: eventType, timestamp: new Date().toISOString(), ...event }, null, 2)
-    const jsonNode = TextNodeRenderable.fromString(`\n\n${jsonText}`, {
-      fg: "#8B949E",
-    })
-    eventText.textNode.add(jsonNode)
-  }
-
-  return eventText
+function clearSession(renderer: CliRenderer): void {
+  eventCount = 0
+  allRawInputs = []
+  allKeyEvents = []
+  visibleEvents = []
+  lastRawInput = null
+  lastSavedFile = null
+  lastSaveError = null
+  refreshUi(renderer)
 }
 
-function addEvent(renderer: CliRenderer, eventType: string, event: object) {
-  if (!scrollBox) return
+function recordParsedEvent(renderer: CliRenderer, type: DebugEventType, snapshot: DebugSnapshot): void {
+  eventCount += 1
 
-  eventCount++
-
-  const eventBox = new BoxRenderable(renderer, {
-    id: `event-${eventCount}`,
-    width: "auto",
-    marginBottom: 1,
-    padding: 1,
-    backgroundColor: "#1f2937",
-    borderColor: "#374151",
-    borderStyle: "single",
-    border: true,
-  })
-
-  const eventDisplay = formatEventAsText(renderer, eventType, event)
-  eventBox.add(eventDisplay)
-  scrollBox.add(eventBox)
-
-  const children = scrollBox.getChildren()
-  if (children.length > 50) {
-    const oldest = children[0]
-    if (oldest) {
-      scrollBox.remove(oldest.id)
-      oldest.destroyRecursively()
-    }
+  const timestamp = new Date().toISOString()
+  const entry: DebugEntry = {
+    id: eventCount,
+    timestamp,
+    type,
+    snapshot,
   }
+
+  allKeyEvents.push({
+    timestamp,
+    type,
+    event: snapshot,
+  })
+  pushVisibleEvent(entry)
+  refreshUi(renderer)
 }
 
 export function run(renderer: CliRenderer): void {
   renderer.setBackgroundColor("#0D1117")
-
-  // Initialize showJson from env var
   showJson = env.OTUI_KEYPRESS_DEBUG_SHOW_JSON
 
-  // Get any debug inputs captured before this tool started (e.g., during setupTerminal)
   const cachedDebugInputs = renderer.getDebugInputs()
   if (cachedDebugInputs.length > 0) {
     allRawInputs.push(...cachedDebugInputs)
-    console.log(`Loaded ${cachedDebugInputs.length} pre-captured debug inputs (including terminal setup)`)
+    lastRawInput = cachedDebugInputs[cachedDebugInputs.length - 1] ?? null
   }
 
-  const mainContainer = new BoxRenderable(renderer, {
-    id: "main-container",
-    flexGrow: 1,
+  mainContainer = new BoxRenderable(renderer, {
+    id: "keypress-debug-main",
+    width: "100%",
+    height: "100%",
+    padding: 1,
     flexDirection: "column",
   })
 
-  renderer.root.add(mainContainer)
-
-  scrollBox = new ScrollBoxRenderable(renderer, {
-    id: "event-scroll-box",
-    stickyScroll: true,
-    stickyStart: "bottom",
-    border: true,
-    borderColor: "#6BCF7F",
-    title: "Keypress Debug Tool (Press ? for keys)",
-    titleAlignment: "center",
-    contentOptions: {
-      paddingLeft: 1,
-      paddingRight: 1,
-      paddingTop: 1,
-    },
+  statusText = new TextRenderable(renderer, {
+    id: "keypress-debug-status",
+    width: "100%",
+    height: 2,
+    flexShrink: 0,
+    fg: "#E6EDF3",
+    wrapMode: "word",
+    selectable: false,
   })
 
-  mainContainer.add(scrollBox)
+  const body = new BoxRenderable(renderer, {
+    id: "keypress-debug-body",
+    width: "100%",
+    flexGrow: 1,
+    flexShrink: 1,
+    flexDirection: "row",
+  })
 
-  // Create help modal (hidden by default)
+  eventFeed = new ScrollBoxRenderable(renderer, {
+    id: "keypress-debug-feed",
+    flexGrow: 1,
+    flexShrink: 1,
+    border: true,
+    borderColor: "#58A6FF",
+    title: "Event Feed",
+    titleAlignment: "left",
+    stickyScroll: true,
+    stickyStart: "bottom",
+    backgroundColor: "#0F1722",
+    contentOptions: {
+      padding: 1,
+    },
+  })
+  eventFeed.verticalScrollbarOptions = { visible: false }
+
+  eventListText = new TextRenderable(renderer, {
+    id: "keypress-debug-feed-text",
+    width: "100%",
+    wrapMode: "none",
+    truncate: true,
+    fg: "#C9D1D9",
+    selectable: false,
+  })
+  eventFeed.add(eventListText)
+
+  detailFeed = new ScrollBoxRenderable(renderer, {
+    id: "keypress-debug-detail-feed",
+    width: "42%",
+    flexShrink: 0,
+    marginLeft: 1,
+    border: true,
+    borderColor: "#A371F7",
+    title: "Session / Latest Event",
+    titleAlignment: "left",
+    backgroundColor: "#111827",
+    contentOptions: {
+      padding: 1,
+    },
+  })
+  detailFeed.verticalScrollbarOptions = { visible: false }
+
+  detailText = new TextRenderable(renderer, {
+    id: "keypress-debug-detail-text",
+    width: "100%",
+    wrapMode: "word",
+    fg: "#E6EDF3",
+    selectable: false,
+  })
+  detailFeed.add(detailText)
+
+  footerText = new TextRenderable(renderer, {
+    id: "keypress-debug-footer",
+    width: "100%",
+    height: 1,
+    flexShrink: 0,
+    fg: "#8B949E",
+    selectable: false,
+  })
+
+  body.add(eventFeed)
+  body.add(detailFeed)
+  mainContainer.add(statusText)
+  mainContainer.add(body)
+  mainContainer.add(footerText)
+  renderer.root.add(mainContainer)
+
   helpModal = new BoxRenderable(renderer, {
-    id: "help-modal",
+    id: "keypress-debug-help-modal",
     position: "absolute",
-    left: "5%",
-    top: "5%",
-    width: "90%",
-    height: "90%",
+    left: "12%",
+    top: 3,
+    width: "76%",
+    height: 16,
+    padding: 1,
     border: true,
     borderStyle: "double",
     borderColor: "#4ECDC4",
     backgroundColor: "#0D1117",
-    title: "Keybindings",
+    title: "Help",
     titleAlignment: "center",
-    flexDirection: "column",
-    zIndex: 100,
     visible: false,
+    zIndex: 100,
   })
 
   helpContent = new TextRenderable(renderer, {
-    id: "help-content",
-    content: `Actions:
-  Shift+C : Refresh terminal capabilities
-  Shift+J : Toggle JSON view (show full JSON)
-  Shift+S : Save all captured data to JSON file
-  ?       : Toggle this help screen
-  ESC     : Return to main menu
-
-Events Captured:
-  • All keypress events
-  • All keyrelease events
-  • Paste events
-  • Raw input sequences (including unhandled)
-
-Env Vars:
-  OTUI_KEYPRESS_DEBUG_SHOW_JSON=true
-    Enable JSON view at startup
-
-The debug tool displays all keyboard and
-input events in real-time. Use Shift+S to
-save all captured data to a timestamped
-JSON file in the current directory.`,
+    id: "keypress-debug-help-content",
+    width: "100%",
+    wrapMode: "word",
     fg: "#E6EDF3",
-    flexGrow: 1,
-    flexShrink: 1,
+    selectable: false,
   })
-
   helpModal.add(helpContent)
-
-  // Scroll hint (shown only when there's content to scroll)
-  scrollHint = new TextRenderable(renderer, {
-    id: "scroll-hint",
-    content: "↑↓ to scroll",
-    fg: "#6E7681",
-    flexShrink: 0,
-    height: 1,
-    visible: false,
-  })
-  helpModal.add(scrollHint)
-
   renderer.root.add(helpModal)
 
-  addEvent(renderer, "capabilities", renderer.capabilities)
-
   inputHandler = (sequence: string) => {
-    // Store all raw input
-    allRawInputs.push({
+    const record = {
       timestamp: new Date().toISOString(),
       sequence,
-    })
+    }
 
-    addEvent(renderer, "raw-input", { sequence })
+    allRawInputs.push(record)
+    lastRawInput = record
+    refreshUi(renderer)
     return false
   }
-  // Prepend to capture everything, even what other handlers process
   renderer.prependInputHandler(inputHandler)
 
   keypressHandler = (event: KeyEvent) => {
-    // Store all keypress events
-    allKeyEvents.push({
-      timestamp: new Date().toISOString(),
-      type: "keypress",
-      event: { ...event },
-    })
-
-    // Handle help modal toggle
-    if (event.raw === "?" && helpModal) {
+    if (event.raw === "?" && !event.ctrl && !event.meta && !event.super && !event.hyper) {
       showingHelp = !showingHelp
-      helpModal.visible = showingHelp
-
-      // Update scroll hint visibility when modal opens
-      if (showingHelp && helpContent && scrollHint) {
-        const canScroll = helpContent.maxScrollY > 0
-        scrollHint.visible = canScroll
-      }
+      refreshUi(renderer)
       return
     }
 
-    // Handle scrolling when help modal is open
-    if (showingHelp && helpContent) {
-      if (event.name === "up") {
-        helpContent.scrollY = Math.max(0, helpContent.scrollY - 1)
-        return
-      } else if (event.name === "down") {
-        helpContent.scrollY = Math.min(helpContent.maxScrollY, helpContent.scrollY + 1)
-        return
-      }
+    if (showingHelp && event.name === "escape") {
+      showingHelp = false
+      refreshUi(renderer)
+      return
     }
 
-    // Handle JSON view toggle
     if (event.name === "j" && event.shift) {
       showJson = !showJson
+      refreshUi(renderer)
       return
     }
 
-    // Handle save to file
     if (event.name === "s" && event.shift) {
-      saveToFile(renderer.capabilities)
+      void saveToFile(renderer)
       return
     }
 
-    // Don't log modal toggle key
-    if (showingHelp && event.raw === "?") {
+    if (event.name === "l" && event.shift) {
+      clearSession(renderer)
       return
     }
 
-    addEvent(renderer, "keypress", event)
-
-    if (event.name === "c" && event.shift) {
-      addEvent(renderer, "capabilities", renderer.capabilities)
-    }
+    recordParsedEvent(renderer, "keypress", snapshotKeyEvent(event))
   }
   renderer.keyInput.on("keypress", keypressHandler)
 
   keyreleaseHandler = (event: KeyEvent) => {
-    // Store all keyrelease events
-    allKeyEvents.push({
-      timestamp: new Date().toISOString(),
-      type: "keyrelease",
-      event: { ...event },
-    })
-
-    addEvent(renderer, "keyrelease", event)
+    recordParsedEvent(renderer, "keyrelease", snapshotKeyEvent(event))
   }
   renderer.keyInput.on("keyrelease", keyreleaseHandler)
 
   pasteHandler = (event: PasteEvent) => {
-    // Store all paste events
-    allKeyEvents.push({
-      timestamp: new Date().toISOString(),
-      type: "paste",
-      event: { ...event },
-    })
-
-    addEvent(renderer, "paste", event)
+    recordParsedEvent(renderer, "paste", snapshotPasteEvent(event))
   }
   renderer.keyInput.on("paste", pasteHandler)
 
-  renderer.requestRender()
+  refreshUi(renderer)
 }
 
 export function destroy(renderer: CliRenderer): void {
   renderer.clearFrameCallbacks()
 
-  // Remove event listeners
   if (keypressHandler) {
     renderer.keyInput.off("keypress", keypressHandler)
     keypressHandler = null
@@ -422,23 +727,31 @@ export function destroy(renderer: CliRenderer): void {
     inputHandler = null
   }
 
-  if (scrollBox) {
-    renderer.root.remove("main-container")
-    scrollBox = null
+  if (mainContainer) {
+    renderer.root.remove(mainContainer.id)
+    mainContainer.destroyRecursively()
+    mainContainer = null
   }
 
-  helpModal?.destroy()
+  helpModal?.destroyRecursively()
   helpModal = null
   helpContent = null
-  scrollHint = null
+  statusText = null
+  footerText = null
+  eventFeed = null
+  eventListText = null
+  detailFeed = null
+  detailText = null
 
-  eventCount = 0
   showingHelp = false
   showJson = false
-
-  // Clear captured data
+  eventCount = 0
+  lastSavedFile = null
+  lastSaveError = null
   allRawInputs = []
   allKeyEvents = []
+  visibleEvents = []
+  lastRawInput = null
 }
 
 if (import.meta.main) {

--- a/packages/core/src/lib/keymapping.test.ts
+++ b/packages/core/src/lib/keymapping.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "bun:test"
 import {
   mergeKeyBindings,
   getKeyBindingKey,
+  getKeyBindingAction,
   buildKeyBindingsMap,
   mergeKeyAliases,
   defaultKeyAliases,
   keyBindingToString,
+  matchesKeyBinding,
   type KeyAliasMap,
 } from "./keymapping.js"
 
@@ -38,6 +40,33 @@ describe("keymapping", () => {
       const superBinding = { name: "z", super: true, action: "test" }
       const key = getKeyBindingKey(superBinding)
       expect(key).toBe("z:0:0:0:1")
+    })
+  })
+
+  describe("getKeyBindingAction", () => {
+    it("should fall back to baseCode when the parsed name differs", () => {
+      const map = buildKeyBindingsMap([{ name: "c", ctrl: true, action: "copy" as const }])
+
+      const action = getKeyBindingAction(map, { name: "ㅊ", baseCode: 99, ctrl: true })
+
+      expect(action).toBe("copy")
+    })
+
+    it("should prefer a direct name match over the baseCode fallback", () => {
+      const map = buildKeyBindingsMap([
+        { name: "c", ctrl: true, action: "copy" as const },
+        { name: "ㅊ", ctrl: true, action: "insert" as const },
+      ])
+
+      const action = getKeyBindingAction(map, { name: "ㅊ", baseCode: 99, ctrl: true })
+
+      expect(action).toBe("insert")
+    })
+  })
+
+  describe("matchesKeyBinding", () => {
+    it("should match a binding by baseCode when available", () => {
+      expect(matchesKeyBinding({ name: "ㅊ", baseCode: 99, ctrl: true }, { name: "c", ctrl: true })).toBe(true)
     })
   })
 

--- a/packages/core/src/lib/keymapping.ts
+++ b/packages/core/src/lib/keymapping.ts
@@ -1,10 +1,18 @@
-export interface KeyBinding<Action extends string = string> {
+export interface KeyBindingLike {
   name: string
   ctrl?: boolean
   shift?: boolean
   meta?: boolean
   super?: boolean
+}
+
+export interface KeyBinding<Action extends string = string> extends KeyBindingLike {
   action: Action
+}
+
+export interface KeyBindingLookup extends KeyBindingLike {
+  // Kitty's base-layout codepoint as a Unicode number. Example: 99 means "c".
+  baseCode?: number
 }
 
 export type KeyAliasMap = Record<string, string>
@@ -62,8 +70,67 @@ export function mergeKeyBindings<Action extends string>(
   return Array.from(map.values())
 }
 
-export function getKeyBindingKey<Action extends string>(binding: KeyBinding<Action>): string {
+export function getKeyBindingKey(binding: KeyBindingLike): string {
   return `${binding.name}:${binding.ctrl ? 1 : 0}:${binding.shift ? 1 : 0}:${binding.meta ? 1 : 0}:${binding.super ? 1 : 0}`
+}
+
+// `baseCode` is Kitty's "base layout codepoint": the character for the same
+// physical key on the keyboard's base layout. Example: an event may arrive as
+// `name: "ㅊ", baseCode: 99`, where `99` is Unicode `c`. We normalize that
+// numeric codepoint to the key names we store in key maps so Ctrl+ㅊ can still
+// match a Ctrl+C binding.
+function getBaseCodeKeyName(baseCode: number | undefined): string | undefined {
+  if (baseCode === undefined || baseCode < 32 || baseCode === 127) {
+    return undefined
+  }
+
+  try {
+    const name = String.fromCodePoint(baseCode)
+
+    if (name.length === 1 && name >= "A" && name <= "Z") {
+      return name.toLowerCase()
+    }
+
+    return name
+  } catch {
+    return undefined
+  }
+}
+
+// Return every lookup key that can represent this event. We try the parsed
+// name first, then the base-layout key when Kitty provides one. That keeps
+// direct character bindings precise, and still lets physical-layout
+// shortcuts resolve.
+export function getKeyBindingKeys(binding: KeyBindingLookup): string[] {
+  const names = new Set([binding.name])
+  const baseCodeName = getBaseCodeKeyName(binding.baseCode)
+
+  if (baseCodeName) {
+    names.add(baseCodeName)
+  }
+
+  return [...names].map((name) => getKeyBindingKey({ ...binding, name }))
+}
+
+export function getKeyBindingAction<Action extends string>(
+  map: Map<string, Action>,
+  binding: KeyBindingLookup,
+): Action | undefined {
+  for (const key of getKeyBindingKeys(binding)) {
+    const action = map.get(key)
+
+    if (action !== undefined) {
+      return action
+    }
+  }
+
+  return undefined
+}
+
+export function matchesKeyBinding(binding: KeyBindingLookup, match: KeyBindingLike): boolean {
+  const matchKey = getKeyBindingKey(match)
+
+  return getKeyBindingKeys(binding).includes(matchKey)
 }
 
 export function buildKeyBindingsMap<Action extends string>(

--- a/packages/core/src/lib/parse.keypress-kitty.ts
+++ b/packages/core/src/lib/parse.keypress-kitty.ts
@@ -310,7 +310,10 @@ export function parseKittyKeyboard(sequence: string): ParsedKey | null {
 
   let text = ""
 
-  // Parse field 1: unicode-key-code:shifted_codepoint:base_layout_codepoint
+  // Parse field 1: unicode-key-code:shifted_codepoint:base_layout_codepoint.
+  // The character this key produced, the shifted variant, and what the same
+  // physical key would be on the base layout. Example: a key can produce `ㅊ`
+  // but still report base-layout codepoint 99, which is Unicode `c`.
   const field1 = fields[0]?.split(":") || []
   const codepointStr = field1[0]
   if (!codepointStr) return null
@@ -347,7 +350,8 @@ export function parseKittyKeyboard(sequence: string): ParsedKey | null {
       const char = String.fromCodePoint(codepoint)
       key.name = char
 
-      // Store base layout codepoint for keyboard layout disambiguation
+      // Keep the raw Unicode codepoint from Kitty so higher-level matching can
+      // later turn `99` into `c` and use that as a layout-stable fallback.
       if (baseCodepoint) {
         key.baseCode = baseCodepoint
       }

--- a/packages/core/src/lib/parse.keypress.test.ts
+++ b/packages/core/src/lib/parse.keypress.test.ts
@@ -179,6 +179,114 @@ test("parseKeypress - ctrl+letter combinations", () => {
   })
 })
 
+test("parseKeypress - raw ctrl+\\ and related control bytes", () => {
+  expect(parseKeypress("\x1c")).toEqual({
+    eventType: "press",
+    name: "\\",
+    ctrl: true,
+    meta: false,
+    shift: false,
+    option: false,
+    number: false,
+    sequence: "\x1c",
+    raw: "\x1c",
+    source: "raw",
+  })
+
+  expect(parseKeypress("\x1d")).toEqual({
+    eventType: "press",
+    name: "]",
+    ctrl: true,
+    meta: false,
+    shift: false,
+    option: false,
+    number: false,
+    sequence: "\x1d",
+    raw: "\x1d",
+    source: "raw",
+  })
+
+  expect(parseKeypress("\x1e")).toEqual({
+    eventType: "press",
+    name: "^",
+    ctrl: true,
+    meta: false,
+    shift: false,
+    option: false,
+    number: false,
+    sequence: "\x1e",
+    raw: "\x1e",
+    source: "raw",
+  })
+
+  expect(parseKeypress("\x1f")).toEqual({
+    eventType: "press",
+    name: "_",
+    ctrl: true,
+    meta: false,
+    shift: false,
+    option: false,
+    number: false,
+    sequence: "\x1f",
+    raw: "\x1f",
+    source: "raw",
+  })
+})
+
+test("parseKeypress - meta+raw ctrl+\\ and related control bytes", () => {
+  expect(parseKeypress("\x1b\x1c")).toEqual({
+    eventType: "press",
+    name: "\\",
+    ctrl: true,
+    meta: true,
+    shift: false,
+    option: false,
+    number: false,
+    sequence: "\x1b\x1c",
+    raw: "\x1b\x1c",
+    source: "raw",
+  })
+
+  expect(parseKeypress("\x1b\x1d")).toEqual({
+    eventType: "press",
+    name: "]",
+    ctrl: true,
+    meta: true,
+    shift: false,
+    option: false,
+    number: false,
+    sequence: "\x1b\x1d",
+    raw: "\x1b\x1d",
+    source: "raw",
+  })
+
+  expect(parseKeypress("\x1b\x1e")).toEqual({
+    eventType: "press",
+    name: "^",
+    ctrl: true,
+    meta: true,
+    shift: false,
+    option: false,
+    number: false,
+    sequence: "\x1b\x1e",
+    raw: "\x1b\x1e",
+    source: "raw",
+  })
+
+  expect(parseKeypress("\x1b\x1f")).toEqual({
+    eventType: "press",
+    name: "_",
+    ctrl: true,
+    meta: true,
+    shift: false,
+    option: false,
+    number: false,
+    sequence: "\x1b\x1f",
+    raw: "\x1b\x1f",
+    source: "raw",
+  })
+})
+
 test("parseKeypress - ctrl+space and alt+space", () => {
   // Ctrl+Space sends \x00 (null character)
   expect(parseKeypress("\x00")).toEqual({

--- a/packages/core/src/lib/parse.keypress.ts
+++ b/packages/core/src/lib/parse.keypress.ts
@@ -111,6 +111,26 @@ const isCtrlKey = (code: string) => {
   return ["Oa", "Ob", "Oc", "Od", "Oe", "[2^", "[3^", "[5^", "[6^", "[7^", "[8^"].includes(code)
 }
 
+// Map raw control bytes to the key names that bindings expect. Terminals send
+// Ctrl+A..Ctrl+Z as 0x01..0x1a, and they send Ctrl+\\..Ctrl+_ as 0x1c..0x1f.
+// The ESC-prefixed meta+ctrl path reuses this mapping, so the raw and meta
+// forms stay aligned.
+const getCtrlKeyName = (charCode: number): string | undefined => {
+  if (charCode === 0) {
+    return "space"
+  }
+
+  if (charCode >= 1 && charCode <= 26) {
+    return String.fromCharCode(charCode + "a".charCodeAt(0) - 1)
+  }
+
+  if (charCode >= 28 && charCode <= 31) {
+    return String.fromCharCode(charCode + 64)
+  }
+
+  return undefined
+}
+
 export type KeyEventType = "press" | "repeat" | "release"
 
 export interface ParsedKey {
@@ -129,6 +149,9 @@ export interface ParsedKey {
   hyper?: boolean
   capsLock?: boolean
   numLock?: boolean
+  // Kitty's base-layout codepoint as a Unicode number. Example: 99 means "c".
+  // This lets shortcut matching recover Ctrl+C from an event whose printed name
+  // is something else under the active layout or IME.
   baseCode?: number
   repeated?: boolean
 }
@@ -233,6 +256,9 @@ export const parseKeypress = (s: Buffer | string = "", options: ParseKeypressOpt
 
   key.sequence = key.sequence || s || key.name
 
+  const ctrlKeyName = s.length === 1 ? getCtrlKeyName(s.charCodeAt(0)) : undefined
+  const metaCtrlKeyName = s.length === 2 && s[0] === "\x1b" ? getCtrlKeyName(s.charCodeAt(1)) : undefined
+
   // Check for Kitty keyboard protocol if enabled
   if (options.useKittyKeyboard) {
     const kittyResult = parseKittyKeyboard(s)
@@ -305,13 +331,9 @@ export const parseKeypress = (s: Buffer | string = "", options: ParseKeypressOpt
   } else if (s === " " || s === "\x1b ") {
     key.name = "space"
     key.meta = s.length === 2
-  } else if (s === "\x00") {
-    // ctrl+space
-    key.name = "space"
-    key.ctrl = true
-  } else if (s.length === 1 && s <= "\x1a") {
-    // ctrl+letter
-    key.name = String.fromCharCode(s.charCodeAt(0) + "a".charCodeAt(0) - 1)
+  } else if (ctrlKeyName) {
+    // ctrl+space, ctrl+letter, ctrl+\\, ctrl+], ctrl+^, ctrl+_
+    key.name = ctrlKeyName
     key.ctrl = true
   } else if (s.length === 1 && s >= "0" && s <= "9") {
     // number - keep the actual number character for vim commands
@@ -344,11 +366,12 @@ export const parseKeypress = (s: Buffer | string = "", options: ParseKeypressOpt
     } else {
       key.name = char
     }
-  } else if (s.length === 2 && s[0] === "\x1b" && s[1]! <= "\x1a") {
-    // meta+ctrl+letter (ESC + control character)
+  } else if (metaCtrlKeyName) {
+    // ESC + control byte is the raw meta+ctrl form. Reuse the same names as
+    // the plain ctrl path, so meta+ctrl+\\ and friends resolve consistently.
     key.meta = true
     key.ctrl = true
-    key.name = String.fromCharCode(s.charCodeAt(1) + "a".charCodeAt(0) - 1)
+    key.name = metaCtrlKeyName
   } else if ((parts = fnKeyRe.exec(s))) {
     const segs = [...s]
 

--- a/packages/core/src/renderables/Select.test.ts
+++ b/packages/core/src/renderables/Select.test.ts
@@ -5,7 +5,7 @@ import { KeyEvent } from "../lib/KeyHandler.js"
 
 // Helper function to create a KeyEvent from a string or object
 function createKeyEvent(
-  input: string | { name: string; shift?: boolean; ctrl?: boolean; meta?: boolean; super?: boolean },
+  input: string | { name: string; shift?: boolean; ctrl?: boolean; meta?: boolean; super?: boolean; baseCode?: number },
 ): KeyEvent {
   if (typeof input === "string") {
     return new KeyEvent({
@@ -28,6 +28,7 @@ function createKeyEvent(
       meta: input.meta ?? false,
       shift: input.shift ?? false,
       super: input.super ?? false,
+      baseCode: input.baseCode,
       option: false,
       number: false,
       raw: input.name,
@@ -418,6 +419,23 @@ describe("SelectRenderable", () => {
       const kHandled = select.handleKeyPress(createKeyEvent("k"))
       expect(kHandled).toBe(true)
       expect(select.getSelectedIndex()).toBe(1)
+    })
+
+    test("should use baseCode for custom bindings from alternate layouts", async () => {
+      const { select } = await createSelectRenderable(currentRenderer, {
+        width: 20,
+        height: 5,
+        options: sampleOptions,
+        selectedIndex: 1,
+        keyBindings: [{ name: "j", action: "move-down" }],
+      })
+
+      select.focus()
+
+      const handled = select.handleKeyPress(createKeyEvent({ name: "ㅓ", baseCode: 106 }))
+
+      expect(handled).toBe(true)
+      expect(select.getSelectedIndex()).toBe(2)
     })
 
     test("should handle enter key", async () => {

--- a/packages/core/src/renderables/Select.ts
+++ b/packages/core/src/renderables/Select.ts
@@ -7,8 +7,8 @@ import type { RenderContext } from "../types.js"
 import {
   type KeyBinding as BaseKeyBinding,
   mergeKeyBindings,
-  getKeyBindingKey,
   buildKeyBindingsMap,
+  getKeyBindingAction,
   type KeyAliasMap,
   defaultKeyAliases,
   mergeKeyAliases,
@@ -328,16 +328,7 @@ export class SelectRenderable extends Renderable {
   }
 
   public handleKeyPress(key: KeyEvent): boolean {
-    const bindingKey = getKeyBindingKey({
-      name: key.name,
-      ctrl: key.ctrl,
-      shift: key.shift,
-      meta: key.meta,
-      super: key.super,
-      action: "move-up" as SelectAction,
-    })
-
-    const action = this._keyBindingsMap.get(bindingKey)
+    const action = getKeyBindingAction(this._keyBindingsMap, key)
 
     if (action) {
       switch (action) {

--- a/packages/core/src/renderables/TabSelect.test.ts
+++ b/packages/core/src/renderables/TabSelect.test.ts
@@ -6,7 +6,32 @@ import {
   type TabSelectOption,
 } from "./TabSelect.js"
 import { createTestRenderer, type MockInput, type TestRenderer } from "../testing/test-renderer.js"
+import { KeyEvent } from "../lib/KeyHandler.js"
 import { ManualClock } from "../testing/manual-clock.js"
+
+function createKeyEvent(input: {
+  name: string
+  shift?: boolean
+  ctrl?: boolean
+  meta?: boolean
+  super?: boolean
+  baseCode?: number
+}): KeyEvent {
+  return new KeyEvent({
+    name: input.name,
+    sequence: input.name === "space" ? " " : input.name,
+    ctrl: input.ctrl ?? false,
+    meta: input.meta ?? false,
+    shift: input.shift ?? false,
+    super: input.super ?? false,
+    baseCode: input.baseCode,
+    option: false,
+    number: false,
+    raw: input.name,
+    eventType: "press",
+    source: "raw",
+  })
+}
 
 let currentRenderer: TestRenderer
 let currentMockInput: MockInput
@@ -69,6 +94,22 @@ describe("TabSelectRenderable", () => {
       // H should move left
       currentMockInput.pressKey("h")
       expect(tabSelect.getSelectedIndex()).toBe(0)
+    })
+
+    test("should use baseCode for custom key bindings from alternate layouts", async () => {
+      const { tabSelect } = await createTabSelectRenderable(currentRenderer, {
+        width: 100,
+        options: sampleOptions,
+        keyBindings: [{ name: "l", action: "move-right" }],
+      })
+
+      tabSelect.focus()
+      expect(tabSelect.getSelectedIndex()).toBe(0)
+
+      const handled = tabSelect.handleKeyPress(createKeyEvent({ name: "ㅣ", baseCode: 108 }))
+
+      expect(handled).toBe(true)
+      expect(tabSelect.getSelectedIndex()).toBe(1)
     })
 
     test("should support key aliases", async () => {

--- a/packages/core/src/renderables/TabSelect.ts
+++ b/packages/core/src/renderables/TabSelect.ts
@@ -6,8 +6,8 @@ import type { RenderContext } from "../types.js"
 import {
   type KeyBinding as BaseKeyBinding,
   mergeKeyBindings,
-  getKeyBindingKey,
   buildKeyBindingsMap,
+  getKeyBindingAction,
   type KeyAliasMap,
   defaultKeyAliases,
   mergeKeyAliases,
@@ -308,16 +308,7 @@ export class TabSelectRenderable extends Renderable {
   }
 
   public handleKeyPress(key: KeyEvent): boolean {
-    const bindingKey = getKeyBindingKey({
-      name: key.name,
-      ctrl: key.ctrl,
-      shift: key.shift,
-      meta: key.meta,
-      super: key.super,
-      action: "move-left" as TabSelectAction,
-    })
-
-    const action = this._keyBindingsMap.get(bindingKey)
+    const action = getKeyBindingAction(this._keyBindingsMap, key)
 
     if (action) {
       switch (action) {

--- a/packages/core/src/renderables/Textarea.ts
+++ b/packages/core/src/renderables/Textarea.ts
@@ -6,8 +6,8 @@ import { EditBufferRenderable, type EditBufferOptions } from "./EditBufferRender
 import {
   type KeyBinding as BaseKeyBinding,
   mergeKeyBindings,
-  getKeyBindingKey,
   buildKeyBindingsMap,
+  getKeyBindingAction,
   type KeyAliasMap,
   defaultKeyAliases,
   mergeKeyAliases,
@@ -261,16 +261,7 @@ export class TextareaRenderable extends EditBufferRenderable {
   }
 
   public handleKeyPress(key: KeyEvent): boolean {
-    const bindingKey = getKeyBindingKey({
-      name: key.name,
-      ctrl: key.ctrl,
-      shift: key.shift,
-      meta: key.meta,
-      super: key.super,
-      action: "move-left" as TextareaAction,
-    })
-
-    const action = this._keyBindingsMap.get(bindingKey)
+    const action = getKeyBindingAction(this._keyBindingsMap, key)
 
     if (action) {
       const handler = this._actionHandlers.get(action)

--- a/packages/core/src/renderables/__tests__/Textarea.keybinding.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.keybinding.test.ts
@@ -6,7 +6,7 @@ import { KeyEvent } from "../../lib/KeyHandler.js"
 
 // Helper function to create a KeyEvent from a string
 function createKeyEvent(
-  input: string | { name: string; shift?: boolean; ctrl?: boolean; meta?: boolean; super?: boolean },
+  input: string | { name: string; shift?: boolean; ctrl?: boolean; meta?: boolean; super?: boolean; baseCode?: number },
 ): KeyEvent {
   if (typeof input === "string") {
     return new KeyEvent({
@@ -29,6 +29,7 @@ function createKeyEvent(
       meta: input.meta ?? false,
       shift: input.shift ?? false,
       super: input.super ?? false,
+      baseCode: input.baseCode,
       option: false,
       number: false,
       raw: input.name,
@@ -622,6 +623,23 @@ describe("Textarea - Keybinding Tests", () => {
 
       currentMockInput.pressKey("g", { ctrl: true })
       expect(editor.logicalCursor.row).toBe(0)
+      expect(editor.logicalCursor.col).toBe(0)
+    })
+
+    it("should use baseCode when matching ctrl shortcuts from alternate layouts", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "Hello World",
+        width: 40,
+        height: 10,
+      })
+
+      editor.focus()
+      editor.gotoLine(9999)
+      expect(editor.logicalCursor.col).toBe(11)
+
+      const handled = editor.handleKeyPress(createKeyEvent({ name: "ㅁ", baseCode: 97, ctrl: true }))
+
+      expect(handled).toBe(true)
       expect(editor.logicalCursor.col).toBe(0)
     })
 

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -37,6 +37,7 @@ import {
 } from "./lib/terminal-capability-detection.js"
 import { type Clock, type TimerHandle, SystemClock } from "./lib/clock.js"
 import { StdinParser, type StdinEvent, type StdinParserProtocolContext } from "./lib/stdin-parser.js"
+import { matchesKeyBinding } from "./lib/keymapping.js"
 
 registerEnvVar({
   name: "OTUI_DUMP_CAPTURES",
@@ -764,7 +765,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     const useKittyForParsing = kittyConfig !== null
     this._keyHandler = new InternalKeyHandler()
     this._keyHandler.on("keypress", (event) => {
-      if (this.exitOnCtrlC && event.name === "c" && event.ctrl) {
+      // Use the shared matcher here too. Kitty can report a non-Latin
+      // character plus a base-layout `c`, and Ctrl+C should still exit.
+      if (this.exitOnCtrlC && matchesKeyBinding(event, { name: "c", ctrl: true })) {
         process.nextTick(() => {
           this.destroy()
         })

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -658,6 +658,36 @@ test("Kitty keyboard ctrl+a via keyInput events", async () => {
   })
 })
 
+test("Kitty keyboard Ctrl+C with alternate base layout still exits the renderer", async () => {
+  const clock = new ManualClock()
+  const { renderer } = await createTestRenderer({ kittyKeyboard: true, clock })
+
+  try {
+    // Simulate Ctrl+C from a non-Latin IME. Kitty reports the produced
+    // character (`ㅊ`) plus the base-layout key (`c`).
+    const keypress = new Promise<KeyEvent>((resolve) => {
+      renderer.keyInput.once("keypress", resolve)
+    })
+
+    renderer.stdin.emit("data", Buffer.from("\x1b[12618::99;5u"))
+    clock.advance(20)
+
+    const event = await keypress
+    expect(event).toMatchObject({
+      name: "ㅊ",
+      ctrl: true,
+      baseCode: 99,
+    })
+
+    await new Promise<void>((resolve) => process.nextTick(resolve))
+    expect(renderer.isDestroyed).toBe(true)
+  } finally {
+    if (!renderer.isDestroyed) {
+      renderer.destroy()
+    }
+  }
+})
+
 test("Kitty keyboard alt+a via keyInput events", async () => {
   const result = await triggerKittyInput("\x1b[97;3u")
   expect(result).toMatchObject({


### PR DESCRIPTION
Rework the keypress debug demo around parsed events instead of large per-event cards. Keep the main feed dense, move raw input into session detail and export output, and show the latest event with useful fields such as source, code, and Kitty baseCode.

Add test that reproduces Ctrl+C when Kitty reports an alternate base layout for a non-Latin IME. For https://github.com/anomalyco/opencode/issues/21163