### PR TITLE
fix: enable truecolor for Windows Terminal via WT_SESSION

### DIFF
--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -483,6 +483,11 @@ fn checkEnvironmentOverrides(self: *Terminal) void {
         }
     }
 
+    if (env_map.get("WT_SESSION") != null) {
+        self.caps.rgb = true;
+        self.caps.ansi256 = true;
+    }
+
     if (!self.term_info.from_xtversion) {
         if (env_map.get("TERMUX_VERSION")) |_| {
             self.caps.unicode = .wcwidth;

--- a/packages/core/src/zig/tests/terminal_test.zig
+++ b/packages/core/src/zig/tests/terminal_test.zig
@@ -207,6 +207,18 @@ test "setHostEnvVar detects ansi256 separately from rgb" {
     try testing.expect(term.caps.ansi256);
 }
 
+test "environment overrides - WT_SESSION enables rgb and ansi256" {
+    var env = std.process.EnvMap.init(testing.allocator);
+    defer env.deinit();
+    try env.put("TERM", "xterm-256color");
+    try env.put("WT_SESSION", "test-session");
+
+    const term = Terminal.init(.{ .env_map = &env });
+
+    try testing.expect(term.caps.rgb);
+    try testing.expect(term.caps.ansi256);
+}
+
 test "parseXtversion - terminal name only" {
     var term = Terminal.init(.{});
     const response = "\x1bP>|wezterm\x1b\\";


### PR DESCRIPTION
Since #844, Windows Terminal now only gets 256 colors:

Windows Terminal supports 24-bit color but [does not set `COLORTERM=truecolor` by default](https://github.com/microsoft/terminal/issues/11057). opentui currently only sees `TERM=xterm-256color`, which sets `ansi256 = true` but leaves `rgb = false`. This causes the renderer to quantize all colors down to the 256-color palette via `cachedNearestPaletteIndex`, resulting in limited/washed up colors.

Funnily enough, PowerShell does not get affected by this due to this check:
```zig
if (builtin.os.tag == .windows) {
    // Windows-specific defaults for ConPTY
    self.caps.rgb = true;
    self.caps.ansi256 = true;
    self.caps.bracketed_paste = true;
}
```

So only WSL is majorly affected.

**Changes**
- Detect `WT_SESSION` in `checkEnvironmentOverrides` and set both `rgb = true` and `ansi256 = true`, consistent with how we already enable hyperlinks and OSC52 for Windows Terminal.
- Add a test verifying that `WT_SESSION` enables truecolor support.
