### PR TITLE
upgrade react-reconciler to 0.33 and optimize host config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,15 +71,15 @@
         "@opentui/solid": "workspace:*",
         "@types/bun": "latest",
         "@types/node": "^24.0.0",
-        "@types/react": "^19.0.0",
-        "react": ">=19.0.0",
+        "@types/react": "^19.2.0",
+        "react": ">=19.2.0",
         "solid-js": "1.9.12",
         "typescript": "^5",
       },
       "peerDependencies": {
         "@opentui/react": "workspace:*",
         "@opentui/solid": "workspace:*",
-        "react": ">=19.0.0",
+        "react": ">=19.2.0",
         "solid-js": "1.9.12",
       },
       "optionalPeers": [
@@ -94,22 +94,22 @@
       "version": "0.2.2",
       "dependencies": {
         "@opentui/core": "workspace:*",
-        "react-reconciler": "^0.32.0",
+        "react-reconciler": "^0.33.0",
       },
       "devDependencies": {
         "@opentui/keymap": "workspace:*",
         "@types/bun": "latest",
         "@types/node": "^24.0.0",
-        "@types/react": "^19.0.0",
-        "@types/react-reconciler": "^0.32.0",
+        "@types/react": "^19.2.0",
+        "@types/react-reconciler": "^0.33.0",
         "@types/ws": "^8.18.1",
-        "react": ">=19.0.0",
+        "react": ">=19.2.0",
         "react-devtools-core": "^7.0.1",
         "typescript": "^5",
         "ws": "^8.18.0",
       },
       "peerDependencies": {
-        "react": ">=19.0.0",
+        "react": ">=19.2.0",
         "react-devtools-core": "^7.0.1",
         "ws": "^8.18.0",
       },
@@ -438,6 +438,18 @@
 
     "@opentui/core": ["@opentui/core@workspace:packages/core"],
 
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tY5n3ZRQx+b0kyhQJJLsyJMeZ+0w4FV37YZc/Qqv3qvOqE9kZPw/7adR77FYwWDm/7fax94mLMrR8Y5bKUkDmw=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-W/R7OnqY30FXcTG0tiP2JkQFmgtYbIte5afQ5PC12TliRoee1RqG3iCG6kY1jxW+3Vg6jge88uiSjUEDpeV2gA=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-1pzTYFEZauYuw6AGycw2TYGtAlZVGjuUtSdxH1fP51kBPS3oVWduUY2j7GKREz3SU5NulvO2Wc6HWsm3feMqwQ=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ucVwUtUYeOYGVFPBLbPoxzbrPdhD0PDyKNQ2X4n1AJ9jlQX4gqBZRcXMEF8hiXDjFxsikZwef7De0ciCcWvAMg=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.2.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-MPhYdJNdxmC5Bqsq6sis/+VkjRgkEjm+bQ1Tl++NSKLuiTU32Re0ImcZlgHbe+LZtZoGMZHVSgZlkGd3oYXO2g=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-19BroLfn2h0RDYfJS5o96Fc8kYCDhRBcseIXtHIkoKIsKMxx62KiDLo/byVye6rp+yQRRB7Xkd2uWqsbdiWo9w=="],
+
     "@opentui/examples": ["@opentui/examples@workspace:packages/examples"],
 
     "@opentui/keymap": ["@opentui/keymap@workspace:packages/keymap"],
@@ -632,7 +644,7 @@
 
     "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 
-    "@types/react-reconciler": ["@types/react-reconciler@0.32.3", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-cMi5ZrLG7UtbL7LTK6hq9w/EZIRk4Mf1Z5qHoI+qBh7/WkYkFXQ7gOto2yfUvPzF5ERMAhaXS5eTQ2SAnHjLzA=="],
+    "@types/react-reconciler": ["@types/react-reconciler@0.33.0", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g=="],
 
     "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
 
@@ -1172,7 +1184,7 @@
 
     "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
 
-    "react-reconciler": ["react-reconciler@0.32.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ=="],
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
@@ -1230,7 +1242,7 @@
 
     "sax": ["sax@1.4.3", "", {}, "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ=="],
 
-    "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 

--- a/packages/core/src/console.ts
+++ b/packages/core/src/console.ts
@@ -146,6 +146,13 @@ class TerminalConsoleCache extends EventEmitter {
     console.debug = (...args: any[]) => {
       this.appendToConsole(LogLevel.DEBUG, ...args)
     }
+
+    // React 19.2's reconciler calls console.timeStamp with a 6-arg Performance Tracks signature.
+    // The new Console instance from setupConsoleCapture lacks timeStamp, so provide a no-op
+    // unless the runtime already supplies one.
+    if (typeof console.timeStamp !== "function") {
+      console.timeStamp = () => {}
+    }
   }
 
   public setCollectCallerInfo(enabled: boolean): void {

--- a/packages/keymap/package.json
+++ b/packages/keymap/package.json
@@ -61,7 +61,7 @@
   "peerDependencies": {
     "@opentui/react": "workspace:*",
     "@opentui/solid": "workspace:*",
-    "react": ">=19.0.0",
+    "react": ">=19.2.0",
     "solid-js": "1.9.12"
   },
   "peerDependenciesMeta": {
@@ -83,8 +83,8 @@
     "@opentui/solid": "workspace:*",
     "@types/bun": "latest",
     "@types/node": "^24.0.0",
-    "@types/react": "^19.0.0",
-    "react": ">=19.0.0",
+    "@types/react": "^19.2.0",
+    "react": ">=19.2.0",
     "solid-js": "1.9.12",
     "typescript": "^5"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -49,16 +49,16 @@
     "@opentui/keymap": "workspace:*",
     "@types/bun": "latest",
     "@types/node": "^24.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-reconciler": "^0.32.0",
+    "@types/react": "^19.2.0",
+    "@types/react-reconciler": "^0.33.0",
     "@types/ws": "^8.18.1",
-    "react": ">=19.0.0",
+    "react": ">=19.2.0",
     "react-devtools-core": "^7.0.1",
     "typescript": "^5",
     "ws": "^8.18.0"
   },
   "peerDependencies": {
-    "react": ">=19.0.0",
+    "react": ">=19.2.0",
     "react-devtools-core": "^7.0.1",
     "ws": "^8.18.0"
   },
@@ -72,6 +72,6 @@
   },
   "dependencies": {
     "@opentui/core": "workspace:*",
-    "react-reconciler": "^0.32.0"
+    "react-reconciler": "^0.33.0"
   }
 }

--- a/packages/react/src/reconciler/host-config.ts
+++ b/packages/react/src/reconciler/host-config.ts
@@ -1,5 +1,5 @@
 import { TextNodeRenderable, TextRenderable, type Renderable } from "@opentui/core"
-import pkgJson from "../../package.json"
+import pkgJson from "../../package.json" with { type: "json" }
 import { createContext } from "react"
 import type { HostConfig, ReactContext } from "react-reconciler"
 import { DefaultEventPriority, NoEventPriority } from "react-reconciler/constants"
@@ -10,6 +10,15 @@ import { getNextId } from "../utils/id.js"
 import { setInitialProperties, updateProperties } from "../utils/index.js"
 
 let currentUpdatePriority = NoEventPriority
+
+// Required by the reconciler at runtime but missing from @types/react-reconciler.
+// Remove this intersection when DefinitelyTyped catches up.
+type ReconcilerExtensions = {
+  maySuspendCommitOnUpdate(type: Type, oldProps: Props, newProps: Props): boolean
+  maySuspendCommitInSyncRender(type: Type, props: Props): boolean
+  rendererPackageName: string
+  rendererVersion: string
+}
 
 // https://github.com/facebook/react/tree/main/packages/react-reconciler#practical-examples
 export const hostConfig: HostConfig<
@@ -27,10 +36,13 @@ export const hostConfig: HostConfig<
   unknown, // TimeoutHandle
   unknown, // NoTimeout
   unknown // TransitionStatus
-> = {
+> &
+  ReconcilerExtensions = {
   supportsMutation: true,
   supportsPersistence: false,
   supportsHydration: false,
+  supportsMicrotasks: true,
+  scheduleMicrotask: queueMicrotask,
 
   // Create instances of opentui components
   createInstance(type: Type, props: Props, rootContainerInstance: Container, hostContext: HostContext) {
@@ -121,9 +133,8 @@ export const hostConfig: HostConfig<
   // No timeout
   noTimeout: -1,
 
-  // Should attempt synchronous flush
   shouldAttemptEagerTransition() {
-    return false
+    return true
   },
 
   // Finalize initial children
@@ -143,16 +154,14 @@ export const hostConfig: HostConfig<
     // We could focus the instance here, but we're handling focus in setInitialProperties
   },
 
-  // Commit update
+  // No explicit requestRender() needed in commit methods — core's property setters
+  // already call requestRender() internally, and resetAfterCommit handles the frame trigger.
   commitUpdate(instance: Instance, type: Type, oldProps: Props, newProps: Props, internalInstanceHandle: any) {
     updateProperties(instance, type, oldProps, newProps)
-    instance.requestRender()
   },
 
-  // Commit text update
   commitTextUpdate(textInstance: TextInstance, oldText: string, newText: string) {
     textInstance.children = [newText]
-    textInstance.requestRender()
   },
 
   // Append child to container
@@ -164,28 +173,21 @@ export const hostConfig: HostConfig<
     parent.add(child)
   },
 
-  // Hide instance
+  // Visibility setters in core call requestRender() internally.
   hideInstance(instance: Instance) {
     instance.visible = false
-    instance.requestRender()
   },
 
-  // Unhide instance
   unhideInstance(instance: Instance, props: Props) {
     instance.visible = true
-    instance.requestRender()
   },
 
-  // Hide text instance
   hideTextInstance(textInstance: TextInstance) {
     textInstance.visible = false
-    textInstance.requestRender()
   },
 
-  // Unhide text instance
   unhideTextInstance(textInstance: TextInstance, text: string) {
     textInstance.visible = true
-    textInstance.requestRender()
   },
 
   // Clear container
@@ -211,6 +213,14 @@ export const hostConfig: HostConfig<
   },
 
   maySuspendCommit() {
+    return false
+  },
+
+  maySuspendCommitOnUpdate() {
+    return false
+  },
+
+  maySuspendCommitInSyncRender() {
     return false
   },
 
@@ -272,7 +282,6 @@ export const hostConfig: HostConfig<
     return null
   },
 
-  // @ts-expect-error DefinitelyTyped is not up to date
   rendererPackageName: "@opentui/react",
   rendererVersion: pkgJson.version,
 }

--- a/packages/react/src/reconciler/react-reconciler-constants.d.ts
+++ b/packages/react/src/reconciler/react-reconciler-constants.d.ts
@@ -1,0 +1,9 @@
+declare module "react-reconciler/constants" {
+  export const DiscreteEventPriority: number
+  export const ContinuousEventPriority: number
+  export const DefaultEventPriority: number
+  export const IdleEventPriority: number
+  export const LegacyRoot: 0
+  export const ConcurrentRoot: 1
+  export const NoEventPriority: number
+}

--- a/packages/react/src/reconciler/reconciler.ts
+++ b/packages/react/src/reconciler/reconciler.ts
@@ -42,8 +42,7 @@ export function _render(element: React.ReactNode, root: RootRenderable) {
     console.error,
     console.error,
     console.error,
-    console.error,
-    null,
+    () => {},
   )
 
   reconciler.updateContainer(element, container, null, () => {})

--- a/packages/react/src/reconciler/renderer.ts
+++ b/packages/react/src/reconciler/renderer.ts
@@ -32,7 +32,6 @@ export function createRoot(renderer: CliRenderer): Root {
   const cleanup = () => {
     if (container) {
       reconciler.updateContainer(null, container, null, () => {})
-      // @ts-expect-error the types for `react-reconciler` are not up to date with the library.
       reconciler.flushSyncWork()
       container = null
     }


### PR DESCRIPTION
## Summary

upgrades `react-reconciler` from 0.32 to 0.33 (react 19.2) and optimizes the host config for lower commit latency.

**breaking:** minimum react version raised from 19.0 to 19.2. consumers must `bun add react@latest` before upgrading.

## Changes

- upgrade `react-reconciler` 0.32 → 0.33, `scheduler` 0.26 → 0.27
- raise `react` peer dep to `>=19.2.0` across `@opentui/react` and `@opentui/keymap`
- fix `createContainer` call signature for new `onDefaultTransitionIndicator` param
- add `maySuspendCommitOnUpdate` / `maySuspendCommitInSyncRender` host config methods
- fix `console.timeStamp` crash from react 19.2 performance tracks (core + react)
- remove redundant `requestRender()` from commit methods (setters already handle it)
- enable `supportsMicrotasks` / `scheduleMicrotask: queueMicrotask`
- enable `shouldAttemptEagerTransition` for lower transition latency
- add module declaration for `react-reconciler/constants`
- remove stale `@ts-expect-error` directives where 0.33 types improved