### PR TITLE
fix(build): pass --cache-dir on Windows to avoid cross-drive zig panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ NOTE: You must have [Zig](https://ziglang.org/learn/getting-started/) installed 
 bun install @opentui/core
 ```
 
+### Windows — cross-drive build
+
+If your project lives on a different drive from your Zig installation (e.g. project on `F:`, Zig on `C:`), the build script automatically passes `--cache-dir %USERPROFILE%\.zig-cache\opentui-core` so Zig's cache stays on one drive. No manual steps needed; the workaround is baked into `scripts/build.ts`.
+
 ## AI Agent Skill
 
 Teach your AI coding assistant OpenTUI's APIs and patterns.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ NOTE: You must have [Zig](https://ziglang.org/learn/getting-started/) installed 
 bun install @opentui/core
 ```
 
-### Windows — cross-drive build
-
-If your project lives on a different drive from your Zig installation (e.g. project on `F:`, Zig on `C:`), the build script automatically passes `--cache-dir %USERPROFILE%\.zig-cache\opentui-core` so Zig's cache stays on one drive. No manual steps needed; the workaround is baked into `scripts/build.ts`.
-
 ## AI Agent Skill
 
 Teach your AI coding assistant OpenTUI's APIs and patterns.

--- a/packages/core/scripts/build.ts
+++ b/packages/core/scripts/build.ts
@@ -90,6 +90,19 @@ if (buildNative) {
     zigArgs.push("-Dgpa-safe-stats=true")
   }
 
+  // On Windows, zig 0.15.x panics when the project and zig's global cache are
+  // on different drives (e.g. project on F:, zig on C:). std.fs.path.relative
+  // returns an absolute path across drives, which triggers an assertion in
+  // Build/Step/Run.zig:662. Workaround: force --cache-dir onto the same drive
+  // as the zig installation (C:) so all path operations stay on one drive.
+  if (process.platform === "win32") {
+    // zig 0.15.x panics when project and zig global cache are on different
+    // Windows drives. Force cache onto the user's home drive (same as zig).
+    const homedir: string = process.env["USERPROFILE"] ?? process.env["HOME"] ?? "C:\\Users\\Default"
+    const zigCacheDir = join(homedir, ".zig-cache", "opentui-core")
+    zigArgs.push("--cache-dir", zigCacheDir)
+  }
+
   const zigBuild: SpawnSyncReturns<Buffer> = spawnSync("zig", zigArgs, {
     cwd: join(rootDir, "src", "zig"),
     stdio: "inherit",


### PR DESCRIPTION
When opentui's build script runs `zig build` on Windows and the project directory and zig's global cache live on different drives (project on `F:`, zig on `C:`), zig 0.15.x panics. `std.fs.path.relative` returns an absolute path across drives, which trips an assertion in `Build/Step/Run.zig:662` inside the `uucode` dependency's build-tables step.

The fix: pass `--cache-dir` pointing to `%USERPROFILE%\.zig-cache\opentui-core` when building on Windows. This keeps all path operations on one drive and sidesteps the panic. No manual steps required from users.

Split from #951 per https://github.com/anomalyco/opentui/pull/951#issuecomment-4258584684