### PR TITLE
Fix broken markdown table in keymap/custom-addons

### DIFF
--- a/packages/web/src/content/docs/keymap/custom-addons.mdx
+++ b/packages/web/src/content/docs/keymap/custom-addons.mdx
@@ -78,11 +78,11 @@ Guidelines:
 
 ### Diagnostics and lifecycle
 
-| API                              | Use for                                                            |
-| -------------------------------- | ------------------------------------------------------------------ | --------- | -------------- | ------------------------------------------------ |
-| `prepend/appendLayerAnalyzer()`  | Emit warnings or errors while layers compile                       |
-| `acquireResource(symbol, setup)` | Share ref-counted setup and teardown across multiple registrations |
-| `on("state"                      | "pendingSequence"                                                  | "warning" | "error", ...)` | Subscribe to derived-state and diagnostic events |
+| API                                                             | Use for                                                            |
+| --------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `prepend/appendLayerAnalyzer()`                                 | Emit warnings or errors while layers compile                       |
+| `acquireResource(symbol, setup)`                                | Share ref-counted setup and teardown across multiple registrations |
+| `on("state" \| "pendingSequence" \| "warning" \| "error", ...)` | Subscribe to derived-state and diagnostic events                   |
 
 Every registration API above returns a disposer.
 


### PR DESCRIPTION
Fix broken markdown table in https://opentui.com/docs/keymap/custom-addons/ due to inline code not properly escaped + incorrect column amount

left: before, right: after

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/40d58879-2d2d-47e6-939a-0d9a433af5e1" />
