### PR TITLE
core: guard palette publish after destroy

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -4031,7 +4031,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this._paletteDetector = createTerminalPalette(
         this.stdin,
         this.stdout,
-        this.writeOut.bind(this),
+        (data) => (this._isDestroyed ? false : this.writeOut(data)),
         isLegacyTmux,
         {
           subscribeOsc: this.subscribeOsc.bind(this),

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -3489,6 +3489,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     if (this._isDestroyed) return
     this._isDestroyed = true
     this._destroyPending = true
+    this._palettePublishGeneration++
 
     if (this.rendering) {
       // Restore terminal/input state immediately, but defer full native teardown until the frame unwinds.
@@ -3587,7 +3588,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this._cachedPalette = null
     this._publishedPaletteSignature = null
     this._paletteEpoch = 0
-    this._palettePublishGeneration = 0
 
     this.themeModeState.dispose()
 
@@ -4067,9 +4067,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     void this.getPalette({ size: NATIVE_PALETTE_QUERY_SIZE })
       .then((colors) => {
+        if (this._isDestroyed) return
         if (this._palettePublishGeneration === publishGeneration) {
           this.syncNativePaletteState(colors)
         }
+        if (this._isDestroyed) return
         this.requestRender()
       })
       .catch(() => {})
@@ -4139,7 +4141,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
         this._paletteDetectionPromise = null
         this._paletteDetectionSize = 0
 
-        if (this._palettePublishGeneration === publishGeneration) {
+        if (!this._isDestroyed && this._palettePublishGeneration === publishGeneration) {
           if (result.palette.length >= NATIVE_PALETTE_QUERY_SIZE) {
             this.syncNativePaletteState(result)
           } else if (this._terminalIsSetup && !this._paletteCache.has(NATIVE_PALETTE_QUERY_SIZE)) {

--- a/packages/core/src/tests/renderer.palette.test.ts
+++ b/packages/core/src/tests/renderer.palette.test.ts
@@ -583,6 +583,22 @@ describe("Palette detector cleanup", () => {
     renderer.finalizeDestroy()
   })
 
+  test("destroy stops pending palette detector writes", async () => {
+    const { renderer, clock } = await createPaletteRenderer()
+
+    // @ts-expect-error - spying on private method for testing
+    const writeOut = spyOn(renderer, "writeOut")
+    const palettePromise = renderer.getPalette({ size: 16, timeout: 300 })
+
+    await flushAsync()
+    clock.advance(0)
+    renderer.destroy()
+    await flushAsync()
+    void palettePromise.catch(() => {})
+
+    expect(writeOut).toHaveBeenCalledTimes(1)
+  })
+
   test("multiple destroy calls don't cause errors", async () => {
     const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 

--- a/packages/core/src/tests/renderer.palette.test.ts
+++ b/packages/core/src/tests/renderer.palette.test.ts
@@ -560,6 +560,9 @@ describe("Palette detector cleanup", () => {
 
     expect(sync).not.toHaveBeenCalled()
     expect(requestRender).not.toHaveBeenCalled()
+
+    sync.mockRestore()
+    requestRender.mockRestore()
   })
 
   test("destroy during render ignores pending palette detection publish", async () => {
@@ -577,6 +580,8 @@ describe("Palette detector cleanup", () => {
 
     expect(sync).not.toHaveBeenCalled()
 
+    sync.mockRestore()
+
     // @ts-expect-error - finish deferred destroy cleanup for the test renderer
     renderer.rendering = false
     // @ts-expect-error - finish deferred destroy cleanup for the test renderer
@@ -584,7 +589,7 @@ describe("Palette detector cleanup", () => {
   })
 
   test("destroy stops pending palette detector writes", async () => {
-    const { renderer, clock } = await createPaletteRenderer()
+    const { renderer, clock } = await createPaletteRenderer({ useThread: false })
 
     // @ts-expect-error - spying on private method for testing
     const writeOut = spyOn(renderer, "writeOut")
@@ -594,9 +599,12 @@ describe("Palette detector cleanup", () => {
     clock.advance(0)
     renderer.destroy()
     await flushAsync()
-    void palettePromise.catch(() => {})
+    clock.advance(300)
+    await palettePromise
 
     expect(writeOut).toHaveBeenCalledTimes(1)
+
+    writeOut.mockRestore()
   })
 
   test("multiple destroy calls don't cause errors", async () => {

--- a/packages/core/src/tests/renderer.palette.test.ts
+++ b/packages/core/src/tests/renderer.palette.test.ts
@@ -542,6 +542,47 @@ describe("Palette detector cleanup", () => {
     expect(renderer._cachedPalette).toBeNull()
   })
 
+  test("destroy ignores pending native palette publish", async () => {
+    const { renderer, clock } = await createPaletteRenderer()
+
+    await detectPaletteAndAdvanceClock(renderer, clock, { size: 256, timeout: 300 })
+
+    // @ts-expect-error - accessing private property for testing
+    renderer._terminalIsSetup = true
+    // @ts-expect-error - spying on private method for testing
+    const sync = spyOn(renderer, "syncNativePaletteState")
+    const requestRender = spyOn(renderer, "requestRender")
+
+    // @ts-expect-error - accessing private method for testing
+    renderer.ensureNativePaletteState()
+    renderer.destroy()
+    await flushAsync()
+
+    expect(sync).not.toHaveBeenCalled()
+    expect(requestRender).not.toHaveBeenCalled()
+  })
+
+  test("destroy during render ignores pending palette detection publish", async () => {
+    const { renderer, clock } = await createPaletteRenderer()
+
+    // @ts-expect-error - spying on private method for testing
+    const sync = spyOn(renderer, "syncNativePaletteState")
+    const palettePromise = renderer.getPalette({ size: 256, timeout: 300 })
+
+    // @ts-expect-error - simulating destroy while a frame is unwinding
+    renderer.rendering = true
+    renderer.destroy()
+    await advancePaletteClock(clock, 300)
+    await palettePromise
+
+    expect(sync).not.toHaveBeenCalled()
+
+    // @ts-expect-error - finish deferred destroy cleanup for the test renderer
+    renderer.rendering = false
+    // @ts-expect-error - finish deferred destroy cleanup for the test renderer
+    renderer.finalizeDestroy()
+  })
+
   test("multiple destroy calls don't cause errors", async () => {
     const { renderer, clock, mockStdin, mockStdout } = await createPaletteRenderer()
 


### PR DESCRIPTION
## Summary
- invalidate pending palette publishes as soon as renderer destroy starts
- skip native palette sync/render requests after destroy, including deferred destroy during render
- stop palette detector OSC writes from reaching native output after destroy
- add palette lifecycle regression coverage

## Verification
- bun test src/tests/renderer.palette.test.ts
- bun run build:lib
- bun run test:js
- temporary native smoke repros for immediate destroy and destroy-during-render completed with ok, then were deleted
- git diff --check

Fixes #992