### PR TITLE
fix(core): keep renderable ids valid

### DIFF
--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -36,6 +36,10 @@ import {
 
 const BrandedRenderable: unique symbol = Symbol.for("@opentui/core/Renderable")
 
+function isValidRenderableId(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0
+}
+
 export enum LayoutEvents {
   LAYOUT_CHANGED = "layout-changed",
   ADDED = "added",
@@ -146,7 +150,7 @@ export abstract class BaseRenderable extends EventEmitter {
   constructor(options: BaseRenderableOptions) {
     super()
     this.num = BaseRenderable.renderableNumber++
-    this._id = options.id ?? `renderable-${this.num}`
+    this._id = isValidRenderableId(options.id) ? options.id : `renderable-${this.num}`
   }
 
   public abstract add(obj: BaseRenderable | unknown, index?: number): number
@@ -163,6 +167,10 @@ export abstract class BaseRenderable extends EventEmitter {
   }
 
   public set id(value: string) {
+    if (!isValidRenderableId(value)) {
+      return
+    }
+
     this._id = value
   }
 
@@ -308,6 +316,10 @@ export abstract class Renderable extends BaseRenderable {
   }
 
   public override set id(value: string) {
+    if (!isValidRenderableId(value)) {
+      return
+    }
+
     if (this.parent) {
       this.parent.renderableMapById.delete(this.id)
       this.parent.renderableMapById.set(value, this)

--- a/packages/core/src/tests/renderable.test.ts
+++ b/packages/core/src/tests/renderable.test.ts
@@ -105,6 +105,22 @@ describe("BaseRenderable", () => {
     expect(renderable.id).toBe("custom-id")
   })
 
+  test("falls back to generated id for invalid constructor id", () => {
+    for (const id of ["", null, 42]) {
+      const renderable = new TestBaseRenderable({ id } as any)
+      expect(renderable.id).toMatch(/^renderable-\d+$/)
+    }
+  })
+
+  test("ignores invalid id assignments", () => {
+    const renderable = new TestBaseRenderable({ id: "stable-id" })
+
+    for (const id of ["", null, undefined, 42]) {
+      renderable.id = id as any
+      expect(renderable.id).toBe("stable-id")
+    }
+  })
+
   test("has unique numbers", () => {
     const r1 = new TestBaseRenderable({})
     const r2 = new TestBaseRenderable({})
@@ -426,6 +442,34 @@ describe("Renderable - Child Management", () => {
 
     expect(parent.getRenderable("child")).toBeUndefined()
     expect(parent.getRenderable("new-child-id")).toBe(child)
+  })
+
+  test("ignores invalid renderable id changes and preserves parent mapping", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const child = new TestRenderable(testRenderer, { id: "child" })
+
+    parent.add(child)
+
+    for (const id of ["", null, undefined, 42]) {
+      child.id = id as any
+      expect(child.id).toBe("child")
+      expect(parent.getRenderable("child")).toBe(child)
+    }
+
+    parent.remove(child.id)
+    expect(parent.getChildrenCount()).toBe(0)
+  })
+
+  test("can remove child created with invalid id option", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const child = new TestRenderable(testRenderer, { id: "" } as any)
+
+    expect(child.id).toMatch(/^renderable-\d+$/)
+
+    parent.add(child)
+    parent.remove(child.id)
+
+    expect(parent.getChildrenCount()).toBe(0)
   })
 
   test("findDescendantById finds direct children", () => {

--- a/packages/react/tests/id-prop-removal.test.tsx
+++ b/packages/react/tests/id-prop-removal.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test"
+import React, { useState, act } from "react"
+import { testRender } from "../src/test-utils.js"
+
+/**
+ * Regression test for: child renderable persists after unmount when its `id`
+ * prop transitioned to undefined on a previous render.
+ *
+ * Before the fix, React could reuse the same host instance for an element whose
+ * `id` prop changed from a string to undefined. That assigned
+ * `instance.id = undefined`, leaving `_id` undefined while the parent still
+ * relied on `child.id` for removal.
+ *
+ * Later, when React unmounted the element, `removeChild` invoked
+ * `parent.remove(child.id)` -> `parent.remove(undefined)`, which early-returned
+ * on falsy id. The child stayed mounted and visible, which showed up in
+ * dialog/mode-switching subtrees that only set an id in one mode.
+ *
+ * The core renderable id setter now preserves the existing id when an invalid
+ * value is assigned.
+ */
+
+const PROBE_TEXT = "PROBE_VISIBLE_BIT"
+
+describe("id prop removal does not orphan children", () => {
+  it("removes a child whose id prop became undefined before unmount", async () => {
+    let setStep: (s: 0 | 1 | 2) => void = () => {}
+    const captured: { box: any | null } = { box: null }
+
+    function App() {
+      const [step, setStepState] = useState<0 | 1 | 2>(0)
+      setStep = setStepState
+      if (step === 2) return null
+      return (
+        <box flexDirection="column">
+          <box
+            ref={(r: any) => {
+              if (r) captured.box = r
+            }}
+            id={step === 0 ? "regression-target-box" : undefined}
+            flexDirection="column"
+          >
+            <text>{PROBE_TEXT}</text>
+          </box>
+        </box>
+      )
+    }
+
+    const testSetup = await testRender(<App />, { width: 40, height: 6 })
+    await testSetup.renderOnce()
+    expect(testSetup.captureCharFrame()).toContain(PROBE_TEXT)
+    expect(captured.box).not.toBeNull()
+    const innerBox = captured.box
+    const parentBox = innerBox.parent
+    expect(parentBox).not.toBeNull()
+    expect(parentBox.renderableMapById.has("regression-target-box")).toBe(true)
+
+    // Drop the id prop while the same fiber is reused.
+    await act(async () => {
+      setStep(1)
+    })
+    await testSetup.renderOnce()
+    // The inner box is still mounted and should still be in the parent map.
+    // After the bug, the id has been clobbered to undefined and the parent
+    // map has lost the previous key. We probe by looking at the inner box's id.
+    expect(innerBox.id == null).toBe(false) // bug: would be true (id undefined)
+
+    // Unmount that subtree entirely. With the bug, the inner box stays
+    // attached because parent.remove(undefined) is a no-op.
+    await act(async () => {
+      setStep(2)
+    })
+    await testSetup.renderOnce()
+    expect(parentBox.renderableMapById.size).toBe(0)
+    expect(testSetup.captureCharFrame()).not.toContain(PROBE_TEXT)
+
+    testSetup.renderer.destroy()
+  })
+})


### PR DESCRIPTION
Ensure renderables always retain a non-empty string id. Invalid constructor ids now fall back to generated ids, and invalid id assignments are ignored so parent child maps remain consistent.

This prevents children from becoming orphaned when removal relies on child.id after an invalid id value is assigned. In practice, this can happen when a reused element in a dialog or mode-switching subtree drops its id before being unmounted, causing parent.remove(child.id) to receive an invalid id and leave the child attached.

Basically, this change protects the basic rule that every renderable must always have a usable id, because parent maps and unmount/removal logic depend on it.

In case it helps, here's the simple change in my app that surfaced this bug:

https://github.com/honeymux/honeymux/commit/5825514966ffab01a57c7e331674fcdbf8cae645#diff-6df7e2acca06e3499038f86a1fbd0712da07bb7b8f4baca4f5beadc973f440d5

The addition of `id` here broke unmount of the component until I fixed this problem on the OpenTUI side.