### PR TITLE
core/ffi: isolate bun:ffi behind platform layer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       "name": "@opentui/core",
       "version": "0.2.1",
       "dependencies": {
-        "bun-ffi-structs": "0.1.2",
+        "bun-ffi-structs": "0.2.2",
         "diff": "9.0.0",
         "marked": "17.0.1",
         "string-width": "7.2.0",
@@ -700,7 +700,7 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "bun-ffi-structs": ["bun-ffi-structs@0.1.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w=="],
+    "bun-ffi-structs": ["bun-ffi-structs@0.2.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "web-tree-sitter": "0.25.10"
   },
   "dependencies": {
-    "bun-ffi-structs": "0.1.2",
+    "bun-ffi-structs": "0.2.2",
     "diff": "9.0.0",
     "marked": "17.0.1",
     "string-width": "7.2.0",

--- a/packages/core/src/NativeSpanFeed.ts
+++ b/packages/core/src/NativeSpanFeed.ts
@@ -1,5 +1,4 @@
-import { toArrayBuffer, type Pointer } from "bun:ffi"
-import { toPointer as toPlatformPointer } from "./platform/ffi.js"
+import { toArrayBuffer, type Pointer } from "./platform/ffi.js"
 import { resolveRenderLib } from "./zig.js"
 import { SpanInfoStruct } from "./zig-structs.js"
 import type { GrowthPolicy, NativeSpanFeedOptions, NativeSpanFeedStats } from "./zig-structs.js"
@@ -13,9 +12,6 @@ const enum EventId {
   DataAvailable = 7,
   StateBuffer = 8,
 }
-
-// TODO: Remove this temporary shim once current Bun FFI call sites use the platform backend.
-const toPointer = toPlatformPointer as unknown as (value: number | bigint) => Pointer
 
 function toNumber(value: number | bigint): number {
   return typeof value === "bigint" ? Number(value) : value
@@ -46,16 +42,15 @@ export class NativeSpanFeed {
     return stream
   }
 
-  static attach(streamPtr: bigint | number, _options?: NativeSpanFeedOptions): NativeSpanFeed {
+  static attach(streamPtr: Pointer, _options?: NativeSpanFeedOptions): NativeSpanFeed {
     const lib = resolveRenderLib()
-    const ptr = toPointer(streamPtr)
-    const stream = new NativeSpanFeed(ptr)
+    const stream = new NativeSpanFeed(streamPtr)
 
-    lib.registerNativeSpanFeedStream(ptr, stream.eventHandler)
+    lib.registerNativeSpanFeedStream(streamPtr, stream.eventHandler)
 
-    const status = lib.attachNativeSpanFeed(ptr)
+    const status = lib.attachNativeSpanFeed(streamPtr)
     if (status !== 0) {
-      lib.unregisterNativeSpanFeedStream(ptr)
+      lib.unregisterNativeSpanFeedStream(streamPtr)
       throw new Error(`Failed to attach stream: ${status}`)
     }
 
@@ -194,7 +189,7 @@ export class NativeSpanFeed {
           break
         }
         case EventId.Error: {
-          const code = arg0
+          const code = toNumber(arg0)
           for (const handler of this.errorHandlers) handler(code)
           break
         }

--- a/packages/core/src/buffer.ts
+++ b/packages/core/src/buffer.ts
@@ -1,6 +1,6 @@
 import { RGBA } from "./lib/index.js"
 import { resolveRenderLib, type RenderLib } from "./zig.js"
-import { type Pointer, toArrayBuffer, ptr } from "bun:ffi"
+import { type Pointer, type PointerInput, toArrayBuffer, toPointer, ptr } from "./platform/ffi.js"
 import { type BorderStyle, type BorderSides, BorderCharArrays, parseBorderStyle } from "./lib/index.js"
 import { TargetChannel, type WidthMethod, type CapturedSpan, type CapturedLine } from "./types.js"
 import type { TextBufferView } from "./text-buffer-view.js"
@@ -352,7 +352,7 @@ export class OptimizedBuffer {
   public drawSuperSampleBuffer(
     x: number,
     y: number,
-    pixelDataPtr: Pointer,
+    pixelDataPtr: PointerInput,
     pixelDataLength: number,
     format: "bgra8unorm" | "rgba8unorm",
     alignedBytesPerRow: number,
@@ -362,7 +362,7 @@ export class OptimizedBuffer {
       this.bufferPtr,
       x,
       y,
-      pixelDataPtr,
+      toPointer(pixelDataPtr),
       pixelDataLength,
       format,
       alignedBytesPerRow,
@@ -370,7 +370,7 @@ export class OptimizedBuffer {
   }
 
   public drawPackedBuffer(
-    dataPtr: Pointer,
+    dataPtr: PointerInput,
     dataLen: number,
     posX: number,
     posY: number,
@@ -380,7 +380,7 @@ export class OptimizedBuffer {
     this.guard()
     this.lib.bufferDrawPackedBuffer(
       this.bufferPtr,
-      dataPtr,
+      toPointer(dataPtr),
       dataLen,
       posX,
       posY,

--- a/packages/core/src/edit-buffer.ts
+++ b/packages/core/src/edit-buffer.ts
@@ -1,5 +1,5 @@
 import { resolveRenderLib, type LogicalCursor, type RenderLib } from "./zig.js"
-import { type Pointer } from "bun:ffi"
+import { type Pointer } from "./platform/ffi.js"
 import { type WidthMethod, type Highlight } from "./types.js"
 import { RGBA } from "./lib/RGBA.js"
 import { EventEmitter } from "events"

--- a/packages/core/src/editor-view.ts
+++ b/packages/core/src/editor-view.ts
@@ -1,6 +1,6 @@
 import { RGBA } from "./lib/RGBA.js"
 import { resolveRenderLib, type RenderLib, type VisualCursor, type LineInfo } from "./zig.js"
-import { type Pointer } from "bun:ffi"
+import { type Pointer } from "./platform/ffi.js"
 import type { EditBuffer } from "./edit-buffer.js"
 import { createExtmarksController } from "./lib/index.js"
 

--- a/packages/core/src/lib/clipboard.ts
+++ b/packages/core/src/lib/clipboard.ts
@@ -1,7 +1,7 @@
 // OSC 52 clipboard support for terminal applications.
 // Delegates to native Zig implementation for ANSI sequence generation.
 
-import type { Pointer } from "bun:ffi"
+import type { Pointer } from "../platform/ffi.js"
 import type { RenderLib } from "../zig.js"
 
 export enum ClipboardTarget {

--- a/packages/core/src/platform/ffi.test.ts
+++ b/packages/core/src/platform/ffi.test.ts
@@ -15,6 +15,7 @@ import {
   POINTER_UNSAFE,
   createBunBackend,
   createNodeBackend,
+  ffiBool,
   toPointer,
   type FFICallbackInstance,
   type Pointer,
@@ -150,6 +151,11 @@ function createMockNodeBackend(options: MockNodeBackendOptions = {}) {
 }
 
 describe("platform/ffi", () => {
+  test("converts JavaScript booleans to numeric FFI booleans", () => {
+    expect(ffiBool(false)).toBe(0)
+    expect(ffiBool(true)).toBe(1)
+  })
+
   test("closes the native library before auto-closing managed callbacks", () => {
     const { backend, events, rawCallbacks } = createMockBackend()
     const library = backend.dlopen("mock", {})

--- a/packages/core/src/platform/ffi.ts
+++ b/packages/core/src/platform/ffi.ts
@@ -5,12 +5,16 @@ declare const pointerBrand: unique symbol
 // This module owns OpenTUI's native FFI surface. Portable code imports this
 // file instead of bun:ffi, so backends can keep the same call sites.
 
-// Runtime pointers are numbers in Bun and bigints in Node's experimental FFI.
-// Keep both in the our own type, and narrow only inside a backend that requires
-// it.
-export type Pointer = (number | bigint) & { readonly [pointerBrand]: "Pointer" }
+// External FFI producers may expose their own branded pointer types. Public APIs
+// that consume foreign pointers should accept the raw pointer shape and normalize
+// it before crossing OpenTUI's native boundary.
+export type PointerInput = number | bigint
 
-type PointerSource = ArrayBuffer | (ArrayBufferView & { buffer: ArrayBuffer })
+// Runtime pointers are numbers in Bun and bigints in Node's experimental FFI.
+// Keep both in our own type, and narrow only inside a backend that requires it.
+export type Pointer = PointerInput & { readonly [pointerBrand]: "Pointer" }
+
+type PointerSource = ArrayBufferLike | ArrayBufferView
 
 // Bun accepts numeric pointers only. Keep this type private so Bun's pointer
 // model does not leak into the exported surface.
@@ -202,18 +206,22 @@ async function loadBackend(): Promise<FfiBackend> {
   }
 }
 
-// Convert pointer values for current Bun-backed call sites that still store
-// numeric pointers.
-//
-// TODO: Remove this temporary shim once current Bun FFI call sites use the
-// platform backend. Do not use this helper to force future Node pointers into
-// numbers.
-export function toPointer(value: number | bigint): Pointer {
-  if (typeof value === "bigint") {
+// Normalize foreign pointer-like values into the current runtime's pointer
+// representation before passing them to native code.
+export function toPointer(value: PointerInput): Pointer {
+  if (isBun && typeof value === "bigint") {
     return toSafeNumberPointer(value) as Pointer
   }
 
+  if (!isBun && typeof value === "number") {
+    return toSafeBigIntPointer(value) as Pointer
+  }
+
   return value as Pointer
+}
+
+export function ffiBool(value: boolean): 0 | 1 {
+  return value ? 1 : 0
 }
 
 // Convert a bigint pointer to a number only when JavaScript can represent it
@@ -228,6 +236,18 @@ function toSafeNumberPointer(pointer: bigint): number {
   }
 
   return Number(pointer)
+}
+
+function toSafeBigIntPointer(pointer: number): bigint {
+  if (pointer < 0) {
+    throw new Error(POINTER_NEGATIVE)
+  }
+
+  if (!Number.isSafeInteger(pointer)) {
+    throw new Error(POINTER_UNSAFE)
+  }
+
+  return BigInt(pointer)
 }
 
 // Wrap a backend callback so the loaded library can close it later. The wrapper

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -13,7 +13,7 @@ import {
   type WidthMethod,
 } from "./types.js"
 import { RGBA, parseColor, type ColorInput } from "./lib/RGBA.js"
-import type { Pointer } from "bun:ffi"
+import type { Pointer } from "./platform/ffi.js"
 import { OptimizedBuffer } from "./buffer.js"
 import { resolveRenderLib, type RenderLib } from "./zig.js"
 import { TerminalConsole, type ConsoleOptions, capture } from "./console.js"

--- a/packages/core/src/syntax-style.ts
+++ b/packages/core/src/syntax-style.ts
@@ -1,6 +1,6 @@
 import { RGBA, parseColor, type ColorInput } from "./lib/RGBA.js"
 import { resolveRenderLib, type RenderLib } from "./zig.js"
-import { type Pointer } from "bun:ffi"
+import { type Pointer } from "./platform/ffi.js"
 import { createTextAttributes } from "./utils.js"
 
 export interface StyleDefinition {

--- a/packages/core/src/text-buffer-view.ts
+++ b/packages/core/src/text-buffer-view.ts
@@ -1,6 +1,6 @@
 import { RGBA } from "./lib/RGBA.js"
 import { resolveRenderLib, type LineInfo, type RenderLib } from "./zig.js"
-import { type Pointer } from "bun:ffi"
+import { type Pointer } from "./platform/ffi.js"
 import type { TextBuffer } from "./text-buffer.js"
 
 export class TextBufferView {

--- a/packages/core/src/text-buffer.ts
+++ b/packages/core/src/text-buffer.ts
@@ -1,7 +1,7 @@
 import type { StyledText } from "./lib/styled-text.js"
 import { RGBA } from "./lib/RGBA.js"
 import { resolveRenderLib, type LineInfo, type RenderLib } from "./zig.js"
-import { type Pointer } from "bun:ffi"
+import { type Pointer } from "./platform/ffi.js"
 import { type WidthMethod, type Highlight } from "./types.js"
 import type { SyntaxStyle } from "./syntax-style.js"
 

--- a/packages/core/src/zig-structs.ts
+++ b/packages/core/src/zig-structs.ts
@@ -1,5 +1,5 @@
 import { defineStruct, defineEnum } from "bun-ffi-structs"
-import { ptr, toArrayBuffer, type Pointer } from "bun:ffi"
+import { ptr, toArrayBuffer, type Pointer } from "./platform/ffi.js"
 import { RGBA, normalizeColorValue } from "./lib/RGBA.js"
 
 const rgbaPackTransform = (rgba?: RGBA) => (rgba ? ptr(rgba.buffer) : null)

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -1,4 +1,4 @@
-import { dlopen, toArrayBuffer, JSCallback, ptr, type Pointer } from "bun:ffi"
+import { dlopen, ffiBool, toArrayBuffer, ptr, type FFICallbackInstance, type Pointer } from "./platform/ffi.js"
 import { existsSync, writeFileSync } from "fs"
 import { EventEmitter } from "events"
 import {
@@ -43,7 +43,6 @@ import type {
   AllocatorStats,
 } from "./zig-structs.js"
 import { isBunfsPath } from "./lib/bunfs.js"
-import { toPointer as toPlatformPointer } from "./platform/ffi.js"
 
 const module = await import(`@opentui/core-${process.platform}-${process.arch}/index.ts`)
 let targetLibPath = module.default
@@ -105,8 +104,6 @@ const MOUSE_STYLE_TO_ID = { default: 0, pointer: 1, text: 2, crosshair: 3, move:
 let globalTraceSymbols: Record<string, number[]> | null = null
 let globalFFILogPath: string | null = null
 let exitHandlerRegistered = false
-// TODO: Remove this temporary shim once current Bun FFI call sites use the platform backend.
-const toPointer = toPlatformPointer as unknown as (value: number | bigint) => Pointer
 
 function toNumber(value: number | bigint): number {
   return typeof value === "bigint" ? Number(value) : value
@@ -1182,6 +1179,7 @@ function getOpenTUILib(libPath?: string) {
 
   if (env.OTUI_DEBUG_FFI || env.OTUI_TRACE_FFI) {
     return {
+      ...rawSymbols,
       symbols: convertToDebugSymbols(rawSymbols.symbols),
     }
   }
@@ -1926,11 +1924,11 @@ class FFIRenderLib implements RenderLib {
   private opentui: ReturnType<typeof getOpenTUILib>
   public readonly encoder: TextEncoder = new TextEncoder()
   public readonly decoder: TextDecoder = new TextDecoder()
-  private logCallbackWrapper: any // Store the FFI callback wrapper
-  private eventCallbackWrapper: any // Store the FFI event callback wrapper
+  private logCallbackWrapper: FFICallbackInstance | null = null
+  private eventCallbackWrapper: FFICallbackInstance | null = null
   private _nativeEvents: EventEmitter = new EventEmitter()
   private _anyEventHandlers: Array<(name: string, data: ArrayBuffer) => void> = []
-  private nativeSpanFeedCallbackWrapper: JSCallback | null = null
+  private nativeSpanFeedCallbackWrapper: FFICallbackInstance | null = null
   private nativeSpanFeedHandlers = new Map<Pointer, NativeSpanFeedEventHandler>()
 
   constructor(libPath?: string) {
@@ -1944,7 +1942,7 @@ class FFIRenderLib implements RenderLib {
       return
     }
 
-    const logCallback = new JSCallback(
+    const logCallback = this.opentui.createCallback(
       (level: number, msgPtr: Pointer, msgLenBigInt: bigint | number) => {
         try {
           const msgLen = typeof msgLenBigInt === "bigint" ? Number(msgLenBigInt) : msgLenBigInt
@@ -2001,7 +1999,7 @@ class FFIRenderLib implements RenderLib {
       return
     }
 
-    const eventCallback = new JSCallback(
+    const eventCallback = this.opentui.createCallback(
       (namePtr: Pointer, nameLenBigInt: bigint | number, dataPtr: Pointer, dataLenBigInt: bigint | number) => {
         try {
           const nameLen = typeof nameLenBigInt === "bigint" ? Number(nameLenBigInt) : nameLenBigInt
@@ -2048,14 +2046,14 @@ class FFIRenderLib implements RenderLib {
     this.setEventCallback(eventCallback.ptr)
   }
 
-  private ensureNativeSpanFeedCallback(): JSCallback {
+  private ensureNativeSpanFeedCallback(): FFICallbackInstance {
     if (this.nativeSpanFeedCallbackWrapper) {
       return this.nativeSpanFeedCallbackWrapper
     }
 
-    const callback = new JSCallback(
+    const callback = this.opentui.createCallback(
       (streamPtr: Pointer, eventId: number, arg0: Pointer, arg1: number | bigint) => {
-        const handler = this.nativeSpanFeedHandlers.get(toPointer(streamPtr))
+        const handler = this.nativeSpanFeedHandlers.get(streamPtr)
         if (handler) {
           handler(eventId, arg0, arg1)
         }
@@ -2082,7 +2080,7 @@ class FFIRenderLib implements RenderLib {
   public createRenderer(width: number, height: number, options: { testing?: boolean; remote?: boolean } = {}) {
     const testing = options.testing ?? false
     const remote = options.remote ?? false
-    return this.opentui.symbols.createRenderer(width, height, testing, remote)
+    return this.opentui.symbols.createRenderer(width, height, ffiBool(testing), ffiBool(remote))
   }
 
   public setTerminalEnvVar(renderer: Pointer, key: string, value: string): boolean {
@@ -2096,11 +2094,11 @@ class FFIRenderLib implements RenderLib {
   }
 
   public setUseThread(renderer: Pointer, useThread: boolean) {
-    this.opentui.symbols.setUseThread(renderer, useThread)
+    this.opentui.symbols.setUseThread(renderer, ffiBool(useThread))
   }
 
   public setClearOnShutdown(renderer: Pointer, clear: boolean) {
-    this.opentui.symbols.setClearOnShutdown(renderer, clear)
+    this.opentui.symbols.setClearOnShutdown(renderer, ffiBool(clear))
   }
 
   public setBackgroundColor(renderer: Pointer, color: RGBA) {
@@ -2233,7 +2231,7 @@ class FFIRenderLib implements RenderLib {
   }
 
   public bufferSetRespectAlpha(buffer: Pointer, respectAlpha: boolean): void {
-    this.opentui.symbols.bufferSetRespectAlpha(buffer, respectAlpha)
+    this.opentui.symbols.bufferSetRespectAlpha(buffer, ffiBool(respectAlpha))
   }
 
   public bufferGetId(buffer: Pointer): string {
@@ -2253,7 +2251,7 @@ class FFIRenderLib implements RenderLib {
       buffer,
       outputBuffer,
       outputBuffer.length,
-      addLineBreaks,
+      ffiBool(addLineBreaks),
     )
     return typeof bytesWritten === "bigint" ? Number(bytesWritten) : bytesWritten
   }
@@ -2520,7 +2518,7 @@ class FFIRenderLib implements RenderLib {
   }
 
   public setCursorPosition(renderer: Pointer, x: number, y: number, visible: boolean) {
-    this.opentui.symbols.setCursorPosition(renderer, x, y, visible)
+    this.opentui.symbols.setCursorPosition(renderer, x, y, ffiBool(visible))
   }
 
   public setCursorColor(renderer: Pointer, color: RGBA) {
@@ -2552,11 +2550,11 @@ class FFIRenderLib implements RenderLib {
   }
 
   public render(renderer: Pointer, force: boolean) {
-    this.opentui.symbols.render(renderer, force)
+    this.opentui.symbols.render(renderer, ffiBool(force))
   }
 
   public repaintSplitFooter(renderer: Pointer, pinnedRenderOffset: number, force: boolean): number {
-    return this.opentui.symbols.repaintSplitFooter(renderer, pinnedRenderOffset, force)
+    return this.opentui.symbols.repaintSplitFooter(renderer, pinnedRenderOffset, ffiBool(force))
   }
 
   public commitSplitFooterSnapshot(
@@ -2574,12 +2572,12 @@ class FFIRenderLib implements RenderLib {
       renderer,
       snapshot.ptr,
       rowColumns,
-      startOnNewLine,
-      trailingNewline,
+      ffiBool(startOnNewLine),
+      ffiBool(trailingNewline),
       pinnedRenderOffset,
-      force,
-      beginFrame,
-      finalizeFrame,
+      ffiBool(force),
+      ffiBool(beginFrame),
+      ffiBool(finalizeFrame),
     )
   }
 
@@ -2600,7 +2598,7 @@ class FFIRenderLib implements RenderLib {
     const bufferPtr = this.opentui.symbols.createOptimizedBuffer(
       width,
       height,
-      respectAlpha,
+      ffiBool(respectAlpha),
       widthMethodCode,
       idBytes,
       idBytes.length,
@@ -2634,7 +2632,7 @@ class FFIRenderLib implements RenderLib {
   }
 
   public setDebugOverlay(renderer: Pointer, enabled: boolean, corner: DebugOverlayCorner) {
-    this.opentui.symbols.setDebugOverlay(renderer, enabled, corner)
+    this.opentui.symbols.setDebugOverlay(renderer, ffiBool(enabled), corner)
   }
 
   public clearTerminal(renderer: Pointer) {
@@ -2712,7 +2710,7 @@ class FFIRenderLib implements RenderLib {
   }
 
   public enableMouse(renderer: Pointer, enableMovement: boolean): void {
-    this.opentui.symbols.enableMouse(renderer, enableMovement)
+    this.opentui.symbols.enableMouse(renderer, ffiBool(enableMovement))
   }
 
   public disableMouse(renderer: Pointer): void {
@@ -2736,7 +2734,7 @@ class FFIRenderLib implements RenderLib {
   }
 
   public setupTerminal(renderer: Pointer, useAlternateScreen: boolean): void {
-    this.opentui.symbols.setupTerminal(renderer, useAlternateScreen)
+    this.opentui.symbols.setupTerminal(renderer, ffiBool(useAlternateScreen))
   }
 
   public suspendRenderer(renderer: Pointer): void {
@@ -2825,7 +2823,7 @@ class FFIRenderLib implements RenderLib {
   }
 
   public textBufferRegisterMemBuffer(buffer: Pointer, bytes: Uint8Array, owned: boolean = false): number {
-    const result = this.opentui.symbols.textBufferRegisterMemBuffer(buffer, bytes, bytes.length, owned)
+    const result = this.opentui.symbols.textBufferRegisterMemBuffer(buffer, bytes, bytes.length, ffiBool(owned))
     if (result === 0xffff) {
       throw new Error("Failed to register memory buffer")
     }
@@ -2838,7 +2836,7 @@ class FFIRenderLib implements RenderLib {
     bytes: Uint8Array,
     owned: boolean = false,
   ): boolean {
-    return this.opentui.symbols.textBufferReplaceMemBuffer(buffer, memId, bytes, bytes.length, owned)
+    return this.opentui.symbols.textBufferReplaceMemBuffer(buffer, memId, bytes, bytes.length, ffiBool(owned))
   }
 
   public textBufferClearMemRegistry(buffer: Pointer): void {
@@ -3147,7 +3145,7 @@ class FFIRenderLib implements RenderLib {
   }
 
   public textBufferViewSetTruncate(view: Pointer, truncate: boolean): void {
-    this.opentui.symbols.textBufferViewSetTruncate(view, truncate)
+    this.opentui.symbols.textBufferViewSetTruncate(view, ffiBool(truncate))
   }
 
   public textBufferViewMeasureForDimensions(
@@ -3274,7 +3272,7 @@ class FFIRenderLib implements RenderLib {
     height: number,
     moveCursor: boolean,
   ): void {
-    this.opentui.symbols.editorViewSetViewport(view, x, y, width, height, moveCursor)
+    this.opentui.symbols.editorViewSetViewport(view, x, y, width, height, ffiBool(moveCursor))
   }
 
   public editorViewGetViewport(view: Pointer): { offsetY: number; offsetX: number; height: number; width: number } {
@@ -3637,8 +3635,8 @@ class FFIRenderLib implements RenderLib {
       focusY,
       bg,
       fg,
-      updateCursor,
-      followCursor,
+      ffiBool(updateCursor),
+      ffiBool(followCursor),
     )
   }
 
@@ -3669,8 +3667,8 @@ class FFIRenderLib implements RenderLib {
       focusY,
       bg,
       fg,
-      updateCursor,
-      followCursor,
+      ffiBool(updateCursor),
+      ffiBool(followCursor),
     )
   }
 
@@ -3875,13 +3873,13 @@ class FFIRenderLib implements RenderLib {
 
   public registerNativeSpanFeedStream(stream: Pointer, handler: NativeSpanFeedEventHandler): void {
     const callback = this.ensureNativeSpanFeedCallback()
-    this.nativeSpanFeedHandlers.set(toPointer(stream), handler)
+    this.nativeSpanFeedHandlers.set(stream, handler)
     this.opentui.symbols.streamSetCallback(stream, callback.ptr)
   }
 
   public unregisterNativeSpanFeedStream(stream: Pointer): void {
     this.opentui.symbols.streamSetCallback(stream, null)
-    this.nativeSpanFeedHandlers.delete(toPointer(stream))
+    this.nativeSpanFeedHandlers.delete(stream)
   }
 
   public createNativeSpanFeed(options?: NativeSpanFeedOptions | null): Pointer {
@@ -3890,7 +3888,7 @@ class FFIRenderLib implements RenderLib {
     if (!streamPtr) {
       throw new Error("Failed to create stream")
     }
-    return toPointer(streamPtr)
+    return streamPtr as Pointer
   }
 
   public attachNativeSpanFeed(stream: Pointer): number {
@@ -3899,7 +3897,7 @@ class FFIRenderLib implements RenderLib {
 
   public destroyNativeSpanFeed(stream: Pointer): void {
     this.opentui.symbols.destroyNativeSpanFeed(stream)
-    this.nativeSpanFeedHandlers.delete(toPointer(stream))
+    this.nativeSpanFeedHandlers.delete(stream)
   }
 
   public streamWrite(stream: Pointer, data: Uint8Array | string): number {


### PR DESCRIPTION
Use platform/ffi so the core stays runtime-agnostic. Callers go
through createCallback and ffiBool helpers instead of touching
bun:ffi directly.

Bump bun-ffi-structs, which drops its static bun:ffi.

Issue #2 