### PR TITLE
test-recorder: fix flaky frame assertions

### DIFF
--- a/packages/core/src/testing/test-recorder.test.ts
+++ b/packages/core/src/testing/test-recorder.test.ts
@@ -105,15 +105,23 @@ describe("TestRecorder", () => {
 
     const text = new TextRenderable(renderer, { content: "Initial" })
     renderer.root.add(text)
-    await Bun.sleep(10)
+    await renderer.idle()
 
     text.content = "Changed"
-    await Bun.sleep(10)
+    await renderer.idle()
     recorder.stop()
 
-    // NOTE: Should this fail, make sure the Bun.sleeps are in sync with maxFps of the renderer
-    const frame1 = recorder.recordedFrames[0].frame
-    const frame2 = recorder.recordedFrames[1].frame
+    const frames = recorder.recordedFrames
+    const initialFrameIndex = frames.findIndex(({ frame }) => frame.includes("Initial"))
+    const changedFrameIndex = frames.findIndex(
+      ({ frame }, index) => index > initialFrameIndex && frame.includes("Changed"),
+    )
+
+    expect(initialFrameIndex).toBeGreaterThanOrEqual(0)
+    expect(changedFrameIndex).toBeGreaterThan(initialFrameIndex)
+
+    const frame1 = frames[initialFrameIndex].frame
+    const frame2 = frames[changedFrameIndex].frame
 
     expect(frame1).toContain("Initial")
     expect(frame2).toContain("Changed")


### PR DESCRIPTION
Bun.sleep(10) raced the renderer's maxFps throttle. At 60 FPS the
next render can be delayed up to ~16.7ms, so on slower CI the test
could call recorder.stop() before the changed-content frame was
captured.

Wait for renderer.idle() instead of sleeping a fixed duration, and
locate the "Initial" and "Changed" frames by content rather than
assuming they sit at fixed indices.
