### PR TITLE
core/buffer: drop !void from infallible methods

### DIFF
--- a/packages/core/src/zig/bench/buffer-color-blending_bench.zig
+++ b/packages/core/src/zig/bench/buffer-color-blending_bench.zig
@@ -94,7 +94,7 @@ fn runTranslucentBoxes(
 
         var stats: BenchStats = .{};
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
             var box_i: usize = 0;
@@ -147,7 +147,7 @@ fn runTranslucentBoxes(
 
         var stats: BenchStats = .{};
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             try buf.pushOpacity(0.5);
             errdefer buf.popOpacity();
@@ -225,7 +225,7 @@ fn runTranslucentTextBuffers(
     if (run_translucent_bg) {
         var stats: BenchStats = .{};
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             const tbs = try allocator.alloc(*UnifiedTextBuffer, TEXT_COUNT);
             const views = try allocator.alloc(*UnifiedTextBufferView, TEXT_COUNT);
@@ -245,7 +245,7 @@ fn runTranslucentTextBuffers(
                 const x: i32 = @intCast(@as(i32, @intCast(buf_i % BUFFER_WIDTH)));
                 const y: i32 = 0;
 
-                try buf.drawTextBuffer(views[buf_i % TEXT_COUNT], x, y);
+                buf.drawTextBuffer(views[buf_i % TEXT_COUNT], x, y);
             }
             stats.record(timer.read());
 
@@ -274,7 +274,7 @@ fn runTranslucentTextBuffers(
     if (run_translucent_opacity) {
         var stats: BenchStats = .{};
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             const tbs = try allocator.alloc(*UnifiedTextBuffer, TEXT_COUNT);
             const views = try allocator.alloc(*UnifiedTextBufferView, TEXT_COUNT);
@@ -297,7 +297,7 @@ fn runTranslucentTextBuffers(
                 const x: i32 = @intCast(@as(i32, @intCast(buf_i % BUFFER_WIDTH)));
                 const y: i32 = 0;
 
-                try buf.drawTextBuffer(views[buf_i % TEXT_COUNT], x, y);
+                buf.drawTextBuffer(views[buf_i % TEXT_COUNT], x, y);
             }
             stats.record(timer.read());
 

--- a/packages/core/src/zig/bench/buffer-draw-box_bench.zig
+++ b/packages/core/src/zig/bench/buffer-draw-box_bench.zig
@@ -71,7 +71,7 @@ fn runTransparentBoxes(
 
         var stats: BenchStats = .{};
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             try buf.pushOpacity(0.0);
             errdefer buf.popOpacity();
@@ -128,7 +128,7 @@ fn runTransparentBoxes(
 
         var stats: BenchStats = .{};
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
             var box_i: usize = 0;
@@ -181,7 +181,7 @@ fn runTransparentBoxes(
 
         var stats: BenchStats = .{};
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
             var box_i: usize = 0;
@@ -261,7 +261,7 @@ fn runFilledBoxes(
 
         var stats: BenchStats = .{};
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
             var box_i: usize = 0;
@@ -314,7 +314,7 @@ fn runFilledBoxes(
 
         var stats: BenchStats = .{};
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
             var box_i: usize = 0;
@@ -367,7 +367,7 @@ fn runFilledBoxes(
 
         var stats: BenchStats = .{};
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             try buf.pushOpacity(0.5);
             errdefer buf.popOpacity();
@@ -445,7 +445,7 @@ fn runFilledBoxesTitle(
 
     var stats: BenchStats = .{};
     for (0..iterations) |i| {
-        try buf.clear(CLEAR_BG, null);
+        buf.clear(CLEAR_BG, null);
 
         var timer = try std.time.Timer.start();
         var box_i: usize = 0;
@@ -519,7 +519,7 @@ fn runFilledBoxesBorders(
 
     var stats: BenchStats = .{};
     for (0..iterations) |i| {
-        try buf.clear(CLEAR_BG, null);
+        buf.clear(CLEAR_BG, null);
 
         var timer = try std.time.Timer.start();
         var box_i: usize = 0;
@@ -598,7 +598,7 @@ fn runFilledBoxesClipped(
     if (run_fully) {
         var stats: BenchStats = .{};
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
             var box_i: usize = 0;
@@ -646,7 +646,7 @@ fn runFilledBoxesClipped(
     if (run_half) {
         var stats: BenchStats = .{};
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
             var box_i: usize = 0;
@@ -696,7 +696,7 @@ fn runFilledBoxesClipped(
     if (run_negative) {
         var stats: BenchStats = .{};
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
             var box_i: usize = 0;

--- a/packages/core/src/zig/bench/buffer-draw-text-buffer_bench.zig
+++ b/packages/core/src/zig/bench/buffer-draw-text-buffer_bench.zig
@@ -112,10 +112,10 @@ fn benchRenderColdCache(
         const buf = try OptimizedBuffer.init(allocator, 120, 40, .{ .pool = pool });
         defer buf.deinit();
 
-        try buf.clear(CLEAR_BG, null);
+        buf.clear(CLEAR_BG, null);
 
         var timer = try std.time.Timer.start();
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
         stats.record(timer.read());
 
         if (i == iterations - 1 and show_mem) {
@@ -171,10 +171,10 @@ fn benchWrapAndRender(
         const buf = try OptimizedBuffer.init(allocator, 120, 40, .{ .pool = pool });
         defer buf.deinit();
 
-        try buf.clear(CLEAR_BG, null);
+        buf.clear(CLEAR_BG, null);
 
         var timer = try std.time.Timer.start();
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
         stats.record(timer.read());
 
         if (i == iterations - 1 and show_mem) {
@@ -236,10 +236,10 @@ fn benchRenderWarmCache(
             const buf = try OptimizedBuffer.init(allocator, 120, 40, .{ .pool = pool });
             defer buf.deinit();
 
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
-            try buf.drawTextBuffer(view, 0, 0);
+            buf.drawTextBuffer(view, 0, 0);
             stats.record(timer.read());
 
             if (i == iterations - 1 and show_mem) {
@@ -275,10 +275,10 @@ fn benchRenderWarmCache(
         var stats: BenchStats = .{};
 
         for (0..iterations) |_| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
-            try buf.drawTextBuffer(view, 0, 0);
+            buf.drawTextBuffer(view, 0, 0);
             stats.record(timer.read());
         }
 
@@ -327,10 +327,10 @@ fn benchRenderSmallResolution(
         var final_buf_mem: usize = 0;
 
         for (0..iterations) |i| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
-            try buf.drawTextBuffer(view, 0, 0);
+            buf.drawTextBuffer(view, 0, 0);
             stats.record(timer.read());
 
             if (i == iterations - 1 and show_mem) {
@@ -366,10 +366,10 @@ fn benchRenderSmallResolution(
         var stats: BenchStats = .{};
 
         for (0..iterations) |_| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
-            try buf.drawTextBuffer(view, 0, 0);
+            buf.drawTextBuffer(view, 0, 0);
             stats.record(timer.read());
         }
 
@@ -414,10 +414,10 @@ fn benchRenderMediumResolution(
     var final_buf_mem: usize = 0;
 
     for (0..iterations) |i| {
-        try buf.clear(CLEAR_BG, null);
+        buf.clear(CLEAR_BG, null);
 
         var timer = try std.time.Timer.start();
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
         stats.record(timer.read());
 
         if (i == iterations - 1 and show_mem) {
@@ -471,10 +471,10 @@ fn benchRenderMassiveResolution(
     var final_buf_mem: usize = 0;
 
     for (0..iterations) |i| {
-        try buf.clear(CLEAR_BG, null);
+        buf.clear(CLEAR_BG, null);
 
         var timer = try std.time.Timer.start();
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
         stats.record(timer.read());
 
         if (i == iterations - 1 and show_mem) {
@@ -528,10 +528,10 @@ fn benchRenderMassiveLines(
     var final_buf_mem: usize = 0;
 
     for (0..iterations) |i| {
-        try buf.clear(CLEAR_BG, null);
+        buf.clear(CLEAR_BG, null);
 
         var timer = try std.time.Timer.start();
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
         stats.record(timer.read());
 
         if (i == iterations - 1 and show_mem) {
@@ -591,10 +591,10 @@ fn benchRenderOneMassiveLine(
     var final_buf_mem: usize = 0;
 
     for (0..iterations) |i| {
-        try buf.clear(CLEAR_BG, null);
+        buf.clear(CLEAR_BG, null);
 
         var timer = try std.time.Timer.start();
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
         stats.record(timer.read());
 
         if (i == iterations - 1 and show_mem) {
@@ -648,10 +648,10 @@ fn benchRenderManySmallChunks(
     var final_buf_mem: usize = 0;
 
     for (0..iterations) |i| {
-        try buf.clear(CLEAR_BG, null);
+        buf.clear(CLEAR_BG, null);
 
         var timer = try std.time.Timer.start();
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
         stats.record(timer.read());
 
         if (i == iterations - 1 and show_mem) {
@@ -711,10 +711,10 @@ fn benchRenderWithViewport(
         var stats: BenchStats = .{};
 
         for (0..iterations) |_| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
-            try buf.drawTextBuffer(view, 0, 0);
+            buf.drawTextBuffer(view, 0, 0);
             stats.record(timer.read());
         }
 
@@ -740,10 +740,10 @@ fn benchRenderWithViewport(
         var stats: BenchStats = .{};
 
         for (0..iterations) |_| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
-            try buf.drawTextBuffer(view, 0, 0);
+            buf.drawTextBuffer(view, 0, 0);
             stats.record(timer.read());
         }
 
@@ -794,10 +794,10 @@ fn benchRenderWithSelection(
         var stats: BenchStats = .{};
 
         for (0..iterations) |_| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
-            try buf.drawTextBuffer(view, 0, 0);
+            buf.drawTextBuffer(view, 0, 0);
             stats.record(timer.read());
         }
 
@@ -823,10 +823,10 @@ fn benchRenderWithSelection(
         var stats: BenchStats = .{};
 
         for (0..iterations) |_| {
-            try buf.clear(CLEAR_BG, null);
+            buf.clear(CLEAR_BG, null);
 
             var timer = try std.time.Timer.start();
-            try buf.drawTextBuffer(view, 0, 0);
+            buf.drawTextBuffer(view, 0, 0);
             stats.record(timer.read());
         }
 

--- a/packages/core/src/zig/buffer.zig
+++ b/packages/core/src/zig/buffer.zig
@@ -415,7 +415,7 @@ pub const OptimizedBuffer = struct {
 
         // Always clear after resize to initialize cells (realloc doesn't zero memory)
         // This handles both growing (new cells are garbage) and shrinking (grapheme cleanup)
-        try self.clear(ansi.rgbColor(0, 0, 0, 255), null);
+        self.clear(ansi.rgbColor(0, 0, 0, 255), null);
     }
 
     fn coordsToIndex(self: *const OptimizedBuffer, x: u32, y: u32) u32 {
@@ -429,7 +429,7 @@ pub const OptimizedBuffer = struct {
         };
     }
 
-    pub fn clear(self: *OptimizedBuffer, bg: RGBA, char: ?u32) !void {
+    pub fn clear(self: *OptimizedBuffer, bg: RGBA, char: ?u32) void {
         const cellChar = char orelse DEFAULT_SPACE_CHAR;
         self.link_tracker.clear();
         self.grapheme_tracker.clear();
@@ -800,11 +800,11 @@ pub const OptimizedBuffer = struct {
         fg: RGBA,
         bg: RGBA,
         attributes: u32,
-    ) !void {
-        return self.setCellWithAlphaBlendingCell(x, y, makeCell(char, fg, bg, attributes));
+    ) void {
+        self.setCellWithAlphaBlendingCell(x, y, makeCell(char, fg, bg, attributes));
     }
 
-    fn setCellWithAlphaBlendingCell(self: *OptimizedBuffer, x: u32, y: u32, cell: Cell) !void {
+    fn setCellWithAlphaBlendingCell(self: *OptimizedBuffer, x: u32, y: u32, cell: Cell) void {
         if (!self.isPointInScissor(@intCast(x), @intCast(y))) return;
 
         const opacity = self.getCurrentOpacity();
@@ -838,11 +838,11 @@ pub const OptimizedBuffer = struct {
         fg: RGBA,
         bg: RGBA,
         attributes: u32,
-    ) !void {
-        return self.setCellWithAlphaBlendingRawCell(x, y, makeCell(char, fg, bg, attributes));
+    ) void {
+        self.setCellWithAlphaBlendingRawCell(x, y, makeCell(char, fg, bg, attributes));
     }
 
-    fn setCellWithAlphaBlendingRawCell(self: *OptimizedBuffer, x: u32, y: u32, cell: Cell) !void {
+    fn setCellWithAlphaBlendingRawCell(self: *OptimizedBuffer, x: u32, y: u32, cell: Cell) void {
         if (!self.isPointInScissor(@intCast(x), @intCast(y))) return;
 
         const opacity = self.getCurrentOpacity();
@@ -914,8 +914,8 @@ pub const OptimizedBuffer = struct {
         fg: RGBA,
         bg: RGBA,
         attributes: u32,
-    ) !void {
-        try self.setCellWithAlphaBlendingCell(x, y, makeCell(char, fg, bg, attributes));
+    ) void {
+        self.setCellWithAlphaBlendingCell(x, y, makeCell(char, fg, bg, attributes));
     }
 
     pub fn fillRect(
@@ -925,7 +925,7 @@ pub const OptimizedBuffer = struct {
         width: u32,
         height: u32,
         bg: RGBA,
-    ) !void {
+    ) void {
         if (self.width == 0 or self.height == 0 or width == 0 or height == 0) return;
         if (x >= self.width or y >= self.height) return;
 
@@ -960,7 +960,7 @@ pub const OptimizedBuffer = struct {
             while (fillY <= clippedEndY) : (fillY += 1) {
                 var fillX = clippedStartX;
                 while (fillX <= clippedEndX) : (fillX += 1) {
-                    try self.setCellWithAlphaBlendingCell(
+                    self.setCellWithAlphaBlendingCell(
                         fillX,
                         fillY,
                         makeCell(DEFAULT_SPACE_CHAR, ansi.rgbColor(255, 255, 255, 255), bg, 0),
@@ -974,7 +974,7 @@ pub const OptimizedBuffer = struct {
             while (fillY <= clippedEndY) : (fillY += 1) {
                 var fillX = clippedStartX;
                 while (fillX <= clippedEndX) : (fillX += 1) {
-                    try self.setCellWithAlphaBlendingRaw(fillX, fillY, DEFAULT_SPACE_CHAR, ansi.rgbColor(255, 255, 255, 255), bg, 0);
+                    self.setCellWithAlphaBlendingRaw(fillX, fillY, DEFAULT_SPACE_CHAR, ansi.rgbColor(255, 255, 255, 255), bg, 0);
                 }
             }
         } else {
@@ -1004,7 +1004,7 @@ pub const OptimizedBuffer = struct {
         width: u32,
         height: u32,
         bg: RGBA,
-    ) !void {
+    ) void {
         if (width == 0 or height == 0) return;
 
         const startX = @max(0, x);
@@ -1014,7 +1014,7 @@ pub const OptimizedBuffer = struct {
 
         if (startX > endX or startY > endY) return;
 
-        try self.fillRect(
+        self.fillRect(
             @intCast(startX),
             @intCast(startY),
             @intCast(endX - startX + 1),
@@ -1102,7 +1102,7 @@ pub const OptimizedBuffer = struct {
                     if (tab_x >= self.width) break;
 
                     if (isRGBAWithAlpha(bgColor)) {
-                        try self.setCellWithAlphaBlendingCell(
+                        self.setCellWithAlphaBlendingCell(
                             tab_x,
                             y,
                             makeCell(DEFAULT_SPACE_CHAR, fg, bgColor, attributes),
@@ -1125,7 +1125,7 @@ pub const OptimizedBuffer = struct {
             }
 
             if (isRGBAWithAlpha(bgColor)) {
-                try self.setCellWithAlphaBlendingCell(
+                self.setCellWithAlphaBlendingCell(
                     charX,
                     y,
                     makeCell(encoded_char, fg, bgColor, attributes),
@@ -1238,7 +1238,7 @@ pub const OptimizedBuffer = struct {
                                 @intCast(dX),
                                 @intCast(dY),
                                 makeCell(DEFAULT_SPACE_CHAR, srcFg, srcBg, srcAttr),
-                            ) catch {};
+                            );
                         }
                         continue;
                     }
@@ -1251,7 +1251,7 @@ pub const OptimizedBuffer = struct {
                         @intCast(dX),
                         @intCast(dY),
                         makeCell(srcChar, srcFg, srcBg, srcAttr),
-                    ) catch {};
+                    );
                     continue;
                 }
 
@@ -1259,7 +1259,7 @@ pub const OptimizedBuffer = struct {
                     @intCast(dX),
                     @intCast(dY),
                     makeCell(srcChar, srcFg, srcBg, srcAttr),
-                ) catch {};
+                );
             }
         }
     }
@@ -1270,8 +1270,8 @@ pub const OptimizedBuffer = struct {
         text_buffer_view: *TextBufferView,
         x: i32,
         y: i32,
-    ) !void {
-        try self.drawTextBufferInternal(TextBufferView, text_buffer_view, x, y);
+    ) void {
+        self.drawTextBufferInternal(TextBufferView, text_buffer_view, x, y);
     }
 
     /// Internal implementation that accepts either TextBufferView or EditorView
@@ -1282,7 +1282,7 @@ pub const OptimizedBuffer = struct {
         view: *ViewType,
         x: i32,
         y: i32,
-    ) !void {
+    ) void {
         const opacity = self.getCurrentOpacity();
         if (opacity == 0.0) return;
 
@@ -1300,7 +1300,7 @@ pub const OptimizedBuffer = struct {
             const base_defaults = view.edit_buffer.getTextBuffer().defaults();
             const default_bg = base_defaults.bg orelse break :blk null;
             if (ansi.alpha(default_bg) == 0) break :blk null;
-            try self.fillRectClipped(x, y, vp.width, vp.height, default_bg);
+            self.fillRectClipped(x, y, vp.width, vp.height, default_bg);
             break :blk .{ .bg = default_bg };
         };
 
@@ -1633,7 +1633,7 @@ pub const OptimizedBuffer = struct {
                                 }
                             }
 
-                            try self.setCellWithAlphaBlendingCell(
+                            self.setCellWithAlphaBlendingCell(
                                 @intCast(currentX + @as(i32, @intCast(tab_col))),
                                 @intCast(currentY),
                                 makeCell(char, fg, drawBg, drawAttributes),
@@ -1665,7 +1665,7 @@ pub const OptimizedBuffer = struct {
                             }
                         }
 
-                        try self.setCellWithAlphaBlendingCell(
+                        self.setCellWithAlphaBlendingCell(
                             @intCast(currentX),
                             @intCast(currentY),
                             makeCell(encoded_char, drawFg, drawBg, drawAttributes),
@@ -1701,8 +1701,8 @@ pub const OptimizedBuffer = struct {
         editor_view: *EditorView,
         x: i32,
         y: i32,
-    ) !void {
-        try self.drawTextBufferInternal(EditorView, editor_view, x, y);
+    ) void {
+        self.drawTextBufferInternal(EditorView, editor_view, x, y);
     }
 
     /// Draw a complete border grid in a single call.
@@ -1902,7 +1902,7 @@ pub const OptimizedBuffer = struct {
             if (!borderSides.top and !borderSides.right and !borderSides.bottom and !borderSides.left) {
                 const fillWidth = @as(u32, @intCast(endX - startX + 1));
                 const fillHeight = @as(u32, @intCast(endY - startY + 1));
-                try self.fillRect(@intCast(startX), @intCast(startY), fillWidth, fillHeight, backgroundColor);
+                self.fillRect(@intCast(startX), @intCast(startY), fillWidth, fillHeight, backgroundColor);
             } else {
                 const innerStartX = startX + if (borderSides.left and isAtActualLeft) @as(i32, 1) else @as(i32, 0);
                 const innerStartY = startY + if (borderSides.top and isAtActualTop) @as(i32, 1) else @as(i32, 0);
@@ -1912,7 +1912,7 @@ pub const OptimizedBuffer = struct {
                 if (innerEndX >= innerStartX and innerEndY >= innerStartY) {
                     const fillWidth = @as(u32, @intCast(innerEndX - innerStartX + 1));
                     const fillHeight = @as(u32, @intCast(innerEndY - innerStartY + 1));
-                    try self.fillRect(@intCast(innerStartX), @intCast(innerStartY), fillWidth, fillHeight, backgroundColor);
+                    self.fillRect(@intCast(innerStartX), @intCast(innerStartY), fillWidth, fillHeight, backgroundColor);
                 }
             }
         }
@@ -1953,7 +1953,7 @@ pub const OptimizedBuffer = struct {
                             self.buffer.fg[index] = borderColor;
                             self.buffer.attributes[index] = 0;
                         } else {
-                            try self.setCellWithAlphaBlendingCell(
+                            self.setCellWithAlphaBlendingCell(
                                 @intCast(drawX),
                                 @intCast(startY),
                                 makeCell(char, borderColor, backgroundColor, 0),
@@ -1987,7 +1987,7 @@ pub const OptimizedBuffer = struct {
                             self.buffer.fg[index] = borderColor;
                             self.buffer.attributes[index] = 0;
                         } else {
-                            try self.setCellWithAlphaBlendingCell(
+                            self.setCellWithAlphaBlendingCell(
                                 @intCast(drawX),
                                 @intCast(endY),
                                 makeCell(char, borderColor, backgroundColor, 0),
@@ -2013,7 +2013,7 @@ pub const OptimizedBuffer = struct {
                         self.buffer.fg[index] = borderColor;
                         self.buffer.attributes[index] = 0;
                     } else {
-                        try self.setCellWithAlphaBlendingCell(
+                        self.setCellWithAlphaBlendingCell(
                             @intCast(startX),
                             @intCast(drawY),
                             makeCell(borderChars[@intFromEnum(BorderCharIndex.vertical)], borderColor, backgroundColor, 0),
@@ -2029,7 +2029,7 @@ pub const OptimizedBuffer = struct {
                         self.buffer.fg[index] = borderColor;
                         self.buffer.attributes[index] = 0;
                     } else {
-                        try self.setCellWithAlphaBlendingCell(
+                        self.setCellWithAlphaBlendingCell(
                             @intCast(endX),
                             @intCast(drawY),
                             makeCell(borderChars[@intFromEnum(BorderCharIndex.vertical)], borderColor, backgroundColor, 0),
@@ -2105,7 +2105,7 @@ pub const OptimizedBuffer = struct {
         len: usize,
         format: u8, // 0: bgra8unorm, 1: rgba8unorm
         alignedBytesPerRow: u32,
-    ) !void {
+    ) void {
         const bytesPerPixel = 4;
         const isBGRA = (format == 0);
 
@@ -2138,7 +2138,7 @@ pub const OptimizedBuffer = struct {
 
                 const cellResult = renderQuadrantBlock(pixelsRgba);
 
-                try self.setCellWithAlphaBlending(
+                self.setCellWithAlphaBlending(
                     x_cell,
                     y_cell,
                     cellResult.char,
@@ -2195,7 +2195,7 @@ pub const OptimizedBuffer = struct {
                 char = BLOCK_CHAR;
             }
 
-            self.setCellWithAlphaBlending(cellX, cellY, char, fg, bg, 0) catch {};
+            self.setCellWithAlphaBlending(cellX, cellY, char, fg, bg, 0);
         }
     }
 
@@ -2264,9 +2264,9 @@ pub const OptimizedBuffer = struct {
                 const fg = applyOpacity(baseFg, opacityToU8(gray * opacity));
 
                 if (graphemeAware or linkAware) {
-                    self.setCellWithAlphaBlendingCell(destX, destY, makeCell(char, fg, bg, 0)) catch {};
+                    self.setCellWithAlphaBlendingCell(destX, destY, makeCell(char, fg, bg, 0));
                 } else {
-                    self.setCellWithAlphaBlendingRawCell(destX, destY, makeCell(char, fg, bg, 0)) catch {};
+                    self.setCellWithAlphaBlendingRawCell(destX, destY, makeCell(char, fg, bg, 0));
                 }
             }
         }
@@ -2346,9 +2346,9 @@ pub const OptimizedBuffer = struct {
                 const fg = applyOpacity(baseFg, opacityToU8(gray * opacity));
 
                 if (graphemeAware or linkAware) {
-                    self.setCellWithAlphaBlendingCell(destX, destY, makeCell(char, fg, bg, 0)) catch {};
+                    self.setCellWithAlphaBlendingCell(destX, destY, makeCell(char, fg, bg, 0));
                 } else {
-                    self.setCellWithAlphaBlendingRawCell(destX, destY, makeCell(char, fg, bg, 0)) catch {};
+                    self.setCellWithAlphaBlendingRawCell(destX, destY, makeCell(char, fg, bg, 0));
                 }
             }
         }

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -591,7 +591,7 @@ export fn clearClipboardOSC52(rendererPtr: *renderer.CliRenderer, target: u8) bo
 
 // Buffer functions
 export fn bufferClear(bufferPtr: *buffer.OptimizedBuffer, bg: [*]const u16) void {
-    bufferPtr.clear(ptrToRGBA(bg), null) catch {};
+    bufferPtr.clear(ptrToRGBA(bg), null);
 }
 
 export fn bufferGetCharPtr(bufferPtr: *buffer.OptimizedBuffer) [*]u32 {
@@ -646,7 +646,7 @@ export fn bufferDrawText(bufferPtr: *buffer.OptimizedBuffer, text: [*]const u8, 
 }
 
 export fn bufferSetCellWithAlphaBlending(bufferPtr: *buffer.OptimizedBuffer, x: u32, y: u32, char: u32, fg: [*]const u16, bg: [*]const u16, attributes: u32) void {
-    bufferPtr.setCellWithAlphaBlending(x, y, char, ptrToRGBA(fg), ptrToRGBA(bg), attributes) catch {};
+    bufferPtr.setCellWithAlphaBlending(x, y, char, ptrToRGBA(fg), ptrToRGBA(bg), attributes);
 }
 
 export fn bufferSetCell(bufferPtr: *buffer.OptimizedBuffer, x: u32, y: u32, char: u32, fg: [*]const u16, bg: [*]const u16, attributes: u32) void {
@@ -659,7 +659,7 @@ export fn bufferSetCell(bufferPtr: *buffer.OptimizedBuffer, x: u32, y: u32, char
 }
 
 export fn bufferFillRect(bufferPtr: *buffer.OptimizedBuffer, x: u32, y: u32, width: u32, height: u32, bg: [*]const u16) void {
-    bufferPtr.fillRect(x, y, width, height, ptrToRGBA(bg)) catch {};
+    bufferPtr.fillRect(x, y, width, height, ptrToRGBA(bg));
 }
 
 export fn bufferColorMatrix(bufferPtr: *buffer.OptimizedBuffer, matrixPtr: [*]const f32, cellMaskPtr: [*]const f32, cellMaskCount: usize, strength: f32, target: u8) void {
@@ -735,7 +735,7 @@ export fn bufferClearOpacity(bufferPtr: *buffer.OptimizedBuffer) void {
 }
 
 export fn bufferDrawSuperSampleBuffer(bufferPtr: *buffer.OptimizedBuffer, x: u32, y: u32, pixelData: [*]const u8, len: usize, format: u8, alignedBytesPerRow: u32) void {
-    bufferPtr.drawSuperSampleBuffer(x, y, pixelData, len, format, alignedBytesPerRow) catch {};
+    bufferPtr.drawSuperSampleBuffer(x, y, pixelData, len, format, alignedBytesPerRow);
 }
 
 export fn linkAlloc(urlPtr: [*]const u8, urlLen: usize) u32 {
@@ -1668,7 +1668,7 @@ export fn bufferDrawEditorView(
     x: i32,
     y: i32,
 ) void {
-    bufferPtr.drawEditorView(viewPtr, x, y) catch {};
+    bufferPtr.drawEditorView(viewPtr, x, y);
 }
 
 export fn bufferDrawTextBufferView(
@@ -1677,7 +1677,7 @@ export fn bufferDrawTextBufferView(
     x: i32,
     y: i32,
 ) void {
-    bufferPtr.drawTextBuffer(viewPtr, x, y) catch {};
+    bufferPtr.drawTextBuffer(viewPtr, x, y);
 }
 
 pub const ExternalHighlight = extern struct {
@@ -1981,5 +1981,5 @@ export fn bufferDrawChar(
     bg: [*]const u16,
     attributes: u32,
 ) void {
-    bufferPtr.drawChar(char, x, y, ptrToRGBA(fg), ptrToRGBA(bg), attributes) catch {};
+    bufferPtr.drawChar(char, x, y, ptrToRGBA(fg), ptrToRGBA(bg), attributes);
 }

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -329,8 +329,8 @@ pub const CliRenderer = struct {
         self.resetFallbackPaletteState();
         nextBuffer.setBlendBackdropColor(ansi.rgbColor(ansi.red(self.backgroundColor), ansi.green(self.backgroundColor), ansi.blue(self.backgroundColor), 255));
 
-        try currentBuffer.clear(self.backgroundColor, CLEAR_CHAR);
-        try nextBuffer.clear(self.backgroundColor, null);
+        currentBuffer.clear(self.backgroundColor, CLEAR_CHAR);
+        nextBuffer.clear(self.backgroundColor, null);
 
         return self;
     }
@@ -549,8 +549,8 @@ pub const CliRenderer = struct {
         try self.nextRenderBuffer.resize(width, height);
         self.nextRenderBuffer.setBlendBackdropColor(ansi.rgbColor(ansi.red(self.backgroundColor), ansi.green(self.backgroundColor), ansi.blue(self.backgroundColor), 255));
 
-        try self.currentRenderBuffer.clear(ansi.rgbColor(0, 0, 0, 255), CLEAR_CHAR);
-        try self.nextRenderBuffer.clear(self.backgroundColor, null);
+        self.currentRenderBuffer.clear(ansi.rgbColor(0, 0, 0, 255), CLEAR_CHAR);
+        self.nextRenderBuffer.clear(self.backgroundColor, null);
 
         const newHitGridSize = width * height;
         const currentHitGridSize = self.hitGridWidth * self.hitGridHeight;
@@ -1513,7 +1513,7 @@ pub const CliRenderer = struct {
         self.last_rendered_palette_epoch = self.palette_epoch;
         self.force_full_repaint = false;
 
-        self.nextRenderBuffer.clear(self.backgroundColor, null) catch {};
+        self.nextRenderBuffer.clear(self.backgroundColor, null);
 
         // Compare hit grids before swap to detect changes. This allows TypeScript to
         // know if hover state needs rechecking without manually tracking dirty state.
@@ -1981,7 +1981,7 @@ pub const CliRenderer = struct {
             },
         }
 
-        self.nextRenderBuffer.fillRect(x, y, width, height, ansi.rgbColor(20, 20, 40, 255)) catch {};
+        self.nextRenderBuffer.fillRect(x, y, width, height, ansi.rgbColor(20, 20, 40, 255));
         self.nextRenderBuffer.drawText("Debug Information", x + 1, y + 1, ansi.rgbColor(255, 255, 100, 255), ansi.rgbColor(0, 0, 0, 0), ansi.TextAttributes.BOLD) catch {};
 
         var row: u32 = 2;

--- a/packages/core/src/zig/tests/buffer-methods_test.zig
+++ b/packages/core/src/zig/tests/buffer-methods_test.zig
@@ -76,7 +76,7 @@ test "colorMatrix - identity matrix leaves colors unchanged" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red; // (0, 0)
     buf.buffer.fg[5] = red; // (1, 1)
 
@@ -105,7 +105,7 @@ test "colorMatrix - applies transformation to specified cells only" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     // Set all FG to red
     @memset(buf.buffer.fg, red);
@@ -140,7 +140,7 @@ test "colorMatrix - globalStrength scales individual cell strengths" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
 
     // Apply sepia with cell strength 1.0 but globalStrength 0.5
@@ -174,7 +174,7 @@ test "colorMatrix - respects target parameter" {
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
     const blue = ansi.rgbaFromFloats(0.0, 0.0, 1.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
     buf.buffer.bg[0] = blue;
     buf.buffer.fg[1] = red;
@@ -218,7 +218,7 @@ test "colorMatrix - skips out-of-bounds coordinates" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[4] = red; // (1, 1)
 
     // Apply to out-of-bounds and valid cell
@@ -247,7 +247,7 @@ test "colorMatrix - skips NaN and Inf coordinates" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[4] = red; // (1, 1)
 
     // Apply with NaN and valid coordinates
@@ -277,7 +277,7 @@ test "colorMatrix - skips zero strength cells" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
 
     // Apply with zero strength
@@ -306,7 +306,7 @@ test "colorMatrix - handles multiple cells in mask" {
     const blue = ansi.rgbaFromFloats(0.0, 0.0, 1.0, 1.0);
     const white = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     // Set different colors at different positions
     buf.buffer.fg[0] = red; // (0, 0)
@@ -361,7 +361,7 @@ test "colorMatrix - truncates incomplete mask triplets" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
     buf.buffer.fg[1] = red;
 
@@ -394,7 +394,7 @@ test "colorMatrix - empty mask returns early" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
 
     // Empty mask - should return early
@@ -420,7 +420,7 @@ test "colorMatrix - empty matrix returns early" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
 
     // Empty matrix - should return early
@@ -455,7 +455,7 @@ test "colorMatrix - alpha channel transformation" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const opaque_color = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = opaque_color;
 
     // Apply matrix that halves alpha
@@ -481,7 +481,7 @@ test "colorMatrix - mask with only 1 element" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
 
     // Mask with only 1 element (incomplete triplet)
@@ -507,7 +507,7 @@ test "colorMatrix - mask with only 2 elements" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
     buf.buffer.fg[1] = red;
 
@@ -535,7 +535,7 @@ test "colorMatrix - infinity strength is skipped" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
 
     // Apply with infinity strength (should be skipped)
@@ -562,7 +562,7 @@ test "colorMatrix - non-finite global strength is skipped" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
 
     const inf = std.math.inf(f32);
@@ -589,7 +589,7 @@ test "colorMatrix - large buffer with SIMD and scalar mix" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     // Set all to red
     @memset(buf.buffer.fg, red);
@@ -622,7 +622,7 @@ test "colorMatrix - negative coordinates are skipped" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[4] = red; // (1, 1)
 
     // Apply with negative coordinates followed by valid
@@ -651,7 +651,7 @@ test "colorMatrix - finite coordinates larger than u32 max are skipped" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[4] = red; // (1, 1)
 
     // First triplet uses finite but out-of-range coordinates for u32 conversion.
@@ -686,7 +686,7 @@ test "colorMatrixUniform - identity matrix leaves colors unchanged" {
     const blue = ansi.rgbaFromFloats(0.0, 0.0, 1.0, 1.0);
     const white = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     // Set specific colors at different positions
     buf.buffer.fg[0] = red;
@@ -719,7 +719,7 @@ test "colorMatrixUniform - zero strength has no effect" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     @memset(buf.buffer.fg, red);
 
@@ -746,7 +746,7 @@ test "colorMatrixUniform - non-finite strength has no effect" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
     buf.buffer.fg[1] = red;
 
@@ -774,7 +774,7 @@ test "colorMatrixUniform - grayscale transformation" {
     const green = ansi.rgbaFromFloats(0.0, 1.0, 0.0, 1.0);
     const blue = ansi.rgbaFromFloats(0.0, 0.0, 1.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     buf.buffer.fg[0] = red;
     buf.buffer.fg[1] = green;
@@ -810,7 +810,7 @@ test "colorMatrixUniform - partial strength blends with original" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
     buf.buffer.fg[1] = red;
 
@@ -844,7 +844,7 @@ test "colorMatrixUniform - target affects correct buffers" {
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
     const blue = ansi.rgbaFromFloats(0.0, 0.0, 1.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     buf.buffer.fg[0] = red;
     buf.buffer.bg[0] = blue;
@@ -901,7 +901,7 @@ test "colorMatrixUniform - handles buffer sizes not divisible by 4" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     // Set all FG to red
     for (0..5) |i| {
@@ -936,7 +936,7 @@ test "colorMatrixUniform - empty matrix returns early" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
 
     // Empty matrix - should return early without changes
@@ -963,7 +963,7 @@ test "colorMatrixUniform - alpha channel transformation" {
     const opaque_color = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
     const transparent_color = ansi.rgbaFromFloats(0.0, 1.0, 0.0, 0.5);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     buf.buffer.fg[0] = opaque_color;
     buf.buffer.fg[1] = transparent_color;
@@ -994,7 +994,7 @@ test "colorMatrixUniform - very small buffer (less than 4 pixels)" {
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
     const green = ansi.rgbaFromFloats(0.0, 1.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
     buf.buffer.fg[1] = green;
 
@@ -1030,7 +1030,7 @@ test "colorMatrixUniform - single pixel buffer" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = red;
 
     // Apply sepia at full strength
@@ -1066,7 +1066,7 @@ test "colorMatrixUniform - values can exceed 1.0 (no clamping)" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const gray = ansi.rgbaFromFloats(0.5, 0.5, 0.5, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     buf.buffer.fg[0] = gray;
 
     // Apply amplification at full strength
@@ -1092,7 +1092,7 @@ test "colorMatrixUniform - 3 pixel buffer (simd_end = 0, all scalar)" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const red = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     for (0..3) |i| {
         buf.buffer.fg[i] = red;
     }

--- a/packages/core/src/zig/tests/buffer_test.zig
+++ b/packages/core/src/zig/tests/buffer_test.zig
@@ -65,7 +65,7 @@ test "OptimizedBuffer - clear fills with default char" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     var y: u32 = 0;
     while (y < 5) : (y += 1) {
@@ -92,7 +92,7 @@ test "OptimizedBuffer - drawText with ASCII" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
     try buf.drawText("Hello", 0, 0, fg, bg, 0);
@@ -119,9 +119,9 @@ test "OptimizedBuffer - alpha blending downgrades blended metadata to rgb" {
     defer buf.deinit();
 
     const base_bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(base_bg, null);
+    buf.clear(base_bg, null);
 
-    try buf.setCellWithAlphaBlending(
+    buf.setCellWithAlphaBlending(
         0,
         0,
         'B',
@@ -142,7 +142,7 @@ test "OptimizedBuffer - alpha blending downgrades blended metadata to rgb" {
         .attributes = 0,
     });
 
-    try buf.setCellWithAlphaBlending(
+    buf.setCellWithAlphaBlending(
         0,
         0,
         'C',
@@ -180,8 +180,8 @@ test "OptimizedBuffer - transparent framebuffer cell background stays transparen
     defer dst.deinit();
 
     const transparent_bg = ansi.rgbColor(0, 0, 0, 0);
-    try src.clear(transparent_bg, null);
-    try dst.clear(transparent_bg, null);
+    src.clear(transparent_bg, null);
+    dst.clear(transparent_bg, null);
     dst.setBlendBackdropColor(ansi.rgbColor(0, 0, 0, 255));
 
     src.set(0, 0, .{
@@ -221,8 +221,8 @@ test "OptimizedBuffer - drawFrameBuffer preserves packed metadata on opaque copy
     defer dst.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try src.clear(bg, null);
-    try dst.clear(bg, null);
+    src.clear(bg, null);
+    dst.clear(bg, null);
 
     src.set(0, 0, .{
         .char = 'X',
@@ -270,7 +270,7 @@ test "OptimizedBuffer - drawTextBuffer transparent fast path preserves destinati
         .attributes = ansi.TextAttributes.BOLD,
     });
 
-    try buf.drawTextBuffer(view, 0, 0);
+    buf.drawTextBuffer(view, 0, 0);
 
     const cell = buf.get(0, 0).?;
     try std.testing.expectEqual(@as(u32, 'A'), cell.char);
@@ -311,7 +311,7 @@ test "OptimizedBuffer - drawTextBuffer transparent non-ascii preserves destinati
         .attributes = ansi.TextAttributes.BOLD,
     });
 
-    try buf.drawTextBuffer(view, 0, 0);
+    buf.drawTextBuffer(view, 0, 0);
 
     const cell = buf.get(0, 0).?;
     try std.testing.expect(gp.isGraphemeChar(cell.char));
@@ -340,7 +340,7 @@ test "OptimizedBuffer - repeated emoji rendering should not exhaust pool" {
 
     var i: u32 = 0;
     while (i < 1000) : (i += 1) {
-        try buf.clear(bg, null);
+        buf.clear(bg, null);
         try buf.drawText("🌟🎨🚀", 0, 0, fg, bg, 0);
     }
 
@@ -367,7 +367,7 @@ test "OptimizedBuffer - repeated CJK rendering should not exhaust pool" {
 
     var i: u32 = 0;
     while (i < 1000) : (i += 1) {
-        try buf.clear(bg, null);
+        buf.clear(bg, null);
         try buf.drawText("测试文字", 0, 0, fg, bg, 0);
     }
 
@@ -401,8 +401,8 @@ test "OptimizedBuffer - drawTextBuffer repeatedly should not exhaust pool" {
 
     var i: u32 = 0;
     while (i < 1000) : (i += 1) {
-        try buf.clear(bg, null);
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.clear(bg, null);
+        buf.drawTextBuffer(view, 0, 0);
     }
 }
 
@@ -425,7 +425,7 @@ test "OptimizedBuffer - mixed ASCII and emoji repeated rendering" {
 
     var i: u32 = 0;
     while (i < 500) : (i += 1) {
-        try buf.clear(bg, null);
+        buf.clear(bg, null);
         try buf.drawText("A🌟B🎨C🚀D", 0, 0, fg, bg, 0);
         try buf.drawText("测试文字处理", 0, 1, fg, bg, 0);
         try buf.drawText("Hello World!", 0, 2, fg, bg, 0);
@@ -482,7 +482,7 @@ test "OptimizedBuffer - rendering to different positions" {
 
     var i: u32 = 0;
     while (i < 100) : (i += 1) {
-        try buf.clear(bg, null);
+        buf.clear(bg, null);
 
         var y: u32 = 0;
         while (y < 20) : (y += 1) {
@@ -536,8 +536,8 @@ test "OptimizedBuffer - large text buffer with wrapping repeated render" {
 
     var i: u32 = 0;
     while (i < 200) : (i += 1) {
-        try buf.clear(bg, null);
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.clear(bg, null);
+        buf.drawTextBuffer(view, 0, 0);
     }
 }
 
@@ -566,7 +566,7 @@ test "OptimizedBuffer - grapheme tracker counts" {
 
     var i: u32 = 0;
     while (i < 100) : (i += 1) {
-        try buf.clear(bg, null);
+        buf.clear(bg, null);
         try buf.drawText("🌟🎨🚀", 0, 0, fg, bg, 0);
     }
 
@@ -627,11 +627,11 @@ test "OptimizedBuffer - drawTextBuffer without clear should not exhaust pool" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     var i: u32 = 0;
     while (i < 2000) : (i += 1) {
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
     }
 
     const count = buf.grapheme_tracker.getGraphemeCount();
@@ -661,11 +661,11 @@ test "OptimizedBuffer - many small graphemes without clear" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     var i: u32 = 0;
     while (i < 5000) : (i += 1) {
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
     }
 
     const count = buf.grapheme_tracker.getGraphemeCount();
@@ -703,11 +703,11 @@ test "OptimizedBuffer - stress test with many graphemes" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     var i: u32 = 0;
     while (i < 1000) : (i += 1) {
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
     }
 
     const count = buf.grapheme_tracker.getGraphemeCount();
@@ -745,9 +745,9 @@ test "OptimizedBuffer - pool slot exhaustion test" {
     var i: u32 = 0;
     while (i < 10000) : (i += 1) {
         if (i % 100 == 0) {
-            try buf.clear(bg, null);
+            buf.clear(bg, null);
         }
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
     }
 
     const cell = buf.get(0, 0).?;
@@ -804,14 +804,11 @@ test "OptimizedBuffer - many unique graphemes with small pool" {
         };
 
         if (render_count % 50 == 0) {
-            try buf.clear(bg, null);
+            buf.clear(bg, null);
             tb.reset();
         }
 
-        buf.drawTextBuffer(view, 0, 0) catch {
-            failure_count += 1;
-            continue;
-        };
+        buf.drawTextBuffer(view, 0, 0);
     }
 
     try std.testing.expect(failure_count == 0);
@@ -841,7 +838,7 @@ test "OptimizedBuffer - continuous rendering without buffer recreation" {
 
     var i: u32 = 0;
     while (i < 50000) : (i += 1) {
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
     }
 }
 
@@ -885,9 +882,9 @@ test "OptimizedBuffer - multiple buffers rendering same TextBuffer" {
 
     var i: u32 = 0;
     while (i < 5000) : (i += 1) {
-        try buf1.drawTextBuffer(view, 0, 0);
-        try buf2.drawTextBuffer(view, 0, 0);
-        try buf3.drawTextBuffer(view, 0, 0);
+        buf1.drawTextBuffer(view, 0, 0);
+        buf2.drawTextBuffer(view, 0, 0);
+        buf3.drawTextBuffer(view, 0, 0);
     }
 }
 
@@ -915,11 +912,11 @@ test "OptimizedBuffer - continuous render without clear with small pool" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     var i: u32 = 0;
     while (i < 100) : (i += 1) {
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
     }
 }
 
@@ -947,13 +944,13 @@ test "OptimizedBuffer - graphemes with scissor clipping and small pool" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     try buf.pushScissorRect(0, 0, 5, 5);
 
     var i: u32 = 0;
     while (i < 100) : (i += 1) {
-        try buf.drawTextBuffer(view, 20, 20);
+        buf.drawTextBuffer(view, 20, 20);
     }
 }
 
@@ -976,7 +973,7 @@ test "OptimizedBuffer - drawText with alpha blending and scissor" {
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
     const bg_alpha = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.5);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     try buf.pushScissorRect(0, 0, 10, 10);
 
@@ -1005,7 +1002,7 @@ test "OptimizedBuffer - many unique graphemes with alpha and small pool" {
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
     const bg_alpha = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.5);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     var i: u32 = 0;
     while (i < 50) : (i += 1) {
@@ -1042,7 +1039,7 @@ test "OptimizedBuffer - fill buffer with many unique graphemes" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     var char_idx: u32 = 0;
     var y: u32 = 0;
@@ -1081,7 +1078,7 @@ test "OptimizedBuffer - verify pool growth works correctly" {
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     var char_idx: u32 = 0;
     while (char_idx < 150) : (char_idx += 1) {
@@ -1160,7 +1157,7 @@ test "OptimizedBuffer - two-buffer pattern should not leak" {
         const cell = nextBuffer.get(0, 0).?;
         currentBuffer.setRaw(0, 0, cell);
 
-        try nextBuffer.clear(bg, null);
+        nextBuffer.clear(bg, null);
     }
 }
 
@@ -1185,7 +1182,7 @@ test "OptimizedBuffer - set and clear cycle should not leak" {
     var frame: u32 = 0;
     while (frame < 200) : (frame += 1) {
         try buf.drawText("•", 0, 0, fg, bg, 0);
-        try buf.clear(bg, null);
+        buf.clear(bg, null);
     }
 }
 
@@ -1213,11 +1210,11 @@ test "OptimizedBuffer - repeated drawTextBuffer without clear should not leak" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     var frame: u32 = 0;
     while (frame < 500) : (frame += 1) {
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
     }
 }
 
@@ -1253,11 +1250,11 @@ test "OptimizedBuffer - renderer two-buffer swap pattern should not leak" {
     defer next.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try current.clear(bg, null);
+    current.clear(bg, null);
 
     var frame: u32 = 0;
     while (frame < 300) : (frame += 1) {
-        try next.drawTextBuffer(view, 0, 0);
+        next.drawTextBuffer(view, 0, 0);
 
         var x: u32 = 0;
         while (x < 10) : (x += 1) {
@@ -1266,7 +1263,7 @@ test "OptimizedBuffer - renderer two-buffer swap pattern should not leak" {
             }
         }
 
-        try next.clear(bg, null);
+        next.clear(bg, null);
     }
 }
 
@@ -1284,7 +1281,7 @@ test "OptimizedBuffer - set should not clear newly written adjacent grapheme con
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     const old_gid = try local_pool.alloc("🌟");
     const old_start = gp.packGraphemeStart(old_gid & gp.GRAPHEME_ID_MASK, 2);
@@ -1331,7 +1328,7 @@ test "OptimizedBuffer - set span cleanup keeps shared link refcounts consistent"
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     const link_id = try local_link_pool.alloc("https://example.com");
     const linked_attr = ansi.TextAttributes.setLinkId(0, link_id);
@@ -1375,7 +1372,7 @@ test "OptimizedBuffer - syncCell updates grapheme tracker for start transitions"
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     const gid_old = try local_pool.alloc("你");
     const gid_new = try local_pool.alloc("好");
@@ -1422,11 +1419,11 @@ test "OptimizedBuffer - sustained rendering should not leak" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     var frame: u32 = 0;
     while (frame < 3000) : (frame += 1) {
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
     }
 }
 
@@ -1452,7 +1449,7 @@ test "OptimizedBuffer - rendering with changing content should not leak" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     var frame: u32 = 0;
     while (frame < 100) : (frame += 1) {
@@ -1473,7 +1470,7 @@ test "OptimizedBuffer - rendering with changing content should not leak" {
 
         tb.setText(&text) catch continue;
 
-        try buf.drawTextBuffer(view, 0, 0);
+        buf.drawTextBuffer(view, 0, 0);
     }
 }
 
@@ -1512,13 +1509,13 @@ test "OptimizedBuffer - multiple TextBuffers rendering simultaneously should not
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     var frame: u32 = 0;
     while (frame < 500) : (frame += 1) {
-        try buf.drawTextBuffer(view1, 0, 0);
-        try buf.drawTextBuffer(view2, 0, 10);
-        try buf.drawTextBuffer(view3, 0, 20);
+        buf.drawTextBuffer(view1, 0, 0);
+        buf.drawTextBuffer(view2, 0, 10);
+        buf.drawTextBuffer(view3, 0, 20);
     }
 }
 
@@ -1586,7 +1583,7 @@ test "OptimizedBuffer - drawTextBuffer with graphemes then clear removes all poo
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
 
-    try buf.drawTextBuffer(view, 0, 0);
+    buf.drawTextBuffer(view, 0, 0);
 
     const count_after_draw = buf.grapheme_tracker.getGraphemeCount();
     try std.testing.expect(count_after_draw > 0);
@@ -1600,7 +1597,7 @@ test "OptimizedBuffer - drawTextBuffer with graphemes then clear removes all poo
     const slots_in_use_after_draw = total_allocated_slots - total_free_slots;
     try std.testing.expect(slots_in_use_after_draw > 0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     const count_after_clear = buf.grapheme_tracker.getGraphemeCount();
     try std.testing.expectEqual(@as(u32, 0), count_after_clear);
@@ -1624,7 +1621,7 @@ test "OptimizedBuffer - drawTextBuffer with graphemes then clear removes all poo
         }
     }
 
-    try buf.drawTextBuffer(view, 0, 0);
+    buf.drawTextBuffer(view, 0, 0);
     const count_after_redraw = buf.grapheme_tracker.getGraphemeCount();
     try std.testing.expect(count_after_redraw > 0);
 
@@ -1637,7 +1634,7 @@ test "OptimizedBuffer - drawTextBuffer with graphemes then clear removes all poo
     const slots_in_use_after_redraw = allocated_after_redraw - free_after_redraw;
     try std.testing.expect(slots_in_use_after_redraw > 0);
 
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     const count_after_second_clear = buf.grapheme_tracker.getGraphemeCount();
     try std.testing.expectEqual(@as(u32, 0), count_after_second_clear);
 
@@ -1673,12 +1670,12 @@ test "OptimizedBuffer - drawTextBuffer with negative y coordinate should not pan
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     // Draw text buffer at negative y coordinate (-2)
     // This simulates a scenario where content is scrolled partially off-screen
     // The first 2 lines should be clipped, and lines 3, 4, 5 should be visible
-    try buf.drawTextBuffer(view, 0, -2);
+    buf.drawTextBuffer(view, 0, -2);
 
     // Verify that content is properly clipped when drawn at negative y
     // Lines that are off-screen (negative y) should be skipped
@@ -1743,7 +1740,7 @@ test "OptimizedBuffer - link encoding round-trip" {
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     // Allocate a link
     const link_id = try local_link_pool.alloc("https://example.com");
@@ -1779,7 +1776,7 @@ test "OptimizedBuffer - link tracker per-cell counting" {
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     // Allocate a link
     const link_id = try local_link_pool.alloc("https://example.com");
@@ -1808,7 +1805,7 @@ test "OptimizedBuffer - link tracker per-cell counting" {
     try std.testing.expectEqual(@as(u32, 1), pool_refcount2);
 
     // Clear all - refcount should be 0 and link freed
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     try std.testing.expectEqual(@as(u32, 0), buf.link_tracker.getLinkCount());
 }
 
@@ -1828,7 +1825,7 @@ test "OptimizedBuffer - fillRect removes links" {
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     // Allocate a link
     const link_id = try local_link_pool.alloc("https://example.com");
@@ -1843,7 +1840,7 @@ test "OptimizedBuffer - fillRect removes links" {
     try std.testing.expect(ansi.TextAttributes.hasLink(buf.get(10, 0).?.attributes));
 
     // Fill rect over first link
-    try buf.fillRect(0, 0, 6, 1, bg);
+    buf.fillRect(0, 0, 6, 1, bg);
 
     // Cells in rect should have no link
     try std.testing.expect(!ansi.TextAttributes.hasLink(buf.get(0, 0).?.attributes));
@@ -1867,14 +1864,14 @@ test "OptimizedBuffer - fillRect alpha path preserves underlying text without tr
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
     try buf.drawText("X", 1, 1, fg, bg, 0);
 
     try std.testing.expect(!buf.grapheme_tracker.hasAny());
     try std.testing.expect(!buf.link_tracker.hasAny());
 
     const overlay_bg = ansi.rgbaFromFloats(0.0, 0.0, 1.0, 0.5);
-    try buf.fillRect(0, 0, 3, 3, overlay_bg);
+    buf.fillRect(0, 0, 3, 3, overlay_bg);
 
     const preserved = buf.get(1, 1).?;
     try std.testing.expectEqual(@as(u32, 'X'), preserved.char);
@@ -1903,7 +1900,7 @@ test "OptimizedBuffer - fillRect transparent path is a no-op without trackers" {
     const yellow_fg = ansi.rgbaFromFloats(1.0, 1.0, 0.0, 1.0);
     const green_fg = ansi.rgbaFromFloats(0.0, 1.0, 0.0, 1.0);
     const blue_bg = ansi.rgbaFromFloats(0.0, 0.0, 1.0, 1.0);
-    try buf.clear(red_bg, null);
+    buf.clear(red_bg, null);
     try buf.drawText("X", 1, 1, yellow_fg, red_bg, ansi.TextAttributes.BOLD);
     try buf.drawText(" ", 0, 1, green_fg, blue_bg, ansi.TextAttributes.UNDERLINE);
 
@@ -1911,7 +1908,7 @@ test "OptimizedBuffer - fillRect transparent path is a no-op without trackers" {
     try std.testing.expect(!buf.link_tracker.hasAny());
 
     const transparent_bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0);
-    try buf.fillRect(0, 0, 3, 3, transparent_bg);
+    buf.fillRect(0, 0, 3, 3, transparent_bg);
 
     const preserved = buf.get(1, 1).?;
     try std.testing.expectEqual(@as(u32, 'X'), preserved.char);
@@ -1950,7 +1947,7 @@ test "OptimizedBuffer - drawBox transparent border preserves destination backgro
     const yellow_fg = ansi.defaultColor(255, 255, 0, 255);
     const green_fg = ansi.indexedColor(4, 0, 255, 0);
     const transparent_bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0);
-    try buf.clear(red_bg, null);
+    buf.clear(red_bg, null);
     buf.set(0, 1, .{
         .char = 'A',
         .fg = yellow_fg,
@@ -2002,7 +1999,7 @@ test "OptimizedBuffer - link reuse after free" {
     try buf.drawText("A", 0, 0, fg, bg, attr1);
 
     // Clear - should free the link
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     // Allocate second link - should reuse same slot but different generation
     const link_id2 = try local_link_pool.alloc("https://second.com");
@@ -2032,7 +2029,7 @@ test "OptimizedBuffer - alpha blending preserves overlay link not dest link" {
     const bg_opaque = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const bg_alpha = ansi.rgbaFromFloats(0.5, 0.5, 0.5, 0.5);
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
-    try buf.clear(bg_opaque, null);
+    buf.clear(bg_opaque, null);
 
     // Draw underlying text with link A
     const link_id_a = try local_link_pool.alloc("https://underlying.com");
@@ -2073,7 +2070,7 @@ test "OptimizedBuffer - alpha blending with no link clears underlying link" {
     const bg_opaque = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
     const bg_alpha = ansi.rgbaFromFloats(0.5, 0.5, 0.5, 0.5);
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
-    try buf.clear(bg_opaque, null);
+    buf.clear(bg_opaque, null);
 
     // Draw underlying text with link
     const link_id = try local_link_pool.alloc("https://underlying.com");
@@ -2111,7 +2108,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer basic rendering" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     // Create a 3x3 intensity buffer with varying values
     const intensities = [_]f32{
@@ -2149,7 +2146,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer negative position clipping" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     // Create a 4x4 intensity buffer
     const intensities = [_]f32{
@@ -2183,7 +2180,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer negative position fully clipped" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     const intensities = [_]f32{
         1.0, 1.0, 1.0, 1.0,
@@ -2213,7 +2210,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer respects scissor rect" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     try buf.pushScissorRect(0, 0, 2, 2);
 
@@ -2252,7 +2249,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer intensity to character mapping" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     const intensities = [_]f32{
         0.005,
@@ -2290,7 +2287,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer alpha blending preserves underlying 
     defer buf.deinit();
 
     const red_bg = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
-    try buf.clear(red_bg, null);
+    buf.clear(red_bg, null);
 
     const initial_cell = buf.get(1, 1).?;
     try std.testing.expectEqual(@as(u8, 255), ansi.red(initial_cell.bg));
@@ -2330,7 +2327,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer fully transparent bg preserves under
     defer buf.deinit();
 
     const green_bg = ansi.rgbaFromFloats(0.0, 1.0, 0.0, 1.0);
-    try buf.clear(green_bg, null);
+    buf.clear(green_bg, null);
 
     const transparent_bg = ansi.rgbaFromFloats(0.0, 0.0, 1.0, 0.0);
     const intensities = [_]f32{
@@ -2364,7 +2361,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer opaque bg overwrites underlying" {
     defer buf.deinit();
 
     const red_bg = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
-    try buf.clear(red_bg, null);
+    buf.clear(red_bg, null);
 
     const blue_bg = ansi.rgbaFromFloats(0.0, 0.0, 1.0, 1.0);
     const intensities = [_]f32{
@@ -2396,7 +2393,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer with opacity stack" {
     defer buf.deinit();
 
     const red_bg = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
-    try buf.clear(red_bg, null);
+    buf.clear(red_bg, null);
 
     try buf.pushOpacity(0.5);
 
@@ -2431,7 +2428,7 @@ test "OptimizedBuffer - drawGrayscaleBufferSupersampled alpha blending" {
     defer buf.deinit();
 
     const red_bg = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
-    try buf.clear(red_bg, null);
+    buf.clear(red_bg, null);
 
     const intensities = [_]f32{
         1.0, 1.0, 1.0, 1.0,
@@ -2463,7 +2460,7 @@ test "OptimizedBuffer - drawGrayscaleBufferSupersampled fully transparent preser
     defer buf.deinit();
 
     const green_bg = ansi.rgbaFromFloats(0.0, 1.0, 0.0, 1.0);
-    try buf.clear(green_bg, null);
+    buf.clear(green_bg, null);
 
     const intensities = [_]f32{
         1.0, 1.0, 1.0, 1.0,
@@ -2496,7 +2493,7 @@ test "OptimizedBuffer - drawGrayscaleBufferSupersampled respects scissor" {
     defer buf.deinit();
 
     const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(bg, null);
+    buf.clear(bg, null);
 
     try buf.pushScissorRect(0, 0, 1, 1);
 
@@ -2532,7 +2529,7 @@ test "OptimizedBuffer - drawGrayscaleBufferSupersampled with opacity stack" {
     defer buf.deinit();
 
     const red_bg = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
-    try buf.clear(red_bg, null);
+    buf.clear(red_bg, null);
 
     try buf.pushOpacity(0.5);
 
@@ -2568,11 +2565,11 @@ test "OptimizedBuffer - blendColors with transparent destination" {
     defer buf.deinit();
 
     const transparent_bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0);
-    try buf.clear(transparent_bg, null);
+    buf.clear(transparent_bg, null);
 
     const semi_white = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 0.5);
     const transparent_fg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0);
-    try buf.setCellWithAlphaBlending(0, 0, 'X', semi_white, transparent_fg, 0);
+    buf.setCellWithAlphaBlending(0, 0, 'X', semi_white, transparent_fg, 0);
 
     const cell = buf.get(0, 0).?;
     try std.testing.expectEqual(@as(u8, 255), ansi.red(cell.fg));
@@ -2596,11 +2593,11 @@ test "OptimizedBuffer - blend backdrop flattens transparent destination" {
     defer buf.deinit();
 
     const transparent_bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0);
-    try buf.clear(transparent_bg, null);
+    buf.clear(transparent_bg, null);
 
     const opaque_fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
     const semi_black_bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.5);
-    try buf.setCellWithAlphaBlending(0, 0, buffer_mod.DEFAULT_SPACE_CHAR, opaque_fg, semi_black_bg, 0);
+    buf.setCellWithAlphaBlending(0, 0, buffer_mod.DEFAULT_SPACE_CHAR, opaque_fg, semi_black_bg, 0);
 
     const cell = buf.get(0, 0).?;
     try std.testing.expectEqual(@as(u8, 127), ansi.red(cell.bg));
@@ -2624,7 +2621,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer with custom fg color" {
     defer buf.deinit();
 
     const black_bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(black_bg, null);
+    buf.clear(black_bg, null);
 
     const intensities = [_]f32{
         1.0, 1.0, 1.0,
@@ -2656,7 +2653,7 @@ test "OptimizedBuffer - drawGrayscaleBuffer custom fg with partial intensity" {
     defer buf.deinit();
 
     const blue_bg = ansi.rgbaFromFloats(0.0, 0.0, 1.0, 1.0);
-    try buf.clear(blue_bg, null);
+    buf.clear(blue_bg, null);
 
     const intensities = [_]f32{
         0.5, 0.5, 0.5,
@@ -2688,7 +2685,7 @@ test "OptimizedBuffer - drawGrayscaleBufferSupersampled with custom fg color" {
     defer buf.deinit();
 
     const black_bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
-    try buf.clear(black_bg, null);
+    buf.clear(black_bg, null);
 
     const intensities = [_]f32{
         1.0, 1.0, 1.0, 1.0,

--- a/packages/core/src/zig/tests/editor-view_test.zig
+++ b/packages/core/src/zig/tests/editor-view_test.zig
@@ -2056,8 +2056,8 @@ test "EditorView - placeholder with styled text renders with correct highlights"
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(tbv_ptr, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(tbv_ptr, 0, 0);
 
     const epsilon: f32 = 0.01;
 
@@ -2747,8 +2747,8 @@ test "EditorView - placeholder renders to buffer when empty" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawEditorView(ev, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawEditorView(ev, 0, 0);
 
     var out_buffer: [1000]u8 = undefined;
     const written = try opt_buffer.writeResolvedChars(&out_buffer, false);
@@ -2758,8 +2758,8 @@ test "EditorView - placeholder renders to buffer when empty" {
 
     try eb.insertText("Hello");
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawEditorView(ev, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawEditorView(ev, 0, 0);
     try std.testing.expect(!ev.placeholder_active);
 
     const written2 = try opt_buffer.writeResolvedChars(&out_buffer, false);
@@ -2809,7 +2809,7 @@ test "EditorView - placeholder shrink clears tail and preserves background" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
 
     var x: u32 = 0;
     while (x < 80) : (x += 1) {
@@ -2817,7 +2817,7 @@ test "EditorView - placeholder shrink clears tail and preserves background" {
     }
 
     try ev.setPlaceholderStyledText(&long_chunks);
-    try opt_buffer.drawEditorView(ev, 0, 0);
+    opt_buffer.drawEditorView(ev, 0, 0);
 
     x = 0;
     while (x < 80) : (x += 1) {
@@ -2825,7 +2825,7 @@ test "EditorView - placeholder shrink clears tail and preserves background" {
     }
 
     try ev.setPlaceholderStyledText(&short_chunks);
-    try opt_buffer.drawEditorView(ev, 0, 0);
+    opt_buffer.drawEditorView(ev, 0, 0);
 
     var out_buffer: [1600]u8 = undefined;
     const written = try opt_buffer.writeResolvedChars(&out_buffer, false);
@@ -2863,8 +2863,8 @@ test "EditorView - translucent default background fills viewport without double 
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawEditorView(ev, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawEditorView(ev, 0, 0);
 
     const text_cell = opt_buffer.get(0, 0).?;
     const trailing_cell = opt_buffer.get(3, 0).?;
@@ -2910,8 +2910,8 @@ test "EditorView - placeholder uses original default background fill" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawEditorView(ev, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawEditorView(ev, 0, 0);
 
     const text_cell = opt_buffer.get(0, 0).?;
     const trailing_cell = opt_buffer.get(4, 0).?;
@@ -2976,8 +2976,8 @@ test "EditorView - tab indicator renders in buffer" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawEditorView(ev, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawEditorView(ev, 0, 0);
 
     const cell_0 = opt_buffer.get(0, 0);
     try std.testing.expect(cell_0 != null);

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -85,7 +85,7 @@ test "renderer - simple text rendering to currentRenderBuffer" {
     defer cli_renderer.destroy();
 
     const next_buffer = cli_renderer.getNextBuffer();
-    try next_buffer.drawTextBuffer(view, 0, 0);
+    next_buffer.drawTextBuffer(view, 0, 0);
 
     cli_renderer.render(false);
 
@@ -128,7 +128,7 @@ test "renderer - multi-line text rendering" {
     defer cli_renderer.destroy();
 
     const next_buffer = cli_renderer.getNextBuffer();
-    try next_buffer.drawTextBuffer(view, 0, 0);
+    next_buffer.drawTextBuffer(view, 0, 0);
     cli_renderer.render(false);
 
     const current_buffer = cli_renderer.getCurrentBuffer();
@@ -170,7 +170,7 @@ test "renderer - emoji (wide grapheme) rendering" {
     defer cli_renderer.destroy();
 
     const next_buffer = cli_renderer.getNextBuffer();
-    try next_buffer.drawTextBuffer(view, 0, 0);
+    next_buffer.drawTextBuffer(view, 0, 0);
     cli_renderer.render(false);
 
     const current_buffer = cli_renderer.getCurrentBuffer();
@@ -228,7 +228,7 @@ test "renderer - CJK characters rendering" {
     defer cli_renderer.destroy();
 
     const next_buffer = cli_renderer.getNextBuffer();
-    try next_buffer.drawTextBuffer(view, 0, 0);
+    next_buffer.drawTextBuffer(view, 0, 0);
     cli_renderer.render(false);
 
     const current_buffer = cli_renderer.getCurrentBuffer();
@@ -282,7 +282,7 @@ test "renderer - mixed ASCII, emoji, and CJK" {
     defer cli_renderer.destroy();
 
     const next_buffer = cli_renderer.getNextBuffer();
-    try next_buffer.drawTextBuffer(view, 0, 0);
+    next_buffer.drawTextBuffer(view, 0, 0);
     cli_renderer.render(false);
 
     const current_buffer = cli_renderer.getCurrentBuffer();
@@ -412,7 +412,7 @@ test "renderer - empty text buffer renders correctly" {
     defer cli_renderer.destroy();
 
     const next_buffer = cli_renderer.getNextBuffer();
-    try next_buffer.drawTextBuffer(view, 0, 0);
+    next_buffer.drawTextBuffer(view, 0, 0);
     cli_renderer.render(false);
 }
 
@@ -439,7 +439,7 @@ test "renderer - multiple renders update currentRenderBuffer" {
 
     try tb.setText("Hello");
     const next_buffer = cli_renderer.getNextBuffer();
-    try next_buffer.drawTextBuffer(view, 0, 0);
+    next_buffer.drawTextBuffer(view, 0, 0);
     cli_renderer.render(false);
 
     var current_buffer = cli_renderer.getCurrentBuffer();
@@ -449,7 +449,7 @@ test "renderer - multiple renders update currentRenderBuffer" {
 
     try tb.setText("World");
     const next_buffer2 = cli_renderer.getNextBuffer();
-    try next_buffer2.drawTextBuffer(view, 0, 0);
+    next_buffer2.drawTextBuffer(view, 0, 0);
     cli_renderer.render(false);
 
     current_buffer = cli_renderer.getCurrentBuffer();
@@ -515,11 +515,11 @@ test "renderer - 1000 frame render loop with setStyledText" {
         }};
 
         try tb.setStyledText(&chunks);
-        try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-        try opt_buffer.drawTextBuffer(view, 0, 0);
+        opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+        opt_buffer.drawTextBuffer(view, 0, 0);
 
         const next_buffer = cli_renderer.getNextBuffer();
-        try next_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+        next_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
         next_buffer.drawFrameBuffer(0, 0, opt_buffer, null, null, null, null);
 
         cli_renderer.render(false);
@@ -587,16 +587,16 @@ test "renderer - grapheme pool refcounting with frame buffer fast path" {
         .attributes = 0,
     }};
     try tb.setStyledText(&chunks);
-    try frame_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try frame_buffer.drawTextBuffer(view, 0, 0);
+    frame_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    frame_buffer.drawTextBuffer(view, 0, 0);
 
     const next_buffer = cli_renderer.getNextBuffer();
     next_buffer.setRespectAlpha(false);
-    try next_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    next_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
 
     next_buffer.drawFrameBuffer(0, 0, frame_buffer, null, null, null, null);
 
-    try frame_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    frame_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
 
     var i: usize = 0;
     while (i < 10) : (i += 1) {
@@ -609,8 +609,8 @@ test "renderer - grapheme pool refcounting with frame buffer fast path" {
             .attributes = 0,
         }};
         try tb.setStyledText(&new_chunks);
-        try frame_buffer.drawTextBuffer(view, 0, 0);
-        try frame_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+        frame_buffer.drawTextBuffer(view, 0, 0);
+        frame_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
     }
 
     cli_renderer.render(false);
@@ -1125,7 +1125,7 @@ test "renderer - explicit_cursor_positioning emits cursor move after wide graphe
     cli_renderer.terminal.caps.explicit_width = false;
 
     const next_buffer = cli_renderer.getNextBuffer();
-    try next_buffer.drawTextBuffer(view, 0, 0);
+    next_buffer.drawTextBuffer(view, 0, 0);
 
     cli_renderer.render(false);
 
@@ -1160,7 +1160,7 @@ test "renderer - explicit_cursor_positioning produces more cursor moves" {
     cli_renderer1.terminal.caps.explicit_width = false;
 
     const next_buffer1 = cli_renderer1.getNextBuffer();
-    try next_buffer1.drawTextBuffer(view, 0, 0);
+    next_buffer1.drawTextBuffer(view, 0, 0);
     cli_renderer1.render(false);
     const output_without = cli_renderer1.getLastOutputForTest();
 
@@ -1177,7 +1177,7 @@ test "renderer - explicit_cursor_positioning produces more cursor moves" {
     cli_renderer2.terminal.caps.explicit_width = false;
 
     const next_buffer2 = cli_renderer2.getNextBuffer();
-    try next_buffer2.drawTextBuffer(view, 0, 0);
+    next_buffer2.drawTextBuffer(view, 0, 0);
     cli_renderer2.render(false);
     const output_with = cli_renderer2.getLastOutputForTest();
 
@@ -1236,7 +1236,7 @@ test "renderer - explicit_cursor_positioning with CJK characters" {
     cli_renderer.terminal.caps.explicit_width = false;
 
     const next_buffer = cli_renderer.getNextBuffer();
-    try next_buffer.drawTextBuffer(view, 0, 0);
+    next_buffer.drawTextBuffer(view, 0, 0);
 
     cli_renderer.render(false);
 
@@ -1275,7 +1275,7 @@ test "renderer - commitSplitFooterSnapshot writes append before footer repaint i
     );
     defer snapshot.deinit();
 
-    try snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
+    snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
     try snapshot.drawText("append-line", 0, 0, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
 
     const appended = "append-line";
@@ -1344,7 +1344,7 @@ test "renderer - commitSplitFooterSnapshot settling phase moves footer downward"
     );
     defer snapshot.deinit();
 
-    try snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
+    snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
     try snapshot.drawText("settle", 0, 0, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
 
     const appended = "settle";
@@ -1405,7 +1405,7 @@ test "renderer - commitSplitFooterSnapshot multiline settling enables bounded sc
     );
     defer snapshot.deinit();
 
-    try snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
+    snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
     try snapshot.drawText("line-a", 0, 0, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
     try snapshot.drawText("line-b", 0, 1, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
 
@@ -1451,7 +1451,7 @@ test "renderer - commitSplitFooterSnapshot multiline short final row keeps conti
     );
     defer first_snapshot.deinit();
 
-    try first_snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
+    first_snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
     try first_snapshot.drawText("1234567890123456", 0, 0, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
     try first_snapshot.drawText("short", 0, 2, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
 
@@ -1467,7 +1467,7 @@ test "renderer - commitSplitFooterSnapshot multiline short final row keeps conti
     );
     defer second_snapshot.deinit();
 
-    try second_snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
+    second_snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
     try second_snapshot.drawText(",", 0, 0, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
 
     _ = cli_renderer.commitSplitFooterSnapshotBatched(second_snapshot, 1, false, false, 2, false, true, true);
@@ -1512,7 +1512,7 @@ test "renderer - commitSplitFooterSnapshot exact-width continuation preserves au
     );
     defer first_snapshot.deinit();
 
-    try first_snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
+    first_snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
     try first_snapshot.drawText("12345678901234567890", 0, 0, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
 
     _ = cli_renderer.commitSplitFooterSnapshotBatched(first_snapshot, 20, false, false, 2, false, true, true);
@@ -1525,7 +1525,7 @@ test "renderer - commitSplitFooterSnapshot exact-width continuation preserves au
     );
     defer second_snapshot.deinit();
 
-    try second_snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
+    second_snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
     try second_snapshot.drawText(" letters", 0, 0, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
 
     _ = cli_renderer.commitSplitFooterSnapshotBatched(second_snapshot, 8, false, false, 2, false, true, true);
@@ -1570,7 +1570,7 @@ test "renderer - commitSplitFooterSnapshot does not emit continuation spaces for
     );
     defer snapshot.deinit();
 
-    try snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
+    snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
     try snapshot.drawText("│甲│乙│丙│", 0, 0, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
     try snapshot.drawText("│😀│🚀│🧪│", 0, 1, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
 
@@ -1740,7 +1740,7 @@ test "renderer - commitSplitFooterSnapshot appends styled snapshot before footer
     );
     defer snapshot.deinit();
 
-    try snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
+    snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
     try snapshot.drawText("SNAP", 0, 0, ansi.rgbaFromFloats(1.0, 0.5, 0.0, 1.0), ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), ansi.TextAttributes.BOLD);
     try snapshot.drawText("SHOT", 0, 1, ansi.rgbaFromFloats(0.2, 0.8, 0.9, 1.0), ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
 
@@ -1789,7 +1789,7 @@ test "renderer - commitSplitFooterSnapshot preserves indexed and default color t
     );
     defer snapshot.deinit();
 
-    try snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
+    snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
     snapshot.set(0, 0, .{
         .char = 'A',
         .fg = ansi.defaultColor(255, 255, 255, 255),
@@ -1844,7 +1844,7 @@ test "renderer - commitSplitFooterSnapshot does not emit NUL padding for short r
     );
     defer snapshot.deinit();
 
-    try snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
+    snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
     try snapshot.drawText("[tool:bash] Shell", 0, 0, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
     try snapshot.drawText("$ pwd", 0, 1, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
 
@@ -1885,7 +1885,7 @@ test "renderer - batched split commits share single sync frame" {
         .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
     );
     defer first_snapshot.deinit();
-    try first_snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
+    first_snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
     try first_snapshot.drawText("FIRST", 0, 0, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
 
     var second_snapshot = try OptimizedBuffer.init(
@@ -1895,7 +1895,7 @@ test "renderer - batched split commits share single sync frame" {
         .{ .pool = pool, .width_method = .unicode, .respectAlpha = false },
     );
     defer second_snapshot.deinit();
-    try second_snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
+    second_snapshot.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 32);
     try second_snapshot.drawText("SECOND", 0, 0, fg, ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0), 0);
 
     _ = cli_renderer.commitSplitFooterSnapshotBatched(

--- a/packages/core/src/zig/tests/text-buffer-drawing_test.zig
+++ b/packages/core/src/zig/tests/text-buffer-drawing_test.zig
@@ -36,8 +36,8 @@ test "drawTextBuffer - simple single line text" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     var out_buffer: [100]u8 = undefined;
     const written = try opt_buffer.writeResolvedChars(&out_buffer, false);
@@ -68,8 +68,8 @@ test "drawTextBuffer - empty text buffer" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 }
 
 test "drawTextBuffer - multiple lines without wrapping" {
@@ -94,8 +94,8 @@ test "drawTextBuffer - multiple lines without wrapping" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const virtual_lines = view.getVirtualLines();
     try std.testing.expect(virtual_lines.len == 3);
@@ -126,8 +126,8 @@ test "drawTextBuffer - text wrapping at word boundaries" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const virtual_lines = view.getVirtualLines();
     try std.testing.expect(virtual_lines.len > 1);
@@ -158,10 +158,10 @@ test "drawTextBuffer - transparent background preserves underlying non-space und
     const red_bg = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
     const blue_bg = ansi.rgbaFromFloats(0.0, 0.0, 1.0, 1.0);
     const green_fg = ansi.rgbaFromFloats(0.0, 1.0, 0.0, 1.0);
-    try opt_buffer.clear(red_bg, 32);
-    try opt_buffer.drawChar('X', 1, 0, green_fg, blue_bg, ansi.TextAttributes.BOLD);
+    opt_buffer.clear(red_bg, 32);
+    opt_buffer.drawChar('X', 1, 0, green_fg, blue_bg, ansi.TextAttributes.BOLD);
 
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const left = opt_buffer.get(0, 0).?;
     try std.testing.expectEqual(@as(u32, 'A'), left.char);
@@ -211,8 +211,8 @@ test "drawTextBuffer - text wrapping at character boundaries" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const virtual_lines = view.getVirtualLines();
     try std.testing.expect(virtual_lines.len == 4);
@@ -243,8 +243,8 @@ test "drawTextBuffer - no wrapping with none mode" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const virtual_lines = view.getVirtualLines();
     try std.testing.expect(virtual_lines.len == 1);
@@ -275,8 +275,8 @@ test "drawTextBuffer - wrapped text with multiple lines" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const virtual_lines = view.getVirtualLines();
     try std.testing.expect(virtual_lines.len >= 3);
@@ -307,8 +307,8 @@ test "drawTextBuffer - unicode characters with wrapping" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const virtual_lines = view.getVirtualLines();
     try std.testing.expect(virtual_lines.len > 0);
@@ -339,8 +339,8 @@ test "drawTextBuffer - wrapping preserves wide characters" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const virtual_lines = view.getVirtualLines();
     try std.testing.expect(virtual_lines.len > 1);
@@ -415,8 +415,8 @@ test "drawTextBuffer - wrapped text with offset position" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 5, 5);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 5, 5);
 
     const cell = opt_buffer.get(5, 5);
     try std.testing.expect(cell != null);
@@ -445,8 +445,8 @@ test "drawTextBuffer - clipping with scrolled view" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const virtual_lines = view.getVirtualLines();
     try std.testing.expect(virtual_lines.len >= 4);
@@ -477,8 +477,8 @@ test "drawTextBuffer - wrapping with very narrow width" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const virtual_lines = view.getVirtualLines();
     try std.testing.expect(virtual_lines.len == 2);
@@ -509,8 +509,8 @@ test "drawTextBuffer - word wrap doesn't break mid-word" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const virtual_lines = view.getVirtualLines();
     try std.testing.expect(virtual_lines.len == 2);
@@ -538,8 +538,8 @@ test "drawTextBuffer - empty lines render correctly" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const virtual_lines = view.getVirtualLines();
     try std.testing.expect(virtual_lines.len == 3);
@@ -570,8 +570,8 @@ test "drawTextBuffer - wrapping with tabs" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 }
 
 test "drawTextBuffer - very long unwrapped line clipping" {
@@ -602,8 +602,8 @@ test "drawTextBuffer - very long unwrapped line clipping" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const virtual_lines = view.getVirtualLines();
     try std.testing.expect(virtual_lines.len == 1);
@@ -699,8 +699,8 @@ test "drawTextBuffer - wrapping with mixed ASCII and Unicode" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const virtual_lines = view.getVirtualLines();
     try std.testing.expect(virtual_lines.len > 1);
@@ -1330,8 +1330,8 @@ test "loadFile - loads and renders file correctly" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     var render_buffer: [200]u8 = undefined;
     const render_written = try opt_buffer.writeResolvedChars(&render_buffer, false);
@@ -1366,8 +1366,8 @@ test "drawTextBuffer - horizontal viewport offset renders correctly without wrap
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     var out_buffer: [100]u8 = undefined;
     const written = try opt_buffer.writeResolvedChars(&out_buffer, false);
@@ -1402,8 +1402,8 @@ test "drawTextBuffer - horizontal viewport offset with multiple lines" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     var out_buffer: [100]u8 = undefined;
     const written = try opt_buffer.writeResolvedChars(&out_buffer, false);
@@ -1440,8 +1440,8 @@ test "drawTextBuffer - combined horizontal and vertical viewport offsets" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     var out_buffer: [100]u8 = undefined;
     const written = try opt_buffer.writeResolvedChars(&out_buffer, false);
@@ -1477,8 +1477,8 @@ test "drawTextBuffer - horizontal viewport stops rendering at viewport width" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     var out_buffer: [100]u8 = undefined;
     const written = try opt_buffer.writeResolvedChars(&out_buffer, false);
@@ -1517,8 +1517,8 @@ test "drawTextBuffer - horizontal viewport with small buffer renders only viewpo
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const cell_0 = opt_buffer.get(0, 0);
     try std.testing.expect(cell_0 != null);
@@ -1567,8 +1567,8 @@ test "drawTextBuffer - horizontal viewport width limits rendering (efficiency te
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     var non_space_count: u32 = 0;
     var i: u32 = 0;
@@ -1604,8 +1604,8 @@ test "drawTextBuffer - overwriting wide grapheme with ASCII leaves no ghost char
     defer opt_buffer.deinit();
 
     try tb.setText("世界");
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const first_cell = opt_buffer.get(0, 0) orelse unreachable;
     try std.testing.expect(gp.isGraphemeChar(first_cell.char));
@@ -1615,8 +1615,8 @@ test "drawTextBuffer - overwriting wide grapheme with ASCII leaves no ghost char
     try std.testing.expect(gp.isContinuationChar(second_cell.char));
 
     try tb.setText("ABC");
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const cell_a = opt_buffer.get(0, 0) orelse unreachable;
     try std.testing.expectEqual(@as(u32, 'A'), cell_a.char);
@@ -1666,8 +1666,8 @@ test "drawTextBuffer - syntax style destroy does not crash" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     var out_buffer: [100]u8 = undefined;
     const written = try opt_buffer.writeResolvedChars(&out_buffer, false);
@@ -1678,8 +1678,8 @@ test "drawTextBuffer - syntax style destroy does not crash" {
 
     try std.testing.expect(tb.getSyntaxStyle() == null);
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const written2 = try opt_buffer.writeResolvedChars(&out_buffer, false);
     const result2 = out_buffer[0..written2];
@@ -1710,8 +1710,8 @@ test "drawTextBuffer - tabs are rendered as spaces (empty cells)" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const cell_0 = opt_buffer.get(0, 0) orelse unreachable;
     try std.testing.expectEqual(@as(u32, 'A'), cell_0.char);
@@ -1759,8 +1759,8 @@ test "drawTextBuffer - tab indicator renders with correct color" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const cell_0 = opt_buffer.get(0, 0) orelse unreachable;
     try std.testing.expectEqual(@as(u32, 'A'), cell_0.char);
@@ -1808,8 +1808,8 @@ test "drawTextBuffer - tab without indicator renders as spaces" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const cell_0 = opt_buffer.get(0, 0) orelse unreachable;
     try std.testing.expectEqual(@as(u32, 'A'), cell_0.char);
@@ -1853,8 +1853,8 @@ test "drawTextBuffer - mixed ASCII and Unicode with emoji renders completely" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const cell_0 = opt_buffer.get(0, 0) orelse unreachable;
     try std.testing.expectEqual(@as(u32, '-'), cell_0.char);
@@ -1987,8 +1987,8 @@ test "viewport width = 31 exactly - last character rendering" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     // BUG CHECK: The last 's' at cell 30 should be present
     const cell_30 = opt_buffer.get(30, 0);
@@ -2049,8 +2049,8 @@ test "drawTextBuffer - complex multilingual text with diverse scripts and emojis
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     // Verify the text buffer can handle complex multilingual content
     const virtual_lines = view.getVirtualLines();
@@ -2101,8 +2101,8 @@ test "drawTextBuffer - complex multilingual text with diverse scripts and emojis
     try std.testing.expect(viewport_lines.len <= 20);
 
     // Verify rendering doesn't crash with complex emoji sequences
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     // Test that line count is reasonable
     const line_count = tb.getLineCount();
@@ -2168,8 +2168,8 @@ test "setStyledText - highlight positioning with Unicode text" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     // Check that "please" (6 characters) all have the green background
     const epsilon: f32 = 0.01;
@@ -2247,8 +2247,8 @@ test "drawTextBuffer - multiple syntax highlights with various horizontal viewpo
         var opt_buffer = try OptimizedBuffer.init(std.testing.allocator, 40, 1, .{ .pool = pool, .width_method = .unicode });
         defer opt_buffer.deinit();
 
-        try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-        try opt_buffer.drawTextBuffer(view, 0, 0);
+        opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+        opt_buffer.drawTextBuffer(view, 0, 0);
 
         // Check "const" is red
         const cell_0 = opt_buffer.get(0, 0) orelse unreachable;
@@ -2275,8 +2275,8 @@ test "drawTextBuffer - multiple syntax highlights with various horizontal viewpo
         var opt_buffer = try OptimizedBuffer.init(std.testing.allocator, 20, 1, .{ .pool = pool, .width_method = .unicode });
         defer opt_buffer.deinit();
 
-        try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-        try opt_buffer.drawTextBuffer(view, 0, 0);
+        opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+        opt_buffer.drawTextBuffer(view, 0, 0);
 
         // Buffer shows characters 3-22 from source: "st x = function(y) {"
         // Position 0: 's' (source 3) - should be RED (part of "const" 0-5)
@@ -2322,8 +2322,8 @@ test "drawTextBuffer - multiple syntax highlights with various horizontal viewpo
         var opt_buffer = try OptimizedBuffer.init(std.testing.allocator, 20, 1, .{ .pool = pool, .width_method = .unicode });
         defer opt_buffer.deinit();
 
-        try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-        try opt_buffer.drawTextBuffer(view, 0, 0);
+        opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+        opt_buffer.drawTextBuffer(view, 0, 0);
 
         // Actual rendering shows: " y * 2; }"
         // Source chars 30-38 are shown
@@ -2375,8 +2375,8 @@ test "drawTextBuffer - syntax highlighting with horizontal viewport offset" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const epsilon: f32 = 0.01;
     const red_fg = ansi.rgbaFromFloats(1.0, 0.0, 0.0, 1.0);
@@ -2504,8 +2504,8 @@ test "drawTextBuffer - setStyledText with multiple colors and horizontal scrolli
         var opt_buffer = try OptimizedBuffer.init(std.testing.allocator, 40, 1, .{ .pool = pool, .width_method = .unicode });
         defer opt_buffer.deinit();
 
-        try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-        try opt_buffer.drawTextBuffer(view, 0, 0);
+        opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+        opt_buffer.drawTextBuffer(view, 0, 0);
 
         const cell_0 = opt_buffer.get(0, 0) orelse unreachable; // 'c' from "const"
         try std.testing.expectEqual(@as(u32, 'c'), cell_0.char);
@@ -2522,8 +2522,8 @@ test "drawTextBuffer - setStyledText with multiple colors and horizontal scrolli
         var opt_buffer = try OptimizedBuffer.init(std.testing.allocator, 20, 1, .{ .pool = pool, .width_method = .unicode });
         defer opt_buffer.deinit();
 
-        try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-        try opt_buffer.drawTextBuffer(view, 0, 0);
+        opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+        opt_buffer.drawTextBuffer(view, 0, 0);
 
         // At x=5, showing chars 5-24: " x = function(y) { "
         // Position 0: ' ' (source 5) - should be white
@@ -2543,8 +2543,8 @@ test "drawTextBuffer - setStyledText with multiple colors and horizontal scrolli
         var opt_buffer = try OptimizedBuffer.init(std.testing.allocator, 20, 1, .{ .pool = pool, .width_method = .unicode });
         defer opt_buffer.deinit();
 
-        try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-        try opt_buffer.drawTextBuffer(view, 0, 0);
+        opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+        opt_buffer.drawTextBuffer(view, 0, 0);
 
         // At x=15, showing chars 15-34: "ion(y) { return y * "
         // "const x = function..."
@@ -2581,8 +2581,8 @@ test "drawTextBuffer - setStyledText with multiple colors and horizontal scrolli
         var opt_buffer = try OptimizedBuffer.init(std.testing.allocator, 20, 1, .{ .pool = pool, .width_method = .unicode });
         defer opt_buffer.deinit();
 
-        try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-        try opt_buffer.drawTextBuffer(view, 0, 0);
+        opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+        opt_buffer.drawTextBuffer(view, 0, 0);
 
         // At x=25, showing chars 25-44: "eturn y * 2; }"
         // Position 0: 'e' (source 25) - should be BLUE (part of "return" 24-30)
@@ -2640,8 +2640,8 @@ test "drawTextBuffer - selection with horizontal viewport offset" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     // The viewport shows positions 5-14 of the text
     // Characters 7-11 (0-indexed) should be highlighted
@@ -2742,8 +2742,8 @@ test "drawTextBuffer - syntax highlight respects truncation" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const epsilon: f32 = 0.01;
 
@@ -2802,8 +2802,8 @@ test "drawTextBuffer - highlight spanning ellipsis continues on suffix" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const epsilon: f32 = 0.01;
 
@@ -2858,8 +2858,8 @@ test "drawTextBuffer - selection respects truncation" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const epsilon: f32 = 0.01;
     const yellow_bg = ansi.rgbaFromFloats(1.0, 1.0, 0.0, 1.0);
@@ -2933,8 +2933,8 @@ test "drawTextBuffer - truncation selection does not overshoot multiline" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const epsilon: f32 = 0.01;
     const yellow_bg = ansi.rgbaFromFloats(1.0, 1.0, 0.0, 1.0);
@@ -2997,8 +2997,8 @@ test "drawTextBuffer - Chinese text with wrapping no stray bytes" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     // Write the rendered buffer to check for stray bytes
     var out_buffer: [2000]u8 = undefined;
@@ -3066,8 +3066,8 @@ test "drawTextBuffer - Chinese text WITHOUT wrapping no duplicate chunks" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     // Write the rendered buffer
     var out_buffer: [2000]u8 = undefined;
@@ -3120,8 +3120,8 @@ test "drawTextBuffer - Chinese text with CHAR wrapping no stray bytes" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     // Write the rendered buffer to check for stray bytes
     var out_buffer: [2000]u8 = undefined;
@@ -3165,8 +3165,8 @@ test "drawTextBuffer - word wrap CJK mixed text without break points" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     var out_buffer: [1000]u8 = undefined;
     const written = try opt_buffer.writeResolvedChars(&out_buffer, false);
@@ -3212,8 +3212,8 @@ test "drawTextBuffer - word wrap CJK text preserves UTF-8 boundaries" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     var out_buffer: [1000]u8 = undefined;
     const written = try opt_buffer.writeResolvedChars(&out_buffer, false);
@@ -3267,8 +3267,8 @@ test "drawTextBuffer - Thai ว่ grapheme in quotes occupies one cell" {
     );
     defer opt_buffer.deinit();
 
-    try opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-    try opt_buffer.drawTextBuffer(view, 0, 0);
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
 
     const cell_0 = opt_buffer.get(0, 0) orelse unreachable;
     try std.testing.expectEqual(@as(u32, '"'), cell_0.char);

--- a/packages/core/src/zig/tests/text-buffer-selection_viewport_test.zig
+++ b/packages/core/src/zig/tests/text-buffer-selection_viewport_test.zig
@@ -338,7 +338,7 @@ test "Selection - RENDER TEST: selection highlights correct cells with viewport 
     var render_buffer = try buffer_mod.OptimizedBuffer.init(std.testing.allocator, 20, 10, .{ .pool = pool, .width_method = .unicode });
     defer render_buffer.deinit();
 
-    try render_buffer.drawTextBuffer(view, 0, 0);
+    render_buffer.drawTextBuffer(view, 0, 0);
 
     var x: u32 = 0;
     while (x < 3) : (x += 1) {


### PR DESCRIPTION
These methods perform no operations that can fail, so the error union
is pointless and causes try/catch noise.
