### PR TITLE
examples/terminal: add OSC palette diagnostics

### DIFF
--- a/packages/examples/src/terminal.ts
+++ b/packages/examples/src/terminal.ts
@@ -26,11 +26,18 @@ let scrollBox: ScrollBoxRenderable | null = null
 let contentContainer: BoxRenderable | null = null
 let paletteGrid: PaletteGridRenderable | null = null
 let statusText: TextRenderable | null = null
+let diagnosticsText: TextRenderable | null = null
+let rawOscText: TextRenderable | null = null
 let hexList: HexListRenderable | null = null
 let specialColorsBuffer: FrameBufferRenderable | null = null
+let ansiComparisonBuffer: FrameBufferRenderable | null = null
 let terminalColors: TerminalColors | null = null
 let keyboardHandler: ((key: any) => void) | null = null
 let paletteSizeInput: InputRenderable | null = null
+let oscUnsubscribe: (() => void) | null = null
+
+const recentColorOscResponses: string[] = []
+const maxRecentColorOscResponses = 8
 
 export function run(renderer: CliRenderer): void {
   renderer.start()
@@ -68,7 +75,8 @@ export function run(renderer: CliRenderer): void {
 
   const subtitleText = new TextRenderable(renderer, {
     id: "terminal_subtitle",
-    content: "Enter palette size (1-256) and press Enter to fetch | Press 'c' to clear cache",
+    content:
+      "Enter palette size (1-256) and press Enter to fetch | 'r' fresh fetch | 'c' clear cache | Watch OSC 10/11 diagnostics below",
     fg: RGBA.fromInts(148, 163, 184), // Slate-400 - softer contrast
   })
   contentContainer.add(subtitleText)
@@ -91,7 +99,6 @@ export function run(renderer: CliRenderer): void {
   paletteSizeInput = new InputRenderable(renderer, {
     id: "palette-size-input",
     width: 10,
-    height: 1,
     backgroundColor: RGBA.fromInts(30, 41, 59),
     textColor: RGBA.fromInts(255, 255, 255),
     placeholder: "16",
@@ -109,6 +116,22 @@ export function run(renderer: CliRenderer): void {
     fg: RGBA.fromInts(56, 189, 248), // Sky blue - modern accent
   })
   contentContainer.add(statusText)
+
+  diagnosticsText = new TextRenderable(renderer, {
+    id: "terminal_diagnostics",
+    content: "Diagnostics: fetching the default 16-color palette...",
+    marginTop: 1,
+    fg: RGBA.fromInts(203, 213, 225),
+  })
+  contentContainer.add(diagnosticsText)
+
+  rawOscText = new TextRenderable(renderer, {
+    id: "terminal_raw_osc",
+    content: "Recent raw OSC color replies: none yet",
+    marginTop: 1,
+    fg: RGBA.fromInts(148, 163, 184),
+  })
+  contentContainer.add(rawOscText)
 
   const instructionsText = new TextRenderable(renderer, {
     id: "terminal_instructions",
@@ -144,12 +167,27 @@ export function run(renderer: CliRenderer): void {
     if (key.name === "c") {
       clearPaletteCache(renderer)
     }
+    if (key.name === "r") {
+      renderer.clearPaletteCache()
+      await fetchAndDisplayPalette(renderer, getRequestedPaletteSize())
+    }
   }
 
   renderer.keyInput.on("keypress", keyboardHandler)
 
+  oscUnsubscribe = renderer.subscribeOsc((sequence) => {
+    if (!isColorOscResponse(sequence)) return
+    recentColorOscResponses.push(sequence)
+    if (recentColorOscResponses.length > maxRecentColorOscResponses) {
+      recentColorOscResponses.splice(0, recentColorOscResponses.length - maxRecentColorOscResponses)
+    }
+    updateRawOscText()
+  })
+
   // Focus the input field on start
   paletteSizeInput.focus()
+
+  void fetchAndDisplayPalette(renderer, 16)
 }
 
 async function fetchAndDisplayPalette(renderer: CliRenderer, size: number): Promise<void> {
@@ -159,6 +197,8 @@ async function fetchAndDisplayPalette(renderer: CliRenderer, size: number): Prom
     const wasAlreadyCached = renderer.paletteDetectionStatus === "cached"
     statusText.content = `Status: ${wasAlreadyCached ? "Using cached palette" : "Fetching palette..."}`
     statusText.fg = RGBA.fromInts(250, 204, 21) // Amber - warm loading state
+    recentColorOscResponses.length = 0
+    updateRawOscText()
 
     const startTime = performance.now()
     terminalColors = await renderer.getPalette({ size })
@@ -180,12 +220,26 @@ function clearPaletteCache(renderer: CliRenderer): void {
   if (!statusText) return
 
   renderer.clearPaletteCache()
+  recentColorOscResponses.length = 0
   statusText.content = "Status: Cache cleared. Enter a size and press Enter to fetch palette again."
   statusText.fg = RGBA.fromInts(148, 163, 184) // Slate-400 - neutral info state
+  if (diagnosticsText) {
+    diagnosticsText.content = "Diagnostics: cache cleared. Fetch again to inspect OSC replies and background fallback."
+  }
+  updateRawOscText()
+}
+
+function getRequestedPaletteSize(): number {
+  const size = parseInt(paletteSizeInput?.value ?? "16", 10)
+  if (Number.isNaN(size) || size < 1 || size > 256) return 16
+  return size
 }
 
 function drawPalette(renderer: CliRenderer, terminalColors: TerminalColors, size: number): void {
-  const colors = terminalColors.palette.slice(0, size)
+  const colors = terminalColors.palette.slice(0, size).map((color) => color ?? "#000000")
+
+  updateDiagnostics(renderer, terminalColors)
+  updateRawOscText()
 
   // Update the palette grid with new colors
   if (paletteGrid) {
@@ -270,9 +324,136 @@ function drawPalette(renderer: CliRenderer, terminalColors: TerminalColors, size
   } else {
     hexList.colors = colors
   }
+
+  drawAnsiComparison(renderer, terminalColors)
+}
+
+function drawAnsiComparison(renderer: CliRenderer, colors: TerminalColors): void {
+  const width = 74
+  const height = 5
+  const labelWidth = 19
+  const swatchWidth = 3
+  const textColor = RGBA.fromInts(203, 213, 225)
+  const mutedTextColor = RGBA.fromInts(148, 163, 184)
+  const bgColor = RGBA.fromInts(30, 41, 59)
+
+  if (!ansiComparisonBuffer) {
+    ansiComparisonBuffer = new FrameBufferRenderable(renderer, {
+      id: "ansi-comparison-buffer",
+      width,
+      height,
+      marginTop: 2,
+    })
+    contentContainer!.add(ansiComparisonBuffer)
+  }
+
+  const buffer = ansiComparisonBuffer.frameBuffer
+  buffer.clear(bgColor)
+
+  buffer.drawText("ANSI Slot Comparison", 0, 0, textColor, bgColor, TextAttributes.BOLD)
+  buffer.drawText("Indexed 0-15:", 0, 1, mutedTextColor, bgColor, TextAttributes.NONE)
+  buffer.drawText("RGB snapshots:", 0, 3, mutedTextColor, bgColor, TextAttributes.NONE)
+
+  for (let index = 0; index < 16; index++) {
+    const x = labelWidth + index * swatchWidth
+    const detected = colors.palette[index]
+    const indexedColor = RGBA.fromIndex(index, detected ?? undefined)
+    const rgbColor = detected ? RGBA.fromHex(detected) : RGBA.fromInts(0, 0, 0)
+
+    for (let dx = 0; dx < swatchWidth; dx++) {
+      buffer.setCell(x + dx, 1, " ", textColor, indexedColor)
+      buffer.setCell(x + dx, 3, " ", textColor, rgbColor)
+    }
+  }
+
+  buffer.drawText(
+    "If rows differ, RGB system-theme colors are not rendering as their source ANSI slots.",
+    0,
+    4,
+    mutedTextColor,
+    bgColor,
+    TextAttributes.NONE,
+  )
+}
+
+function isColorOscResponse(sequence: string): boolean {
+  return /^\x1b\](?:4;0|10|11);/.test(sequence)
+}
+
+function formatHex(value: string | null): string {
+  return value?.toUpperCase() ?? "N/A"
+}
+
+function inferModeFromHex(value: string | null): "dark" | "light" | "unknown" {
+  if (!value) return "unknown"
+  const [r, g, b] = RGBA.fromHex(value).toInts()
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000
+  return brightness > 128 ? "light" : "dark"
+}
+
+function visibleOsc(sequence: string): string {
+  return sequence
+    .replace(/\x1b\\/g, " ST")
+    .replace(/\x1b/g, "ESC")
+    .replace(/\x07/g, " BEL")
+}
+
+function updateDiagnostics(renderer: CliRenderer, colors: TerminalColors): void {
+  if (!diagnosticsText) return
+
+  const palette0 = colors.palette[0] ?? null
+  const defaultBackground = colors.defaultBackground
+  const effectiveBackground = defaultBackground ?? palette0
+  const rendererMode = renderer.themeMode ?? "unknown"
+  const inferredMode = inferModeFromHex(effectiveBackground)
+  const modeMismatch = rendererMode !== "unknown" && inferredMode !== "unknown" && rendererMode !== inferredMode
+  const rawRgbaSeen = recentColorOscResponses.some((sequence) => sequence.includes("rgba:"))
+  const backgroundSource = defaultBackground
+    ? "OSC 11 defaultBackground"
+    : palette0
+      ? "palette[0] fallback because OSC 11 was missing or unparsed"
+      : "none"
+  const verdict = defaultBackground
+    ? modeMismatch
+      ? "ERR: renderer.themeMode disagrees with the detected background; derived system colors will be wrong."
+      : "OK : defaultBackground parsed; system theme can use the terminal background."
+    : rawRgbaSeen
+      ? "ERR : raw rgba response seen, but defaultBackground is N/A. The parser dropped OSC 11."
+      : "WARN: defaultBackground is N/A. System themes will fall back to palette[0]."
+
+  diagnosticsText.content = [
+    "Diagnostics:",
+    `  renderer.themeMode: ${rendererMode}`,
+    `  bg-inferred mode: ${inferredMode}`,
+    `  Default FG (OSC 10): ${formatHex(colors.defaultForeground)}`,
+    `  Default BG (OSC 11): ${formatHex(defaultBackground)}`,
+    `  palette[0]: ${formatHex(palette0)}`,
+    `  system-theme background source: ${backgroundSource}`,
+    `  effective background: ${formatHex(effectiveBackground)}`,
+    `  ${verdict}`,
+  ].join("\n")
+}
+
+function updateRawOscText(): void {
+  if (!rawOscText) return
+
+  if (recentColorOscResponses.length === 0) {
+    rawOscText.content = "Recent raw OSC color replies: none yet"
+    return
+  }
+
+  rawOscText.content = [
+    "Recent raw OSC color replies:",
+    ...recentColorOscResponses.map((sequence) => `  ${visibleOsc(sequence)}`),
+  ].join("\n")
 }
 
 export function destroy(renderer: CliRenderer): void {
+  if (oscUnsubscribe) {
+    oscUnsubscribe()
+    oscUnsubscribe = null
+  }
+
   if (keyboardHandler) {
     renderer.keyInput.off("keypress", keyboardHandler)
     keyboardHandler = null
@@ -292,8 +473,12 @@ export function destroy(renderer: CliRenderer): void {
   paletteGrid = null
   hexList = null
   specialColorsBuffer = null
+  ansiComparisonBuffer = null
+  diagnosticsText = null
+  rawOscText = null
   statusText = null
   terminalColors = null
+  recentColorOscResponses.length = 0
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
Surface raw OSC 10/11 replies, the resolved background source, and
an indexed-vs-RGB swatch comparison alongside the existing palette
view. This makes it possible to spot terminals where themeMode or
defaultBackground disagree with the real background without adding
ad-hoc instrumentation.
