### PR TITLE
fix(markdown): dedupe [url](url) chunks when label equals href

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -181,11 +181,45 @@ export class MarkdownRenderable extends Renderable {
   _blockStates: BlockState[] = []
   _stableBlockCount = 0
   private _styleDirty: boolean = false
-  private _linkifyMarkdownChunks: OnChunksCallback = (chunks, context) =>
-    detectLinks(chunks, {
-      content: context.content,
-      highlights: context.highlights,
-    })
+  private _linkifyMarkdownChunks: OnChunksCallback = (chunks, context) => {
+    const linkified =
+      detectLinks(chunks, {
+        content: context.content,
+        highlights: context.highlights,
+      }) ?? chunks
+    // Deduplicate `[url](url)` pattern where label text equals href.
+    // Tree-sitter markdown conceal produces the sequence:
+    //   [label][" "]["("][url][")"]
+    // where label and url are identical text chunks. Collapse to a single chunk.
+    const out: typeof linkified = []
+    let i = 0
+    while (i < linkified.length) {
+      const c = linkified[i]
+      const n1 = linkified[i + 1]
+      const n2 = linkified[i + 2]
+      const n3 = linkified[i + 3]
+      const n4 = linkified[i + 4]
+      if (
+        c &&
+        n1 &&
+        n2 &&
+        n3 &&
+        n4 &&
+        n1.text === " " &&
+        n2.text === "(" &&
+        n4.text === ")" &&
+        c.text &&
+        n3.text === c.text
+      ) {
+        out.push(c)
+        i += 5
+        continue
+      }
+      out.push(c)
+      i += 1
+    }
+    return out
+  }
 
   protected _contentDefaultOptions = {
     content: "",

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -449,9 +449,15 @@ export class MarkdownRenderable extends Renderable {
           for (const child of token.tokens) {
             this.renderInlineTokenWithStyle(child as MarkedToken, chunks, "markup.link.label", linkHref)
           }
-          chunks.push(this.createChunk(" (", "markup.link", linkHref))
-          chunks.push(this.createChunk(token.href, "markup.link.url", linkHref))
-          chunks.push(this.createChunk(")", "markup.link", linkHref))
+          // Skip redundant `(href)` suffix when the label already equals the URL
+          // (bare URLs and markdown autolinks like `[https://x.com](https://x.com)`),
+          // which would otherwise render as `https://x.com (https://x.com)`.
+          const labelText = token.tokens.map((t) => (t as MarkedToken).raw).join("")
+          if (labelText !== token.href) {
+            chunks.push(this.createChunk(" (", "markup.link", linkHref))
+            chunks.push(this.createChunk(token.href, "markup.link.url", linkHref))
+            chunks.push(this.createChunk(")", "markup.link", linkHref))
+          }
         } else {
           chunks.push(this.createChunk("[", "markup.link", linkHref))
           for (const child of token.tokens) {

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1373,6 +1373,24 @@ test("incomplete link (no closing paren)", async () => {
   `)
 })
 
+test("link with label equal to href is deduped", async () => {
+  const markdown = `[https://example.com](https://example.com)`
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    https://example.com"
+  `)
+})
+
+test("link with label different from href shows both", async () => {
+  const markdown = `[Example](https://example.com)`
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    Example (https://example.com)"
+  `)
+})
+
 test("incomplete table (only header)", async () => {
   const markdown = `| Header1 | Header2 |`
 

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -530,6 +530,24 @@ test("table with links", async () => {
   `)
 })
 
+test("table with links where label equals href is deduped", async () => {
+  const markdown = `| Service | URL |
+|---|---|
+| Example | [https://example.com](https://example.com) |
+| Docs | [https://docs.example.com](https://docs.example.com) |`
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    ┌───────┬────────────────────────┐
+    │Service│URL                     │
+    ├───────┼────────────────────────┤
+    │Example│https://example.com     │
+    ├───────┼────────────────────────┤
+    │Docs   │https://docs.example.com│
+    └───────┴────────────────────────┘"
+  `)
+})
+
 test("single row table (header + delimiter only)", async () => {
   const markdown = `| Only | Header |
 |---|---|`


### PR DESCRIPTION
Fixes `[url](url)` markdown links rendering as `url (url)` in conceal mode when the visible label text equals the href — a common pattern for auto-links written in full form.

## Issue

Before (conceal mode on):

```
[https://example.com](https://example.com)
→ https://example.com (https://example.com)   ← duplicate
```

In tables:

```markdown
| Service | URL |
|---|---|
| Example | [https://example.com](https://example.com) |
```

Renders with `https://example.com (https://example.com)` inside the cell.

After: just `https://example.com`.

## Context

This supersedes #707, which was closed with "we already updated the test". The referenced test covers *incomplete* links (no closing paren) — a different case. The original duplicate-href issue is still reproducible in v0.1.101+.

The markdown rendering pipeline has been refactored significantly since then. Markdown now takes two code paths:

1. **Table cells** → `renderInlineToken` (marked renderer)
2. **Normal paragraph text** → `CodeRenderable` with tree-sitter markdown grammar + `_linkifyMarkdownChunks` post-processor

This PR fixes both paths.

## Changes

### 1. `renderInlineToken` (covers table cells)

Skip appending ` (href)` suffix when the label text already equals `token.href`.

### 2. `_linkifyMarkdownChunks` (covers inline text)

Tree-sitter markdown conceal produces this 5-chunk sequence for `[url](url)`:

```
[url][" "]["("][url][")"]
```

When the first and fourth chunks have identical text, collapse to a single chunk retaining link metadata.

## Tests

3 new inline snapshot tests:

- `link with label equal to href is deduped` — inline text dedup
- `link with label different from href shows both` — regression guard (unchanged behavior)
- `table with links where label equals href is deduped` — table cells dedup

All pass. Existing `table with links` and `incomplete link (no closing paren)` tests continue to pass unchanged.

## Verification in consumer

Tested in opencode TUI with `OPENCODE_EXPERIMENTAL_MARKDOWN=true`. Applied via `patchedDependencies`. Confirmed visually for both inline text and table cells.

## Related

- Supersedes #707 (closed with incorrect assumption that test coverage existed)
