### PR TITLE
fix(core): force full repaint after resume

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -3432,7 +3432,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.enableMouse()
     }
 
-    this.currentRenderBuffer.clear(this.backgroundColor)
+    this.forceFullRepaintRequested = true
     this._controlState = this._previousControlState
 
     if (

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -612,6 +612,33 @@ test("CliRenderer reuses generic suspend/resume native helpers in split-footer m
   resumeGenericSpy.mockRestore()
 })
 
+test("CliRenderer split-footer resume forces the next footer repaint", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  renderer.start()
+  renderer.suspend()
+
+  const repaintSpy = spyOn((renderer as any).lib, "repaintSplitFooter")
+  renderer.resume()
+  renderer.pause()
+
+  const lastCall = repaintSpy.mock.calls[repaintSpy.mock.calls.length - 1]
+  expect(lastCall?.[2]).toBe(true)
+  expect((renderer as any).forceFullRepaintRequested).toBe(false)
+
+  repaintSpy.mockRestore()
+})
+
 test("CliRenderer does not flush captured split output during resize while suspended", async () => {
   const result = await createTestRenderer({
     width: 40,

--- a/packages/core/src/tests/renderer.control.test.ts
+++ b/packages/core/src/tests/renderer.control.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, beforeEach, afterEach } from "bun:test"
+import { test, expect, beforeEach, afterEach, spyOn } from "bun:test"
 import { createTestRenderer, type TestRenderer, type MockInput, type MockMouse } from "../testing/test-renderer.js"
 import { RendererControlState } from "../renderer.js"
 import { Renderable } from "../Renderable.js"
@@ -21,6 +21,25 @@ beforeEach(async () => {
 afterEach(() => {
   renderer.destroy()
 })
+
+async function expectStartedResumeForcesNextRender(screenMode: "main-screen" | "alternate-screen"): Promise<void> {
+  renderer.destroy()
+  ;({ renderer, mockInput, mockMouse, renderOnce } = await createTestRenderer({ screenMode }))
+  ;(renderer as any)._terminalIsSetup = true
+
+  renderer.start()
+  renderer.suspend()
+
+  const renderSpy = spyOn((renderer as any).lib, "render")
+  renderer.resume()
+  renderer.pause()
+
+  const lastCall = renderSpy.mock.calls[renderSpy.mock.calls.length - 1]
+  expect(lastCall?.[1]).toBe(true)
+  expect((renderer as any).forceFullRepaintRequested).toBe(false)
+
+  renderSpy.mockRestore()
+}
 
 test("initial renderer state is IDLE", () => {
   expect(renderer.controlState).toBe(RendererControlState.IDLE)
@@ -114,6 +133,14 @@ test("resume() restores previous AUTO_STARTED state and restarts rendering", () 
   renderer.resume()
   expect(renderer.controlState).toBe(RendererControlState.AUTO_STARTED)
   expect(renderer.isRunning).toBe(true)
+})
+
+test("resume() forces the next main-screen render to fully repaint", async () => {
+  await expectStartedResumeForcesNextRender("main-screen")
+})
+
+test("resume() forces the next alternate-screen render to fully repaint", async () => {
+  await expectStartedResumeForcesNextRender("alternate-screen")
 })
 
 test("stop() transitions to EXPLICIT_STOPPED and stops rendering", () => {


### PR DESCRIPTION
## Summary
- Force the next native render after `CliRenderer.resume()` so terminal contents are fully repainted after process suspend/resume.
- Replace `currentRenderBuffer.clear(this.backgroundColor)` with the existing one-shot `forceFullRepaintRequested` latch.
- Add regression coverage for main-screen, alternate-screen, and split-footer resume paths.

## Problem

After `Ctrl+Z` / `fg`, or equivalent `SIGTSTP` / `SIGCONT` flows, the terminal can contain stale content while OpenTUI's render buffers still believe cells are current.

This is especially visible for blank or background-only regions: text and other non-background content may repaint, but blank/background cells can remain stale because diff rendering skips cells that compare equal.

The previous `resume()` behavior tried to invalidate rendering with:

```ts
this.currentRenderBuffer.clear(this.backgroundColor)
```

That was the wrong invalidation model for this bug. It clears OpenTUI's current render buffer to the terminal background/default renderer background, not necessarily to the application's themed background, such as opencode's theme background. For cells that should repaint as blanks or background-only theme cells, this can make the current buffer compare equal to the next frame and skip exactly the cells that need to overwrite stale terminal content.

## Fix

`resume()` now requests a one-shot full repaint:

```ts
this.forceFullRepaintRequested = true
```

The existing `renderNative()` paths consume that latch and pass `force=true` to native rendering:
- main/alternate rendering uses `lib.render(..., true)`
- split-footer capture mode forces the next footer repaint path

This keeps repaint recovery inside the normal render loop instead of issuing immediate native renders or raw terminal clear sequences from `resume()`.

## Screenshots

<img width="1508" height="941" alt="Screenshot_20260501_104430" src="https://github.com/user-attachments/assets/07bc4828-7f3c-4151-9562-ac1111360636" />
<img width="1508" height="941" alt="Screenshot_20260501_104515" src="https://github.com/user-attachments/assets/a38862d3-377c-4339-b8ff-151b9a1c3b1b" />

## Fixes

Fixes anomalyco/opentui#922  
Fixes anomalyco/opencode#16327  
Fixes anomalyco/opencode#22423

## Replaces

Closes anomalyco/opentui#928  
Closes anomalyco/opencode#16326

The core idea from anomalyco/opentui#928 is retained: use native forced repaint instead of clearing `currentRenderBuffer`. This PR differs by using the existing one-shot render latch rather than calling native render immediately inside `resume()`.

The repaint portion of anomalyco/opencode#16326 should no longer be needed because stale terminal repaint recovery belongs in OpenTUI rather than opencode app code.

## Related But Not Replaced

These address external suspend cleanup / mouse/raw-mode leakage and are complementary:
- https://github.com/anomalyco/opentui/issues/906
- https://github.com/anomalyco/opentui/pull/907
- https://github.com/anomalyco/opencode/issues/20506
- https://github.com/anomalyco/opencode/pull/20507

If OpenTUI later handles external `SIGTSTP` / `SIGCONT` directly, that path should call the same `suspend()` / `resume()` methods so this repaint recovery still applies.

## Testing

- `bun test src/tests/renderer.control.test.ts src/tests/renderer.console-startup.test.ts`
- `bunx tsc --noEmit -p tsconfig.build.json`
- Manual opencode verification with `Ctrl+Z` then `fg`