### PR TITLE
Theme mode fallback

### DIFF
--- a/packages/core/dev/theme-mode.ts
+++ b/packages/core/dev/theme-mode.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+import { BoxRenderable, type CliRenderer, createCliRenderer, TextRenderable } from "../src/index.js"
+import { parseColor } from "../src/lib/RGBA.js"
+
+let renderer: CliRenderer | null = null
+let themeText: TextRenderable | null = null
+let statusText: TextRenderable | null = null
+
+function updateThemeDisplay() {
+  if (!renderer || renderer.isDestroyed) return
+  if (!themeText || !statusText) return
+
+  const currentTheme = renderer.themeMode
+
+  if (currentTheme === "dark") {
+    themeText.content = "🌙 Dark Mode"
+    themeText.fg = parseColor("#A5D6FF")
+    statusText.content = "Terminal is in dark mode"
+    renderer.setBackgroundColor("#1a1a2e")
+  } else if (currentTheme === "light") {
+    themeText.content = "☀️ Light Mode"
+    themeText.fg = parseColor("#FF7B72")
+    statusText.content = "Terminal is in light mode"
+    renderer.setBackgroundColor("#f5f5f0")
+  } else {
+    themeText.content = "❓ Unknown"
+    themeText.fg = parseColor("#FFA500")
+    statusText.content = "Theme mode not detected. Try switching your terminal theme."
+    renderer.setBackgroundColor("#2d2d2d")
+  }
+}
+
+async function main() {
+  renderer = await createCliRenderer({
+    exitOnCtrlC: true,
+    targetFps: 30,
+  })
+
+  const mainContainer = new BoxRenderable(renderer, {
+    id: "main-container",
+    flexGrow: 1,
+    flexDirection: "column",
+    padding: 2,
+  })
+
+  renderer.root.add(mainContainer)
+
+  const titleText = new TextRenderable(renderer, {
+    id: "title",
+    content: "Theme Mode Monitor",
+    bold: true,
+    fg: parseColor("#6BCF7F"),
+    marginBottom: 2,
+  })
+
+  themeText = new TextRenderable(renderer, {
+    id: "theme-display",
+    content: "Detecting...",
+    bold: true,
+    marginBottom: 1,
+  })
+
+  statusText = new TextRenderable(renderer, {
+    id: "status",
+    content: "Waiting for theme detection...",
+    dim: true,
+    marginBottom: 2,
+  })
+
+  const helpText = new TextRenderable(renderer, {
+    id: "help",
+    content: "Press Ctrl+C to exit. Try switching your terminal's light/dark theme to see updates.",
+    dim: true,
+    fg: parseColor("#888888"),
+  })
+
+  mainContainer.add(titleText)
+  mainContainer.add(themeText)
+  mainContainer.add(statusText)
+  mainContainer.add(helpText)
+
+  // Initial display
+  updateThemeDisplay()
+
+  // Listen for theme mode changes from the terminal
+  renderer.on("theme_mode", () => {
+    updateThemeDisplay()
+  })
+
+  renderer.requestRender()
+}
+
+main().catch((err) => {
+  console.error("Error:", err)
+  process.exit(1)
+})

--- a/packages/core/dev/theme-mode.ts
+++ b/packages/core/dev/theme-mode.ts
@@ -7,19 +7,24 @@ let titleText: TextRenderable | null = null
 let themeText: TextRenderable | null = null
 let statusText: TextRenderable | null = null
 let eventCountText: TextRenderable | null = null
+let firstDrawText: TextRenderable | null = null
 let historyText: TextRenderable | null = null
 let helpText: TextRenderable | null = null
 let themeModeEventCount = 0
+let firstDrawStartedAt = 0
+let timeToFirstDrawMs: number | null = null
 const updateThemeHistory: string[] = []
 
 function updateThemeDisplay() {
   if (!renderer || renderer.isDestroyed) return
-  if (!titleText || !themeText || !statusText || !eventCountText || !historyText || !helpText) return
+  if (!titleText || !themeText || !statusText || !eventCountText || !firstDrawText || !historyText || !helpText) return
 
   const currentTheme = renderer.themeMode
   updateThemeHistory.push(`updateThemeDisplay ${updateThemeHistory.length + 1}: themeMode=${currentTheme ?? "null"}`)
 
   eventCountText.content = `theme_mode events: ${themeModeEventCount}`
+  firstDrawText.content =
+    timeToFirstDrawMs === null ? "time to first draw: pending" : `time to first draw: ${timeToFirstDrawMs.toFixed(1)}ms`
   historyText.content = `updateThemeDisplay history:
 ${updateThemeHistory.join("\n")}`
 
@@ -30,6 +35,7 @@ ${updateThemeHistory.join("\n")}`
     statusText.content = "Terminal is in dark mode"
     statusText.fg = parseColor("#D7DBE0")
     eventCountText.fg = parseColor("#B8C0CC")
+    firstDrawText.fg = parseColor("#B8C0CC")
     historyText.fg = parseColor("#B8C0CC")
     helpText.fg = parseColor("#8F9BA8")
     renderer.setBackgroundColor("#1a1a2e")
@@ -40,6 +46,7 @@ ${updateThemeHistory.join("\n")}`
     statusText.content = "Terminal is in light mode"
     statusText.fg = parseColor("#1F2937")
     eventCountText.fg = parseColor("#374151")
+    firstDrawText.fg = parseColor("#374151")
     historyText.fg = parseColor("#374151")
     helpText.fg = parseColor("#4B5563")
     renderer.setBackgroundColor("#f5f5f0")
@@ -50,6 +57,7 @@ ${updateThemeHistory.join("\n")}`
     statusText.content = "Theme mode not detected. Try switching your terminal theme."
     statusText.fg = parseColor("#D7DBE0")
     eventCountText.fg = parseColor("#B8C0CC")
+    firstDrawText.fg = parseColor("#B8C0CC")
     historyText.fg = parseColor("#B8C0CC")
     helpText.fg = parseColor("#8F9BA8")
     renderer.setBackgroundColor("#2d2d2d")
@@ -57,6 +65,8 @@ ${updateThemeHistory.join("\n")}`
 }
 
 async function main() {
+  firstDrawStartedAt = performance.now()
+
   renderer = await createCliRenderer({
     exitOnCtrlC: true,
     targetFps: 30,
@@ -98,6 +108,12 @@ async function main() {
     marginBottom: 2,
   })
 
+  firstDrawText = new TextRenderable(renderer, {
+    id: "first-draw",
+    content: "time to first draw: pending",
+    marginBottom: 2,
+  })
+
   historyText = new TextRenderable(renderer, {
     id: "history",
     content: "updateThemeDisplay history:\n(none)",
@@ -114,6 +130,7 @@ async function main() {
   mainContainer.add(themeText)
   mainContainer.add(statusText)
   mainContainer.add(eventCountText)
+  mainContainer.add(firstDrawText)
   mainContainer.add(historyText)
   mainContainer.add(helpText)
 
@@ -128,6 +145,18 @@ async function main() {
   if (themeModeEventCount === 0) {
     updateThemeDisplay()
   }
+
+  const handleFirstDraw = async () => {
+    if (!renderer || !firstDrawText || timeToFirstDrawMs !== null) {
+      return
+    }
+
+    timeToFirstDrawMs = performance.now() - firstDrawStartedAt
+    renderer.removeFrameCallback(handleFirstDraw)
+    updateThemeDisplay()
+  }
+
+  renderer.setFrameCallback(handleFirstDraw)
 
   renderer.requestRender()
 }

--- a/packages/core/dev/theme-mode.ts
+++ b/packages/core/dev/theme-mode.ts
@@ -3,16 +3,18 @@ import { BoxRenderable, type CliRenderer, createCliRenderer, TextRenderable } fr
 import { parseColor } from "../src/lib/RGBA.js"
 
 let renderer: CliRenderer | null = null
+let titleText: TextRenderable | null = null
 let themeText: TextRenderable | null = null
 let statusText: TextRenderable | null = null
 let eventCountText: TextRenderable | null = null
 let historyText: TextRenderable | null = null
+let helpText: TextRenderable | null = null
 let themeModeEventCount = 0
 const updateThemeHistory: string[] = []
 
 function updateThemeDisplay() {
   if (!renderer || renderer.isDestroyed) return
-  if (!themeText || !statusText || !eventCountText || !historyText) return
+  if (!titleText || !themeText || !statusText || !eventCountText || !historyText || !helpText) return
 
   const currentTheme = renderer.themeMode
   updateThemeHistory.push(`updateThemeDisplay ${updateThemeHistory.length + 1}: themeMode=${currentTheme ?? "null"}`)
@@ -22,19 +24,34 @@ function updateThemeDisplay() {
 ${updateThemeHistory.join("\n")}`
 
   if (currentTheme === "dark") {
+    titleText.fg = parseColor("#6BCF7F")
     themeText.content = "🌙 Dark Mode"
     themeText.fg = parseColor("#A5D6FF")
     statusText.content = "Terminal is in dark mode"
+    statusText.fg = parseColor("#D7DBE0")
+    eventCountText.fg = parseColor("#B8C0CC")
+    historyText.fg = parseColor("#B8C0CC")
+    helpText.fg = parseColor("#8F9BA8")
     renderer.setBackgroundColor("#1a1a2e")
   } else if (currentTheme === "light") {
+    titleText.fg = parseColor("#166534")
     themeText.content = "☀️ Light Mode"
-    themeText.fg = parseColor("#FF7B72")
+    themeText.fg = parseColor("#C2410C")
     statusText.content = "Terminal is in light mode"
+    statusText.fg = parseColor("#1F2937")
+    eventCountText.fg = parseColor("#374151")
+    historyText.fg = parseColor("#374151")
+    helpText.fg = parseColor("#4B5563")
     renderer.setBackgroundColor("#f5f5f0")
   } else {
+    titleText.fg = parseColor("#6BCF7F")
     themeText.content = "❓ Unknown"
     themeText.fg = parseColor("#FFA500")
     statusText.content = "Theme mode not detected. Try switching your terminal theme."
+    statusText.fg = parseColor("#D7DBE0")
+    eventCountText.fg = parseColor("#B8C0CC")
+    historyText.fg = parseColor("#B8C0CC")
+    helpText.fg = parseColor("#8F9BA8")
     renderer.setBackgroundColor("#2d2d2d")
   }
 }
@@ -54,7 +71,7 @@ async function main() {
 
   renderer.root.add(mainContainer)
 
-  const titleText = new TextRenderable(renderer, {
+  titleText = new TextRenderable(renderer, {
     id: "title",
     content: "Theme Mode Monitor",
     bold: true,
@@ -72,28 +89,24 @@ async function main() {
   statusText = new TextRenderable(renderer, {
     id: "status",
     content: "Waiting for theme detection...",
-    dim: true,
     marginBottom: 2,
   })
 
   eventCountText = new TextRenderable(renderer, {
     id: "event-count",
     content: "theme_mode events: 0",
-    dim: true,
     marginBottom: 2,
   })
 
   historyText = new TextRenderable(renderer, {
     id: "history",
     content: "updateThemeDisplay history:\n(none)",
-    dim: true,
     marginBottom: 2,
   })
 
-  const helpText = new TextRenderable(renderer, {
+  helpText = new TextRenderable(renderer, {
     id: "help",
     content: "Press Ctrl+C to exit. Try switching your terminal's light/dark theme to see updates.",
-    dim: true,
     fg: parseColor("#888888"),
   })
 

--- a/packages/core/dev/theme-mode.ts
+++ b/packages/core/dev/theme-mode.ts
@@ -5,12 +5,21 @@ import { parseColor } from "../src/lib/RGBA.js"
 let renderer: CliRenderer | null = null
 let themeText: TextRenderable | null = null
 let statusText: TextRenderable | null = null
+let eventCountText: TextRenderable | null = null
+let historyText: TextRenderable | null = null
+let themeModeEventCount = 0
+const updateThemeHistory: string[] = []
 
 function updateThemeDisplay() {
   if (!renderer || renderer.isDestroyed) return
-  if (!themeText || !statusText) return
+  if (!themeText || !statusText || !eventCountText || !historyText) return
 
   const currentTheme = renderer.themeMode
+  updateThemeHistory.push(`updateThemeDisplay ${updateThemeHistory.length + 1}: themeMode=${currentTheme ?? "null"}`)
+
+  eventCountText.content = `theme_mode events: ${themeModeEventCount}`
+  historyText.content = `updateThemeDisplay history:
+${updateThemeHistory.join("\n")}`
 
   if (currentTheme === "dark") {
     themeText.content = "🌙 Dark Mode"
@@ -67,6 +76,20 @@ async function main() {
     marginBottom: 2,
   })
 
+  eventCountText = new TextRenderable(renderer, {
+    id: "event-count",
+    content: "theme_mode events: 0",
+    dim: true,
+    marginBottom: 2,
+  })
+
+  historyText = new TextRenderable(renderer, {
+    id: "history",
+    content: "updateThemeDisplay history:\n(none)",
+    dim: true,
+    marginBottom: 2,
+  })
+
   const helpText = new TextRenderable(renderer, {
     id: "help",
     content: "Press Ctrl+C to exit. Try switching your terminal's light/dark theme to see updates.",
@@ -77,6 +100,8 @@ async function main() {
   mainContainer.add(titleText)
   mainContainer.add(themeText)
   mainContainer.add(statusText)
+  mainContainer.add(eventCountText)
+  mainContainer.add(historyText)
   mainContainer.add(helpText)
 
   // Initial display
@@ -84,6 +109,7 @@ async function main() {
 
   // Listen for theme mode changes from the terminal
   renderer.on("theme_mode", () => {
+    themeModeEventCount++
     updateThemeDisplay()
   })
 

--- a/packages/core/dev/theme-mode.ts
+++ b/packages/core/dev/theme-mode.ts
@@ -8,16 +8,20 @@ let themeText: TextRenderable | null = null
 let statusText: TextRenderable | null = null
 let eventCountText: TextRenderable | null = null
 let firstDrawText: TextRenderable | null = null
+let waitForThemeModeText: TextRenderable | null = null
 let historyText: TextRenderable | null = null
 let helpText: TextRenderable | null = null
 let themeModeEventCount = 0
 let firstDrawStartedAt = 0
 let timeToFirstDrawMs: number | null = null
+let waitForThemeModeStartedAt = 0
+let waitForThemeModeResolvedMs: number | null = null
+let waitForThemeModeResolvedValue: string | null = null
 const updateThemeHistory: string[] = []
 
 function updateThemeDisplay() {
   if (!renderer || renderer.isDestroyed) return
-  if (!titleText || !themeText || !statusText || !eventCountText || !firstDrawText || !historyText || !helpText) return
+  if (!titleText || !themeText || !statusText || !eventCountText || !firstDrawText || !waitForThemeModeText || !historyText || !helpText) return
 
   const currentTheme = renderer.themeMode
   updateThemeHistory.push(`updateThemeDisplay ${updateThemeHistory.length + 1}: themeMode=${currentTheme ?? "null"}`)
@@ -25,6 +29,10 @@ function updateThemeDisplay() {
   eventCountText.content = `theme_mode events: ${themeModeEventCount}`
   firstDrawText.content =
     timeToFirstDrawMs === null ? "time to first draw: pending" : `time to first draw: ${timeToFirstDrawMs.toFixed(1)}ms`
+  waitForThemeModeText.content =
+    waitForThemeModeResolvedMs === null
+      ? "waitForThemeMode: pending"
+      : `waitForThemeMode: ${waitForThemeModeResolvedMs.toFixed(1)}ms (resolved ${waitForThemeModeResolvedValue ?? "null"})`
   historyText.content = `updateThemeDisplay history:
 ${updateThemeHistory.join("\n")}`
 
@@ -36,6 +44,7 @@ ${updateThemeHistory.join("\n")}`
     statusText.fg = parseColor("#D7DBE0")
     eventCountText.fg = parseColor("#B8C0CC")
     firstDrawText.fg = parseColor("#B8C0CC")
+    waitForThemeModeText.fg = parseColor("#B8C0CC")
     historyText.fg = parseColor("#B8C0CC")
     helpText.fg = parseColor("#8F9BA8")
     renderer.setBackgroundColor("#1a1a2e")
@@ -47,6 +56,7 @@ ${updateThemeHistory.join("\n")}`
     statusText.fg = parseColor("#1F2937")
     eventCountText.fg = parseColor("#374151")
     firstDrawText.fg = parseColor("#374151")
+    waitForThemeModeText.fg = parseColor("#374151")
     historyText.fg = parseColor("#374151")
     helpText.fg = parseColor("#4B5563")
     renderer.setBackgroundColor("#f5f5f0")
@@ -58,6 +68,7 @@ ${updateThemeHistory.join("\n")}`
     statusText.fg = parseColor("#D7DBE0")
     eventCountText.fg = parseColor("#B8C0CC")
     firstDrawText.fg = parseColor("#B8C0CC")
+    waitForThemeModeText.fg = parseColor("#B8C0CC")
     historyText.fg = parseColor("#B8C0CC")
     helpText.fg = parseColor("#8F9BA8")
     renderer.setBackgroundColor("#2d2d2d")
@@ -114,6 +125,12 @@ async function main() {
     marginBottom: 2,
   })
 
+  waitForThemeModeText = new TextRenderable(renderer, {
+    id: "wait-for-theme-mode",
+    content: "waitForThemeMode: pending",
+    marginBottom: 2,
+  })
+
   historyText = new TextRenderable(renderer, {
     id: "history",
     content: "updateThemeDisplay history:\n(none)",
@@ -131,6 +148,7 @@ async function main() {
   mainContainer.add(statusText)
   mainContainer.add(eventCountText)
   mainContainer.add(firstDrawText)
+  mainContainer.add(waitForThemeModeText)
   mainContainer.add(historyText)
   mainContainer.add(helpText)
 
@@ -140,11 +158,12 @@ async function main() {
     updateThemeDisplay()
   })
 
-  await renderer.waitForThemeMode()
+  waitForThemeModeStartedAt = performance.now()
+  const resolvedThemeMode = await renderer.waitForThemeMode()
+  waitForThemeModeResolvedMs = performance.now() - waitForThemeModeStartedAt
+  waitForThemeModeResolvedValue = resolvedThemeMode
 
-  if (themeModeEventCount === 0) {
-    updateThemeDisplay()
-  }
+  updateThemeDisplay()
 
   const handleFirstDraw = async () => {
     if (!renderer || !firstDrawText || timeToFirstDrawMs !== null) {

--- a/packages/core/dev/theme-mode.ts
+++ b/packages/core/dev/theme-mode.ts
@@ -117,14 +117,17 @@ async function main() {
   mainContainer.add(historyText)
   mainContainer.add(helpText)
 
-  // Initial display
-  updateThemeDisplay()
-
   // Listen for theme mode changes from the terminal
   renderer.on("theme_mode", () => {
     themeModeEventCount++
     updateThemeDisplay()
   })
+
+  await renderer.waitForThemeMode()
+
+  if (themeModeEventCount === 0) {
+    updateThemeDisplay()
+  }
 
   renderer.requestRender()
 }

--- a/packages/core/dev/theme-mode.ts
+++ b/packages/core/dev/theme-mode.ts
@@ -21,7 +21,17 @@ const updateThemeHistory: string[] = []
 
 function updateThemeDisplay() {
   if (!renderer || renderer.isDestroyed) return
-  if (!titleText || !themeText || !statusText || !eventCountText || !firstDrawText || !waitForThemeModeText || !historyText || !helpText) return
+  if (
+    !titleText ||
+    !themeText ||
+    !statusText ||
+    !eventCountText ||
+    !firstDrawText ||
+    !waitForThemeModeText ||
+    !historyText ||
+    !helpText
+  )
+    return
 
   const currentTheme = renderer.themeMode
   updateThemeHistory.push(`updateThemeDisplay ${updateThemeHistory.length + 1}: themeMode=${currentTheme ?? "null"}`)

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -39,6 +39,35 @@ import { type Clock, type TimerHandle, SystemClock } from "./lib/clock.js"
 import { StdinParser, type StdinEvent, type StdinParserProtocolContext } from "./lib/stdin-parser.js"
 import { matchesKeyBinding } from "./lib/keymapping.js"
 
+const OSC_THEME_RESPONSE =
+  /\x1b](10|11);(?:(?:rgb:)([0-9a-fA-F]+)\/([0-9a-fA-F]+)\/([0-9a-fA-F]+)|#([0-9a-fA-F]{6}))(?:\x07|\x1b\\)/g
+
+function scaleOscThemeComponent(component: string): string {
+  const value = parseInt(component, 16)
+  const maxValue = (1 << (4 * component.length)) - 1
+  return Math.round((value / maxValue) * 255)
+    .toString(16)
+    .padStart(2, "0")
+}
+
+function oscThemeColorToHex(r?: string, g?: string, b?: string, hex6?: string): string {
+  if (hex6) {
+    return `#${hex6.toLowerCase()}`
+  }
+
+  if (r && g && b) {
+    return `#${scaleOscThemeComponent(r)}${scaleOscThemeComponent(g)}${scaleOscThemeComponent(b)}`
+  }
+
+  return "#000000"
+}
+
+function inferThemeModeFromBackgroundColor(color: string): ThemeMode {
+  const [r, g, b] = parseColor(color).toInts()
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000
+  return brightness > 128 ? "light" : "dark"
+}
+
 registerEnvVar({
   name: "OTUI_DUMP_CAPTURES",
   description: "Dump captured stdout and console caches when the renderer exit handler runs.",
@@ -627,6 +656,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private _paletteDetectionPromise: Promise<TerminalColors> | null = null
   private _onDestroy?: () => void
   private _themeMode: ThemeMode | null = null
+  private _themeModeSource: "none" | "osc" | "csi" = "none"
+  private _themeFallbackPending: boolean = true
+  private _themeOscForeground: string | null = null
+  private _themeOscBackground: string | null = null
   private _terminalFocusState: boolean | null = null
 
   private sequenceHandlers: ((sequence: string) => boolean)[] = []
@@ -1447,21 +1480,61 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private themeModeHandler: (sequence: string) => boolean = ((sequence: string) => {
     if (sequence === "\x1b[?997;1n") {
-      if (this._themeMode !== "dark") {
-        this._themeMode = "dark"
-        this.emit(CliRenderEvents.THEME_MODE, "dark")
-      }
+      this.applyThemeMode("dark", "csi")
+      this._themeFallbackPending = false
       return true
     }
     if (sequence === "\x1b[?997;2n") {
-      if (this._themeMode !== "light") {
-        this._themeMode = "light"
-        this.emit(CliRenderEvents.THEME_MODE, "light")
-      }
+      this.applyThemeMode("light", "csi")
+      this._themeFallbackPending = false
       return true
     }
-    return false
+
+    let handledOscThemeResponse = false
+    let match: RegExpExecArray | null
+
+    OSC_THEME_RESPONSE.lastIndex = 0
+    while ((match = OSC_THEME_RESPONSE.exec(sequence))) {
+      handledOscThemeResponse = true
+      const color = oscThemeColorToHex(match[2], match[3], match[4], match[5])
+
+      if (match[1] === "10") {
+        this._themeOscForeground = color
+      } else {
+        this._themeOscBackground = color
+      }
+    }
+
+    if (!handledOscThemeResponse) {
+      return false
+    }
+
+    if (!this._themeFallbackPending) {
+      return true
+    }
+
+    if (this._themeOscForeground && this._themeOscBackground) {
+      this.applyThemeMode(inferThemeModeFromBackgroundColor(this._themeOscBackground), "osc")
+      this._themeFallbackPending = false
+    }
+
+    return true
   }).bind(this)
+
+  private applyThemeMode(mode: ThemeMode, source: "osc" | "csi"): void {
+    if (source === "osc" && this._themeModeSource === "csi") {
+      return
+    }
+
+    const changed = this._themeMode !== mode
+
+    this._themeMode = mode
+    this._themeModeSource = source
+
+    if (changed) {
+      this.emit(CliRenderEvents.THEME_MODE, mode)
+    }
+  }
 
   private dispatchSequenceHandlers(sequence: string): boolean {
     if (this._debugModeEnabled) {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1204,6 +1204,47 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     return this._themeMode
   }
 
+  public waitForThemeMode(timeoutMs: number = 1000): Promise<ThemeMode | null> {
+    if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+      throw new Error("timeoutMs must be a non-negative finite number")
+    }
+
+    if (this._themeMode !== null || this._isDestroyed || timeoutMs === 0) {
+      return Promise.resolve(this._themeMode)
+    }
+
+    return new Promise<ThemeMode | null>((resolve) => {
+      let timeoutHandle: TimerHandle | null = null
+
+      const cleanup = () => {
+        if (timeoutHandle !== null) {
+          this.clock.clearTimeout(timeoutHandle)
+          timeoutHandle = null
+        }
+
+        this.off(CliRenderEvents.THEME_MODE, handleThemeMode)
+        this.off(CliRenderEvents.DESTROY, handleDestroy)
+      }
+
+      const finish = () => {
+        cleanup()
+        resolve(this._themeMode)
+      }
+
+      const handleThemeMode = () => {
+        finish()
+      }
+
+      const handleDestroy = () => {
+        finish()
+      }
+
+      this.on(CliRenderEvents.THEME_MODE, handleThemeMode)
+      this.on(CliRenderEvents.DESTROY, handleDestroy)
+      timeoutHandle = this.clock.setTimeout(finish, timeoutMs)
+    })
+  }
+
   public getDebugInputs(): Array<{ timestamp: string; sequence: string }> {
     return [...this._debugInputs]
   }

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -1671,6 +1671,79 @@ test("multiple DECRPM responses in sequence", async () => {
   expect(keypresses).toHaveLength(0)
 })
 
+test("OSC 10/11 fallback sets initial theme mode once both colors arrive", () => {
+  const themeModes: string[] = []
+  currentRenderer.on("theme_mode", (mode) => {
+    themeModes.push(mode)
+  })
+
+  currentRenderer.stdin.emit("data", Buffer.from("\x1b]10;#ffffff\x07"))
+  advanceCurrentClock()
+
+  expect(currentRenderer.themeMode).toBeNull()
+  expect(themeModes).toEqual([])
+
+  currentRenderer.stdin.emit("data", Buffer.from("\x1b]11;#000000\x07"))
+  advanceCurrentClock()
+
+  expect(currentRenderer.themeMode).toBe("dark")
+  expect(themeModes).toEqual(["dark"])
+})
+
+test("CSI 997 overrides OSC fallback when the reported mode differs", () => {
+  const themeModes: string[] = []
+  currentRenderer.on("theme_mode", (mode) => {
+    themeModes.push(mode)
+  })
+
+  currentRenderer.stdin.emit("data", Buffer.from("\x1b]10;#ffffff\x07"))
+  currentRenderer.stdin.emit("data", Buffer.from("\x1b]11;#000000\x07"))
+  advanceCurrentClock()
+
+  expect(currentRenderer.themeMode).toBe("dark")
+  expect(themeModes).toEqual(["dark"])
+
+  currentRenderer.stdin.emit("data", Buffer.from("\x1b[?997;2n"))
+  advanceCurrentClock()
+
+  expect(currentRenderer.themeMode).toBe("light")
+  expect(themeModes).toEqual(["dark", "light"])
+})
+
+test("CSI 997 with the same mode as OSC fallback does not emit twice", () => {
+  const themeModes: string[] = []
+  currentRenderer.on("theme_mode", (mode) => {
+    themeModes.push(mode)
+  })
+
+  currentRenderer.stdin.emit("data", Buffer.from("\x1b]10;#ffffff\x07"))
+  currentRenderer.stdin.emit("data", Buffer.from("\x1b]11;#000000\x07"))
+  advanceCurrentClock()
+
+  currentRenderer.stdin.emit("data", Buffer.from("\x1b[?997;1n"))
+  advanceCurrentClock()
+
+  expect(currentRenderer.themeMode).toBe("dark")
+  expect(themeModes).toEqual(["dark"])
+})
+
+test("OSC fallback does not override CSI 997", () => {
+  const themeModes: string[] = []
+  currentRenderer.on("theme_mode", (mode) => {
+    themeModes.push(mode)
+  })
+
+  currentRenderer.stdin.emit("data", Buffer.from("\x1b[?997;2n"))
+  advanceCurrentClock()
+
+  currentRenderer.stdin.emit("data", Buffer.from("\x1b]10;#ffffff\x07"))
+  currentRenderer.stdin.emit("data", Buffer.from("\x1b]11;#000000\x07"))
+  advanceCurrentClock()
+
+  expect(currentRenderer.themeMode).toBe("light")
+  expect(themeModes).toEqual(["light"])
+})
+
 test("pixel resolution response should not trigger keypress", async () => {
   const keypresses: KeyEvent[] = []
   currentRenderer.keyInput.on("keypress", (event) => {

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -91,6 +91,10 @@ function advanceKittyClock(ms: number = 20): void {
   kittyClock.advance(ms)
 }
 
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+}
+
 class MouseTarget extends Renderable {
   constructor(context: RenderContext, options: RenderableOptions) {
     super(context, options)
@@ -1742,6 +1746,46 @@ test("OSC fallback does not override CSI 997", () => {
 
   expect(currentRenderer.themeMode).toBe("light")
   expect(themeModes).toEqual(["light"])
+})
+
+test("waitForThemeMode resolves when initial theme mode is set", async () => {
+  const themeModePromise = currentRenderer.waitForThemeMode(500)
+
+  currentRenderer.stdin.emit("data", Buffer.from("\x1b[?997;1n"))
+  advanceCurrentClock()
+
+  await expect(themeModePromise).resolves.toBe("dark")
+})
+
+test("waitForThemeMode resolves immediately when theme mode is already set", async () => {
+  currentRenderer.stdin.emit("data", Buffer.from("\x1b[?997;2n"))
+  advanceCurrentClock()
+
+  await expect(currentRenderer.waitForThemeMode()).resolves.toBe("light")
+})
+
+test("waitForThemeMode returns current theme mode after the default timeout", async () => {
+  let resolvedThemeMode: string | null | undefined
+
+  currentRenderer.waitForThemeMode().then((mode) => {
+    resolvedThemeMode = mode
+  })
+
+  advanceCurrentClock(999)
+  await flushMicrotasks()
+  expect(resolvedThemeMode).toBeUndefined()
+
+  advanceCurrentClock(1)
+  await flushMicrotasks()
+  expect(resolvedThemeMode).toBeNull()
+})
+
+test("waitForThemeMode resolves with current theme mode when renderer is destroyed", async () => {
+  const themeModePromise = currentRenderer.waitForThemeMode(500)
+
+  currentRenderer.destroy()
+
+  await expect(themeModePromise).resolves.toBeNull()
 })
 
 test("pixel resolution response should not trigger keypress", async () => {

--- a/packages/core/src/zig/ansi.zig
+++ b/packages/core/src/zig/ansi.zig
@@ -73,7 +73,7 @@ pub const ANSI = struct {
     pub const restoreCursorState = "\x1b[u";
 
     pub fn setMousePointerOutput(writer: anytype, shape: []const u8) AnsiError!void {
-        writer.print("\x1b]22;{s}\x07", .{ shape }) catch return AnsiError.WriteFailed;
+        writer.print("\x1b]22;{s}\x07", .{shape}) catch return AnsiError.WriteFailed;
     }
 
     pub const switchToAlternateScreen = "\x1b[?1049h";
@@ -161,6 +161,8 @@ pub const ANSI = struct {
     pub const colorSchemeRequest = "\x1b[?996n";
     pub const colorSchemeSet = "\x1b[?2031h";
     pub const colorSchemeReset = "\x1b[?2031l";
+    pub const oscThemeQueries = "\x1b]10;?\x07\x1b]11;?\x07";
+    pub const oscThemeQueriesTmux = wrapForTmux(oscThemeQueries);
 
     // Key encoding
     pub const csiUPush = "\x1b[>{d}u";

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -106,6 +106,7 @@ skip_graphics_query: bool = false,
 skip_explicit_width_query: bool = false,
 graphics_query_pending: bool = false,
 capability_queries_pending: bool = false,
+theme_queries_pending: bool = false,
 
 state: struct {
     alt_screen: bool = false,
@@ -117,6 +118,7 @@ state: struct {
     mouse_was_enabled: bool = false,
     pixel_mouse: bool = false,
     color_scheme_updates: bool = false,
+    theme_queries_sent: bool = false,
     focus_tracking: bool = false,
     modify_other_keys: bool = false,
     mouse_pointer: MousePointerStyle = .default,
@@ -278,6 +280,14 @@ pub fn sendPendingQueries(self: *Terminal, tty: anytype) !bool {
         sent = true;
     }
 
+    if (self.theme_queries_pending) {
+        if (self.term_info.from_xtversion and is_tmux) {
+            try tty.writeAll(ansi.ANSI.oscThemeQueriesTmux);
+            sent = true;
+        }
+        self.theme_queries_pending = false;
+    }
+
     return sent;
 }
 
@@ -313,9 +323,22 @@ pub fn enableDetectedFeatures(self: *Terminal, tty: anytype, use_kitty_keyboard:
         try self.setFocusTracking(tty, true);
     }
 
+    const is_tmux = self.in_tmux or self.isXtversionTmux();
+
     if (!self.state.color_scheme_updates) {
         try self.setColorSchemeUpdates(tty, true);
         try tty.writeAll(ansi.ANSI.colorSchemeRequest);
+    }
+
+    if (!self.state.theme_queries_sent) {
+        if (is_tmux) {
+            try tty.writeAll(ansi.ANSI.oscThemeQueriesTmux);
+            self.theme_queries_pending = false;
+        } else {
+            try tty.writeAll(ansi.ANSI.oscThemeQueries);
+            self.theme_queries_pending = true;
+        }
+        self.state.theme_queries_sent = true;
     }
 }
 

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -230,6 +230,18 @@ pub fn queryTerminalSend(self: *Terminal, tty: anytype) !void {
     self.checkEnvironmentOverrides();
     self.graphics_query_pending = !self.skip_graphics_query;
     self.capability_queries_pending = false;
+    self.theme_queries_pending = false;
+
+    try self.setColorSchemeUpdates(tty, true);
+    try tty.writeAll(ansi.ANSI.colorSchemeRequest);
+
+    if (self.in_tmux) {
+        try tty.writeAll(ansi.ANSI.oscThemeQueriesTmux);
+    } else {
+        try tty.writeAll(ansi.ANSI.oscThemeQueries);
+        self.theme_queries_pending = true;
+    }
+    self.state.theme_queries_sent = true;
 
     // Send xtversion first (doesn't need DCS wrapping - used for tmux detection)
     try tty.writeAll(ansi.ANSI.xtversion ++

--- a/packages/core/src/zig/tests/terminal_test.zig
+++ b/packages/core/src/zig/tests/terminal_test.zig
@@ -694,6 +694,48 @@ test "queryTerminalSend - sends OSC 66 queries when OPENTUI_FORCE_EXPLICIT_WIDTH
     try testing.expect(!term.skip_explicit_width_query);
 }
 
+test "enableDetectedFeatures - sends initial theme queries" {
+    var env = std.process.EnvMap.init(testing.allocator);
+    defer env.deinit();
+
+    var term = Terminal.init(.{ .env_map = &env });
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.enableDetectedFeatures(&writer, false);
+
+    const output = writer.getWritten();
+
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.colorSchemeSet) != null);
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.colorSchemeRequest) != null);
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b]10;?\x07") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b]11;?\x07") != null);
+    try testing.expect(term.theme_queries_pending);
+    try testing.expect(term.state.theme_queries_sent);
+}
+
+test "sendPendingQueries - sends wrapped OSC theme queries after tmux detected via xtversion" {
+    var term = Terminal.init(.{});
+    term.in_tmux = false;
+    term.theme_queries_pending = true;
+
+    term.term_info.from_xtversion = true;
+    term.term_info.name_len = 4;
+    @memcpy(term.term_info.name[0..4], "tmux");
+
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    const did_send = try term.sendPendingQueries(&writer);
+
+    try testing.expect(did_send);
+
+    const output = writer.getWritten();
+    try testing.expect(std.mem.indexOf(u8, output, "\x1bPtmux;\x1b\x1b]10;?\x07") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b\x1b]11;?\x07") != null);
+    try testing.expect(!term.theme_queries_pending);
+}
+
 test "setMouseMode - enable without movement keeps click/drag only" {
     var term = Terminal.init(.{});
     var writer = TestWriter.init(testing.allocator);

--- a/packages/core/src/zig/tests/terminal_test.zig
+++ b/packages/core/src/zig/tests/terminal_test.zig
@@ -237,8 +237,14 @@ test "queryTerminalSend - sends unwrapped queries when not in tmux" {
 
     const output = writer.getWritten();
 
+    const idx_color_scheme_request = std.mem.indexOf(u8, output, ansi.ANSI.colorSchemeRequest).?;
+    const idx_osc_theme_queries = std.mem.indexOf(u8, output, ansi.ANSI.oscThemeQueries).?;
+    const idx_xtversion = std.mem.indexOf(u8, output, "\x1b[>0q").?;
+
     // Should contain xtversion
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[>0q") != null);
+    try testing.expect(idx_color_scheme_request < idx_xtversion);
+    try testing.expect(idx_osc_theme_queries < idx_xtversion);
 
     // Should contain unwrapped DECRQM queries (single ESC)
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[?1016$p") != null);
@@ -250,6 +256,7 @@ test "queryTerminalSend - sends unwrapped queries when not in tmux" {
 
     // Should mark capability queries as pending
     try testing.expect(term.capability_queries_pending);
+    try testing.expect(term.theme_queries_pending);
 }
 
 test "queryTerminalSend - sends DCS wrapped queries when in tmux" {
@@ -268,8 +275,14 @@ test "queryTerminalSend - sends DCS wrapped queries when in tmux" {
 
     const output = writer.getWritten();
 
+    const idx_color_scheme_request = std.mem.indexOf(u8, output, ansi.ANSI.colorSchemeRequest).?;
+    const idx_osc_theme_queries = std.mem.indexOf(u8, output, ansi.ANSI.oscThemeQueriesTmux).?;
+    const idx_xtversion = std.mem.indexOf(u8, output, "\x1b[>0q").?;
+
     // Should contain xtversion (unwrapped - used for detection)
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[>0q") != null);
+    try testing.expect(idx_color_scheme_request < idx_xtversion);
+    try testing.expect(idx_osc_theme_queries < idx_xtversion);
 
     // Should contain tmux DCS wrapper start and doubled ESC for queries
     // wrapForTmux wraps all queries together with one DCS envelope
@@ -277,6 +290,7 @@ test "queryTerminalSend - sends DCS wrapped queries when in tmux" {
 
     // Should NOT mark capability queries as pending (already sent wrapped)
     try testing.expect(!term.capability_queries_pending);
+    try testing.expect(!term.theme_queries_pending);
 }
 
 test "sendPendingQueries - sends wrapped queries after tmux detected via xtversion" {


### PR DESCRIPTION
Added OSC 10/11 theme color query fallback for detecting terminal light/dark mode when CSI 997 isn't supported, along with a waitForThemeMode() API.