### PR TITLE
markdown: expose stable top-level blocks

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -20,7 +20,17 @@ import { parseMarkdownIncremental, type ParseState } from "./markdown-parser.js"
 import type { OptimizedBuffer } from "../buffer.js"
 import { detectLinks } from "../lib/detect-links.js"
 
+export type MarkdownTableStyle = "grid" | "columns"
+
 export interface MarkdownTableOptions {
+  /**
+   * Visual style preset for markdown tables.
+   * - "grid": boxed table with visible borders.
+   * - "columns": borderless columns optimized for separated block output.
+   *
+   * Defaults to "columns" in `internalBlockMode: "top-level"`, otherwise "grid".
+   */
+  style?: MarkdownTableStyle
   /**
    * Strategy for sizing table columns.
    * - "content": columns fit to intrinsic content width.
@@ -94,6 +104,12 @@ export interface MarkdownOptions extends RenderableOptions<MarkdownRenderable> {
    * or undefined/null to use default rendering.
    */
   renderNode?: (token: Token, context: RenderNodeContext) => Renderable | undefined | null
+  /**
+   * Internal only.
+   * - "coalesced": combine ordinary markdown into larger render blocks.
+   * - "top-level": preserve top-level markdown blocks as separate render blocks.
+   */
+  internalBlockMode?: "coalesced" | "top-level"
 }
 
 export interface RenderNodeContext {
@@ -115,6 +131,7 @@ interface ResolvedTableRenderableOptions {
   columnFitter: TextTableColumnFitter
   wrapMode: "none" | "char" | "word"
   cellPadding: number
+  columnGap: number
   border: boolean
   outerBorder: boolean
   showBorders: boolean
@@ -124,6 +141,7 @@ interface ResolvedTableRenderableOptions {
 }
 
 const TRAILING_MARKDOWN_BLOCK_BREAKS_RE = /(?:\r?\n){2,}$/
+const TRAILING_MARKDOWN_BLOCK_NEWLINES_RE = /(?:\r?\n)+$/
 
 function colorsEqual(left?: RGBA, right?: RGBA): boolean {
   if (!left || !right) return left === right
@@ -133,11 +151,18 @@ function colorsEqual(left?: RGBA, right?: RGBA): boolean {
 export interface BlockState {
   token: MarkedToken
   tokenRaw: string // Cache raw for comparison
+  marginTop?: number
   renderable: Renderable
   tableContentCache?: TableContentCache
 }
 
 export type { ParseState }
+
+interface MarkdownRenderBlock {
+  token: MarkedToken
+  sourceTokenEnd: number
+  marginTop: number
+}
 
 export class MarkdownRenderable extends Renderable {
   private _content: string = ""
@@ -149,10 +174,12 @@ export class MarkdownRenderable extends Renderable {
   private _treeSitterClient?: TreeSitterClient
   private _tableOptions?: MarkdownTableOptions
   private _renderNode?: MarkdownOptions["renderNode"]
+  private _internalBlockMode: "coalesced" | "top-level"
 
   _parseState: ParseState | null = null
   private _streaming: boolean = false
   _blockStates: BlockState[] = []
+  _stableBlockCount = 0
   private _styleDirty: boolean = false
   private _linkifyMarkdownChunks: OnChunksCallback = (chunks, context) =>
     detectLinks(chunks, {
@@ -165,6 +192,7 @@ export class MarkdownRenderable extends Renderable {
     conceal: true,
     concealCode: false,
     streaming: false,
+    internalBlockMode: "coalesced",
   } satisfies Partial<MarkdownOptions>
 
   constructor(ctx: RenderContext, options: MarkdownOptions) {
@@ -184,6 +212,7 @@ export class MarkdownRenderable extends Renderable {
     this._tableOptions = options.tableOptions
     this._renderNode = options.renderNode
     this._streaming = options.streaming ?? this._contentDefaultOptions.streaming
+    this._internalBlockMode = options.internalBlockMode ?? this._contentDefaultOptions.internalBlockMode
 
     this.updateBlocks()
   }
@@ -460,6 +489,11 @@ export class MarkdownRenderable extends Renderable {
     }
   }
 
+  private applyMargins(renderable: Renderable, marginTop: number, marginBottom: number): void {
+    renderable.marginTop = marginTop
+    renderable.marginBottom = marginBottom
+  }
+
   private createMarkdownCodeRenderable(content: string, id: string, marginBottom: number = 0): CodeRenderable {
     return new CodeRenderable(this.ctx, {
       id,
@@ -541,6 +575,10 @@ export class MarkdownRenderable extends Renderable {
     return raw.replace(TRAILING_MARKDOWN_BLOCK_BREAKS_RE, "\n")
   }
 
+  private normalizeScrollbackMarkdownBlockRaw(raw: string): string {
+    return raw.replace(TRAILING_MARKDOWN_BLOCK_NEWLINES_RE, "")
+  }
+
   private buildRenderableTokens(tokens: MarkedToken[]): MarkedToken[] {
     if (this._renderNode) {
       return tokens.filter((token) => token.type !== "space")
@@ -590,6 +628,35 @@ export class MarkdownRenderable extends Renderable {
     flushMarkdownRaw()
 
     return renderTokens
+  }
+
+  private buildTopLevelRenderBlocks(tokens: MarkedToken[]): MarkdownRenderBlock[] {
+    const blocks: MarkdownRenderBlock[] = []
+    let gapBefore = ""
+
+    for (let i = 0; i < tokens.length; i += 1) {
+      const token = tokens[i]
+      if (token.type === "space") {
+        gapBefore += token.raw
+        continue
+      }
+
+      const prev = blocks[blocks.length - 1]
+      const marginTop =
+        prev &&
+        (this.shouldRenderSeparately(prev.token) || TRAILING_MARKDOWN_BLOCK_BREAKS_RE.test(prev.token.raw + gapBefore))
+          ? 1
+          : 0
+
+      blocks.push({
+        token,
+        sourceTokenEnd: i + 1,
+        marginTop,
+      })
+      gapBefore = ""
+    }
+
+    return blocks
   }
 
   private getTableRowsToRender(table: Tokens.Table): Tokens.TableCell[][] {
@@ -746,14 +813,35 @@ export class MarkdownRenderable extends Renderable {
     }
   }
 
+  private resolveTableStyle(options: MarkdownTableOptions | undefined = this._tableOptions): MarkdownTableStyle {
+    if (options?.style === "columns") {
+      return "columns"
+    }
+
+    if (options?.style === "grid") {
+      return "grid"
+    }
+
+    return this._internalBlockMode === "top-level" ? "columns" : "grid"
+  }
+
+  private usesBorderlessColumnSpacing(options: MarkdownTableOptions | undefined = this._tableOptions): boolean {
+    const style = this.resolveTableStyle(options)
+    const borders = options?.borders ?? style === "grid"
+
+    return style === "columns" && !borders
+  }
+
   private resolveTableRenderableOptions(): ResolvedTableRenderableOptions {
-    const borders = this._tableOptions?.borders ?? true
+    const style = this.resolveTableStyle()
+    const borders = this._tableOptions?.borders ?? style === "grid"
 
     return {
-      columnWidthMode: this._tableOptions?.widthMode ?? "full",
+      columnWidthMode: this._tableOptions?.widthMode ?? (style === "columns" ? "content" : "full"),
       columnFitter: this._tableOptions?.columnFitter ?? "proportional",
       wrapMode: this._tableOptions?.wrapMode ?? "word",
       cellPadding: this._tableOptions?.cellPadding ?? 0,
+      columnGap: this.usesBorderlessColumnSpacing() ? 2 : 0,
       border: borders,
       outerBorder: this._tableOptions?.outerBorder ?? borders,
       showBorders: borders,
@@ -771,6 +859,7 @@ export class MarkdownRenderable extends Renderable {
     tableRenderable.columnFitter = options.columnFitter
     tableRenderable.wrapMode = options.wrapMode
     tableRenderable.cellPadding = options.cellPadding
+    tableRenderable.columnGap = options.columnGap
     tableRenderable.border = options.border
     tableRenderable.outerBorder = options.outerBorder
     tableRenderable.showBorders = options.showBorders
@@ -810,6 +899,7 @@ export class MarkdownRenderable extends Renderable {
       columnFitter: options.columnFitter,
       wrapMode: options.wrapMode,
       cellPadding: options.cellPadding,
+      columnGap: options.columnGap,
       border: options.border,
       outerBorder: options.outerBorder,
       showBorders: options.showBorders,
@@ -838,6 +928,100 @@ export class MarkdownRenderable extends Renderable {
       renderable: this.createTextTableRenderable(cache.content, id, marginBottom),
       tableContentCache: cache,
     }
+  }
+
+  private getStableBlockCount(blocks: MarkdownRenderBlock[], stableTokenCount: number): number {
+    if (this._internalBlockMode !== "top-level") {
+      return 0
+    }
+
+    let stableBlockCount = 0
+    for (const block of blocks) {
+      if (block.sourceTokenEnd <= stableTokenCount) {
+        stableBlockCount += 1
+        continue
+      }
+
+      break
+    }
+
+    return stableBlockCount
+  }
+
+  private syncTopLevelBlockState(
+    state: BlockState,
+    block: MarkdownRenderBlock,
+    tableContentCache: TableContentCache | undefined = state.tableContentCache,
+  ): void {
+    state.token = block.token
+    state.tokenRaw = block.token.raw
+    state.marginTop = block.marginTop
+    state.tableContentCache = tableContentCache
+  }
+
+  private getTopLevelBlockRaw(token: MarkedToken): string | undefined {
+    if (!token.raw) {
+      return undefined
+    }
+
+    return this.shouldRenderSeparately(token) ? token.raw : this.normalizeScrollbackMarkdownBlockRaw(token.raw)
+  }
+
+  private createTopLevelDefaultRenderable(
+    block: MarkdownRenderBlock,
+    index: number,
+  ): { renderable: Renderable | undefined; tableContentCache?: TableContentCache } {
+    const { token, marginTop } = block
+    const id = `${this.id}-block-${index}`
+
+    if (token.type === "code") {
+      const renderable = this.createCodeRenderable(token, id)
+      renderable.marginTop = marginTop
+      return { renderable }
+    }
+
+    if (token.type === "table") {
+      const next = this.createTableBlock(token, id)
+      next.renderable.marginTop = marginTop
+      return next
+    }
+
+    const markdownRaw = this.getTopLevelBlockRaw(token)
+    if (!markdownRaw) {
+      return { renderable: undefined }
+    }
+
+    const renderable = this.createMarkdownCodeRenderable(markdownRaw, id)
+    renderable.marginTop = marginTop
+    return { renderable }
+  }
+
+  private createTopLevelRenderable(
+    block: MarkdownRenderBlock,
+    index: number,
+  ): { renderable: Renderable | undefined; tableContentCache?: TableContentCache } {
+    if (!this._renderNode) {
+      return this.createTopLevelDefaultRenderable(block, index)
+    }
+
+    let next: { renderable: Renderable | undefined; tableContentCache?: TableContentCache } | undefined
+    const context: RenderNodeContext = {
+      syntaxStyle: this._syntaxStyle,
+      conceal: this._conceal,
+      concealCode: this._concealCode,
+      treeSitterClient: this._treeSitterClient,
+      defaultRender: () => {
+        next = this.createTopLevelDefaultRenderable(block, index)
+        return next.renderable ?? null
+      },
+    }
+    const custom = this._renderNode(block.token, context)
+    if (custom) {
+      this.applyMargins(custom, block.marginTop, 0)
+      return { renderable: custom }
+    }
+
+    return next ?? this.createTopLevelDefaultRenderable(block, index)
   }
 
   private createDefaultRenderable(token: MarkedToken, index: number, hasNextToken: boolean = false): Renderable | null {
@@ -923,11 +1107,68 @@ export class MarkdownRenderable extends Renderable {
     state.renderable = markdownRenderable
   }
 
+  private updateTopLevelBlocks(tokens: MarkedToken[], forceTableRefresh: boolean): void {
+    const blocks = this.buildTopLevelRenderBlocks(tokens)
+    this._stableBlockCount = this.getStableBlockCount(blocks, this._parseState?.stableTokenCount ?? 0)
+
+    let blockIndex = 0
+    for (let i = 0; i < blocks.length; i += 1) {
+      const block = blocks[i]
+      const existing = this._blockStates[blockIndex]
+
+      if (existing && existing.token === block.token && !forceTableRefresh) {
+        if (existing.marginTop !== block.marginTop) {
+          this.applyMargins(existing.renderable, block.marginTop, 0)
+        }
+        this.syncTopLevelBlockState(existing, block)
+        blockIndex++
+        continue
+      }
+
+      if (
+        existing &&
+        existing.tokenRaw === block.token.raw &&
+        existing.token.type === block.token.type &&
+        !forceTableRefresh
+      ) {
+        if (existing.marginTop !== block.marginTop) {
+          this.applyMargins(existing.renderable, block.marginTop, 0)
+        }
+        this.syncTopLevelBlockState(existing, block)
+        blockIndex++
+        continue
+      }
+
+      if (existing) {
+        existing.renderable.destroyRecursively()
+      }
+
+      const next = this.createTopLevelRenderable(block, blockIndex)
+      if (next.renderable) {
+        this.add(next.renderable)
+        this._blockStates[blockIndex] = {
+          token: block.token,
+          tokenRaw: block.token.raw,
+          marginTop: block.marginTop,
+          renderable: next.renderable,
+          tableContentCache: next.tableContentCache,
+        }
+      }
+      blockIndex++
+    }
+
+    while (this._blockStates.length > blockIndex) {
+      const removed = this._blockStates.pop()!
+      removed.renderable.destroyRecursively()
+    }
+  }
+
   private updateBlocks(forceTableRefresh: boolean = false): void {
     if (this.isDestroyed) return
     if (!this._content) {
       this.clearBlockStates()
       this._parseState = null
+      this._stableBlockCount = 0
       return
     }
 
@@ -936,21 +1177,28 @@ export class MarkdownRenderable extends Renderable {
 
     const tokens = this._parseState.tokens
 
-    // Parse failure fallback
     if (tokens.length === 0 && this._content.length > 0) {
       this.clearBlockStates()
+      this._stableBlockCount = 0
       const fallback = this.createMarkdownCodeRenderable(this._content, `${this.id}-fallback`)
       this.add(fallback)
       this._blockStates = [
         {
           token: { type: "text", raw: this._content, text: this._content } as MarkedToken,
           tokenRaw: this._content,
+          marginTop: 0,
           renderable: fallback,
         },
       ]
       return
     }
 
+    if (this._internalBlockMode === "top-level") {
+      this.updateTopLevelBlocks(tokens, forceTableRefresh)
+      return
+    }
+
+    this._stableBlockCount = 0
     const blockTokens = this.buildRenderableTokens(tokens)
     const lastBlockIndex = blockTokens.length - 1
 
@@ -962,7 +1210,6 @@ export class MarkdownRenderable extends Renderable {
 
       const shouldForceRefresh = forceTableRefresh
 
-      // Same token object reference means unchanged
       if (existing && existing.token === token) {
         if (shouldForceRefresh) {
           this.updateBlockRenderable(existing, token, blockIndex, hasNextToken)
@@ -972,7 +1219,6 @@ export class MarkdownRenderable extends Renderable {
         continue
       }
 
-      // Same content, update reference
       if (existing && existing.tokenRaw === token.raw && existing.token.type === token.type) {
         existing.token = token
         if (shouldForceRefresh) {
@@ -983,7 +1229,6 @@ export class MarkdownRenderable extends Renderable {
         continue
       }
 
-      // Same type, different content - update in place
       if (existing && existing.token.type === token.type) {
         this.updateBlockRenderable(existing, token, blockIndex, hasNextToken)
         existing.token = token
@@ -992,7 +1237,6 @@ export class MarkdownRenderable extends Renderable {
         continue
       }
 
-      // Different type or new block
       if (existing) {
         existing.renderable.destroyRecursively()
       }
@@ -1056,6 +1300,7 @@ export class MarkdownRenderable extends Renderable {
       state.renderable.destroyRecursively()
     }
     this._blockStates = []
+    this._stableBlockCount = 0
   }
 
   /**
@@ -1063,6 +1308,11 @@ export class MarkdownRenderable extends Renderable {
    * Used when only style/conceal changes - much faster than full rebuild.
    */
   private rerenderBlocks(): void {
+    if (this._internalBlockMode === "top-level") {
+      this.updateBlocks(true)
+      return
+    }
+
     for (let i = 0; i < this._blockStates.length; i++) {
       const state = this._blockStates[i]
       const hasNextToken = i < this._blockStates.length - 1

--- a/packages/core/src/renderables/TextTable.ts
+++ b/packages/core/src/renderables/TextTable.ts
@@ -77,6 +77,7 @@ export interface TextTableOptions extends RenderableOptions<TextTableRenderable>
   columnWidthMode?: TextTableColumnWidthMode
   columnFitter?: TextTableColumnFitter
   cellPadding?: number
+  columnGap?: number
   showBorders?: boolean
   border?: boolean
   outerBorder?: boolean
@@ -98,6 +99,7 @@ export class TextTableRenderable extends Renderable {
   private _columnWidthMode: TextTableColumnWidthMode
   private _columnFitter: TextTableColumnFitter
   private _cellPadding: number
+  private _columnGap: number
   private _showBorders: boolean
   private _border: boolean
   private _outerBorder: boolean
@@ -132,6 +134,7 @@ export class TextTableRenderable extends Renderable {
     columnWidthMode: "full" as TextTableColumnWidthMode,
     columnFitter: "proportional" as TextTableColumnFitter,
     cellPadding: 0,
+    columnGap: 0,
     showBorders: true,
     border: true,
     outerBorder: true,
@@ -155,6 +158,7 @@ export class TextTableRenderable extends Renderable {
     this._columnWidthMode = options.columnWidthMode ?? this._defaultOptions.columnWidthMode
     this._columnFitter = this.resolveColumnFitter(options.columnFitter)
     this._cellPadding = this.resolveCellPadding(options.cellPadding)
+    this._columnGap = this.resolveColumnGap(options.columnGap)
     this._showBorders = options.showBorders ?? this._defaultOptions.showBorders
     this._border = options.border ?? this._defaultOptions.border
     this._hasExplicitOuterBorder = options.outerBorder !== undefined
@@ -229,6 +233,17 @@ export class TextTableRenderable extends Renderable {
     const next = this.resolveCellPadding(value)
     if (this._cellPadding === next) return
     this._cellPadding = next
+    this.invalidateLayoutAndRaster()
+  }
+
+  public get columnGap(): number {
+    return this._columnGap
+  }
+
+  public set columnGap(value: number) {
+    const next = this.resolveColumnGap(value)
+    if (this._columnGap === next) return
+    this._columnGap = next
     this.invalidateLayoutAndRaster()
   }
 
@@ -623,6 +638,7 @@ export class TextTableRenderable extends Renderable {
       borderLayout.left,
       borderLayout.right,
       borderLayout.innerVertical,
+      this.getInterColumnGap(borderLayout),
     )
     const rowOffsets = this.computeOffsets(
       rowHeights,
@@ -665,7 +681,10 @@ export class TextTableRenderable extends Renderable {
       return intrinsicWidths
     }
 
-    const maxContentWidth = Math.max(1, Math.floor(maxTableWidth) - this.getVerticalBorderCount(borderLayout))
+    const maxContentWidth = Math.max(
+      1,
+      Math.floor(maxTableWidth) - this.getVerticalBorderCount(borderLayout) - this.getTotalInterColumnGap(borderLayout),
+    )
     const currentWidth = intrinsicWidths.reduce((sum, width) => sum + width, 0)
 
     if (currentWidth === maxContentWidth) {
@@ -905,18 +924,31 @@ export class TextTableRenderable extends Renderable {
     startBoundary: boolean,
     endBoundary: boolean,
     includeInnerBoundaries: boolean,
+    innerGap: number = 0,
   ): number[] {
     const offsets: number[] = [startBoundary ? 0 : -1]
     let cursor = offsets[0] ?? 0
 
     for (let idx = 0; idx < parts.length; idx++) {
       const size = parts[idx] ?? 1
-      const hasBoundaryAfter = idx < parts.length - 1 ? includeInnerBoundaries : endBoundary
-      cursor += size + (hasBoundaryAfter ? 1 : 0)
+      const separatorAfter = idx < parts.length - 1 ? (includeInnerBoundaries ? 1 : innerGap) : endBoundary ? 1 : 0
+      cursor += size + separatorAfter
       offsets.push(cursor)
     }
 
     return offsets
+  }
+
+  private getInterColumnGap(borderLayout: ResolvedTableBorderLayout): number {
+    if (borderLayout.innerVertical) {
+      return 0
+    }
+
+    return this._columnGap
+  }
+
+  private getTotalInterColumnGap(borderLayout: ResolvedTableBorderLayout): number {
+    return Math.max(0, this._columnCount - 1) * this.getInterColumnGap(borderLayout)
   }
 
   private applyLayoutToViews(layout: TextTableLayout): void {
@@ -1319,6 +1351,14 @@ export class TextTableRenderable extends Renderable {
   private resolveCellPadding(value: number | undefined): number {
     if (value === undefined || !Number.isFinite(value)) {
       return this._defaultOptions.cellPadding
+    }
+
+    return Math.max(0, Math.floor(value))
+  }
+
+  private resolveColumnGap(value: number | undefined): number {
+    if (value === undefined || !Number.isFinite(value)) {
+      return this._defaultOptions.columnGap
     }
 
     return Math.max(0, Math.floor(value))

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1,4 +1,5 @@
 import { test, expect, beforeAll, beforeEach, afterEach, afterAll } from "bun:test"
+import { Lexer } from "marked"
 import { MarkdownRenderable, type MarkdownOptions } from "../Markdown.js"
 import { CodeRenderable } from "../Code.js"
 import { TextRenderable } from "../Text.js"
@@ -185,6 +186,97 @@ test("tableOptions updates existing markdown table renderable", async () => {
   expect(updatedTable.outerBorder).toBe(false)
   expect(updatedTable.showBorders).toBe(false)
   expect(updatedTable.selectable).toBe(false)
+})
+
+test("internalBlockMode=top-level defaults markdown tables to borderless columns", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-top-level-table-default-style",
+    content: "| Name | Age |\n|---|---|\n| Alice | 30 |",
+    syntaxStyle,
+    internalBlockMode: "top-level",
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const table = md._blockStates[0]?.renderable as TextTableRenderable
+  expect(table).toBeInstanceOf(TextTableRenderable)
+  expect(table.columnWidthMode).toBe("content")
+  expect(table.columnGap).toBe(2)
+  expect(table.border).toBe(false)
+  expect(table.outerBorder).toBe(false)
+  expect(table.showBorders).toBe(false)
+
+  const rendered = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+
+  expect(rendered).not.toContain("┌")
+  expect(rendered).toMatch(/Name\s{2,}Age/)
+  expect(rendered).toMatch(/Alice\s{2,}30/)
+})
+
+test("tableOptions.style updates existing markdown table renderable content layout", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-table-style-updates",
+    content: "| Name | Age |\n|---|---|\n| Alice | 30 |",
+    syntaxStyle,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const table = md._blockStates[0]?.renderable as TextTableRenderable
+  expect(table).toBeInstanceOf(TextTableRenderable)
+  expect(table.border).toBe(true)
+
+  md.tableOptions = { style: "columns" }
+
+  await renderer.idle()
+
+  const updatedTable = md._blockStates[0]?.renderable as TextTableRenderable
+  expect(updatedTable).toBe(table)
+  expect(updatedTable.columnWidthMode).toBe("content")
+  expect(updatedTable.columnGap).toBe(2)
+  expect(updatedTable.border).toBe(false)
+  expect(updatedTable.outerBorder).toBe(false)
+  expect(updatedTable.showBorders).toBe(false)
+
+  const rendered = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+
+  expect(rendered).not.toContain("┌")
+  expect(rendered).toMatch(/Name\s{2,}Age/)
+  expect(rendered).toMatch(/Alice\s{2,}30/)
+})
+
+test("borderless column tables keep visual spacing out of copied text", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-top-level-table-selection",
+    content: "| Name | Age |\n|---|---|\n| Alice | 30 |",
+    syntaxStyle,
+    internalBlockMode: "top-level",
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const table = md._blockStates[0]?.renderable as TextTableRenderable
+  expect(table).toBeInstanceOf(TextTableRenderable)
+
+  const lines = captureFrame().split("\n")
+  const headerY = lines.findIndex((line) => line.includes("Name"))
+  const rowY = lines.findIndex((line) => line.includes("Alice"))
+  const startX = lines[headerY]!.indexOf("Name")
+  const endX = table.x + table.width - 1
+
+  await mockMouse.drag(startX, headerY, endX, rowY)
+  await renderer.idle()
+
+  expect(table.getSelectedText()).toBe("Name\tAge\nAlice\t30")
 })
 
 test("table with inline code (backticks)", async () => {
@@ -1173,6 +1265,45 @@ const x = 1;
   `)
 })
 
+test("custom renderNode output survives top-level spacing updates", async () => {
+  const md = createMarkdownRenderable({
+    id: "custom-spacing-update",
+    content: "Paragraph\n# Heading",
+    syntaxStyle,
+    internalBlockMode: "top-level",
+    renderNode: (node, ctx) => {
+      if (node.type === "heading") {
+        return new TextRenderable(renderer, {
+          id: "custom-text-spacing",
+          content: "CUSTOM",
+          width: "100%",
+        })
+      }
+
+      return ctx.defaultRender()
+    },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  md.content = "Paragraph\n\n# Heading"
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates.map((state) => state.marginTop ?? 0)).toEqual([0, 1])
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    Paragraph
+
+    CUSTOM"
+  `)
+})
+
 test("custom renderNode returning null uses default", async () => {
   const md = createMarkdownRenderable({
     id: "custom-null",
@@ -1377,6 +1508,129 @@ test("table at end with trailing blank lines", async () => {
 })
 
 // Incremental parsing tests
+
+test("internalBlockMode=top-level preserves top-level block boundaries", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-top-level-blocks",
+    content: "# Title\n\n```ts\nconst x = 1\n```\n\n| A |\n|---|\n| 1 |",
+    syntaxStyle,
+    streaming: false,
+    internalBlockMode: "top-level",
+    tableOptions: { widthMode: "content" },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates.map((state) => state.token.type)).toEqual(["heading", "code", "table"])
+  expect(md._blockStates[1]?.renderable).toBeInstanceOf(CodeRenderable)
+  expect(md._blockStates[2]?.renderable).toBeInstanceOf(TextTableRenderable)
+  expect(md._stableBlockCount).toBe(3)
+})
+
+test("internalBlockMode=top-level normalizes one blank row between top-level blocks", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-top-level-spacing",
+    content: "# Title\n\nParagraph\n\n```ts\nconst x = 1\n```",
+    syntaxStyle,
+    internalBlockMode: "top-level",
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    Title
+
+    Paragraph
+
+    const x = 1"
+  `)
+})
+
+test("internalBlockMode=top-level keeps tight paragraph list transitions tight", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-top-level-tight-list-spacing",
+    content: "Paragraph:\n- one\n- two",
+    syntaxStyle,
+    internalBlockMode: "top-level",
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates.map((state) => state.marginTop ?? 0)).toEqual([0, 0])
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    Paragraph:
+    - one
+    - two"
+  `)
+})
+
+test("internalBlockMode=top-level tightens spacing when a blank line is removed", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-top-level-tighten-spacing",
+    content: "Paragraph\n\n- one\n- two",
+    syntaxStyle,
+    internalBlockMode: "top-level",
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  md.content = "Paragraph\n- one\n- two"
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates.map((state) => state.marginTop ?? 0)).toEqual([0, 0])
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    Paragraph
+    - one
+    - two"
+  `)
+})
+
+test("internalBlockMode=top-level preserves spacing after tight fenced code blocks", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-top-level-tight-code-spacing",
+    content: "```ts\nconst x = 1\n```\nParagraph",
+    syntaxStyle,
+    internalBlockMode: "top-level",
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates.map((state) => state.marginTop ?? 0)).toEqual([0, 1])
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    const x = 1
+
+    Paragraph"
+  `)
+})
+
 test("incremental update reuses unchanged blocks when appending", async () => {
   const md = createMarkdownRenderable({
     id: "markdown",
@@ -1482,6 +1736,68 @@ test("non-streaming mode parses all tokens as stable", async () => {
   expect(parseState!.tokens.length).toBeGreaterThan(0)
 })
 
+test("internalBlockMode=top-level exposes a conservative stable block prefix", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-top-level-stable-prefix",
+    content: "# Title\n\nPara 1\n\n",
+    syntaxStyle,
+    streaming: true,
+    internalBlockMode: "top-level",
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  md.content = "# Title\n\nPara 1\n\nPara 2"
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates.map((state) => state.token.type)).toEqual(["heading", "paragraph", "paragraph"])
+  expect(md._stableBlockCount).toBe(1)
+})
+
+test("default block mode still coalesces ordinary markdown blocks", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-default-coalesced-blocks",
+    content: "# Title\n\nPara 1",
+    syntaxStyle,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates).toHaveLength(1)
+  expect(md._blockStates[0]?.token.type).toBe("paragraph")
+  expect(md._stableBlockCount).toBe(0)
+})
+
+test("parse failure fallback leaves stable block count at zero", async () => {
+  const lexerRef = Lexer as unknown as { lex: typeof Lexer.lex }
+  const originalLex = lexerRef.lex
+
+  lexerRef.lex = (() => {
+    throw new Error("parse failed")
+  }) as typeof Lexer.lex
+
+  try {
+    const md = createMarkdownRenderable({
+      id: "markdown-parse-failure-stable-blocks",
+      content: "# Broken",
+      syntaxStyle,
+      streaming: true,
+      internalBlockMode: "top-level",
+    })
+
+    renderer.root.add(md)
+    await renderMarkdownRenderable(md)
+
+    expect(md._stableBlockCount).toBe(0)
+    expect(md._blockStates).toHaveLength(1)
+    expect(md._blockStates[0]?.renderable).toBeInstanceOf(CodeRenderable)
+  } finally {
+    lexerRef.lex = originalLex
+  }
+})
+
 test("content update with same text does not rebuild", async () => {
   const md = createMarkdownRenderable({
     id: "markdown",
@@ -1519,7 +1835,7 @@ test("block type change creates new renderable", async () => {
   await renderer.idle()
 
   const blockAfter = md._blockStates[0]?.renderable
-  // Non-special markdown blocks are merged and reused as one markdown code renderable
+  // Non-special markdown blocks are coalesced and reused as one markdown code renderable
   expect(blockAfter).toBe(blockBefore)
 })
 

--- a/packages/core/src/renderables/__tests__/markdown-parser.test.ts
+++ b/packages/core/src/renderables/__tests__/markdown-parser.test.ts
@@ -8,6 +8,7 @@ test("first parse returns all tokens", () => {
   expect(state.content).toBe("# Hello\n\nParagraph")
   expect(state.tokens.length).toBeGreaterThan(0)
   expect(state.tokens[0].type).toBe("heading")
+  expect(state.stableTokenCount).toBe(Math.max(0, state.tokens.length - 2))
 })
 
 test("reuses unchanged tokens when appending content", () => {
@@ -17,6 +18,7 @@ test("reuses unchanged tokens when appending content", () => {
   // First tokens should be same object reference (reused)
   expect(state2.tokens[0]).toBe(state1.tokens[0]) // heading
   expect(state2.tokens[1]).toBe(state1.tokens[1]) // paragraph
+  expect(state2.stableTokenCount).toBe(state2.tokens.length)
 })
 
 test("trailing unstable tokens are re-parsed", () => {
@@ -55,6 +57,26 @@ test("handles empty previous state", () => {
 
   expect(state.tokens.length).toBeGreaterThan(0)
   expect(state.tokens[0].type).toBe("heading")
+})
+
+test("parseMarkdownIncremental reports stableTokenCount for the reused prefix", () => {
+  const first = parseMarkdownIncremental("# Hello\n\nPara 1\n\n", null, 2)
+  const second = parseMarkdownIncremental("# Hello\n\nPara 1\n\nPara 2", first, 2)
+
+  expect(second.stableTokenCount).toBe(1)
+  expect(second.tokens[0]).toBe(first.tokens[0])
+})
+
+test("stableTokenCount equals tokens.length when trailingUnstable is zero", () => {
+  const state = parseMarkdownIncremental("# Hello\n\nPara 1", null, 0)
+
+  expect(state.stableTokenCount).toBe(state.tokens.length)
+})
+
+test("initial parse keeps a conservative unstable tail", () => {
+  const state = parseMarkdownIncremental("# Hello\n\nPara 1\n\nPara 2", null, 2)
+
+  expect(state.stableTokenCount).toBe(Math.max(0, state.tokens.length - 2))
 })
 
 test("handles content truncation", () => {
@@ -189,6 +211,7 @@ test("falls back to full re-parse when incremental tail parse fails", () => {
     const table = state2.tokens.find((token) => token.type === "table") as any
 
     expect(lexCalls).toBeGreaterThanOrEqual(2)
+    expect(state2.stableTokenCount).toBe(0)
     expect(table).toBeDefined()
     expect(table.rows.length).toBe(2)
   } finally {
@@ -211,6 +234,7 @@ test("returns empty token list when both incremental and full parse fail", () =>
   try {
     const state2 = parseMarkdownIncremental(content2, state1, 2)
     expect(state2.tokens).toEqual([])
+    expect(state2.stableTokenCount).toBe(0)
   } finally {
     lexerRef.lex = originalLex
   }

--- a/packages/core/src/renderables/markdown-parser.ts
+++ b/packages/core/src/renderables/markdown-parser.ts
@@ -3,6 +3,7 @@ import { Lexer, type MarkedToken } from "marked"
 export interface ParseState {
   content: string
   tokens: MarkedToken[]
+  stableTokenCount?: number
 }
 
 /**
@@ -17,9 +18,13 @@ export function parseMarkdownIncremental(
   if (!prevState || prevState.tokens.length === 0) {
     try {
       const tokens = Lexer.lex(newContent, { gfm: true }) as MarkedToken[]
-      return { content: newContent, tokens }
+      return {
+        content: newContent,
+        tokens,
+        stableTokenCount: Math.max(0, tokens.length - trailingUnstable),
+      }
     } catch {
-      return { content: newContent, tokens: [] }
+      return { content: newContent, tokens: [], stableTokenCount: 0 }
     }
   }
 
@@ -49,18 +54,26 @@ export function parseMarkdownIncremental(
   const remainingContent = newContent.slice(offset)
 
   if (!remainingContent) {
-    return { content: newContent, tokens: stableTokens }
+    return {
+      content: newContent,
+      tokens: stableTokens,
+      stableTokenCount: stableTokens.length,
+    }
   }
 
   try {
     const newTokens = Lexer.lex(remainingContent, { gfm: true }) as MarkedToken[]
-    return { content: newContent, tokens: [...stableTokens, ...newTokens] }
+    return {
+      content: newContent,
+      tokens: [...stableTokens, ...newTokens],
+      stableTokenCount: trailingUnstable === 0 ? stableTokens.length + newTokens.length : stableTokens.length,
+    }
   } catch {
     try {
       const fullTokens = Lexer.lex(newContent, { gfm: true }) as MarkedToken[]
-      return { content: newContent, tokens: fullTokens }
+      return { content: newContent, tokens: fullTokens, stableTokenCount: 0 }
     } catch {
-      return { content: newContent, tokens: [] }
+      return { content: newContent, tokens: [], stableTokenCount: 0 }
     }
   }
 }


### PR DESCRIPTION
Expose a conservative stable prefix from incremental parses and map it to top-level render blocks. This lets the streaming path commit only the stable prefix to scrollback while the unstable tail keeps updating, without collapsing block boundaries.