### PR TITLE
stdin-parser: handle theme mode DSR replies

### DIFF
--- a/packages/core/src/lib/stdin-parser.test.ts
+++ b/packages/core/src/lib/stdin-parser.test.ts
@@ -1304,6 +1304,37 @@ describe("StdinParser", () => {
       }
     })
 
+    test("theme mode replies are emitted as CSI responses", () => {
+      const parser = createParser({
+        protocolContext: { privateCapabilityRepliesActive: true },
+      })
+
+      try {
+        parser.push(Buffer.from("\x1b[?997;1n"))
+        expect(snap(parser)).toEqual([resp("csi", "\x1b[?997;1n")])
+      } finally {
+        parser.destroy()
+      }
+    })
+
+    test("partial theme mode reply stays pending after timeout while capability probe is active", () => {
+      const { parser, clock } = createTimedParser({
+        protocolContext: { privateCapabilityRepliesActive: true },
+      })
+
+      try {
+        parser.push(Buffer.from("\x1b[?997;1"))
+        expect(snap(parser)).toEqual([])
+        clock.advance(10)
+        expect(snap(parser)).toEqual([])
+
+        parser.push(Buffer.from("n"))
+        expect(snap(parser)).toEqual([resp("csi", "\x1b[?997;1n")])
+      } finally {
+        parser.destroy()
+      }
+    })
+
     test("timed-out modified CSI key still flushes before later final byte", () => {
       const { parser, clock } = createTimedParser({
         protocolContext: { explicitWidthCprActive: true },

--- a/packages/core/src/lib/stdin-parser.ts
+++ b/packages/core/src/lib/stdin-parser.ts
@@ -434,6 +434,7 @@ function canCompleteDeferredPrivateReplyCsi(
   if (!context.privateCapabilityRepliesActive) return false
   if (state.sawDollar) return state.hasDigit && byte === 0x79
   if (byte === 0x63) return state.hasDigit || state.semicolons > 0
+  if (byte === 0x6e) return state.hasDigit
   return state.hasDigit && byte === 0x75
 }
 
@@ -1341,7 +1342,7 @@ export class StdinParser {
 
           if (byte >= 0x40 && byte <= 0x7e) {
             const end = this.cursor + 1
-            this.emitKeyOrResponse("csi", decodeUtf8(bytes.subarray(this.unitStart, end)))
+            this.emitOpaqueResponse("csi", bytes.subarray(this.unitStart, end))
             this.state = { tag: "ground" }
             this.consumePrefix(end)
             continue


### PR DESCRIPTION
Recognize 'n' as a valid final byte for deferred private CSI
replies so theme mode responses like CSI?997;1n stay buffered
during capability probing. Emit completed private replies as opaque
responses to avoid misclassifying them as key input.
