### PR TITLE
web: make the docs tree an installable OpenTUI skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,19 @@ bun install @opentui/core
 
 Teach your AI coding assistant OpenTUI's APIs and patterns.
 
-**For [OpenCode](https://opencode.ai) (includes `/opentui` command):**
+**Universal skill install with [`npx skills`](https://skills.sh):**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/msmps/opentui-skill/main/install.sh | bash
+npx skills add anomalyco/opentui --skill opentui
 ```
 
-**For other AI coding assistants:**
+Install globally for every project:
 
 ```bash
-npx skills add msmps/opentui-skill
+npx skills add anomalyco/opentui --skill opentui -g
 ```
+
+OpenCode uses the same install command. No separate installer is needed.
 
 ## Try Examples
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,12 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "scaffold": "bun scripts/test-doc-examples.ts"
+    "scaffold": "bun scripts/test-doc-examples.ts",
+    "validate:docs:metadata": "bun scripts/validate-doc-metadata.ts",
+    "validate:docs:links": "bun scripts/validate-doc-links.ts",
+    "validate:docs:skill": "bun scripts/validate-skill-docs.ts",
+    "validate:docs:examples": "bun scripts/verify-doc-examples.ts",
+    "validate:docs": "bun run validate:docs:metadata && bun run validate:docs:links && bun run validate:docs:skill && bun run validate:docs:examples"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.1",

--- a/packages/web/scripts/validate-doc-links.ts
+++ b/packages/web/scripts/validate-doc-links.ts
@@ -1,0 +1,227 @@
+#!/usr/bin/env bun
+
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { buildDocsIndex } from "../src/lib/docs-index"
+
+interface HeadingInfo {
+  anchor: string
+  lineNumber: number
+}
+
+interface LinkInfo {
+  target: string
+  lineNumber: number
+}
+
+const REPO_ROOT = join(import.meta.dir, "../../..")
+
+async function main() {
+  try {
+    const index = await buildDocsIndex()
+    const anchorsBySlug = new Map<string, Set<string>>()
+    const violations: string[] = []
+
+    for (const page of index.pages) {
+      const content = await readFile(join(REPO_ROOT, page.sourcePath), "utf8")
+      const headings = collectHeadings(content)
+      anchorsBySlug.set(page.slug, new Set(headings.map((heading) => heading.anchor)))
+    }
+
+    for (const page of index.pages) {
+      const content = await readFile(join(REPO_ROOT, page.sourcePath), "utf8")
+
+      for (const link of collectLinks(content)) {
+        const target = link.target.trim()
+
+        if (isExternalLink(target)) {
+          continue
+        }
+
+        if (target.startsWith("packages/web/src/content/docs/")) {
+          violations.push(
+            `${page.sourcePath}:${link.lineNumber}: use /docs/... URLs instead of repo file paths (${target})`,
+          )
+          continue
+        }
+
+        if (page.skill.include && isRelativeDocLink(target)) {
+          violations.push(`${page.sourcePath}:${link.lineNumber}: use /docs/... URLs for cross-doc links (${target})`)
+          continue
+        }
+
+        if (target.startsWith("#")) {
+          const anchor = normalizeAnchor(target.slice(1))
+          const anchors = anchorsBySlug.get(page.slug) ?? new Set<string>()
+          if (!anchors.has(anchor)) {
+            violations.push(`${page.sourcePath}:${link.lineNumber}: unresolved local anchor #${anchor}`)
+          }
+          continue
+        }
+
+        if (!target.startsWith("/docs/")) {
+          continue
+        }
+
+        const { slug, anchor } = normalizeDocTarget(target)
+        const linkedPage = index.pagesBySlug[slug]
+        if (!linkedPage) {
+          violations.push(`${page.sourcePath}:${link.lineNumber}: unresolved doc link ${target}`)
+          continue
+        }
+
+        if (!anchor) {
+          continue
+        }
+
+        const anchors = anchorsBySlug.get(slug) ?? new Set<string>()
+        if (!anchors.has(anchor)) {
+          violations.push(`${page.sourcePath}:${link.lineNumber}: unresolved doc anchor ${target}`)
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      console.error("Link validation failed:\n")
+      for (const violation of violations.sort()) {
+        console.error(`- ${violation}`)
+      }
+      process.exit(1)
+    }
+
+    console.log(`Link validation passed for ${index.pages.length} docs.`)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}
+
+function collectHeadings(content: string): HeadingInfo[] {
+  const headings: HeadingInfo[] = []
+  const anchorCounts = new Map<string, number>()
+  let fence: { marker: string; length: number } | undefined
+
+  for (const [index, line] of content.replace(/\r\n/g, "\n").split("\n").entries()) {
+    const trimmed = line.trim()
+    const fenceMarker = getFenceMarker(trimmed)
+
+    if (!fence && fenceMarker) {
+      fence = fenceMarker
+      continue
+    }
+
+    if (fence && closesFence(trimmed, fence)) {
+      fence = undefined
+      continue
+    }
+
+    if (fence) {
+      continue
+    }
+
+    const match = trimmed.match(/^(#{1,6})\s+(.*)$/)
+    if (!match) {
+      continue
+    }
+
+    const baseAnchor = slugifyHeading(match[2])
+    if (!baseAnchor) {
+      continue
+    }
+
+    const duplicateIndex = anchorCounts.get(baseAnchor) ?? 0
+    anchorCounts.set(baseAnchor, duplicateIndex + 1)
+
+    headings.push({
+      anchor: duplicateIndex === 0 ? baseAnchor : `${baseAnchor}-${duplicateIndex}`,
+      lineNumber: index + 1,
+    })
+  }
+
+  return headings
+}
+
+function collectLinks(content: string): LinkInfo[] {
+  const links: LinkInfo[] = []
+  let fence: { marker: string; length: number } | undefined
+
+  for (const [index, line] of content.replace(/\r\n/g, "\n").split("\n").entries()) {
+    const trimmed = line.trim()
+    const fenceMarker = getFenceMarker(trimmed)
+
+    if (!fence && fenceMarker) {
+      fence = fenceMarker
+      continue
+    }
+
+    if (fence && closesFence(trimmed, fence)) {
+      fence = undefined
+      continue
+    }
+
+    if (fence) {
+      continue
+    }
+
+    const linkPattern = /\[[^\]]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g
+    let match: RegExpExecArray | null
+    while ((match = linkPattern.exec(line)) !== null) {
+      links.push({ target: match[1], lineNumber: index + 1 })
+    }
+  }
+
+  return links
+}
+
+function slugifyHeading(text: string): string {
+  return text
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/<([^>]+)>/g, "$1")
+    .replace(/[*_~]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+}
+
+function getFenceMarker(line: string): { marker: string; length: number } | undefined {
+  const match = line.match(/^(`{3,}|~{3,})/)
+  if (!match) {
+    return undefined
+  }
+
+  return { marker: match[1][0], length: match[1].length }
+}
+
+function closesFence(line: string, fence: { marker: string; length: number }): boolean {
+  const pattern = new RegExp(`^${fence.marker}{${fence.length},}\\s*$`)
+  return pattern.test(line)
+}
+
+function isExternalLink(target: string): boolean {
+  return /^(https?:\/\/|mailto:)/.test(target)
+}
+
+function isRelativeDocLink(target: string): boolean {
+  return target.startsWith("./") || target.startsWith("../") || target.endsWith(".md") || target.endsWith(".mdx")
+}
+
+function normalizeDocTarget(target: string): { slug: string; anchor?: string } {
+  const [pathPart, anchorPart] = target.split("#", 2)
+  const normalizedPath = pathPart.endsWith("/") ? pathPart.slice(0, -1) : pathPart
+  const slug = normalizedPath.replace(/^\/docs\//, "")
+
+  return {
+    slug,
+    anchor: anchorPart ? normalizeAnchor(anchorPart) : undefined,
+  }
+}
+
+function normalizeAnchor(anchor: string): string {
+  return decodeURIComponent(anchor).trim().toLowerCase()
+}
+
+main()

--- a/packages/web/scripts/validate-doc-metadata.ts
+++ b/packages/web/scripts/validate-doc-metadata.ts
@@ -1,0 +1,115 @@
+#!/usr/bin/env bun
+
+import { buildDocsIndex, DOC_SECTION_CONFIG, type DocPage } from "../src/lib/docs-index"
+
+async function main() {
+  try {
+    const index = await buildDocsIndex()
+    const violations: string[] = []
+
+    for (const page of index.pages) {
+      if (!(page.section in DOC_SECTION_CONFIG)) {
+        violations.push(`${page.sourcePath}: unknown section \`${page.section}\``)
+      }
+
+      if (page.navTitle.trim().length === 0) {
+        violations.push(`${page.sourcePath}: navTitle must be non-empty when provided`)
+      }
+
+      if (page.skill.entry && !page.skill.include) {
+        violations.push(`${page.sourcePath}: skill.entry requires skill.include !== false`)
+      }
+
+      if (page.skill.entry && page.skill.intents.length === 0) {
+        violations.push(`${page.sourcePath}: skill.entry requires at least one skill intent`)
+      }
+
+      const duplicateIntents = findDuplicates(page.skill.intents)
+      for (const intent of duplicateIntents) {
+        violations.push(`${page.sourcePath}: duplicate skill intent \`${intent}\``)
+      }
+    }
+
+    addDuplicateKeyViolations(index.pages, (page) => page.slug, "slug", violations)
+    addDuplicateKeyViolations(index.pages, (page) => page.url, "url", violations)
+    addDuplicateKeyViolations(index.pages, (page) => page.sourcePath, "sourcePath", violations)
+    addOrderCollisionViolations(index.pages, violations)
+
+    if (violations.length > 0) {
+      console.error("Metadata validation failed:\n")
+      for (const violation of violations.sort()) {
+        console.error(`- ${violation}`)
+      }
+      process.exit(1)
+    }
+
+    console.log(`Metadata validation passed for ${index.pages.length} docs.`)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}
+
+function addDuplicateKeyViolations(
+  pages: DocPage[],
+  getKey: (page: DocPage) => string,
+  label: string,
+  violations: string[],
+) {
+  const grouped = new Map<string, DocPage[]>()
+
+  for (const page of pages) {
+    const key = getKey(page)
+    grouped.set(key, [...(grouped.get(key) ?? []), page])
+  }
+
+  for (const [key, matches] of grouped) {
+    if (matches.length < 2) {
+      continue
+    }
+
+    violations.push(`duplicate ${label} \`${key}\`: ${matches.map((page) => page.sourcePath).join(", ")}`)
+  }
+}
+
+function addOrderCollisionViolations(pages: DocPage[], violations: string[]) {
+  const grouped = new Map<string, DocPage[]>()
+
+  for (const page of pages) {
+    if (page.order === undefined) {
+      continue
+    }
+
+    const key = `${page.section}:${page.order}`
+    grouped.set(key, [...(grouped.get(key) ?? []), page])
+  }
+
+  for (const [key, matches] of grouped) {
+    if (matches.length < 2) {
+      continue
+    }
+
+    const [section, order] = key.split(":")
+    violations.push(
+      `order collision in ${section} for order ${order}: ${matches.map((page) => page.sourcePath).join(", ")}`,
+    )
+  }
+}
+
+function findDuplicates(values: string[]): string[] {
+  const seen = new Set<string>()
+  const duplicates = new Set<string>()
+
+  for (const value of values) {
+    if (seen.has(value)) {
+      duplicates.add(value)
+      continue
+    }
+
+    seen.add(value)
+  }
+
+  return [...duplicates]
+}
+
+main()

--- a/packages/web/scripts/validate-skill-docs.ts
+++ b/packages/web/scripts/validate-skill-docs.ts
@@ -1,0 +1,205 @@
+#!/usr/bin/env bun
+
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { buildDocsIndex } from "../src/lib/docs-index"
+
+interface CodeLine {
+  lineNumber: number
+  text: string
+}
+
+interface CodeFence {
+  disabledRules: Set<string>
+  language: string
+  lines: CodeLine[]
+}
+
+interface Violation {
+  rule: string
+  sourcePath: string
+  lineNumber: number
+  message: string
+}
+
+const REPO_ROOT = join(import.meta.dir, "../../..")
+const SHELL_LANGUAGES = new Set(["bash", "console", "shell", "sh", "zsh"])
+
+async function main() {
+  try {
+    const index = await buildDocsIndex()
+    const violations: Violation[] = []
+
+    for (const page of index.skillPages) {
+      const content = await readFile(join(REPO_ROOT, page.sourcePath), "utf8")
+      violations.push(...validateSkillDoc(page.sourcePath, content))
+    }
+
+    if (violations.length > 0) {
+      console.error("Skill doc validation failed:\n")
+      for (const violation of violations.sort(compareViolations)) {
+        console.error(`- [${violation.rule}] ${violation.sourcePath}:${violation.lineNumber}: ${violation.message}`)
+      }
+      process.exit(1)
+    }
+
+    console.log(`Skill doc validation passed for ${index.skillPages.length} docs.`)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}
+
+function validateSkillDoc(sourcePath: string, content: string): Violation[] {
+  const violations: Violation[] = []
+  const pendingDisables: string[] = []
+
+  let fence: { marker: string; length: number; data: CodeFence } | undefined
+
+  for (const [index, line] of content.replace(/\r\n/g, "\n").split("\n").entries()) {
+    const lineNumber = index + 1
+    const trimmed = line.trim()
+    const disableMatch = trimmed.match(/^<!--\s*docs-lint-disable\s+([a-z0-9-]+)\s*-->$/)
+
+    if (disableMatch) {
+      pendingDisables.push(disableMatch[1])
+      continue
+    }
+
+    const fenceMarker = getFenceMarker(trimmed)
+    if (!fence && fenceMarker) {
+      fence = {
+        marker: fenceMarker.marker,
+        length: fenceMarker.length,
+        data: {
+          disabledRules: new Set(pendingDisables.splice(0)),
+          language: getFenceLanguage(trimmed),
+          lines: [],
+        },
+      }
+      continue
+    }
+
+    if (fence && closesFence(trimmed, fence)) {
+      violations.push(...validateCodeFence(sourcePath, fence.data))
+      fence = undefined
+      continue
+    }
+
+    if (fence) {
+      fence.data.lines.push({ lineNumber, text: line })
+      continue
+    }
+
+    if (!trimmed) {
+      continue
+    }
+
+    const disabledRules = new Set(pendingDisables.splice(0))
+
+    if (!disabledRules.has("mdx-esm-import") && /^import\s/.test(trimmed)) {
+      violations.push({
+        rule: "mdx-esm-import",
+        sourcePath,
+        lineNumber,
+        message: "top-level MDX import statements are not allowed in skill docs",
+      })
+    }
+
+    if (!disabledRules.has("mdx-esm-export") && /^export\s/.test(trimmed)) {
+      violations.push({
+        rule: "mdx-esm-export",
+        sourcePath,
+        lineNumber,
+        message: "top-level MDX export statements are not allowed in skill docs",
+      })
+    }
+
+    if (!disabledRules.has("mdx-component-node") && isProbableMdxNode(trimmed)) {
+      violations.push({
+        rule: "mdx-component-node",
+        sourcePath,
+        lineNumber,
+        message: "rendered JSX/MDX component nodes are not allowed outside fenced code blocks",
+      })
+    }
+  }
+
+  return violations
+}
+
+function validateCodeFence(sourcePath: string, fence: CodeFence): Violation[] {
+  const violations: Violation[] = []
+
+  for (const line of fence.lines) {
+    if (!fence.disabledRules.has("process-exit-example") && line.text.includes("process.exit(")) {
+      violations.push({
+        rule: "process-exit-example",
+        sourcePath,
+        lineNumber: line.lineNumber,
+        message: "prefer renderer.destroy() over process.exit() in positive examples",
+      })
+    }
+
+    if (fence.disabledRules.has("non-bun-setup-command")) {
+      continue
+    }
+
+    if (!SHELL_LANGUAGES.has(fence.language)) {
+      continue
+    }
+
+    if (/\bnpm install\b|\byarn(?:\s|$)|\bpnpm(?:\s|$)|\bnode\s+/.test(line.text)) {
+      violations.push({
+        rule: "non-bun-setup-command",
+        sourcePath,
+        lineNumber: line.lineNumber,
+        message: "use Bun-native setup commands in runnable examples",
+      })
+    }
+  }
+
+  return violations
+}
+
+function getFenceMarker(line: string): { marker: string; length: number } | undefined {
+  const match = line.match(/^(`{3,}|~{3,})/)
+  if (!match) {
+    return undefined
+  }
+
+  return { marker: match[1][0], length: match[1].length }
+}
+
+function getFenceLanguage(line: string): string {
+  const match = line.match(/^(`{3,}|~{3,})([^\s]*)/)
+  return match?.[2]?.trim().toLowerCase() ?? ""
+}
+
+function closesFence(line: string, fence: { marker: string; length: number }): boolean {
+  const pattern = new RegExp(`^${fence.marker}{${fence.length},}\\s*$`)
+  return pattern.test(line)
+}
+
+function isProbableMdxNode(line: string): boolean {
+  if (!line.startsWith("<") || line.startsWith("<!--")) {
+    return false
+  }
+
+  return /^<\/?[A-Za-z][A-Za-z0-9:_-]*(\s|>|\/)/.test(line)
+}
+
+function compareViolations(left: Violation, right: Violation): number {
+  if (left.sourcePath !== right.sourcePath) {
+    return left.sourcePath.localeCompare(right.sourcePath)
+  }
+
+  if (left.lineNumber !== right.lineNumber) {
+    return left.lineNumber - right.lineNumber
+  }
+
+  return left.rule.localeCompare(right.rule)
+}
+
+main()

--- a/packages/web/scripts/verify-doc-examples.ts
+++ b/packages/web/scripts/verify-doc-examples.ts
@@ -12,12 +12,14 @@
  */
 
 import { readFile, writeFile, mkdir, rm } from "node:fs/promises"
-import { join, relative } from "node:path"
+import { join } from "node:path"
 import { existsSync } from "node:fs"
 
+import { buildDocsIndex } from "../src/lib/docs-index"
+
+const REPO_ROOT = join(import.meta.dir, "../../..")
 const DOCS_DIR = join(import.meta.dir, "../src/content/docs")
 const CORE_PACKAGE = join(import.meta.dir, "../../core")
-const CORE_DIST = join(CORE_PACKAGE, "dist")
 const TEST_DIR = "/tmp/opentui-doc-verify"
 
 interface CodeBlock {
@@ -42,17 +44,41 @@ interface VerificationResult {
 // Extract code blocks from MDX content
 function extractCodeBlocks(content: string, file: string): CodeBlock[] {
   const blocks: CodeBlock[] = []
-  const codeBlockRegex = /```(typescript|ts|javascript|js|tsx|jsx)\n([\s\S]*?)```/g
+  let currentBlock:
+    | { file: string; language: string; lineNumber: number; lines: string[]; fenceLength: number }
+    | undefined
 
-  let match
-  while ((match = codeBlockRegex.exec(content)) !== null) {
-    const lineNumber = content.substring(0, match.index).split("\n").length
-    blocks.push({
-      code: match[2],
-      language: match[1],
-      lineNumber,
-      file,
-    })
+  for (const [index, line] of content.replace(/\r\n/g, "\n").split("\n").entries()) {
+    const trimmed = line.trim()
+
+    if (!currentBlock) {
+      const openMatch = trimmed.match(/^(`{3,})(typescript|ts|javascript|js|tsx|jsx)\s*$/)
+      if (!openMatch) {
+        continue
+      }
+
+      currentBlock = {
+        file,
+        language: openMatch[2],
+        lineNumber: index + 2,
+        lines: [],
+        fenceLength: openMatch[1].length,
+      }
+      continue
+    }
+
+    if (/^`+\s*$/.test(trimmed) && trimmed.length >= currentBlock.fenceLength) {
+      blocks.push({
+        code: currentBlock.lines.join("\n"),
+        file: currentBlock.file,
+        language: currentBlock.language,
+        lineNumber: currentBlock.lineNumber,
+      })
+      currentBlock = undefined
+      continue
+    }
+
+    currentBlock.lines.push(line)
   }
 
   return blocks
@@ -72,8 +98,7 @@ function isPropertyFragment(code: string): boolean {
 
 // Check if code contains JSX syntax
 function hasJSX(code: string): boolean {
-  // Look for JSX patterns: <Component />, <Component>, </Component>
-  return /<[A-Z][a-zA-Z]*[\s/>]/.test(code) || /<\/[A-Z][a-zA-Z]*>/.test(code)
+  return /(^|[\s(=,:])<[A-Za-z][\w-]*(\s|\/?>)/m.test(code) || /<\/[A-Za-z][\w-]*>/.test(code)
 }
 
 // Wrap a code block to make it type-checkable
@@ -88,33 +113,34 @@ function wrapCodeForTypeCheck(code: string, blockIndex: number): string {
     return ""
   }
 
+  const { importStatements, bodyLines } = splitImportsAndBody(code)
+  const importedModules = importStatements.map(getImportModule).filter((value): value is string => Boolean(value))
+
   // Skip fragments without imports - they're incomplete by design
-  if (!isCompleteExample(code)) {
+  if (importStatements.length === 0 || importedModules.length === 0 || !isCompleteExample(code)) {
     return ""
   }
 
-  // Split into imports and body
-  const lines = code.split("\n")
-  const importLines: string[] = []
-  const bodyLines: string[] = []
-
-  let pastImports = false
-  for (const line of lines) {
-    if (!pastImports && (line.trim().startsWith("import ") || line.trim() === "")) {
-      importLines.push(line)
-    } else {
-      pastImports = true
-      bodyLines.push(line)
-    }
+  if (importedModules.some((module) => !module.startsWith("@opentui/core"))) {
+    return ""
   }
 
   const body = bodyLines.join("\n")
 
+  if (!hasExecutableStatements(body) || isPreexistingTargetFragment(body)) {
+    return ""
+  }
+
+  if (hasUndeclaredReceiverCalls(importStatements, body)) {
+    return ""
+  }
+
   // Add renderer declaration if body uses it but doesn't define it
-  const usesRenderer = body.includes("renderer.") || body.includes("renderer,") || body.includes("renderer)")
+  const usesRenderer =
+    body.includes("renderer.") || body.includes("renderer,") || body.includes("renderer)") || body.includes("(renderer")
   const definesRenderer = body.includes("const renderer") || body.includes("let renderer")
 
-  let preamble = importLines.join("\n")
+  let preamble = importStatements.join("\n")
 
   if (usesRenderer && !definesRenderer) {
     // Add renderer declaration and createCliRenderer import if not already imported
@@ -132,6 +158,156 @@ function wrapCodeForTypeCheck(code: string, blockIndex: number): string {
   return preamble + "\n" + body
 }
 
+function splitImportsAndBody(code: string): { importStatements: string[]; bodyLines: string[] } {
+  const importStatements: string[] = []
+  const bodyLines: string[] = []
+  let currentImport: string[] | undefined
+  let readingImports = true
+
+  for (const line of code.split("\n")) {
+    const trimmed = line.trim()
+
+    if (!readingImports) {
+      bodyLines.push(line)
+      continue
+    }
+
+    if (currentImport) {
+      currentImport.push(line)
+      if (isImportStatementComplete(currentImport.join("\n"))) {
+        importStatements.push(currentImport.join("\n"))
+        currentImport = undefined
+      }
+      continue
+    }
+
+    if (!trimmed) {
+      continue
+    }
+
+    if (trimmed.startsWith("import ")) {
+      currentImport = [line]
+      if (isImportStatementComplete(trimmed)) {
+        importStatements.push(trimmed)
+        currentImport = undefined
+      }
+      continue
+    }
+
+    readingImports = false
+    bodyLines.push(line)
+  }
+
+  if (currentImport) {
+    bodyLines.unshift(...currentImport)
+  }
+
+  return { importStatements, bodyLines }
+}
+
+function isImportStatementComplete(statement: string): boolean {
+  return (
+    /^import\s+["'][^"']+["'](?:\s+with\s+\{[\s\S]*\})?\s*$/s.test(statement) ||
+    /\bfrom\s+["'][^"']+["'](?:\s+with\s+\{[\s\S]*\})?\s*$/s.test(statement)
+  )
+}
+
+function getImportModule(statement: string): string | undefined {
+  const sideEffectMatch = statement.match(/^import\s+["']([^"']+)["']/s)
+  if (sideEffectMatch) {
+    return sideEffectMatch[1]
+  }
+
+  const fromMatch = statement.match(/\bfrom\s+["']([^"']+)["']/s)
+  return fromMatch?.[1]
+}
+
+function hasExecutableStatements(body: string): boolean {
+  return body
+    .split("\n")
+    .map((line) => line.trim())
+    .some((line) => line.length > 0 && !line.startsWith("//"))
+}
+
+function isPreexistingTargetFragment(body: string): boolean {
+  const firstExecutableLine = body
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0 && !line.startsWith("//"))
+
+  if (!firstExecutableLine) {
+    return true
+  }
+
+  return /^[A-Za-z_$][\w$]*\./.test(firstExecutableLine)
+}
+
+function hasUndeclaredReceiverCalls(importStatements: string[], body: string): boolean {
+  const allowedReceivers = new Set<string>([
+    ...collectImportedBindings(importStatements),
+    ...collectDeclaredBindings(body),
+    "Array",
+    "Bun",
+    "JSON",
+    "Math",
+    "Number",
+    "Object",
+    "Promise",
+    "String",
+    "console",
+    "process",
+  ])
+
+  const receiverPattern = /\b([A-Za-z_$][\w$]*)\./g
+  let match: RegExpExecArray | null
+
+  while ((match = receiverPattern.exec(body)) !== null) {
+    if (!allowedReceivers.has(match[1])) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function collectImportedBindings(importStatements: string[]): string[] {
+  const bindings: string[] = []
+
+  for (const statement of importStatements) {
+    const namedMatch = statement.match(/\{([\s\S]*?)\}/)
+    if (namedMatch) {
+      for (const part of namedMatch[1].split(",")) {
+        const binding = part
+          .replace(/\btype\b/g, "")
+          .split(" as ")[0]
+          ?.trim()
+        if (binding) {
+          bindings.push(binding)
+        }
+      }
+    }
+
+    const defaultMatch = statement.match(/^import\s+([A-Za-z_$][\w$]*)\s*(,|from)/)
+    if (defaultMatch) {
+      bindings.push(defaultMatch[1])
+    }
+  }
+
+  return bindings
+}
+
+function collectDeclaredBindings(body: string): string[] {
+  const bindings = new Set<string>()
+  const declarationPattern = /\b(?:const|let|var|class|function|interface|type)\s+([A-Za-z_$][\w$]*)/g
+  let match: RegExpExecArray | null
+
+  while ((match = declarationPattern.exec(body)) !== null) {
+    bindings.add(match[1])
+  }
+
+  return [...bindings]
+}
+
 // Setup the test environment
 async function setupTestEnv(): Promise<boolean> {
   if (existsSync(TEST_DIR)) {
@@ -139,20 +315,19 @@ async function setupTestEnv(): Promise<boolean> {
   }
   await mkdir(TEST_DIR, { recursive: true })
 
-  // Check that dist exists
-  if (!existsSync(CORE_DIST)) {
-    console.error(`ERROR: ${CORE_DIST} not found. Run 'bun run build' in packages/core first.`)
+  if (!existsSync(CORE_PACKAGE)) {
+    console.error(`ERROR: ${CORE_PACKAGE} not found.`)
     return false
   }
 
-  // Create package.json - use dist for proper type declarations
+  // Create package.json for the verifier sandbox.
   await writeFile(
     join(TEST_DIR, "package.json"),
     JSON.stringify({
       name: "doc-verify",
       type: "module",
       dependencies: {
-        "@opentui/core": `file:${CORE_DIST}`,
+        "@opentui/core": `file:${CORE_PACKAGE}`,
       },
     }),
   )
@@ -169,9 +344,10 @@ async function setupTestEnv(): Promise<boolean> {
         skipLibCheck: true,
         esModuleInterop: true,
         noEmit: true,
+        jsx: "preserve",
         types: ["bun-types"],
       },
-      include: ["*.ts"],
+      include: ["*.ts", "*.tsx"],
     }),
   )
 
@@ -235,9 +411,9 @@ async function typeCheckBlock(block: CodeBlock, blockIndex: number): Promise<Iss
 }
 
 // Process a single MDX file
-async function processFile(filePath: string): Promise<VerificationResult[]> {
+async function processFile(filePath: string, sourcePath: string): Promise<VerificationResult[]> {
   const content = await readFile(filePath, "utf-8")
-  const blocks = extractCodeBlocks(content, filePath)
+  const blocks = extractCodeBlocks(content, sourcePath)
   const results: VerificationResult[] = []
 
   for (let i = 0; i < blocks.length; i++) {
@@ -246,7 +422,7 @@ async function processFile(filePath: string): Promise<VerificationResult[]> {
 
     if (issues.length > 0) {
       results.push({
-        file: filePath,
+        file: sourcePath,
         lineNumber: block.lineNumber,
         issues,
         codePreview: block.code.split("\n")[0].substring(0, 60),
@@ -258,10 +434,18 @@ async function processFile(filePath: string): Promise<VerificationResult[]> {
 }
 
 async function main() {
-  const pattern = process.argv[2] || "**/*.mdx"
+  const pattern = process.argv[2]
+  const index = await buildDocsIndex()
+  const matchedSourcePaths = pattern ? collectMatchedSourcePaths(pattern) : undefined
+  const pages = index.skillPages.filter((page) => !matchedSourcePaths || matchedSourcePaths.has(page.sourcePath))
 
   console.log(`Verifying documentation examples in: ${DOCS_DIR}`)
-  console.log(`Pattern: ${pattern}\n`)
+  console.log(`Scope: ${pattern ? `skill docs matching ${pattern}` : "all skill-included docs"}\n`)
+
+  if (pages.length === 0) {
+    console.error("No matching docs found.")
+    process.exit(1)
+  }
 
   // Setup test environment
   console.log("Setting up test environment...")
@@ -271,21 +455,17 @@ async function main() {
   }
   console.log("Test environment ready.\n")
 
-  // Find MDX files
-  const globber = new Bun.Glob(pattern)
-  const files = [...globber.scanSync({ cwd: DOCS_DIR, absolute: true })]
-
-  console.log(`Found ${files.length} MDX files to verify\n`)
+  console.log(`Found ${pages.length} MDX files to verify\n`)
 
   let totalErrors = 0
   let filesWithIssues = 0
   const allResults: VerificationResult[] = []
 
-  for (const file of files) {
-    const relPath = relative(DOCS_DIR, file)
-    process.stdout.write(`Checking ${relPath}...`)
+  for (const page of pages) {
+    const absolutePath = join(REPO_ROOT, page.sourcePath)
+    process.stdout.write(`Checking ${page.sourcePath}...`)
 
-    const results = await processFile(file)
+    const results = await processFile(absolutePath, page.sourcePath)
     allResults.push(...results)
 
     if (results.length > 0) {
@@ -305,11 +485,10 @@ async function main() {
     // Group by file
     const byFile = new Map<string, VerificationResult[]>()
     for (const result of allResults) {
-      const relPath = relative(DOCS_DIR, result.file)
-      if (!byFile.has(relPath)) {
-        byFile.set(relPath, [])
+      if (!byFile.has(result.file)) {
+        byFile.set(result.file, [])
       }
-      byFile.get(relPath)!.push(result)
+      byFile.get(result.file)!.push(result)
     }
 
     for (const [file, results] of byFile) {
@@ -326,7 +505,7 @@ async function main() {
 
   console.log(`\n${"=".repeat(60)}`)
   console.log(`Summary:`)
-  console.log(`  Files checked: ${files.length}`)
+  console.log(`  Files checked: ${pages.length}`)
   console.log(`  Files with issues: ${filesWithIssues}`)
   console.log(`  Total errors: ${totalErrors}`)
 
@@ -334,6 +513,24 @@ async function main() {
   await rm(TEST_DIR, { recursive: true })
 
   process.exit(totalErrors > 0 ? 1 : 0)
+}
+
+function collectMatchedSourcePaths(pattern: string): Set<string> {
+  const matched = new Set<string>()
+
+  for (const file of new Bun.Glob(pattern).scanSync({ cwd: DOCS_DIR, absolute: false })) {
+    matched.add(`packages/web/src/content/docs/${normalizePath(file)}`)
+  }
+
+  for (const file of new Bun.Glob(pattern).scanSync({ cwd: REPO_ROOT, absolute: false })) {
+    matched.add(normalizePath(file))
+  }
+
+  return matched
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/")
 }
 
 main().catch((err) => {

--- a/packages/web/src/content/SKILL.md
+++ b/packages/web/src/content/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: opentui
+description: Build terminal UIs with OpenTUI. Covers the core API, React and Solid bindings, components, layout, keyboard input, plugins, and testing.
+---
+
+# OpenTUI Skill
+
+Canonical reference docs are authored once in sibling `docs/**/*.mdx` files.
+
+Inside the OpenTUI repo, this skill root lives at `packages/web/src/content/`, so the same files are also visible at `packages/web/src/content/docs/**/*.mdx`.
+
+## Path invariant
+
+- `/docs/<slug>` maps to `docs/<slug>.mdx` relative to this skill root
+- in the repo, that same slug maps to `packages/web/src/content/docs/<slug>.mdx`
+
+## Reading order by area
+
+- Getting started: `/docs/getting-started`
+- Core: `/docs/core-concepts/renderer`
+- React: `/docs/bindings/react`
+- Solid: `/docs/bindings/solid`
+- Components: `/docs/components/text`, `/docs/components/input`
+- Layout: `/docs/core-concepts/layout`
+- Keyboard: `/docs/core-concepts/keyboard`
+- Plugins: `/docs/plugins/slots`
+- Reference: `/docs/reference/env-vars`
+
+## Quick routing by intent
+
+| Intent(s)                                                  | Start here                        |
+| ---------------------------------------------------------- | --------------------------------- |
+| `getting-started`, `installation`, `quickstart`, `intro`   | `docs/getting-started.mdx`        |
+| `core`, `renderer`, `terminal`, `scrollback`, `lifecycle`  | `docs/core-concepts/renderer.mdx` |
+| `layout`, `flexbox`, `yoga`, `positioning`                 | `docs/core-concepts/layout.mdx`   |
+| `keyboard`, `input`, `keybindings`, `paste`, `focus`       | `docs/core-concepts/keyboard.mdx` |
+| `react`, `jsx`, `hooks`, `animation`, `testing`            | `docs/bindings/react.mdx`         |
+| `solid`, `signals`, `jsx`, `hooks`, `animation`, `testing` | `docs/bindings/solid.mdx`         |
+| `plugins`, `plugin`, `slots`, `registry`, `extensions`     | `docs/plugins/slots.mdx`          |
+| `text`, `styling`, `content`, `selection`                  | `docs/components/text.mdx`        |
+| `input`, `form`, `editing`, `focus`                        | `docs/components/input.mdx`       |
+| `env`, `environment`, `configuration`, `flags`             | `docs/reference/env-vars.mdx`     |
+
+For concrete component requests, jump straight to `docs/components/<name>.mdx` after the relevant entry page. For plugin implementation details, narrow from `docs/plugins/slots.mdx` into `docs/plugins/core.mdx`, `docs/plugins/react.mdx`, or `docs/plugins/solid.mdx`.
+
+## Current skill entry pages
+
+- `docs/getting-started.mdx`
+- `docs/core-concepts/renderer.mdx`
+- `docs/core-concepts/layout.mdx`
+- `docs/core-concepts/keyboard.mdx`
+- `docs/bindings/react.mdx`
+- `docs/bindings/solid.mdx`
+- `docs/plugins/slots.mdx`
+- `docs/components/text.mdx`
+- `docs/components/input.mdx`
+- `docs/reference/env-vars.mdx`
+
+## Working rules
+
+- Prefer the current entry pages first, then read narrower docs in the same section.
+- Read the sibling `docs/**/*.mdx` files directly instead of copying prose into this file.
+- Use stable `/docs/...` URLs when cross-referencing docs.

--- a/packages/web/src/content/config.ts
+++ b/packages/web/src/content/config.ts
@@ -5,7 +5,15 @@ const docs = defineCollection({
   schema: z.object({
     title: z.string(),
     description: z.string().optional(),
-    order: z.number().optional(),
+    order: z.number().int().nonnegative().optional(),
+    navTitle: z.string().optional(),
+    skill: z
+      .object({
+        include: z.boolean().default(true),
+        entry: z.boolean().default(false),
+        intents: z.array(z.string().trim().min(1)).default([]),
+      })
+      .optional(),
   }),
 })
 

--- a/packages/web/src/content/docs/bindings/react.mdx
+++ b/packages/web/src/content/docs/bindings/react.mdx
@@ -2,6 +2,9 @@
 title: React
 description: Build terminal UIs with React and OpenTUI
 order: 2
+skill:
+  entry: true
+  intents: [react, jsx, hooks, keyboard, animation, testing]
 ---
 
 # React bindings
@@ -144,16 +147,18 @@ function App() {
 Handle keyboard events.
 
 ```tsx
-import { useKeyboard } from "@opentui/react"
+import { useKeyboard, useRenderer } from "@opentui/react"
 
 function App() {
+  const renderer = useRenderer()
+
   useKeyboard((key) => {
     if (key.name === "escape") {
-      process.exit(0)
+      renderer.destroy()
     }
   })
 
-  return <text>Press ESC to exit</text>
+  return <text>Press ESC to close</text>
 }
 ```
 

--- a/packages/web/src/content/docs/bindings/solid.mdx
+++ b/packages/web/src/content/docs/bindings/solid.mdx
@@ -2,6 +2,9 @@
 title: Solid.js
 description: Build terminal UIs with Solid.js and OpenTUI
 order: 1
+skill:
+  entry: true
+  intents: [solid, jsx, signals, hooks, keyboard, animation, testing]
 ---
 
 # Solid.js bindings
@@ -210,16 +213,18 @@ const App = () => {
 Subscribe to keyboard events.
 
 ```tsx
-import { useKeyboard } from "@opentui/solid"
+import { useKeyboard, useRenderer } from "@opentui/solid"
 
 const App = () => {
+  const renderer = useRenderer()
+
   useKeyboard((key) => {
     if (key.name === "escape") {
-      process.exit(0)
+      renderer.destroy()
     }
   })
 
-  return <text>Press ESC to exit</text>
+  return <text>Press ESC to close</text>
 }
 ```
 
@@ -457,22 +462,23 @@ If that executable loads external plugins/modules at runtime, keep `import "@ope
 ## Example: counter
 
 ```tsx
-import { render, useKeyboard } from "@opentui/solid"
+import { render, useKeyboard, useRenderer } from "@opentui/solid"
 import { createSignal } from "solid-js"
 
 const App = () => {
   const [count, setCount] = createSignal(0)
+  const renderer = useRenderer()
 
   useKeyboard((key) => {
     if (key.name === "up") setCount((c) => c + 1)
     if (key.name === "down") setCount((c) => c - 1)
-    if (key.name === "escape") process.exit(0)
+    if (key.name === "escape") renderer.destroy()
   })
 
   return (
     <box border padding={2}>
       <text>Count: {count()}</text>
-      <text fg="#888">Up/Down to change, ESC to exit</text>
+      <text fg="#888">Up/Down to change, ESC to close</text>
     </box>
   )
 }

--- a/packages/web/src/content/docs/components/ascii-font.mdx
+++ b/packages/web/src/content/docs/components/ascii-font.mdx
@@ -1,7 +1,7 @@
 ---
 title: ASCIIFont
 description: Display text using ASCII art fonts
-order: 6
+order: 14
 ---
 
 # ASCIIFont

--- a/packages/web/src/content/docs/components/code.mdx
+++ b/packages/web/src/content/docs/components/code.mdx
@@ -1,7 +1,7 @@
 ---
 title: Code
 description: Syntax-highlighted code display component with Tree-sitter support
-order: 6
+order: 10
 ---
 
 # Code
@@ -186,7 +186,12 @@ const code = new CodeRenderable(renderer, {
 Use `LineNumberRenderable` to add line numbers:
 
 ```typescript
-import { CodeRenderable, LineNumberRenderable, ScrollBoxRenderable } from "@opentui/core"
+import { CodeRenderable, LineNumberRenderable, RGBA, ScrollBoxRenderable, SyntaxStyle } from "@opentui/core"
+
+const sourceCode = "const answer = 42\nconsole.log(answer)\n"
+const syntaxStyle = SyntaxStyle.fromStyles({
+  default: { fg: RGBA.fromHex("#E6EDF3") },
+})
 
 const code = new CodeRenderable(renderer, {
   id: "code",
@@ -213,6 +218,7 @@ const scrollbox = new ScrollBoxRenderable(renderer, {
   height: 20,
 })
 scrollbox.add(lineNumbers)
+renderer.root.add(scrollbox)
 ```
 
 ## Properties

--- a/packages/web/src/content/docs/components/frame-buffer.mdx
+++ b/packages/web/src/content/docs/components/frame-buffer.mdx
@@ -1,7 +1,7 @@
 ---
 title: FrameBuffer
 description: Low-level rendering surface for custom graphics
-order: 7
+order: 13
 ---
 
 # FrameBuffer

--- a/packages/web/src/content/docs/components/input.mdx
+++ b/packages/web/src/content/docs/components/input.mdx
@@ -2,6 +2,9 @@
 title: Input
 description: Text input field with cursor and focus states
 order: 3
+skill:
+  entry: true
+  intents: [input, form, editing, focus]
 ---
 
 # Input

--- a/packages/web/src/content/docs/components/markdown.mdx
+++ b/packages/web/src/content/docs/components/markdown.mdx
@@ -89,7 +89,11 @@ markdown.streaming = false
 To use it, render with `internalBlockMode: "top-level"`. The renderable keeps each top-level markdown block (heading, paragraph, list, table, fenced code) as its own child renderable, and exposes `markdown._stableBlockCount` — the number of blocks at the head of the tree that are stable right now. This matches the shape [`ScrollbackSurface`](/docs/core-concepts/renderer#writing-to-scrollback) expects when you commit streamed output row-by-row.
 
 ```typescript
-import { MarkdownRenderable } from "@opentui/core"
+import { MarkdownRenderable, RGBA, SyntaxStyle } from "@opentui/core"
+
+const syntaxStyle = SyntaxStyle.fromStyles({
+  default: { fg: RGBA.fromHex("#E6EDF3") },
+})
 
 const md = new MarkdownRenderable(renderer, {
   content: "",

--- a/packages/web/src/content/docs/components/scrollbox.mdx
+++ b/packages/web/src/content/docs/components/scrollbox.mdx
@@ -1,7 +1,7 @@
 ---
 title: ScrollBox
 description: A scrollable container component with customizable scrollbars
-order: 5
+order: 7
 ---
 
 # ScrollBox

--- a/packages/web/src/content/docs/components/select.mdx
+++ b/packages/web/src/content/docs/components/select.mdx
@@ -1,7 +1,7 @@
 ---
 title: Select
 description: List selection component for choosing from options
-order: 4
+order: 5
 ---
 
 # Select

--- a/packages/web/src/content/docs/components/tab-select.mdx
+++ b/packages/web/src/content/docs/components/tab-select.mdx
@@ -1,7 +1,7 @@
 ---
 title: TabSelect
 description: Horizontal tab-based selection component
-order: 5
+order: 6
 ---
 
 # TabSelect

--- a/packages/web/src/content/docs/components/text.mdx
+++ b/packages/web/src/content/docs/components/text.mdx
@@ -2,6 +2,9 @@
 title: Text
 description: Display styled text content
 order: 1
+skill:
+  entry: true
+  intents: [text, styling, content, selection]
 ---
 
 # Text

--- a/packages/web/src/content/docs/core-concepts/colors.mdx
+++ b/packages/web/src/content/docs/core-concepts/colors.mdx
@@ -1,7 +1,7 @@
 ---
 title: Colors
 description: Working with RGBA colors and palette-aware color intent in OpenTUI
-order: 2
+order: 8
 ---
 
 # Colors

--- a/packages/web/src/content/docs/core-concepts/console.mdx
+++ b/packages/web/src/content/docs/core-concepts/console.mdx
@@ -1,7 +1,7 @@
 ---
 title: Console overlay
 description: Built-in debugging console for TUI applications
-order: 4
+order: 7
 ---
 
 # Console overlay

--- a/packages/web/src/content/docs/core-concepts/keyboard.mdx
+++ b/packages/web/src/content/docs/core-concepts/keyboard.mdx
@@ -1,7 +1,10 @@
 ---
 title: Keyboard input
 description: Handling keyboard events in OpenTUI
-order: 3
+order: 6
+skill:
+  entry: true
+  intents: [keyboard, input, keybindings, paste, focus]
 ---
 
 # Keyboard input
@@ -187,9 +190,9 @@ const renderer = await createCliRenderer({
 
 renderer.keyInput.on("keypress", (key: KeyEvent) => {
   if (key.ctrl && key.name === "c") {
-    // Custom cleanup before exit
+    // Custom cleanup before shutdown
     cleanup()
-    process.exit(0)
+    renderer.destroy()
   }
 })
 ```

--- a/packages/web/src/content/docs/core-concepts/layout.mdx
+++ b/packages/web/src/content/docs/core-concepts/layout.mdx
@@ -1,7 +1,10 @@
 ---
 title: Layout System
 description: Flexible positioning and sizing with Yoga/Flexbox
-order: 1
+order: 5
+skill:
+  entry: true
+  intents: [layout, flexbox, yoga, positioning]
 ---
 
 # Layout System

--- a/packages/web/src/content/docs/core-concepts/lifecycle.mdx
+++ b/packages/web/src/content/docs/core-concepts/lifecycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Lifecycle and cleanup
 description: Managing renderer lifecycle and terminal cleanup
-order: 6
+order: 9
 ---
 
 # Lifecycle and cleanup
@@ -31,22 +31,25 @@ const renderer = await createCliRenderer()
 renderer.destroy()
 ```
 
-For reliable cleanup, handle errors and signals in your app:
+For reliable cleanup, keep renderer teardown in the same control flow as your app startup:
 
 ```typescript
+import { createCliRenderer } from "@opentui/core"
+
+async function runApp() {
+  // ... your application code ...
+}
+
 const renderer = await createCliRenderer()
 
-process.on("uncaughtException", (error) => {
-  console.error("Uncaught exception:", error)
+try {
+  await runApp()
+} catch (error) {
+  console.error("OpenTUI app failed:", error)
+  process.exitCode = 1
+} finally {
   renderer.destroy()
-  process.exit(1)
-})
-
-process.on("unhandledRejection", (reason) => {
-  console.error("Unhandled rejection:", reason)
-  renderer.destroy()
-  process.exit(1)
-})
+}
 ```
 
 ## Signal handling

--- a/packages/web/src/content/docs/core-concepts/renderables-vs-constructs.mdx
+++ b/packages/web/src/content/docs/core-concepts/renderables-vs-constructs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Renderables vs Constructs
 description: Two approaches to building UIs in OpenTUI
-order: 5
+order: 4
 ---
 
 # Renderables vs Constructs

--- a/packages/web/src/content/docs/core-concepts/renderer.mdx
+++ b/packages/web/src/content/docs/core-concepts/renderer.mdx
@@ -2,6 +2,9 @@
 title: Renderer
 description: CliRenderer manages terminal output and the render loop
 order: 1
+skill:
+  entry: true
+  intents: [core, renderer, terminal, scrollback, lifecycle]
 ---
 
 # Renderer

--- a/packages/web/src/content/docs/getting-started.mdx
+++ b/packages/web/src/content/docs/getting-started.mdx
@@ -2,6 +2,10 @@
 title: Getting started
 description: Install OpenTUI and create your first terminal UI
 order: 1
+navTitle: Introduction
+skill:
+  entry: true
+  intents: [getting-started, installation, quickstart, intro]
 ---
 
 # Getting started

--- a/packages/web/src/content/docs/plugins/core.mdx
+++ b/packages/web/src/content/docs/plugins/core.mdx
@@ -153,7 +153,13 @@ Because `SlotRenderable` extends `Renderable`, it accepts all standard layout op
 Resolve slot entries without mounting them. Useful when you need to inspect or render plugin output manually.
 
 ```typescript
-import { resolveCoreSlot } from "@opentui/core"
+import { createCliRenderer, createCoreSlotRegistry, resolveCoreSlot } from "@opentui/core"
+
+const renderer = await createCliRenderer()
+const registry = createCoreSlotRegistry<"statusbar">(renderer, {
+  appName: "core-app",
+  version: "1.0.0",
+})
 
 const entries = resolveCoreSlot(registry, "statusbar")
 // Array<{ id: string, renderer: (ctx, data) => BaseRenderable }>

--- a/packages/web/src/content/docs/plugins/slots.mdx
+++ b/packages/web/src/content/docs/plugins/slots.mdx
@@ -2,6 +2,10 @@
 title: Plugin Slots
 description: Shared slot registry API used by core, React, and Solid
 order: 1
+navTitle: Overview
+skill:
+  entry: true
+  intents: [plugins, plugin, slots, registry, extensions]
 ---
 
 # Plugin slots
@@ -53,6 +57,11 @@ The context can be any object. `PluginContext` is a type alias for `object` — 
 
 ```typescript
 import { createSlotRegistry } from "@opentui/core"
+
+type AppSlots = {
+  statusbar: { user: string }
+  sidebar: { section: "left" | "right" }
+}
 
 const context = { appName: "my-app", version: "1.0.0" }
 

--- a/packages/web/src/content/docs/reference/env-vars.mdx
+++ b/packages/web/src/content/docs/reference/env-vars.mdx
@@ -2,6 +2,9 @@
 title: Environment variables
 description: Runtime configuration flags for OpenTUI
 order: 1
+skill:
+  entry: true
+  intents: [env, environment, configuration, flags]
 ---
 
 # Environment variables

--- a/packages/web/src/content/docs/reference/tree-sitter.mdx
+++ b/packages/web/src/content/docs/reference/tree-sitter.mdx
@@ -146,10 +146,14 @@ await updateAssets({
 ## Using with CodeRenderable
 
 ```typescript
-import { CodeRenderable, getTreeSitterClient } from "@opentui/core"
+import { CodeRenderable, RGBA, SyntaxStyle, getTreeSitterClient } from "@opentui/core"
 
 const client = getTreeSitterClient()
 await client.initialize()
+
+const syntaxStyle = SyntaxStyle.fromStyles({
+  default: { fg: RGBA.fromHex("#E6EDF3") },
+})
 
 const code = new CodeRenderable(renderer, {
   id: "code",

--- a/packages/web/src/layouts/Docs.astro
+++ b/packages/web/src/layouts/Docs.astro
@@ -1,5 +1,6 @@
 ---
 import Base from "./Base.astro"
+import { buildDocsIndex } from "../lib/docs-index"
 
 interface Props {
   title: string
@@ -7,6 +8,7 @@ interface Props {
 }
 
 const { title, description } = Astro.props
+const docsIndex = await buildDocsIndex()
 
 const currentPath = Astro.url.pathname
 const isActive = (path: string) => currentPath === path || currentPath === `${path}/`
@@ -51,75 +53,20 @@ const isActive = (path: string) => currentPath === path || currentPath === `${pa
         <div class="mobile-nav-overlay" aria-hidden="true"></div>
         <div class="docs-layout">
           <aside class="sidebar" id="mobile-nav">
-            <div class="sidebar-section">
-              <div class="sidebar-title">Getting Started</div>
-              <ul class="sidebar-links">
-                <li><a href="/docs/getting-started" class:list={{ active: isActive("/docs/getting-started") }}>Introduction</a></li>
-              </ul>
-            </div>
-
-            <div class="sidebar-section">
-              <div class="sidebar-title">Core Concepts</div>
-              <ul class="sidebar-links">
-                <li><a href="/docs/core-concepts/renderer" class:list={{ active: isActive("/docs/core-concepts/renderer") }}>Renderer</a></li>
-                <li><a href="/docs/core-concepts/renderables" class:list={{ active: isActive("/docs/core-concepts/renderables") }}>Renderables</a></li>
-                <li><a href="/docs/core-concepts/constructs" class:list={{ active: isActive("/docs/core-concepts/constructs") }}>Constructs</a></li>
-                <li><a href="/docs/core-concepts/renderables-vs-constructs" class:list={{ active: isActive("/docs/core-concepts/renderables-vs-constructs") }}>Renderables vs Constructs</a></li>
-                <li><a href="/docs/core-concepts/layout" class:list={{ active: isActive("/docs/core-concepts/layout") }}>Layout</a></li>
-                <li><a href="/docs/core-concepts/keyboard" class:list={{ active: isActive("/docs/core-concepts/keyboard") }}>Keyboard</a></li>
-                <li><a href="/docs/core-concepts/console" class:list={{ active: isActive("/docs/core-concepts/console") }}>Console</a></li>
-                <li><a href="/docs/core-concepts/colors" class:list={{ active: isActive("/docs/core-concepts/colors") }}>Colors</a></li>
-                <li><a href="/docs/core-concepts/lifecycle" class:list={{ active: isActive("/docs/core-concepts/lifecycle") }}>Lifecycle</a></li>
-              </ul>
-            </div>
-
-            <div class="sidebar-section">
-              <div class="sidebar-title">Plugin API</div>
-              <ul class="sidebar-links">
-                <li><a href="/docs/plugins/slots" class:list={{ active: isActive("/docs/plugins/slots") }}>Overview</a></li>
-                <li><a href="/docs/plugins/core" class:list={{ active: isActive("/docs/plugins/core") }}>Core</a></li>
-                <li><a href="/docs/plugins/react" class:list={{ active: isActive("/docs/plugins/react") }}>React</a></li>
-                <li><a href="/docs/plugins/solid" class:list={{ active: isActive("/docs/plugins/solid") }}>Solid</a></li>
-              </ul>
-            </div>
-
-            <div class="sidebar-section">
-              <div class="sidebar-title">Components</div>
-              <ul class="sidebar-links">
-                <li><a href="/docs/components/text" class:list={{ active: isActive("/docs/components/text") }}>Text</a></li>
-                <li><a href="/docs/components/box" class:list={{ active: isActive("/docs/components/box") }}>Box</a></li>
-                <li><a href="/docs/components/input" class:list={{ active: isActive("/docs/components/input") }}>Input</a></li>
-                <li><a href="/docs/components/textarea" class:list={{ active: isActive("/docs/components/textarea") }}>Textarea</a></li>
-                <li><a href="/docs/components/select" class:list={{ active: isActive("/docs/components/select") }}>Select</a></li>
-                <li><a href="/docs/components/tab-select" class:list={{ active: isActive("/docs/components/tab-select") }}>TabSelect</a></li>
-                <li><a href="/docs/components/scrollbox" class:list={{ active: isActive("/docs/components/scrollbox") }}>ScrollBox</a></li>
-                <li><a href="/docs/components/scrollbar" class:list={{ active: isActive("/docs/components/scrollbar") }}>ScrollBar</a></li>
-                <li><a href="/docs/components/slider" class:list={{ active: isActive("/docs/components/slider") }}>Slider</a></li>
-                <li><a href="/docs/components/code" class:list={{ active: isActive("/docs/components/code") }}>Code</a></li>
-                <li><a href="/docs/components/markdown" class:list={{ active: isActive("/docs/components/markdown") }}>Markdown</a></li>
-                <li><a href="/docs/components/line-number" class:list={{ active: isActive("/docs/components/line-number") }}>Line numbers</a></li>
-                <li><a href="/docs/components/frame-buffer" class:list={{ active: isActive("/docs/components/frame-buffer") }}>FrameBuffer</a></li>
-                <li><a href="/docs/components/ascii-font" class:list={{ active: isActive("/docs/components/ascii-font") }}>ASCIIFont</a></li>
-                <li><a href="/docs/components/diff" class:list={{ active: isActive("/docs/components/diff") }}>Diff</a></li>
-              </ul>
-            </div>
-
-            <div class="sidebar-section">
-              <div class="sidebar-title">Bindings</div>
-              <ul class="sidebar-links">
-                <li><a href="/docs/bindings/solid" class:list={{ active: isActive("/docs/bindings/solid") }}>Solid.js</a></li>
-                <li><a href="/docs/bindings/react" class:list={{ active: isActive("/docs/bindings/react") }}>React</a></li>
-              </ul>
-            </div>
-
-            <div class="sidebar-section">
-              <div class="sidebar-title">Reference</div>
-              <ul class="sidebar-links">
-                <li><a href="/docs/reference/env-vars" class:list={{ active: isActive("/docs/reference/env-vars") }}>Environment variables</a></li>
-                <li><a href="/docs/reference/tree-sitter" class:list={{ active: isActive("/docs/reference/tree-sitter") }}>Tree-sitter</a></li>
-                <li><a href="/docs/reference/color-matrix" class:list={{ active: isActive("/docs/reference/color-matrix") }}>Color matrix</a></li>
-              </ul>
-            </div>
+            {
+              docsIndex.sections.map((section) => (
+                <div class="sidebar-section">
+                  <div class="sidebar-title">{section.title}</div>
+                  <ul class="sidebar-links">
+                    {section.pages.map((page) => (
+                      <li>
+                        <a href={page.url} class:list={{ active: isActive(page.url) }}>{page.navTitle}</a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))
+            }
           </aside>
 
           <article class="content">

--- a/packages/web/src/lib/docs-index.ts
+++ b/packages/web/src/lib/docs-index.ts
@@ -1,0 +1,368 @@
+import { readdir, readFile } from "node:fs/promises"
+import { join, relative, sep } from "node:path"
+import { fileURLToPath } from "node:url"
+
+export type DocSectionId = "getting-started" | "core-concepts" | "plugins" | "components" | "bindings" | "reference"
+
+export interface SkillMetadata {
+  include: boolean
+  entry: boolean
+  intents: string[]
+}
+
+export interface DocPage {
+  id: string
+  slug: string
+  url: `/docs/${string}`
+  sourcePath: string
+  section: DocSectionId
+  title: string
+  navTitle: string
+  description?: string
+  order?: number
+  skill: SkillMetadata
+}
+
+export interface DocSection {
+  id: DocSectionId
+  title: string
+  order: number
+  pages: DocPage[]
+}
+
+export interface DocsIndex {
+  pages: DocPage[]
+  pagesBySlug: Record<string, DocPage>
+  pagesByUrl: Record<string, DocPage>
+  sections: DocSection[]
+  skillPages: DocPage[]
+  skillEntryPages: DocPage[]
+  intentIndex: Record<string, DocPage[]>
+}
+
+interface RawSkillMetadata {
+  include?: unknown
+  entry?: unknown
+  intents?: unknown
+}
+
+interface RawDocMetadata {
+  title?: unknown
+  description?: unknown
+  order?: unknown
+  navTitle?: unknown
+  skill?: unknown
+}
+
+const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url))
+const DOCS_ROOT = join(REPO_ROOT, "packages/web/src/content/docs")
+
+export const DOC_SECTION_CONFIG: Record<DocSectionId, { title: string; order: number }> = {
+  "getting-started": { title: "Getting Started", order: 1 },
+  "core-concepts": { title: "Core Concepts", order: 2 },
+  plugins: { title: "Plugin API", order: 3 },
+  components: { title: "Components", order: 4 },
+  bindings: { title: "Bindings", order: 5 },
+  reference: { title: "Reference", order: 6 },
+}
+
+let docsIndexPromise: Promise<DocsIndex> | undefined
+
+export async function buildDocsIndex(): Promise<DocsIndex> {
+  docsIndexPromise ??= loadDocsIndex()
+  return docsIndexPromise
+}
+
+export function getDocBySlug(index: DocsIndex, slug: string): DocPage | undefined {
+  return index.pagesBySlug[slug]
+}
+
+export function getDocByUrl(index: DocsIndex, url: string): DocPage | undefined {
+  return index.pagesByUrl[normalizeDocUrl(url)]
+}
+
+export function getDocsForIntent(index: DocsIndex, intent: string): DocPage[] {
+  return index.intentIndex[normalizeIntent(intent)] ?? []
+}
+
+export function getPrevNextDocs(index: DocsIndex, slug: string): { prev?: DocPage; next?: DocPage } {
+  const pageIndex = index.pages.findIndex((page) => page.slug === slug)
+  if (pageIndex === -1) {
+    return {}
+  }
+
+  return {
+    prev: pageIndex > 0 ? index.pages[pageIndex - 1] : undefined,
+    next: pageIndex < index.pages.length - 1 ? index.pages[pageIndex + 1] : undefined,
+  }
+}
+
+async function loadDocsIndex(): Promise<DocsIndex> {
+  const sourceFiles = await listDocFiles(DOCS_ROOT)
+  const pages = await Promise.all(sourceFiles.map((filePath) => buildDocPage(filePath)))
+
+  pages.sort(comparePages)
+
+  const sections = Object.entries(DOC_SECTION_CONFIG)
+    .map(([id, config]) => ({
+      id: id as DocSectionId,
+      title: config.title,
+      order: config.order,
+      pages: pages.filter((page) => page.section === id),
+    }))
+    .filter((section) => section.pages.length > 0)
+
+  const pagesBySlug = Object.fromEntries(pages.map((page) => [page.slug, page]))
+  const pagesByUrl = Object.fromEntries(pages.map((page) => [page.url, page]))
+  const skillPages = pages.filter((page) => page.skill.include)
+  const skillEntryPages = pages.filter((page) => page.skill.include && page.skill.entry)
+  const intentIndex = buildIntentIndex(skillPages)
+
+  return {
+    pages,
+    pagesBySlug,
+    pagesByUrl,
+    sections,
+    skillPages,
+    skillEntryPages,
+    intentIndex,
+  }
+}
+
+async function buildDocPage(filePath: string): Promise<DocPage> {
+  const source = await readFile(filePath, "utf8")
+  const { data } = parseFrontmatter(source, filePath)
+  const raw = data as RawDocMetadata
+
+  if (typeof raw.title !== "string") {
+    throw new Error(`Missing or invalid title in ${toSourcePath(filePath)}`)
+  }
+
+  const sourcePath = toSourcePath(filePath)
+  const slug = toSlug(filePath)
+  const section = toSection(slug, sourcePath)
+  const skill = normalizeSkill(raw.skill, sourcePath)
+
+  return {
+    id: slug,
+    slug,
+    url: `/docs/${slug}`,
+    sourcePath,
+    section,
+    title: raw.title,
+    navTitle: typeof raw.navTitle === "string" ? raw.navTitle : raw.title,
+    description: typeof raw.description === "string" ? raw.description : undefined,
+    order: typeof raw.order === "number" ? raw.order : undefined,
+    skill,
+  }
+}
+
+async function listDocFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const filePath = join(dir, entry.name)
+
+      if (entry.isDirectory()) {
+        return listDocFiles(filePath)
+      }
+
+      return entry.name.endsWith(".mdx") ? [filePath] : []
+    }),
+  )
+
+  return files.flat()
+}
+
+function parseFrontmatter(source: string, filePath: string): { data: Record<string, unknown>; content: string } {
+  const normalizedSource = source.replace(/\r\n/g, "\n")
+  const match = normalizedSource.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)
+
+  if (!match) {
+    throw new Error(`Expected frontmatter in ${toSourcePath(filePath)}`)
+  }
+
+  return {
+    data: parseSimpleYaml(match[1], filePath),
+    content: match[2],
+  }
+}
+
+function parseSimpleYaml(source: string, filePath: string): Record<string, unknown> {
+  const root: Record<string, unknown> = {}
+  const stack: Array<{ indent: number; value: Record<string, unknown> }> = [{ indent: -1, value: root }]
+
+  for (const [index, line] of source.split("\n").entries()) {
+    if (!line.trim()) {
+      continue
+    }
+
+    if (line.includes("\t")) {
+      throw new Error(`Tabs are not supported in frontmatter: ${toSourcePath(filePath)}:${index + 1}`)
+    }
+
+    const match = line.match(/^(\s*)([A-Za-z][A-Za-z0-9_-]*):(?:\s*(.*))?$/)
+    if (!match) {
+      throw new Error(`Unsupported frontmatter line in ${toSourcePath(filePath)}:${index + 1}`)
+    }
+
+    const indent = match[1].length
+    const key = match[2]
+    const rawValue = match[3] ?? ""
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) {
+      stack.pop()
+    }
+
+    const parent = stack[stack.length - 1].value
+    if (rawValue === "") {
+      const child: Record<string, unknown> = {}
+      parent[key] = child
+      stack.push({ indent, value: child })
+      continue
+    }
+
+    parent[key] = parseSimpleYamlValue(rawValue)
+  }
+
+  return root
+}
+
+function parseSimpleYamlValue(rawValue: string): unknown {
+  const value = rawValue.trim()
+
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1)
+  }
+
+  if (value === "true") {
+    return true
+  }
+
+  if (value === "false") {
+    return false
+  }
+
+  if (/^-?\d+$/.test(value)) {
+    return Number(value)
+  }
+
+  if (value.startsWith("[") && value.endsWith("]")) {
+    return splitInlineArray(value.slice(1, -1)).map((item) => String(parseSimpleYamlValue(item)))
+  }
+
+  return value
+}
+
+function splitInlineArray(value: string): string[] {
+  const items: string[] = []
+  let current = ""
+  let quote: '"' | "'" | undefined
+
+  for (const char of value) {
+    if ((char === '"' || char === "'") && (!quote || quote === char)) {
+      quote = quote ? undefined : (char as '"' | "'")
+      current += char
+      continue
+    }
+
+    if (char === "," && !quote) {
+      if (current.trim()) {
+        items.push(current.trim())
+      }
+      current = ""
+      continue
+    }
+
+    current += char
+  }
+
+  if (current.trim()) {
+    items.push(current.trim())
+  }
+
+  return items
+}
+
+function normalizeSkill(rawSkill: unknown, sourcePath: string): SkillMetadata {
+  if (rawSkill === undefined) {
+    return { include: true, entry: false, intents: [] }
+  }
+
+  if (!rawSkill || typeof rawSkill !== "object" || Array.isArray(rawSkill)) {
+    throw new Error(`Invalid skill metadata in ${sourcePath}`)
+  }
+
+  const skill = rawSkill as RawSkillMetadata
+  const rawIntents = skill.intents
+  const intents = Array.isArray(rawIntents)
+    ? rawIntents.map((value) => String(value).trim().toLowerCase()).filter((value) => value.length > 0)
+    : []
+
+  return {
+    include: typeof skill.include === "boolean" ? skill.include : true,
+    entry: typeof skill.entry === "boolean" ? skill.entry : false,
+    intents,
+  }
+}
+
+function toSlug(filePath: string): string {
+  const relativePath = relative(DOCS_ROOT, filePath).split(sep).join("/")
+  return relativePath.replace(/\.mdx$/, "")
+}
+
+function toSection(slug: string, sourcePath: string): DocSectionId {
+  const section = slug.split("/")[0]
+  if (section in DOC_SECTION_CONFIG) {
+    return section as DocSectionId
+  }
+
+  throw new Error(`Unknown doc section for ${sourcePath}: ${section}`)
+}
+
+function toSourcePath(filePath: string): string {
+  return relative(REPO_ROOT, filePath).split(sep).join("/")
+}
+
+function buildIntentIndex(pages: DocPage[]): Record<string, DocPage[]> {
+  const intentIndex: Record<string, DocPage[]> = {}
+
+  for (const page of pages) {
+    for (const intent of page.skill.intents) {
+      intentIndex[intent] ??= []
+      intentIndex[intent].push(page)
+    }
+  }
+
+  return intentIndex
+}
+
+function comparePages(left: DocPage, right: DocPage): number {
+  const sectionDelta = DOC_SECTION_CONFIG[left.section].order - DOC_SECTION_CONFIG[right.section].order
+  if (sectionDelta !== 0) {
+    return sectionDelta
+  }
+
+  if (left.order === undefined && right.order !== undefined) {
+    return 1
+  }
+
+  if (left.order !== undefined && right.order === undefined) {
+    return -1
+  }
+
+  if (left.order !== undefined && right.order !== undefined && left.order !== right.order) {
+    return left.order - right.order
+  }
+
+  return left.title.localeCompare(right.title)
+}
+
+function normalizeDocUrl(url: string): `/docs/${string}` {
+  const normalized = url.endsWith("/") && url !== "/docs/" ? url.slice(0, -1) : url
+  return normalized as `/docs/${string}`
+}
+
+function normalizeIntent(intent: string): string {
+  return intent.trim().toLowerCase()
+}

--- a/packages/web/src/pages/index.astro
+++ b/packages/web/src/pages/index.astro
@@ -5,7 +5,7 @@ import TuiSurface from "../components/TuiSurface.astro"
 const installCommands = {
   create: { cmd: "bun create", pkg: "tui" },
   manual: { cmd: "bun add", pkg: "@opentui/core" },
-  skill: { cmd: "npx skills add", pkg: "msmps/opentui-skill" },
+  skill: { cmd: "npx skills add", pkg: "anomalyco/opentui --skill opentui" },
 }
 
 const features = [
@@ -278,7 +278,7 @@ renderer.root.<span class="function">add</span>(
   const installCommands: Record<string, { cmd: string; pkg: string }> = {
     create: { cmd: "bun create", pkg: "tui" },
     manual: { cmd: "bun add", pkg: "@opentui/core" },
-    skill: { cmd: "npx skills add", pkg: "msmps/opentui-skill" },
+    skill: { cmd: "npx skills add", pkg: "anomalyco/opentui --skill opentui" },
   }
 
   // Tab switching


### PR DESCRIPTION
Place the skill root above src/content/docs so npx skills add anomalyco/opentui
--skill opentui works while keeping one authored docs source. Add a shared docs
index and validation so site navigation, skill routing, and examples stay
aligned as the docs evolve.
