### PR TITLE
core: add node:ffi backend

### DIFF
--- a/packages/core/src/platform/ffi.test.ts
+++ b/packages/core/src/platform/ffi.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, test } from "bun:test"
-import { createBunBackend, toPointer, type FFICallbackInstance, type Pointer } from "./ffi.js"
+import { join } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import {
+  BUN_DLOPEN_NULL,
+  FFIType,
+  LIBRARY_CLOSED,
+  NODE_CALLBACK_THREADSAFE,
+  NODE_NAPI_UNSUPPORTED,
+  NODE_POINTER_OVERRIDE,
+  NODE_PTR_VALUE,
+  NODE_STRING_RETURN,
+  NODE_USIZE_UNSUPPORTED,
+  POINTER_NEGATIVE,
+  POINTER_UNSAFE,
+  createBunBackend,
+  createNodeBackend,
+  toPointer,
+  type FFICallbackInstance,
+  type Pointer,
+} from "./ffi.js"
 
 function createMockBackend() {
   const events: string[] = []
@@ -57,6 +76,79 @@ function createMockBackend() {
   return { backend, callbackDefinitions, events, rawCallbacks, symbolDefinitions, toArrayBufferPointers }
 }
 
+interface MockNodeBackendOptions {
+  closeError?: Error
+}
+
+function createMockNodeBackend(options: MockNodeBackendOptions = {}) {
+  const events: string[] = []
+  const paths: Array<string | null> = []
+  const symbolDefinitions: unknown[] = []
+  const callbackDefinitions: unknown[] = []
+  const toArrayBufferCalls: Array<{ pointer: bigint; length: number; copy: boolean | undefined }> = []
+  const rawPointers = new WeakMap<ArrayBuffer, bigint>()
+  let nextCallbackPtr = 9000n
+  let nextRawPointer = 1000n
+
+  const backend = createNodeBackend({
+    dlopen(
+      path: string | null,
+      symbols: Record<string, { readonly parameters: readonly string[]; readonly result: string }>,
+    ) {
+      paths.push(path)
+      symbolDefinitions.push(symbols)
+
+      return {
+        lib: {
+          close() {
+            events.push("library.close")
+            if (options.closeError) {
+              throw options.closeError
+            }
+          },
+          registerCallback(
+            signature: { readonly parameters: readonly string[]; readonly result: string },
+            _callback: (...args: any[]) => any,
+          ) {
+            const pointer = nextCallbackPtr++
+            events.push(`callback.register:${pointer}`)
+            callbackDefinitions.push(signature)
+            return pointer
+          },
+          unregisterCallback(pointer: bigint) {
+            events.push(`callback.unregister:${pointer}`)
+          },
+        },
+        functions: Object.fromEntries(Object.keys(symbols).map((name) => [name, () => undefined])),
+      }
+    },
+    getRawPointer(source: ArrayBuffer) {
+      let pointer = rawPointers.get(source)
+      if (pointer == null) {
+        pointer = nextRawPointer
+        nextRawPointer += 100n
+        rawPointers.set(source, pointer)
+      }
+
+      return pointer
+    },
+    suffix: "mock",
+    toArrayBuffer(pointer: bigint, length: number, copy?: boolean) {
+      toArrayBufferCalls.push({ pointer, length, copy })
+      return new ArrayBuffer(length)
+    },
+  })
+
+  return {
+    backend,
+    callbackDefinitions,
+    events,
+    paths,
+    symbolDefinitions,
+    toArrayBufferCalls,
+  }
+}
+
 describe("platform/ffi", () => {
   test("closes the native library before auto-closing managed callbacks", () => {
     const { backend, events, rawCallbacks } = createMockBackend()
@@ -102,9 +194,7 @@ describe("platform/ffi", () => {
 
     library.close()
 
-    expect(() => library.createCallback(() => undefined, { returns: "void" })).toThrow(
-      "Cannot create FFI callback after library.close() has been called.",
-    )
+    expect(() => library.createCallback(() => undefined, { returns: "void" })).toThrow(LIBRARY_CLOSED)
   })
 
   test("normalizes safe bigint pointers at the Bun backend boundary", () => {
@@ -127,16 +217,229 @@ describe("platform/ffi", () => {
     const negativePointer = -1n as Pointer
 
     expect(toPointer(1n)).toBe(1 as Pointer)
-    expect(() => toPointer(BigInt(Number.MAX_SAFE_INTEGER) + 1n)).toThrow("Pointer exceeds safe integer range")
-    expect(() => toPointer(-1n)).toThrow("Pointer must be non-negative")
-    expect(() => backend.toArrayBuffer(unsafePointer, 0, 1)).toThrow("Pointer exceeds safe integer range")
-    expect(() => backend.dlopen("mock", { withPtr: { ptr: unsafePointer } })).toThrow(
-      "Pointer exceeds safe integer range",
-    )
+    expect(() => toPointer(BigInt(Number.MAX_SAFE_INTEGER) + 1n)).toThrow(POINTER_UNSAFE)
+    expect(() => toPointer(-1n)).toThrow(POINTER_NEGATIVE)
+    expect(() => backend.toArrayBuffer(unsafePointer, 0, 1)).toThrow(POINTER_UNSAFE)
+    expect(() => backend.dlopen("mock", { withPtr: { ptr: unsafePointer } })).toThrow(POINTER_UNSAFE)
 
     const library = backend.dlopen("mock", {})
     expect(() => library.createCallback(() => undefined, { ptr: negativePointer, returns: "void" })).toThrow(
-      "Pointer must be non-negative",
+      POINTER_NEGATIVE,
+    )
+  })
+
+  test("converts file: URLs to filesystem paths at Node dlopen", () => {
+    const { backend, paths } = createMockNodeBackend()
+    const filePath = join(process.cwd(), "libopentui.mock")
+    const fileUrl = pathToFileURL(filePath)
+
+    backend.dlopen(fileUrl, {})
+    backend.dlopen("/usr/lib/libfoo.so", {})
+
+    expect(paths).toEqual([fileURLToPath(fileUrl), "/usr/lib/libfoo.so"])
+  })
+
+  test("normalizes Node integer, char, bool, and void FFIType aliases", () => {
+    const { backend, symbolDefinitions } = createMockNodeBackend()
+
+    backend.dlopen("mock", {
+      primitives: {
+        args: [
+          FFIType.char,
+          FFIType.int8_t,
+          FFIType.i8,
+          FFIType.uint8_t,
+          FFIType.u8,
+          FFIType.int16_t,
+          FFIType.i16,
+          FFIType.uint16_t,
+          FFIType.u16,
+          FFIType.int32_t,
+          FFIType.int,
+          FFIType.i32,
+          FFIType.uint32_t,
+          FFIType.u32,
+          FFIType.int64_t,
+          FFIType.i64,
+          FFIType.uint64_t,
+          FFIType.u64,
+          FFIType.bool,
+        ],
+        returns: FFIType.void,
+      },
+    })
+
+    expect(symbolDefinitions).toEqual([
+      {
+        primitives: {
+          parameters: [
+            "char",
+            "i8",
+            "i8",
+            "u8",
+            "u8",
+            "i16",
+            "i16",
+            "u16",
+            "u16",
+            "i32",
+            "i32",
+            "i32",
+            "u32",
+            "u32",
+            "i64",
+            "i64",
+            "u64",
+            "u64",
+            "bool",
+          ],
+          result: "void",
+        },
+      },
+    ])
+  })
+
+  test("normalizes Node float FFIType aliases", () => {
+    const { backend, symbolDefinitions } = createMockNodeBackend()
+
+    backend.dlopen("mock", {
+      floats: {
+        args: [FFIType.float, FFIType.f32, FFIType.double, FFIType.f64],
+        returns: FFIType.void,
+      },
+    })
+
+    expect(symbolDefinitions).toEqual([
+      {
+        floats: {
+          parameters: ["f32", "f32", "f64", "f64"],
+          result: "void",
+        },
+      },
+    ])
+  })
+
+  test("normalizes Node pointer-like FFIType aliases", () => {
+    const { backend, symbolDefinitions } = createMockNodeBackend()
+    const library = backend.dlopen("mock", {
+      pointers: {
+        args: [FFIType.ptr, FFIType.pointer, FFIType.function, FFIType.callback, FFIType.buffer, FFIType.cstring],
+        returns: FFIType.void,
+      },
+    })
+
+    expect(typeof library.symbols.pointers).toBe("function")
+    expect(symbolDefinitions).toEqual([
+      {
+        pointers: {
+          parameters: ["pointer", "pointer", "pointer", "pointer", "buffer", "string"],
+          result: "void",
+        },
+      },
+    ])
+  })
+
+  test("uses Node pointer and toArrayBuffer memory semantics", () => {
+    const { backend, toArrayBufferCalls } = createMockNodeBackend()
+    const buffer = new ArrayBuffer(16)
+    const view = new Uint8Array(buffer, 4, 8)
+    const otherBuffer = new ArrayBuffer(16)
+
+    expect(backend.ptr(buffer)).toBe(1000n as Pointer)
+    expect(backend.ptr(view)).toBe(1004n as Pointer)
+    expect(backend.ptr(buffer)).toBe(1000n as Pointer)
+    expect(backend.ptr(otherBuffer)).toBe(1100n as Pointer)
+    expect(() => backend.ptr({} as ArrayBuffer)).toThrow(NODE_PTR_VALUE)
+
+    backend.toArrayBuffer(2000n as Pointer, 8, 32)
+    backend.toArrayBuffer(3000n as Pointer, undefined, 16)
+
+    expect(toArrayBufferCalls).toEqual([
+      { pointer: 2008n, length: 32, copy: false },
+      { pointer: 3000n, length: 16, copy: false },
+    ])
+  })
+
+  test("passes dlopen(null) to Node and rejects it in Bun", () => {
+    const bun = createMockBackend()
+    const node = createMockNodeBackend()
+
+    node.backend.dlopen(null, {})
+    expect(node.paths).toEqual([null])
+
+    expect(() => bun.backend.dlopen(null, {})).toThrow(BUN_DLOPEN_NULL)
+  })
+
+  test("manages Node callbacks through the loaded library", () => {
+    const { backend, callbackDefinitions, events } = createMockNodeBackend()
+    const library = backend.dlopen("mock", {})
+    const callback = library.createCallback(() => undefined, { args: [FFIType.i32], returns: FFIType.i32 })
+
+    expect(callback.ptr).toBe(9000n as Pointer)
+    expect(callback.threadsafe).toBe(false)
+    expect(callbackDefinitions).toEqual([{ parameters: ["i32"], result: "i32" }])
+
+    callback.close()
+    callback.close()
+    library.close()
+
+    expect(callback.ptr).toBeNull()
+    expect(events).toEqual(["callback.register:9000", "callback.unregister:9000", "library.close"])
+  })
+
+  test("marks Node callbacks closed after library close without unregistering an already closed library", () => {
+    const { backend, events } = createMockNodeBackend()
+    const library = backend.dlopen("mock", {})
+    const callback = library.createCallback(() => undefined, { returns: FFIType.void })
+
+    library.close()
+    library.close()
+    callback.close()
+
+    expect(callback.ptr).toBeNull()
+    expect(() => library.createCallback(() => undefined, { returns: FFIType.void })).toThrow(LIBRARY_CLOSED)
+    expect(events).toEqual(["callback.register:9000", "library.close"])
+  })
+
+  test("does not unregister Node callbacks after a throwing library close starts", () => {
+    const closeError = new Error("close failed")
+    const { backend, events } = createMockNodeBackend({ closeError })
+    const library = backend.dlopen("mock", {})
+    const callback = library.createCallback(() => undefined, { returns: FFIType.void })
+
+    expect(() => library.close()).toThrow(closeError)
+
+    expect(callback.ptr).toBeNull()
+    expect(events).toEqual(["callback.register:9000", "library.close"])
+  })
+
+  test("rejects Node-only unsupported callback and symbol definitions", () => {
+    const { backend } = createMockNodeBackend()
+
+    expect(() => backend.dlopen("mock", { withPtr: { ptr: 1n as Pointer, returns: FFIType.void } })).toThrow(
+      NODE_POINTER_OVERRIDE,
+    )
+
+    expect(() => backend.dlopen("mock", { withUsize: { args: [FFIType.usize], returns: FFIType.void } })).toThrow(
+      NODE_USIZE_UNSUPPORTED,
+    )
+    expect(() => backend.dlopen("mock", { withNapi: { args: [FFIType.napi_env], returns: FFIType.void } })).toThrow(
+      NODE_NAPI_UNSUPPORTED,
+    )
+    expect(() => backend.dlopen("mock", { returnsNapi: { returns: FFIType.napi_value } })).toThrow(
+      NODE_NAPI_UNSUPPORTED,
+    )
+    expect(() => backend.dlopen("mock", { returnsString: { returns: FFIType.cstring } })).toThrow(NODE_STRING_RETURN)
+    expect(() => backend.dlopen("mock", { invalid: { args: ["bad" as FFIType], returns: FFIType.void } })).toThrow(
+      "Unsupported FFIType for node:ffi: bad",
+    )
+
+    const library = backend.dlopen("mock", {})
+    expect(() => library.createCallback(() => undefined, { returns: FFIType.void, threadsafe: true })).toThrow(
+      NODE_CALLBACK_THREADSAFE,
+    )
+    expect(() => library.createCallback(() => undefined, { ptr: 1n as Pointer, returns: FFIType.void })).toThrow(
+      NODE_POINTER_OVERRIDE,
     )
   })
 })

--- a/packages/core/src/platform/ffi.ts
+++ b/packages/core/src/platform/ffi.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url"
+
 declare const pointerBrand: unique symbol
 
 // This module owns OpenTUI's native FFI surface. Portable code imports this
@@ -8,12 +10,14 @@ declare const pointerBrand: unique symbol
 // it.
 export type Pointer = (number | bigint) & { readonly [pointerBrand]: "Pointer" }
 
+type PointerSource = ArrayBuffer | (ArrayBufferView & { buffer: ArrayBuffer })
+
 // Bun accepts numeric pointers only. Keep this type private so Bun's pointer
 // model does not leak into the exported surface.
 type BunPointer = number
 
-// These names match the FFI type strings used today. Backends map them at
-// library load time instead of wrapping every native call.
+// These names match the Bun FFI type strings OpenTUI uses today. Other
+// backends map them at library load time instead of wrapping every native call.
 export const FFIType = {
   char: "char",
   int8_t: "int8_t",
@@ -51,6 +55,7 @@ export const FFIType = {
 } as const
 
 export type FFIType = (typeof FFIType)[keyof typeof FFIType]
+// Kept as a source-shape compatibility alias for Bun-style call sites.
 export type FFITypeOrString = FFIType
 
 // A function definition describes one native symbol. `ptr` overrides the symbol
@@ -88,7 +93,7 @@ export interface Library<Fns extends Record<string, FFIFunction>> {
 // here unless a backend must adapt them.
 interface FfiBackend {
   dlopen<Fns extends Record<string, FFIFunction>>(path: string | URL, symbols: Fns): Library<Fns>
-  ptr(value: ArrayBufferLike | ArrayBufferView): Pointer
+  ptr(value: PointerSource): Pointer
   suffix: string
   toArrayBuffer(pointer: Pointer, offset: number | undefined, length: number): ArrayBuffer
 }
@@ -108,32 +113,66 @@ interface BunFfiLibrary<Fns extends Record<string, BunFFIFunction>> {
 interface BunFfiBackend {
   JSCallback: new (callback: (...args: any[]) => any, definition: BunFFIFunction) => FFICallbackInstance
   dlopen<Fns extends Record<string, BunFFIFunction>>(path: string | URL, symbols: Fns): BunFfiLibrary<Fns>
-  ptr(value: ArrayBufferLike | ArrayBufferView): Pointer
+  ptr(value: PointerSource): Pointer
   suffix: string
   toArrayBuffer(pointer: BunPointer, offset: number | undefined, length: number): ArrayBuffer
 }
 
-const FFI_UNAVAILABLE = "OpenTUI native FFI is not available for this runtime yet."
-const LIBRARY_CLOSED = "Cannot create FFI callback after library.close() has been called."
-const POINTER_NEGATIVE = "Pointer must be non-negative"
-const POINTER_UNSAFE = "Pointer exceeds safe integer range"
+interface NodeFFIFunction {
+  readonly parameters: readonly string[]
+  readonly result: string
+}
 
-function unavailable(): never {
-  throw new Error(FFI_UNAVAILABLE)
+interface NodeDynamicLibrary {
+  close(): void
+  registerCallback(signature: NodeFFIFunction, callback: (...args: any[]) => any): bigint
+  unregisterCallback(pointer: bigint): void
+}
+
+interface NodeFfiLibrary {
+  readonly lib: NodeDynamicLibrary
+  readonly functions: Record<string, (...args: any[]) => any>
+}
+
+interface NodeFfiBackend {
+  dlopen(path: string | null, symbols: Record<string, NodeFFIFunction>): NodeFfiLibrary
+  getRawPointer(source: ArrayBuffer): bigint
+  suffix: string
+  toArrayBuffer(pointer: bigint, length: number, copy?: boolean): ArrayBuffer
+}
+
+export const FFI_UNAVAILABLE = "OpenTUI native FFI is not available for this runtime yet"
+export const BUN_DLOPEN_NULL = "Bun FFI backend does not support dlopen(null)"
+export const LIBRARY_CLOSED = "Cannot create FFI callback after library.close() has been called"
+export const NODE_CALLBACK_THREADSAFE =
+  "Node FFI callbacks are same-thread only and do not support threadsafe callbacks"
+export const NODE_NAPI_UNSUPPORTED = "Node FFI backend does not support Bun N-API FFI types"
+export const NODE_POINTER_OVERRIDE = "Node FFI backend does not support FFIFunction.ptr overrides"
+export const NODE_PTR_VALUE =
+  "node:ffi ptr() only supports ArrayBuffer and ArrayBufferView values backed by ArrayBuffer"
+export const NODE_STRING_RETURN = "Node FFI backend does not normalize string return values (yet)"
+export const NODE_USIZE_UNSUPPORTED = "Node FFI backend does not support usize until (yet)"
+export const POINTER_NEGATIVE = "Pointer must be non-negative"
+export const POINTER_UNSAFE = "Pointer exceeds safe integer range"
+
+function unavailable(cause?: unknown): never {
+  throw new Error(FFI_UNAVAILABLE, { cause })
 }
 
 // The placeholder backend lets non-Bun runtimes load without errors.
-const unsupportedBackend: FfiBackend = {
-  dlopen() {
-    return unavailable()
-  },
-  ptr() {
-    return unavailable()
-  },
-  suffix: "",
-  toArrayBuffer() {
-    return unavailable()
-  },
+function createUnsupportedBackend(cause?: unknown): FfiBackend {
+  return {
+    dlopen() {
+      return unavailable(cause)
+    },
+    ptr() {
+      return unavailable(cause)
+    },
+    suffix: "",
+    toArrayBuffer() {
+      return unavailable(cause)
+    },
+  }
 }
 
 const isBun =
@@ -142,12 +181,25 @@ const isBun =
   process.versions !== null &&
   typeof process.versions.bun === "string"
 
-// Keep the Bun module import behind the runtime check so Node does not resolve
-// bun:ffi during import.
-const backend = isBun ? createBunBackend(await importModule<BunFfiBackend>("bun:ffi")) : unsupportedBackend
+const backend = await loadBackend()
 
 function importModule<T>(specifier: string): Promise<T> {
   return import(specifier) as Promise<T>
+}
+
+async function loadBackend(): Promise<FfiBackend> {
+  // Keep the Bun module import behind the runtime check so Node does not
+  // resolve bun:ffi during import.
+  if (isBun) {
+    return createBunBackend(await importModule<BunFfiBackend>("bun:ffi"))
+  }
+
+  try {
+    const nodeFfi = await importModule<NodeFfiBackend & { default?: NodeFfiBackend }>("node:ffi")
+    return createNodeBackend(nodeFfi.default ?? nodeFfi)
+  } catch (error) {
+    return createUnsupportedBackend(error)
+  }
 }
 
 // Convert pointer values for current Bun-backed call sites that still store
@@ -242,6 +294,10 @@ function toBunPointer(pointer: Pointer): BunPointer {
 export function createBunBackend(bun: BunFfiBackend): FfiBackend {
   return {
     dlopen(path, symbols) {
+      if (path === null) {
+        throw new Error(BUN_DLOPEN_NULL)
+      }
+
       const library = bun.dlopen(path, normalizeBunDefinitions(symbols))
       const callbacks = new Set<FFICallbackInstance>()
       let closed = false
@@ -291,6 +347,190 @@ export function createBunBackend(bun: BunFfiBackend): FfiBackend {
       return bun.toArrayBuffer(toBunPointer(pointer), offset, length)
     },
   }
+}
+
+// Create a Node backend from node:ffi.
+export function createNodeBackend(nodeFfi: NodeFfiBackend): FfiBackend {
+  return {
+    dlopen(path, symbols) {
+      const { lib, functions } = nodeFfi.dlopen(toNodeLibraryPath(path), normalizeNodeDefinitions(symbols))
+      const callbacks = new Set<FFICallbackInstance>()
+      let closed = false
+      let libraryClosed = false
+
+      return {
+        symbols: functions as { [K in keyof typeof symbols]: (...args: any[]) => any },
+        createCallback(callback, definition) {
+          if (closed) {
+            throw new Error(LIBRARY_CLOSED)
+          }
+
+          if (definition.threadsafe) {
+            throw new Error(NODE_CALLBACK_THREADSAFE)
+          }
+
+          const callbackPointer = lib.registerCallback(normalizeNodeDefinition(definition), callback)
+          const raw: FFICallbackInstance = {
+            ptr: callbackPointer as Pointer,
+            threadsafe: false,
+            close() {
+              if (!libraryClosed) {
+                lib.unregisterCallback(callbackPointer)
+              }
+            },
+          }
+
+          return createManagedCallback(raw, callbacks)
+        },
+        close() {
+          if (closed) {
+            return
+          }
+
+          closed = true
+
+          try {
+            libraryClosed = true
+            lib.close()
+          } finally {
+            for (const callback of [...callbacks]) {
+              callback.close()
+            }
+          }
+        },
+      }
+    },
+    ptr(value) {
+      if (ArrayBuffer.isView(value)) {
+        if (!(value.buffer instanceof ArrayBuffer)) {
+          throw new TypeError(NODE_PTR_VALUE)
+        }
+
+        return (nodeFfi.getRawPointer(value.buffer) + BigInt(value.byteOffset)) as Pointer
+      }
+
+      if (value instanceof ArrayBuffer) {
+        return nodeFfi.getRawPointer(value) as Pointer
+      }
+
+      throw new TypeError(NODE_PTR_VALUE)
+    },
+    suffix: nodeFfi.suffix,
+    toArrayBuffer(pointer, offset, length) {
+      return nodeFfi.toArrayBuffer(toBigIntPointer(pointer) + BigInt(offset ?? 0), length, false)
+    },
+  }
+}
+
+function toNodeLibraryPath(path: string | URL | null): string | null {
+  return path instanceof URL ? fileURLToPath(path) : path
+}
+
+function normalizeNodeDefinitions<Fns extends Record<string, FFIFunction>>(
+  definitions: Fns,
+): Record<string, NodeFFIFunction> {
+  return Object.fromEntries(
+    Object.entries(definitions).map(([name, definition]) => [name, normalizeNodeDefinition(definition)]),
+  )
+}
+
+function normalizeNodeDefinition(definition: FFIFunction): NodeFFIFunction {
+  if (definition.ptr != null) {
+    throw new Error(NODE_POINTER_OVERRIDE)
+  }
+
+  return {
+    parameters: (definition.args ?? []).map((type) => toNodeFFIType(type, "parameter")),
+    result: toNodeFFIType(definition.returns ?? FFIType.void, "result"),
+  }
+}
+
+function toNodeFFIType(type: FFITypeOrString, position: "parameter" | "result"): string {
+  switch (type) {
+    case FFIType.char:
+      return "char"
+    case FFIType.int8_t:
+    case FFIType.i8:
+      return "i8"
+    case FFIType.uint8_t:
+    case FFIType.u8:
+      return "u8"
+    case FFIType.int16_t:
+    case FFIType.i16:
+      return "i16"
+    case FFIType.uint16_t:
+    case FFIType.u16:
+      return "u16"
+    case FFIType.int32_t:
+    case FFIType.int:
+    case FFIType.i32:
+      return "i32"
+    case FFIType.uint32_t:
+    case FFIType.u32:
+      return "u32"
+    case FFIType.int64_t:
+    case FFIType.i64:
+      return "i64"
+    case FFIType.uint64_t:
+    case FFIType.u64:
+      return "u64"
+    case FFIType.double:
+    case FFIType.f64:
+      return "f64"
+    case FFIType.float:
+    case FFIType.f32:
+      return "f32"
+    case FFIType.bool:
+      return "bool"
+    case FFIType.ptr:
+    case FFIType.pointer:
+      return "pointer"
+    case FFIType.void:
+      return "void"
+    case FFIType.cstring:
+      // TODO(audit): cstring vs string semantics differ between backends.
+      //
+      // The type-name mapping here is intentional, but the runtime marshalling
+      // is not equivalent:
+      //   - Bun's `cstring` parameter rejects raw JavaScript strings; callers
+      //     must pass a TypedArray, a Pointer, or a CString.
+      //   - Node's `string` parameter copies a JavaScript string to a
+      //     temporary NUL-terminated UTF-8 buffer for the duration of the
+      //     call.
+      //
+      // Callsites should encode strings into byte buffers and pass pointers
+      // instead of relying on either backend's string handling.
+      if (position === "result") {
+        throw new Error(NODE_STRING_RETURN)
+      }
+
+      return "string"
+    case FFIType.function:
+    case FFIType.callback:
+      // Pointer-like types (pointer, string, buffer, arraybuffer, and function)
+      // are all passed as pointers in node:ffi.
+      return "pointer"
+    case FFIType.usize:
+      // `usize` needs an ABI audit before Node support; use u64 would require
+      // BigInt call sites and u32 can truncate pointers.
+      throw new Error(NODE_USIZE_UNSUPPORTED)
+    case FFIType.napi_env:
+    case FFIType.napi_value:
+      // Bun's N-API bridge types are not equivalent to raw Node FFI pointers.
+      throw new Error(NODE_NAPI_UNSUPPORTED)
+    case FFIType.buffer:
+      return "buffer"
+    default:
+      return unsupportedNodeFFIType(type)
+  }
+}
+
+function unsupportedNodeFFIType(type: never): never {
+  throw new Error(`Unsupported FFIType for node:ffi: ${String(type)}`)
+}
+
+function toBigIntPointer(pointer: Pointer): bigint {
+  return typeof pointer === "bigint" ? pointer : BigInt(pointer)
 }
 
 export const dlopen = backend.dlopen


### PR DESCRIPTION
Add a node:ffi backend that maps Bun's FFIType aliases to node:ffi parameter
strings and adapts Bun's numeric pointer model to BigInt arithmetic

I added this now mostly to improve the facade a little before starting
to use it for Bun.
