### PR TITLE
fix(core): add missing requestRender() in CodeRenderable streaming content setter

### DIFF
--- a/packages/core/src/renderables/Code.ts
+++ b/packages/core/src/renderables/Code.ts
@@ -98,6 +98,7 @@ export class CodeRenderable extends TextBufferRenderable {
       this._highlightSnapshotId++
 
       if (this._streaming && !this._drawUnstyledText && this._filetype) {
+        this.requestRender()
         return
       }
 

--- a/packages/core/src/renderables/__tests__/Code.test.ts
+++ b/packages/core/src/renderables/__tests__/Code.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "bun:test"
+import { createTestRenderer } from "../../testing/test-renderer.js"
+import { CodeRenderable } from "../Code.js"
+import { SyntaxStyle } from "../../syntax-style.js"
+import { MockTreeSitterClient } from "../../testing/mock-tree-sitter-client.js"
+
+describe("CodeRenderable", () => {
+  test("streaming content update schedules render and starts highlighting when renderer is idle", async () => {
+    const { renderer, renderOnce } = await createTestRenderer({
+      width: 30,
+      height: 10,
+    })
+
+    const client = new MockTreeSitterClient()
+    const syntaxStyle = SyntaxStyle.create()
+
+    const code = new CodeRenderable(renderer, {
+      content: "",
+      filetype: "typescript",
+      syntaxStyle,
+      drawUnstyledText: false,
+      streaming: true,
+      width: "100%",
+      height: "100%",
+      treeSitterClient: client,
+    })
+
+    renderer.root.add(code)
+    await renderOnce()
+
+    // Set content in streaming mode — this should schedule a render
+    code.content = 'console.log("hello")'
+
+    // Render once — this should trigger startHighlight because highlights are dirty
+    await renderOnce()
+
+    // Highlighting should have started (mock client hasn't resolved yet)
+    expect(code.isHighlighting).toBe(true)
+    expect(client.isHighlighting()).toBe(true)
+
+    // Resolve the highlight so the test cleans up properly
+    client.resolveAllHighlightOnce()
+    await code.highlightingDone
+  })
+})


### PR DESCRIPTION
Fixes #963

## Summary
When streaming content into a `CodeRenderable` with `_drawUnstyledText=false` and an active `_filetype`, the `content` setter was returning early without calling `requestRender()`. If the renderer was otherwise idle (no animations, no input), no frame was ever scheduled, so `renderSelf()` never ran, `startHighlight()` never started, and the display stayed stale indefinitely.

## Root Cause
The streaming optimization in the `content` setter:
```ts
if (this._streaming && !this._drawUnstyledText && this._filetype) {
  return  // no requestRender()
}
```
Stored the new content and marked highlights dirty, but never scheduled a render frame.

## Fix
Added `this.requestRender()` before the early return:
```ts
if (this._streaming && !this._drawUnstyledText && this._filetype) {
  this.requestRender()
  return
}
```

## Test
Added `packages/core/src/renderables/__tests__/Code.test.ts` with a test that verifies:
1. Setting content in streaming mode schedules a render
2. The subsequent render triggers `startHighlight()` (asserted via `isHighlighting` and mock client state)

## Verification
- New test: **1 pass**
- Existing `LineNumberRenderable` tests (which exercise `CodeRenderable`): **29 pass, 0 fail**