### PR TITLE
fix: paletteBuffer.length passed instead of palette.length

### DIFF
--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -2203,7 +2203,7 @@ class FFIRenderLib implements RenderLib {
     this.opentui.symbols.rendererSetPaletteState(
       renderer,
       paletteBuffer,
-      paletteBuffer.length,
+      palette.length,
       defaultForeground.buffer,
       defaultBackground.buffer,
       paletteEpoch >>> 0,

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -510,7 +510,7 @@ export fn rendererSetPaletteState(
     defaultBgPtr: [*]const f32,
     paletteEpoch: u32,
 ) void {
-    if (paletteLen < 256 * 4) return;
+    if (paletteLen < 256) return;
 
     var palette: [256]renderer.RGBA = undefined;
     var index: usize = 0;


### PR DESCRIPTION
~~`paletteBuffer` is a Float32Array sized to `palette.length * 4`, but the Zig side expects the count of RGBA structs. Passing `paletteBuffer.length` (1024) instead of `palette.length` (256) overstates the buffer by 4×.~~

~~It still worked because the native code currently clamps to 256 in packages/core/src/zig/renderer.zig:~~
```zig
const copy_len = @min(palette.len, self.palette_rgba.len);
```

~~self.palette_rgba.len is fixed at 256 (it's the terminal's internal palette array). So even though TypeScript passes 1024 as palette.len, min(1024, 256) evaluates to 256, and the for loop on line 605 only copies 256 colors.~~

wrong, the code worked correctly and this min line has nothing to do with what was passed, just the variable names mismatched, i adjusted it so it works correctly and with the right variable names