### PR TITLE
chore: invalidate deinitialized core zig structs

### DIFF
--- a/packages/core/src/zig/buffer.zig
+++ b/packages/core/src/zig/buffer.zig
@@ -274,6 +274,9 @@ pub const OptimizedBuffer = struct {
     }
 
     pub fn deinit(self: *OptimizedBuffer) void {
+        const allocator = self.allocator;
+        defer allocator.destroy(self);
+
         self.opacity_stack.deinit(self.allocator);
         self.scissor_stack.deinit(self.allocator);
         self.link_tracker.deinit();
@@ -283,7 +286,7 @@ pub const OptimizedBuffer = struct {
         self.allocator.free(self.buffer.bg);
         self.allocator.free(self.buffer.attributes);
         self.allocator.free(self.id);
-        self.allocator.destroy(self);
+        self.* = undefined;
     }
 
     pub fn getCurrentScissorRect(self: *const OptimizedBuffer) ?ClipRect {

--- a/packages/core/src/zig/edit-buffer.zig
+++ b/packages/core/src/zig/edit-buffer.zig
@@ -128,11 +128,14 @@ pub const EditBuffer = struct {
     }
 
     pub fn deinit(self: *EditBuffer) void {
+        const allocator = self.allocator;
+        defer allocator.destroy(self);
+
         // Registry owns all AddBuffer memory, don't free it manually
         self.events.deinit();
         self.tb.deinit();
         self.cursors.deinit(self.allocator);
-        self.allocator.destroy(self);
+        self.* = undefined;
     }
 
     pub fn getId(self: *const EditBuffer) u16 {

--- a/packages/core/src/zig/editor-view.zig
+++ b/packages/core/src/zig/editor-view.zig
@@ -99,6 +99,9 @@ pub const EditorView = struct {
     }
 
     pub fn deinit(self: *EditorView) void {
+        const global_allocator = self.global_allocator;
+        defer global_allocator.destroy(self);
+
         self.edit_buffer.events.off(.cursorChanged, self.cursor_changed_listener);
 
         if (self.placeholder_syntax_style) |style| {
@@ -110,7 +113,7 @@ pub const EditorView = struct {
         }
 
         self.text_buffer_view.deinit();
-        self.global_allocator.destroy(self);
+        self.* = undefined;
     }
 
     /// Set the viewport. If wrapping is enabled and viewport width differs from current wrap width,

--- a/packages/core/src/zig/grapheme.zig
+++ b/packages/core/src/zig/grapheme.zig
@@ -83,6 +83,8 @@ pub const GraphemePool = struct {
         while (i < MAX_CLASSES) : (i += 1) {
             self.classes[i].deinit();
         }
+
+        self.* = undefined;
     }
 
     /// removeInternedLiveId removes an interned ID from the live set if it
@@ -279,6 +281,7 @@ pub const GraphemePool = struct {
         pub fn deinit(self: *ClassPool) void {
             self.slots.deinit(self.allocator);
             self.free_list.deinit(self.allocator);
+            self.* = undefined;
         }
 
         fn grow(self: *ClassPool) GraphemePoolError!void {
@@ -520,6 +523,7 @@ pub const GraphemeTracker = struct {
     pub fn deinit(self: *GraphemeTracker) void {
         self.decRefAll();
         self.used_ids.deinit();
+        self.* = undefined;
     }
 
     pub fn clear(self: *GraphemeTracker) void {

--- a/packages/core/src/zig/link.zig
+++ b/packages/core/src/zig/link.zig
@@ -58,6 +58,7 @@ pub const LinkPool = struct {
 
         self.slots.deinit(self.allocator);
         self.free_list.deinit(self.allocator);
+        self.* = undefined;
     }
 
     fn grow(self: *LinkPool) LinkPoolError!void {
@@ -271,6 +272,7 @@ pub const LinkTracker = struct {
     pub fn deinit(self: *LinkTracker) void {
         self.decRefAll();
         self.used_ids.deinit();
+        self.* = undefined;
     }
 
     pub fn clear(self: *LinkTracker) void {

--- a/packages/core/src/zig/mem-registry.zig
+++ b/packages/core/src/zig/mem-registry.zig
@@ -35,6 +35,7 @@ pub const MemRegistry = struct {
         }
         self.buffers.deinit(self.allocator);
         self.free_slots.deinit(self.allocator);
+        self.* = undefined;
     }
 
     pub fn register(self: *MemRegistry, data: []const u8, owned: bool) MemRegistryError!u8 {

--- a/packages/core/src/zig/syntax-style.zig
+++ b/packages/core/src/zig/syntax-style.zig
@@ -59,11 +59,14 @@ pub const SyntaxStyle = struct {
     }
 
     pub fn deinit(self: *SyntaxStyle) void {
+        const global_allocator = self.global_allocator;
+        defer global_allocator.destroy(self);
+
         self.emitter.emit(.Destroy);
         self.emitter.deinit();
         self.arena.deinit();
-        self.global_allocator.destroy(self.arena);
-        self.global_allocator.destroy(self);
+        global_allocator.destroy(self.arena);
+        self.* = undefined;
     }
 
     fn putStyle(self: *SyntaxStyle, name: []const u8, definition: StyleDefinition) SyntaxStyleError!u32 {

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -154,6 +154,7 @@ pub fn deinit(self: *Terminal) void {
         self.host_env_map = null;
     }
     self.opts.env_map = null;
+    self.* = undefined;
 }
 
 pub fn setHostEnvVar(self: *Terminal, allocator: std.mem.Allocator, key: []const u8, value: []const u8) !void {

--- a/packages/core/src/zig/tests/terminal_test.zig
+++ b/packages/core/src/zig/tests/terminal_test.zig
@@ -254,6 +254,7 @@ const TestWriter = struct {
 
     pub fn deinit(self: *TestWriter) void {
         self.buffer.deinit(self.allocator);
+        self.* = undefined;
     }
 
     pub fn writeAll(self: *TestWriter, data: []const u8) !void {

--- a/packages/core/src/zig/text-buffer-view.zig
+++ b/packages/core/src/zig/text-buffer-view.zig
@@ -108,6 +108,7 @@ pub const VirtualLine = struct {
 
     pub fn deinit(self: *VirtualLine, allocator: Allocator) void {
         self.chunks.deinit(allocator);
+        self.* = undefined;
     }
 };
 
@@ -225,11 +226,14 @@ pub const UnifiedTextBufferView = struct {
     /// Destroying the TextBuffer first will cause use-after-free when calling deinit.
     /// The TypeScript wrappers enforce this order via the destroy() methods.
     pub fn deinit(self: *Self) void {
+        const global_allocator = self.global_allocator;
+        defer global_allocator.destroy(self);
+
         self.original_text_buffer.unregisterView(self.view_id);
         self.virtual_lines_arena.deinit();
-        self.global_allocator.destroy(self.virtual_lines_arena);
+        global_allocator.destroy(self.virtual_lines_arena);
         self.measure_arena.deinit();
-        self.global_allocator.destroy(self);
+        self.* = undefined;
     }
 
     pub fn setViewport(self: *Self, vp: ?Viewport) void {

--- a/packages/core/src/zig/text-buffer.zig
+++ b/packages/core/src/zig/text-buffer.zig
@@ -230,6 +230,9 @@ pub const UnifiedTextBuffer = struct {
     }
 
     pub fn deinit(self: *Self) void {
+        const global_allocator = self.global_allocator;
+        defer global_allocator.destroy(self);
+
         if (self.syntax_style) |style| {
             (@constCast(style)).offDestroy(@ptrCast(self), onSyntaxStyleDestroyed);
         }
@@ -262,8 +265,8 @@ pub const UnifiedTextBuffer = struct {
 
         self.mem_registry.deinit();
         self.arena.deinit();
-        self.global_allocator.destroy(self.arena);
-        self.global_allocator.destroy(self);
+        global_allocator.destroy(self.arena);
+        self.* = undefined;
     }
 
     // View registration (same as original)

--- a/packages/core/src/zig/utf8.zig
+++ b/packages/core/src/zig/utf8.zig
@@ -72,6 +72,7 @@ pub const LineBreakResult = struct {
 
     pub fn deinit(self: *LineBreakResult) void {
         self.breaks.deinit(self.allocator);
+        self.* = undefined;
     }
 
     pub fn reset(self: *LineBreakResult) void {
@@ -92,6 +93,7 @@ pub const TabStopResult = struct {
 
     pub fn deinit(self: *TabStopResult) void {
         self.positions.deinit(self.allocator);
+        self.* = undefined;
     }
 
     pub fn reset(self: *TabStopResult) void {
@@ -123,6 +125,7 @@ pub const WrapBreakResult = struct {
 
     pub fn deinit(self: *WrapBreakResult) void {
         self.breaks.deinit(self.allocator);
+        self.* = undefined;
     }
 
     pub fn reset(self: *WrapBreakResult) void {
@@ -1645,6 +1648,7 @@ pub const GraphemeInfoResult = struct {
 
     pub fn deinit(self: *GraphemeInfoResult) void {
         self.graphemes.deinit();
+        self.* = undefined;
     }
 
     pub fn reset(self: *GraphemeInfoResult) void {


### PR DESCRIPTION
Set `self.* = undefined` in `deinit` methods and defer
`destroy(self)` where needed so freed objects fail fast when reused.
This makes use-after-deinit bugs easier to catch.
