### PR TITLE
fix(react): correct runtime-plugin-support import path for published package

### DIFF
--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -1,0 +1,1 @@
+export * from "./src/index.js"

--- a/packages/react/scripts/runtime-plugin-support.ts
+++ b/packages/react/scripts/runtime-plugin-support.ts
@@ -4,7 +4,7 @@ import { createRuntimePlugin, type RuntimeModuleEntry } from "@opentui/core/runt
 import * as reactRuntime from "react"
 import * as reactJsxRuntime from "react/jsx-runtime"
 import * as reactJsxDevRuntime from "react/jsx-dev-runtime"
-import * as opentuiReactRuntime from "../src/index.js"
+import * as opentuiReactRuntime from "../index.js"
 
 const runtimePluginSupportInstalledKey = "__opentuiReactRuntimePluginSupportInstalled__"
 


### PR DESCRIPTION
## Summary
- Fixed `runtime-plugin-support.ts` importing from `../src/index.js` which doesn't exist in the published `dist/` (only `dist/index.js` does)
- Changed to `../index.js` to match the pattern `@opentui/solid` already uses
- Added root `index.ts` barrel so the import resolves at dev time and tsc can generate declarations

Fixes #960