### PR TITLE
core: close FFI callbacks with their library

### DIFF
--- a/packages/core/src/NativeSpanFeed.ts
+++ b/packages/core/src/NativeSpanFeed.ts
@@ -1,4 +1,5 @@
 import { toArrayBuffer, type Pointer } from "bun:ffi"
+import { toPointer as toPlatformPointer } from "./platform/ffi.js"
 import { resolveRenderLib } from "./zig.js"
 import { SpanInfoStruct } from "./zig-structs.js"
 import type { GrowthPolicy, NativeSpanFeedOptions, NativeSpanFeedStats } from "./zig-structs.js"
@@ -13,15 +14,8 @@ const enum EventId {
   StateBuffer = 8,
 }
 
-function toPointer(value: number | bigint): Pointer {
-  if (typeof value === "bigint") {
-    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
-      throw new Error("Pointer exceeds safe integer range")
-    }
-    return Number(value) as Pointer
-  }
-  return value as Pointer
-}
+// TODO: Remove this temporary shim once current Bun FFI call sites use the platform backend.
+const toPointer = toPlatformPointer as unknown as (value: number | bigint) => Pointer
 
 function toNumber(value: number | bigint): number {
   return typeof value === "bigint" ? Number(value) : value

--- a/packages/core/src/platform/ffi.test.ts
+++ b/packages/core/src/platform/ffi.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test"
+import { createBunBackend, toPointer, type FFICallbackInstance, type Pointer } from "./ffi.js"
+
+function createMockBackend() {
+  const events: string[] = []
+  const symbolDefinitions: unknown[] = []
+  const callbackDefinitions: unknown[] = []
+  const toArrayBufferPointers: number[] = []
+  const rawCallbacks: MockJSCallback[] = []
+  let nextPtr = 1
+
+  class MockJSCallback implements FFICallbackInstance {
+    ptr: Pointer | null
+    readonly threadsafe: boolean
+    closeCount = 0
+
+    constructor(_callback: (...args: any[]) => any, definition: { readonly threadsafe?: boolean }) {
+      this.ptr = nextPtr++ as Pointer
+      this.threadsafe = definition.threadsafe ?? false
+      callbackDefinitions.push(definition)
+      rawCallbacks.push(this)
+    }
+
+    close(): void {
+      if (this.closeCount > 0) {
+        return
+      }
+
+      this.closeCount++
+      events.push(`callback.close:${this.ptr}`)
+      this.ptr = null
+    }
+  }
+
+  const backend = createBunBackend({
+    JSCallback: MockJSCallback,
+    dlopen(_path, symbols) {
+      symbolDefinitions.push(symbols)
+
+      return {
+        symbols: Object.fromEntries(Object.keys(symbols).map((name) => [name, () => undefined])) as any,
+        close() {
+          events.push("library.close")
+        },
+      }
+    },
+    ptr() {
+      return 1 as Pointer
+    },
+    suffix: ".mock",
+    toArrayBuffer(pointer, _offset, length) {
+      toArrayBufferPointers.push(pointer)
+      return new ArrayBuffer(length)
+    },
+  })
+
+  return { backend, callbackDefinitions, events, rawCallbacks, symbolDefinitions, toArrayBufferPointers }
+}
+
+describe("platform/ffi", () => {
+  test("closes the native library before auto-closing managed callbacks", () => {
+    const { backend, events, rawCallbacks } = createMockBackend()
+    const library = backend.dlopen("mock", {})
+
+    const first = library.createCallback(() => undefined, { returns: "void" })
+    const second = library.createCallback(() => undefined, { returns: "void" })
+
+    expect(first.ptr).toBe(1 as Pointer)
+    expect(second.ptr).toBe(2 as Pointer)
+
+    library.close()
+
+    expect(events).toEqual(["library.close", "callback.close:1", "callback.close:2"])
+    expect(first.ptr).toBeNull()
+    expect(second.ptr).toBeNull()
+    expect(rawCallbacks.map((callback) => callback.closeCount)).toEqual([1, 1])
+
+    library.close()
+    first.close()
+
+    expect(events).toEqual(["library.close", "callback.close:1", "callback.close:2"])
+    expect(rawCallbacks.map((callback) => callback.closeCount)).toEqual([1, 1])
+  })
+
+  test("removes explicitly closed callbacks from library-owned cleanup", () => {
+    const { backend, events, rawCallbacks } = createMockBackend()
+    const library = backend.dlopen("mock", {})
+    const callback = library.createCallback(() => undefined, { returns: "void" })
+
+    callback.close()
+    callback.close()
+    library.close()
+
+    expect(callback.ptr).toBeNull()
+    expect(events).toEqual(["callback.close:1", "library.close"])
+    expect(rawCallbacks[0]?.closeCount).toBe(1)
+  })
+
+  test("throws when creating a callback after library close", () => {
+    const { backend } = createMockBackend()
+    const library = backend.dlopen("mock", {})
+
+    library.close()
+
+    expect(() => library.createCallback(() => undefined, { returns: "void" })).toThrow(
+      "Cannot create FFI callback after library.close() has been called.",
+    )
+  })
+
+  test("normalizes safe bigint pointers at the Bun backend boundary", () => {
+    const { backend, callbackDefinitions, symbolDefinitions, toArrayBufferPointers } = createMockBackend()
+
+    backend.dlopen("mock", { withPtr: { ptr: 12n as Pointer } })
+    expect((symbolDefinitions[0] as any).withPtr.ptr).toBe(12)
+
+    const library = backend.dlopen("mock", {})
+    library.createCallback(() => undefined, { ptr: 13n as Pointer, returns: "void" })
+    expect((callbackDefinitions[0] as any).ptr).toBe(13)
+
+    backend.toArrayBuffer(14n as Pointer, 0, 1)
+    expect(toArrayBufferPointers).toEqual([14])
+  })
+
+  test("rejects unsafe bigint pointer narrowing", () => {
+    const { backend } = createMockBackend()
+    const unsafePointer = (BigInt(Number.MAX_SAFE_INTEGER) + 1n) as Pointer
+    const negativePointer = -1n as Pointer
+
+    expect(toPointer(1n)).toBe(1 as Pointer)
+    expect(() => toPointer(BigInt(Number.MAX_SAFE_INTEGER) + 1n)).toThrow("Pointer exceeds safe integer range")
+    expect(() => toPointer(-1n)).toThrow("Pointer must be non-negative")
+    expect(() => backend.toArrayBuffer(unsafePointer, 0, 1)).toThrow("Pointer exceeds safe integer range")
+    expect(() => backend.dlopen("mock", { withPtr: { ptr: unsafePointer } })).toThrow(
+      "Pointer exceeds safe integer range",
+    )
+
+    const library = backend.dlopen("mock", {})
+    expect(() => library.createCallback(() => undefined, { ptr: negativePointer, returns: "void" })).toThrow(
+      "Pointer must be non-negative",
+    )
+  })
+})

--- a/packages/core/src/platform/ffi.ts
+++ b/packages/core/src/platform/ffi.ts
@@ -1,7 +1,19 @@
 declare const pointerBrand: unique symbol
 
+// This module owns OpenTUI's native FFI surface. Portable code imports this
+// file instead of bun:ffi, so backends can keep the same call sites.
+
+// Runtime pointers are numbers in Bun and bigints in Node's experimental FFI.
+// Keep both in the our own type, and narrow only inside a backend that requires
+// it.
 export type Pointer = (number | bigint) & { readonly [pointerBrand]: "Pointer" }
 
+// Bun accepts numeric pointers only. Keep this type private so Bun's pointer
+// model does not leak into the exported surface.
+type BunPointer = number
+
+// These names match the FFI type strings used today. Backends map them at
+// library load time instead of wrapping every native call.
 export const FFIType = {
   char: "char",
   int8_t: "int8_t",
@@ -41,6 +53,8 @@ export const FFIType = {
 export type FFIType = (typeof FFIType)[keyof typeof FFIType]
 export type FFITypeOrString = FFIType
 
+// A function definition describes one native symbol. `ptr` overrides the symbol
+// address and follows the same pointer safety rules as normal pointer values.
 export interface FFIFunction {
   readonly args?: readonly FFITypeOrString[]
   readonly returns?: FFITypeOrString
@@ -48,18 +62,30 @@ export interface FFIFunction {
   readonly threadsafe?: boolean
 }
 
+// A callback instance owns a native trampoline. `close()` invalidates `ptr`;
+// callers must not pass that pointer to native code after close.
 export interface FFICallbackInstance {
   readonly ptr: Pointer | null
   readonly threadsafe: boolean
   close(): void
 }
 
+// A loaded library owns callbacks created through `createCallback()`.
+//
+// Typical use:
+// const callback = library.createCallback(handler, { args: ["ptr"], returns: "void" })
+// library.symbols.setLogCallback(callback.ptr)
+//
+// `close()` first closes the native library, then closes any callbacks that
+// remain open.
 export interface Library<Fns extends Record<string, FFIFunction>> {
   symbols: { [K in keyof Fns]: (...args: any[]) => any }
   createCallback(callback: (...args: any[]) => any, definition: FFIFunction): FFICallbackInstance
   close(): void
 }
 
+// A backend normalizes runtime differences once. Do not wrap hot symbol calls
+// here unless a backend must adapt them.
 interface FfiBackend {
   dlopen<Fns extends Record<string, FFIFunction>>(path: string | URL, symbols: Fns): Library<Fns>
   ptr(value: ArrayBufferLike | ArrayBufferView): Pointer
@@ -67,25 +93,36 @@ interface FfiBackend {
   toArrayBuffer(pointer: Pointer, offset: number | undefined, length: number): ArrayBuffer
 }
 
-interface BunFfiLibrary<Fns extends Record<string, FFIFunction>> {
+interface BunFFIFunction {
+  readonly args?: readonly FFITypeOrString[]
+  readonly returns?: FFITypeOrString
+  readonly ptr?: BunPointer
+  readonly threadsafe?: boolean
+}
+
+interface BunFfiLibrary<Fns extends Record<string, BunFFIFunction>> {
   symbols: { [K in keyof Fns]: (...args: any[]) => any }
   close(): void
 }
 
 interface BunFfiBackend {
-  JSCallback: new (callback: (...args: any[]) => any, definition: FFIFunction) => FFICallbackInstance
-  dlopen<Fns extends Record<string, FFIFunction>>(path: string | URL, symbols: Fns): BunFfiLibrary<Fns>
+  JSCallback: new (callback: (...args: any[]) => any, definition: BunFFIFunction) => FFICallbackInstance
+  dlopen<Fns extends Record<string, BunFFIFunction>>(path: string | URL, symbols: Fns): BunFfiLibrary<Fns>
   ptr(value: ArrayBufferLike | ArrayBufferView): Pointer
   suffix: string
-  toArrayBuffer(pointer: Pointer, offset: number | undefined, length: number): ArrayBuffer
+  toArrayBuffer(pointer: BunPointer, offset: number | undefined, length: number): ArrayBuffer
 }
 
 const FFI_UNAVAILABLE = "OpenTUI native FFI is not available for this runtime yet."
+const LIBRARY_CLOSED = "Cannot create FFI callback after library.close() has been called."
+const POINTER_NEGATIVE = "Pointer must be non-negative"
+const POINTER_UNSAFE = "Pointer exceeds safe integer range"
 
 function unavailable(): never {
   throw new Error(FFI_UNAVAILABLE)
 }
 
+// The placeholder backend lets non-Bun runtimes load without errors.
 const unsupportedBackend: FfiBackend = {
   dlopen() {
     return unavailable()
@@ -104,30 +141,155 @@ const isBun =
   typeof process.versions === "object" &&
   process.versions !== null &&
   typeof process.versions.bun === "string"
+
+// Keep the Bun module import behind the runtime check so Node does not resolve
+// bun:ffi during import.
 const backend = isBun ? createBunBackend(await importModule<BunFfiBackend>("bun:ffi")) : unsupportedBackend
 
 function importModule<T>(specifier: string): Promise<T> {
   return import(specifier) as Promise<T>
 }
 
-function createBunBackend(bun: BunFfiBackend): FfiBackend {
+// Convert pointer values for current Bun-backed call sites that still store
+// numeric pointers.
+//
+// TODO: Remove this temporary shim once current Bun FFI call sites use the
+// platform backend. Do not use this helper to force future Node pointers into
+// numbers.
+export function toPointer(value: number | bigint): Pointer {
+  if (typeof value === "bigint") {
+    return toSafeNumberPointer(value) as Pointer
+  }
+
+  return value as Pointer
+}
+
+// Convert a bigint pointer to a number only when JavaScript can represent it
+// exactly. A rounded pointer would target the wrong address.
+function toSafeNumberPointer(pointer: bigint): number {
+  if (pointer < 0n) {
+    throw new Error(POINTER_NEGATIVE)
+  }
+
+  if (pointer > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(POINTER_UNSAFE)
+  }
+
+  return Number(pointer)
+}
+
+// Wrap a backend callback so the loaded library can close it later. The wrapper
+// keeps `ptr` live until close, then clears it so callers cannot reuse a stale
+// trampoline pointer.
+function createManagedCallback(raw: FFICallbackInstance, callbacks: Set<FFICallbackInstance>): FFICallbackInstance {
+  let ptr = raw.ptr
+  let closed = false
+
+  const instance: FFICallbackInstance = {
+    get ptr() {
+      return ptr
+    },
+    get threadsafe() {
+      return raw.threadsafe
+    },
+    close() {
+      if (closed) {
+        return
+      }
+
+      closed = true
+      callbacks.delete(instance)
+      try {
+        raw.close()
+      } finally {
+        // Clear the pointer even if the backend close throws. The trampoline is
+        // no longer safe to use.
+        ptr = null
+      }
+    },
+  }
+
+  callbacks.add(instance)
+
+  return instance
+}
+
+function normalizeBunDefinitions<Fns extends Record<string, FFIFunction>>(
+  definitions: Fns,
+): { [K in keyof Fns]: BunFFIFunction } {
+  // Normalize all Bun definitions before `dlopen()`. Bun rejects bigint pointer
+  // overrides, so convert them once before loading the native library.
+  return Object.fromEntries(
+    Object.entries(definitions).map(([name, definition]) => [name, normalizeBunDefinition(definition)]),
+  ) as { [K in keyof Fns]: BunFFIFunction }
+}
+
+function normalizeBunDefinition(definition: FFIFunction): BunFFIFunction {
+  return {
+    args: definition.args,
+    returns: definition.returns,
+    ptr: definition.ptr == null ? undefined : toBunPointer(definition.ptr),
+    threadsafe: definition.threadsafe,
+  }
+}
+
+// Convert Pointer pointers to Bun pointers at the Bun boundary only.
+function toBunPointer(pointer: Pointer): BunPointer {
+  return typeof pointer === "bigint" ? toSafeNumberPointer(pointer) : pointer
+}
+
+// Create a Bun backend from bun:ffi.
+export function createBunBackend(bun: BunFfiBackend): FfiBackend {
   return {
     dlopen(path, symbols) {
-      const library = bun.dlopen(path, symbols)
+      const library = bun.dlopen(path, normalizeBunDefinitions(symbols))
+      const callbacks = new Set<FFICallbackInstance>()
+      let closed = false
 
       return {
         symbols: library.symbols,
         createCallback(callback, definition) {
-          return new bun.JSCallback(callback, definition)
+          if (closed) {
+            // A closed library no longer owns native state. New callbacks would
+            // have no cleanup path.
+            throw new Error(LIBRARY_CLOSED)
+          }
+
+          // Bun callbacks are standalone objects. OpenTUI treats them as
+          // library-owned to match the future Node FFI shape and to avoid
+          // leaked trampolines.
+          const raw = new bun.JSCallback(callback, normalizeBunDefinition(definition))
+
+          return createManagedCallback(raw, callbacks)
         },
         close() {
-          library.close()
+          if (closed) {
+            return
+          }
+
+          closed = true
+
+          try {
+            // Close native state while callbacks still point to live
+            // trampolines. Native teardown may call back during final cleanup.
+            library.close()
+          } finally {
+            // After native teardown, close any JS trampolines the caller did
+            // not close explicitly.
+            for (const callback of [...callbacks]) {
+              callback.close()
+            }
+          }
         },
       }
     },
     ptr: bun.ptr,
     suffix: bun.suffix,
-    toArrayBuffer: bun.toArrayBuffer,
+    toArrayBuffer(pointer, offset, length) {
+      // Bun only accepts numeric pointers here. Keep the coercion at this
+      // backend boundary.
+      return bun.toArrayBuffer(toBunPointer(pointer), offset, length)
+    },
   }
 }
 

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -43,6 +43,7 @@ import type {
   AllocatorStats,
 } from "./zig-structs.js"
 import { isBunfsPath } from "./lib/bunfs.js"
+import { toPointer as toPlatformPointer } from "./platform/ffi.js"
 
 const module = await import(`@opentui/core-${process.platform}-${process.arch}/index.ts`)
 let targetLibPath = module.default
@@ -104,16 +105,8 @@ const MOUSE_STYLE_TO_ID = { default: 0, pointer: 1, text: 2, crosshair: 3, move:
 let globalTraceSymbols: Record<string, number[]> | null = null
 let globalFFILogPath: string | null = null
 let exitHandlerRegistered = false
-
-function toPointer(value: number | bigint): Pointer {
-  if (typeof value === "bigint") {
-    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
-      throw new Error("Pointer exceeds safe integer range")
-    }
-    return Number(value) as Pointer
-  }
-  return value as Pointer
-}
+// TODO: Remove this temporary shim once current Bun FFI call sites use the platform backend.
+const toPointer = toPlatformPointer as unknown as (value: number | bigint) => Pointer
 
 function toNumber(value: number | bigint): number {
   return typeof value === "bigint" ? Number(value) : value


### PR DESCRIPTION
Callbacks created via Library.createCallback held native bridges
that outlived the library returned by dlopen. Callers had to close
each callback before closing the library or leak the underlying
JSCallback. Track callbacks per library so library.close closes
any still open, and make callback.close idempotent so explicit and
automatic cleanup compose safely.

Also normalize bigint Pointers to numbers before forwarding them to
Bun-specific APIs (dlopen symbol ptr overrides, JSCallback
definitions, and toArrayBuffer), which reject bigint values.
