### PR TITLE
core/diff: per-kind line-number fg + side-targeted line color API

### DIFF
--- a/packages/core/src/renderables/Diff.ts
+++ b/packages/core/src/renderables/Diff.ts
@@ -181,6 +181,27 @@ export class DiffRenderable extends Renderable {
     }
   }
 
+  private buildLineConfig(kind: "added" | "removed" | "context"): LineColorConfig {
+    const gutterBg =
+      kind === "added" ? this._addedLineNumberBg : kind === "removed" ? this._removedLineNumberBg : this._lineNumberBg
+    const baseBg = kind === "added" ? this._addedBg : kind === "removed" ? this._removedBg : this._contextBg
+    const overrideBg =
+      kind === "added" ? this._addedContentBg : kind === "removed" ? this._removedContentBg : this._contextContentBg
+    const fg =
+      kind === "added"
+        ? this._addedLineNumberFg
+        : kind === "removed"
+          ? this._removedLineNumberFg
+          : this._contextLineNumberFg
+
+    const config: LineColorConfig = {
+      gutter: gutterBg,
+      content: overrideBg ?? baseBg,
+    }
+    if (fg) config.fg = fg
+    return config
+  }
+
   private buildView(): void {
     if (this._parseError) {
       this.buildErrorView()
@@ -506,18 +527,7 @@ export class DiffRenderable extends Renderable {
 
         if (firstChar === "+") {
           contentLines.push(content)
-          const config: LineColorConfig = {
-            gutter: this._addedLineNumberBg,
-          }
-          if (this._addedContentBg) {
-            config.content = this._addedContentBg
-          } else {
-            config.content = this._addedBg
-          }
-          if (this._addedLineNumberFg) {
-            config.fg = this._addedLineNumberFg
-          }
-          lineColors.set(lineIndex, config)
+          lineColors.set(lineIndex, this.buildLineConfig("added"))
           lineSigns.set(lineIndex, {
             after: " +",
             afterColor: this._addedSignColor,
@@ -527,18 +537,7 @@ export class DiffRenderable extends Renderable {
           lineIndex++
         } else if (firstChar === "-") {
           contentLines.push(content)
-          const config: LineColorConfig = {
-            gutter: this._removedLineNumberBg,
-          }
-          if (this._removedContentBg) {
-            config.content = this._removedContentBg
-          } else {
-            config.content = this._removedBg
-          }
-          if (this._removedLineNumberFg) {
-            config.fg = this._removedLineNumberFg
-          }
-          lineColors.set(lineIndex, config)
+          lineColors.set(lineIndex, this.buildLineConfig("removed"))
           lineSigns.set(lineIndex, {
             after: " -",
             afterColor: this._removedSignColor,
@@ -548,18 +547,7 @@ export class DiffRenderable extends Renderable {
           lineIndex++
         } else if (firstChar === " ") {
           contentLines.push(content)
-          const config: LineColorConfig = {
-            gutter: this._lineNumberBg,
-          }
-          if (this._contextContentBg) {
-            config.content = this._contextContentBg
-          } else {
-            config.content = this._contextBg
-          }
-          if (this._contextLineNumberFg) {
-            config.fg = this._contextLineNumberFg
-          }
-          lineColors.set(lineIndex, config)
+          lineColors.set(lineIndex, this.buildLineConfig("context"))
           lineNumbers.set(lineIndex, newLineNum)
           oldLineNum++
           newLineNum++
@@ -817,31 +805,9 @@ export class DiffRenderable extends Renderable {
         leftHideLineNumbers.add(index)
       }
       if (line.type === "remove") {
-        const config: LineColorConfig = {
-          gutter: this._removedLineNumberBg,
-        }
-        if (this._removedContentBg) {
-          config.content = this._removedContentBg
-        } else {
-          config.content = this._removedBg
-        }
-        if (this._removedLineNumberFg) {
-          config.fg = this._removedLineNumberFg
-        }
-        leftLineColors.set(index, config)
+        leftLineColors.set(index, this.buildLineConfig("removed"))
       } else if (line.type === "context") {
-        const config: LineColorConfig = {
-          gutter: this._lineNumberBg,
-        }
-        if (this._contextContentBg) {
-          config.content = this._contextContentBg
-        } else {
-          config.content = this._contextBg
-        }
-        if (this._contextLineNumberFg) {
-          config.fg = this._contextLineNumberFg
-        }
-        leftLineColors.set(index, config)
+        leftLineColors.set(index, this.buildLineConfig("context"))
       }
       if (line.sign) {
         leftLineSigns.set(index, line.sign)
@@ -856,31 +822,9 @@ export class DiffRenderable extends Renderable {
         rightHideLineNumbers.add(index)
       }
       if (line.type === "add") {
-        const config: LineColorConfig = {
-          gutter: this._addedLineNumberBg,
-        }
-        if (this._addedContentBg) {
-          config.content = this._addedContentBg
-        } else {
-          config.content = this._addedBg
-        }
-        if (this._addedLineNumberFg) {
-          config.fg = this._addedLineNumberFg
-        }
-        rightLineColors.set(index, config)
+        rightLineColors.set(index, this.buildLineConfig("added"))
       } else if (line.type === "context") {
-        const config: LineColorConfig = {
-          gutter: this._lineNumberBg,
-        }
-        if (this._contextContentBg) {
-          config.content = this._contextContentBg
-        } else {
-          config.content = this._contextBg
-        }
-        if (this._contextLineNumberFg) {
-          config.fg = this._contextLineNumberFg
-        }
-        rightLineColors.set(index, config)
+        rightLineColors.set(index, this.buildLineConfig("context"))
       }
       if (line.sign) {
         rightLineSigns.set(index, line.sign)
@@ -1247,27 +1191,28 @@ export class DiffRenderable extends Renderable {
     }
   }
 
+  private forSide(side: DiffSide, fn: (target: LineNumberRenderable) => void): void {
+    if (side !== "right" && this.leftSide) fn(this.leftSide)
+    if (side !== "left" && this.rightSide) fn(this.rightSide)
+  }
+
   public setLineColor(line: number, color: string | RGBA | LineColorConfig, side: DiffSide = "both"): void {
-    if (side !== "right") this.leftSide?.setLineColor(line, color)
-    if (side !== "left") this.rightSide?.setLineColor(line, color)
+    this.forSide(side, (target) => target.setLineColor(line, color))
   }
 
   public clearLineColor(line: number, side: DiffSide = "both"): void {
-    if (side !== "right") this.leftSide?.clearLineColor(line)
-    if (side !== "left") this.rightSide?.clearLineColor(line)
+    this.forSide(side, (target) => target.clearLineColor(line))
   }
 
   public setLineColors(
     lineColors: Map<number, string | RGBA | LineColorConfig>,
     side: DiffSide = "both",
   ): void {
-    if (side !== "right") this.leftSide?.setLineColors(lineColors)
-    if (side !== "left") this.rightSide?.setLineColors(lineColors)
+    this.forSide(side, (target) => target.setLineColors(lineColors))
   }
 
   public clearAllLineColors(side: DiffSide = "both"): void {
-    if (side !== "right") this.leftSide?.clearAllLineColors()
-    if (side !== "left") this.rightSide?.clearAllLineColors()
+    this.forSide(side, (target) => target.clearAllLineColors())
   }
 
   public highlightLines(
@@ -1276,12 +1221,10 @@ export class DiffRenderable extends Renderable {
     color: string | RGBA | LineColorConfig,
     side: DiffSide = "both",
   ): void {
-    if (side !== "right") this.leftSide?.highlightLines(startLine, endLine, color)
-    if (side !== "left") this.rightSide?.highlightLines(startLine, endLine, color)
+    this.forSide(side, (target) => target.highlightLines(startLine, endLine, color))
   }
 
   public clearHighlightLines(startLine: number, endLine: number, side: DiffSide = "both"): void {
-    if (side !== "right") this.leftSide?.clearHighlightLines(startLine, endLine)
-    if (side !== "left") this.rightSide?.clearHighlightLines(startLine, endLine)
+    this.forSide(side, (target) => target.clearHighlightLines(startLine, endLine))
   }
 }

--- a/packages/core/src/renderables/Diff.ts
+++ b/packages/core/src/renderables/Diff.ts
@@ -49,7 +49,12 @@ export interface DiffRenderableOptions extends RenderableOptions<DiffRenderable>
   removedSignColor?: string | RGBA
   addedLineNumberBg?: string | RGBA
   removedLineNumberBg?: string | RGBA
+  addedLineNumberFg?: string | RGBA
+  removedLineNumberFg?: string | RGBA
+  contextLineNumberFg?: string | RGBA
 }
+
+export type DiffSide = "left" | "right" | "both"
 
 export class DiffRenderable extends Renderable {
   private _diff: string
@@ -84,6 +89,9 @@ export class DiffRenderable extends Renderable {
   private _removedSignColor: RGBA
   private _addedLineNumberBg: RGBA
   private _removedLineNumberBg: RGBA
+  private _addedLineNumberFg: RGBA | null
+  private _removedLineNumberFg: RGBA | null
+  private _contextLineNumberFg: RGBA | null
 
   private leftSide: LineNumberRenderable | null = null
   private rightSide: LineNumberRenderable | null = null
@@ -139,6 +147,9 @@ export class DiffRenderable extends Renderable {
     this._removedSignColor = parseColor(options.removedSignColor ?? "#ef4444")
     this._addedLineNumberBg = parseColor(options.addedLineNumberBg ?? "transparent")
     this._removedLineNumberBg = parseColor(options.removedLineNumberBg ?? "transparent")
+    this._addedLineNumberFg = options.addedLineNumberFg ? parseColor(options.addedLineNumberFg) : null
+    this._removedLineNumberFg = options.removedLineNumberFg ? parseColor(options.removedLineNumberFg) : null
+    this._contextLineNumberFg = options.contextLineNumberFg ? parseColor(options.contextLineNumberFg) : null
 
     if (this._diff) {
       this.parseDiff()
@@ -503,6 +514,9 @@ export class DiffRenderable extends Renderable {
           } else {
             config.content = this._addedBg
           }
+          if (this._addedLineNumberFg) {
+            config.fg = this._addedLineNumberFg
+          }
           lineColors.set(lineIndex, config)
           lineSigns.set(lineIndex, {
             after: " +",
@@ -521,6 +535,9 @@ export class DiffRenderable extends Renderable {
           } else {
             config.content = this._removedBg
           }
+          if (this._removedLineNumberFg) {
+            config.fg = this._removedLineNumberFg
+          }
           lineColors.set(lineIndex, config)
           lineSigns.set(lineIndex, {
             after: " -",
@@ -538,6 +555,9 @@ export class DiffRenderable extends Renderable {
             config.content = this._contextContentBg
           } else {
             config.content = this._contextBg
+          }
+          if (this._contextLineNumberFg) {
+            config.fg = this._contextLineNumberFg
           }
           lineColors.set(lineIndex, config)
           lineNumbers.set(lineIndex, newLineNum)
@@ -805,6 +825,9 @@ export class DiffRenderable extends Renderable {
         } else {
           config.content = this._removedBg
         }
+        if (this._removedLineNumberFg) {
+          config.fg = this._removedLineNumberFg
+        }
         leftLineColors.set(index, config)
       } else if (line.type === "context") {
         const config: LineColorConfig = {
@@ -814,6 +837,9 @@ export class DiffRenderable extends Renderable {
           config.content = this._contextContentBg
         } else {
           config.content = this._contextBg
+        }
+        if (this._contextLineNumberFg) {
+          config.fg = this._contextLineNumberFg
         }
         leftLineColors.set(index, config)
       }
@@ -838,6 +864,9 @@ export class DiffRenderable extends Renderable {
         } else {
           config.content = this._addedBg
         }
+        if (this._addedLineNumberFg) {
+          config.fg = this._addedLineNumberFg
+        }
         rightLineColors.set(index, config)
       } else if (line.type === "context") {
         const config: LineColorConfig = {
@@ -847,6 +876,9 @@ export class DiffRenderable extends Renderable {
           config.content = this._contextContentBg
         } else {
           config.content = this._contextBg
+        }
+        if (this._contextLineNumberFg) {
+          config.fg = this._contextLineNumberFg
         }
         rightLineColors.set(index, config)
       }
@@ -1069,6 +1101,42 @@ export class DiffRenderable extends Renderable {
     }
   }
 
+  public get addedLineNumberFg(): RGBA | null {
+    return this._addedLineNumberFg
+  }
+
+  public set addedLineNumberFg(value: string | RGBA | null) {
+    const parsed = value ? parseColor(value) : null
+    if (this._addedLineNumberFg !== parsed) {
+      this._addedLineNumberFg = parsed
+      this.rebuildView()
+    }
+  }
+
+  public get removedLineNumberFg(): RGBA | null {
+    return this._removedLineNumberFg
+  }
+
+  public set removedLineNumberFg(value: string | RGBA | null) {
+    const parsed = value ? parseColor(value) : null
+    if (this._removedLineNumberFg !== parsed) {
+      this._removedLineNumberFg = parsed
+      this.rebuildView()
+    }
+  }
+
+  public get contextLineNumberFg(): RGBA | null {
+    return this._contextLineNumberFg
+  }
+
+  public set contextLineNumberFg(value: string | RGBA | null) {
+    const parsed = value ? parseColor(value) : null
+    if (this._contextLineNumberFg !== parsed) {
+      this._contextLineNumberFg = parsed
+      this.rebuildView()
+    }
+  }
+
   public get lineNumberBg(): RGBA {
     return this._lineNumberBg
   }
@@ -1179,33 +1247,41 @@ export class DiffRenderable extends Renderable {
     }
   }
 
-  public setLineColor(line: number, color: string | RGBA | LineColorConfig): void {
-    this.leftSide?.setLineColor(line, color)
-    this.rightSide?.setLineColor(line, color)
+  public setLineColor(line: number, color: string | RGBA | LineColorConfig, side: DiffSide = "both"): void {
+    if (side !== "right") this.leftSide?.setLineColor(line, color)
+    if (side !== "left") this.rightSide?.setLineColor(line, color)
   }
 
-  public clearLineColor(line: number): void {
-    this.leftSide?.clearLineColor(line)
-    this.rightSide?.clearLineColor(line)
+  public clearLineColor(line: number, side: DiffSide = "both"): void {
+    if (side !== "right") this.leftSide?.clearLineColor(line)
+    if (side !== "left") this.rightSide?.clearLineColor(line)
   }
 
-  public setLineColors(lineColors: Map<number, string | RGBA | LineColorConfig>): void {
-    this.leftSide?.setLineColors(lineColors)
-    this.rightSide?.setLineColors(lineColors)
+  public setLineColors(
+    lineColors: Map<number, string | RGBA | LineColorConfig>,
+    side: DiffSide = "both",
+  ): void {
+    if (side !== "right") this.leftSide?.setLineColors(lineColors)
+    if (side !== "left") this.rightSide?.setLineColors(lineColors)
   }
 
-  public clearAllLineColors(): void {
-    this.leftSide?.clearAllLineColors()
-    this.rightSide?.clearAllLineColors()
+  public clearAllLineColors(side: DiffSide = "both"): void {
+    if (side !== "right") this.leftSide?.clearAllLineColors()
+    if (side !== "left") this.rightSide?.clearAllLineColors()
   }
 
-  public highlightLines(startLine: number, endLine: number, color: string | RGBA | LineColorConfig): void {
-    this.leftSide?.highlightLines(startLine, endLine, color)
-    this.rightSide?.highlightLines(startLine, endLine, color)
+  public highlightLines(
+    startLine: number,
+    endLine: number,
+    color: string | RGBA | LineColorConfig,
+    side: DiffSide = "both",
+  ): void {
+    if (side !== "right") this.leftSide?.highlightLines(startLine, endLine, color)
+    if (side !== "left") this.rightSide?.highlightLines(startLine, endLine, color)
   }
 
-  public clearHighlightLines(startLine: number, endLine: number): void {
-    this.leftSide?.clearHighlightLines(startLine, endLine)
-    this.rightSide?.clearHighlightLines(startLine, endLine)
+  public clearHighlightLines(startLine: number, endLine: number, side: DiffSide = "both"): void {
+    if (side !== "right") this.leftSide?.clearHighlightLines(startLine, endLine)
+    if (side !== "left") this.rightSide?.clearHighlightLines(startLine, endLine)
   }
 }

--- a/packages/core/src/renderables/Diff.ts
+++ b/packages/core/src/renderables/Diff.ts
@@ -1204,10 +1204,7 @@ export class DiffRenderable extends Renderable {
     this.forSide(side, (target) => target.clearLineColor(line))
   }
 
-  public setLineColors(
-    lineColors: Map<number, string | RGBA | LineColorConfig>,
-    side: DiffSide = "both",
-  ): void {
+  public setLineColors(lineColors: Map<number, string | RGBA | LineColorConfig>, side: DiffSide = "both"): void {
     this.forSide(side, (target) => target.setLineColors(lineColors))
   }
 

--- a/packages/core/src/renderables/LineNumberRenderable.ts
+++ b/packages/core/src/renderables/LineNumberRenderable.ts
@@ -14,6 +14,7 @@ export interface LineSign {
 export interface LineColorConfig {
   gutter?: string | RGBA
   content?: string | RGBA
+  fg?: string | RGBA
 }
 
 export interface LineNumberOptions extends RenderableOptions<LineNumberRenderable> {
@@ -41,6 +42,7 @@ class GutterRenderable extends Renderable {
   private _paddingRight: number
   private _lineColorsGutter: Map<number, RGBA>
   private _lineColorsContent: Map<number, RGBA>
+  private _lineColorsFg: Map<number, RGBA>
   private _lineSigns: Map<number, LineSign>
   private _lineNumberOffset: number
   private _hideLineNumbers: Set<number>
@@ -60,6 +62,7 @@ class GutterRenderable extends Renderable {
       paddingRight: number
       lineColorsGutter: Map<number, RGBA>
       lineColorsContent: Map<number, RGBA>
+      lineColorsFg: Map<number, RGBA>
       lineSigns: Map<number, LineSign>
       lineNumberOffset: number
       hideLineNumbers: Set<number>
@@ -83,6 +86,7 @@ class GutterRenderable extends Renderable {
     this._paddingRight = options.paddingRight
     this._lineColorsGutter = options.lineColorsGutter
     this._lineColorsContent = options.lineColorsContent
+    this._lineColorsFg = options.lineColorsFg
     this._lineSigns = options.lineSigns
     this._lineNumberOffset = options.lineNumberOffset
     this._hideLineNumbers = options.hideLineNumbers
@@ -184,9 +188,14 @@ class GutterRenderable extends Renderable {
     return baseWidth + this._maxBeforeWidth + this._maxAfterWidth
   }
 
-  public setLineColors(lineColorsGutter: Map<number, RGBA>, lineColorsContent: Map<number, RGBA>): void {
+  public setLineColors(
+    lineColorsGutter: Map<number, RGBA>,
+    lineColorsContent: Map<number, RGBA>,
+    lineColorsFg: Map<number, RGBA>,
+  ): void {
     this._lineColorsGutter = lineColorsGutter
     this._lineColorsContent = lineColorsContent
+    this._lineColorsFg = lineColorsFg
     this.requestRender()
   }
 
@@ -212,10 +221,11 @@ class GutterRenderable extends Renderable {
     }
   }
 
-  public getLineColors(): { gutter: Map<number, RGBA>; content: Map<number, RGBA> } {
+  public getLineColors(): { gutter: Map<number, RGBA>; content: Map<number, RGBA>; fg: Map<number, RGBA> } {
     return {
       gutter: this._lineColorsGutter,
       content: this._lineColorsContent,
+      fg: this._lineColorsFg,
     }
   }
 
@@ -287,6 +297,7 @@ class GutterRenderable extends Renderable {
 
       const logicalLine = sources[visualLineIndex]
       const lineBg = this._lineColorsGutter.get(logicalLine) ?? this._bg
+      const lineFg = this._lineColorsFg.get(logicalLine) ?? this._fg
 
       // Fill background for this line if it has a custom color
       if (lineBg !== this._bg) {
@@ -306,7 +317,7 @@ class GutterRenderable extends Renderable {
           // Pad to max before width for alignment
           const padding = this._maxBeforeWidth - beforeWidth
           currentX += padding
-          const beforeColor = sign.beforeColor ? parseColor(sign.beforeColor) : this._fg
+          const beforeColor = sign.beforeColor ? parseColor(sign.beforeColor) : lineFg
           buffer.drawText(sign.before, currentX, startY + i, beforeColor, lineBg)
           currentX += beforeWidth
         } else if (this._maxBeforeWidth > 0) {
@@ -324,14 +335,14 @@ class GutterRenderable extends Renderable {
           const lineNumX = startX + this._maxBeforeWidth + 1 + availableSpace - lineNumWidth - 1
 
           if (lineNumX >= startX + this._maxBeforeWidth + 1) {
-            buffer.drawText(lineNumStr, lineNumX, startY + i, this._fg, lineBg)
+            buffer.drawText(lineNumStr, lineNumX, startY + i, lineFg, lineBg)
           }
         }
 
         // Draw 'after' sign if present
         if (sign?.after) {
           const afterX = startX + this.width - this._paddingRight - this._maxAfterWidth
-          const afterColor = sign.afterColor ? parseColor(sign.afterColor) : this._fg
+          const afterColor = sign.afterColor ? parseColor(sign.afterColor) : lineFg
           buffer.drawText(sign.after, afterX, startY + i, afterColor, lineBg)
         }
       }
@@ -351,6 +362,7 @@ export class LineNumberRenderable extends Renderable {
   private target: (Renderable & LineInfoProvider) | null = null
   private _lineColorsGutter: Map<number, RGBA>
   private _lineColorsContent: Map<number, RGBA>
+  private _lineColorsFg: Map<number, RGBA>
   private _lineSigns: Map<number, LineSign>
   private _fg: RGBA
   private _bg: RGBA
@@ -367,7 +379,7 @@ export class LineNumberRenderable extends Renderable {
   }
 
   private parseLineColor(line: number, color: string | RGBA | LineColorConfig): void {
-    if (typeof color === "object" && "gutter" in color) {
+    if (typeof color === "object" && !(color instanceof RGBA) && ("gutter" in color || "content" in color || "fg" in color)) {
       // LineColorConfig format
       const config = color as LineColorConfig
       if (config.gutter) {
@@ -378,6 +390,9 @@ export class LineNumberRenderable extends Renderable {
       } else if (config.gutter) {
         // If only gutter is specified, use a darker version for content
         this._lineColorsContent.set(line, darkenColor(parseColor(config.gutter)))
+      }
+      if (config.fg) {
+        this._lineColorsFg.set(line, parseColor(config.fg))
       }
     } else {
       // Simple format - same color for both, but content is darker
@@ -406,6 +421,7 @@ export class LineNumberRenderable extends Renderable {
 
     this._lineColorsGutter = new Map<number, RGBA>()
     this._lineColorsContent = new Map<number, RGBA>()
+    this._lineColorsFg = new Map<number, RGBA>()
     if (options.lineColors) {
       for (const [line, color] of options.lineColors) {
         this.parseLineColor(line, color)
@@ -451,6 +467,7 @@ export class LineNumberRenderable extends Renderable {
       paddingRight: this._paddingRight,
       lineColorsGutter: this._lineColorsGutter,
       lineColorsContent: this._lineColorsContent,
+      lineColorsFg: this._lineColorsFg,
       lineSigns: this._lineSigns,
       lineNumberOffset: this._lineNumberOffset,
       hideLineNumbers: this._hideLineNumbers,
@@ -591,42 +608,46 @@ export class LineNumberRenderable extends Renderable {
     this.parseLineColor(line, color)
     // Update gutter if it exists
     if (this.gutter) {
-      this.gutter.setLineColors(this._lineColorsGutter, this._lineColorsContent)
+      this.gutter.setLineColors(this._lineColorsGutter, this._lineColorsContent, this._lineColorsFg)
     }
   }
 
   public clearLineColor(line: number): void {
     this._lineColorsGutter.delete(line)
     this._lineColorsContent.delete(line)
+    this._lineColorsFg.delete(line)
     if (this.gutter) {
-      this.gutter.setLineColors(this._lineColorsGutter, this._lineColorsContent)
+      this.gutter.setLineColors(this._lineColorsGutter, this._lineColorsContent, this._lineColorsFg)
     }
   }
 
   public clearAllLineColors(): void {
     this._lineColorsGutter.clear()
     this._lineColorsContent.clear()
+    this._lineColorsFg.clear()
     if (this.gutter) {
-      this.gutter.setLineColors(this._lineColorsGutter, this._lineColorsContent)
+      this.gutter.setLineColors(this._lineColorsGutter, this._lineColorsContent, this._lineColorsFg)
     }
   }
 
   public setLineColors(lineColors: Map<number, string | RGBA | LineColorConfig>): void {
     this._lineColorsGutter.clear()
     this._lineColorsContent.clear()
+    this._lineColorsFg.clear()
     for (const [line, color] of lineColors) {
       this.parseLineColor(line, color)
     }
     // Update gutter once after all colors are set
     if (this.gutter) {
-      this.gutter.setLineColors(this._lineColorsGutter, this._lineColorsContent)
+      this.gutter.setLineColors(this._lineColorsGutter, this._lineColorsContent, this._lineColorsFg)
     }
   }
 
-  public getLineColors(): { gutter: Map<number, RGBA>; content: Map<number, RGBA> } {
+  public getLineColors(): { gutter: Map<number, RGBA>; content: Map<number, RGBA>; fg: Map<number, RGBA> } {
     return {
       gutter: this._lineColorsGutter,
       content: this._lineColorsContent,
+      fg: this._lineColorsFg,
     }
   }
 
@@ -708,7 +729,7 @@ export class LineNumberRenderable extends Renderable {
       this.parseLineColor(i, color)
     }
     if (this.gutter) {
-      this.gutter.setLineColors(this._lineColorsGutter, this._lineColorsContent)
+      this.gutter.setLineColors(this._lineColorsGutter, this._lineColorsContent, this._lineColorsFg)
     }
   }
 
@@ -716,9 +737,10 @@ export class LineNumberRenderable extends Renderable {
     for (let i = startLine; i <= endLine; i++) {
       this._lineColorsGutter.delete(i)
       this._lineColorsContent.delete(i)
+      this._lineColorsFg.delete(i)
     }
     if (this.gutter) {
-      this.gutter.setLineColors(this._lineColorsGutter, this._lineColorsContent)
+      this.gutter.setLineColors(this._lineColorsGutter, this._lineColorsContent, this._lineColorsFg)
     }
   }
 }

--- a/packages/core/src/renderables/LineNumberRenderable.ts
+++ b/packages/core/src/renderables/LineNumberRenderable.ts
@@ -17,6 +17,15 @@ export interface LineColorConfig {
   fg?: string | RGBA
 }
 
+function isLineColorConfig(value: unknown): value is LineColorConfig {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !(value instanceof RGBA) &&
+    ("gutter" in value || "content" in value || "fg" in value)
+  )
+}
+
 export interface LineNumberOptions extends RenderableOptions<LineNumberRenderable> {
   target?: Renderable & LineInfoProvider
   fg?: string | RGBA
@@ -379,24 +388,21 @@ export class LineNumberRenderable extends Renderable {
   }
 
   private parseLineColor(line: number, color: string | RGBA | LineColorConfig): void {
-    if (typeof color === "object" && !(color instanceof RGBA) && ("gutter" in color || "content" in color || "fg" in color)) {
-      // LineColorConfig format
-      const config = color as LineColorConfig
-      if (config.gutter) {
-        this._lineColorsGutter.set(line, parseColor(config.gutter))
+    if (isLineColorConfig(color)) {
+      if (color.gutter) {
+        this._lineColorsGutter.set(line, parseColor(color.gutter))
       }
-      if (config.content) {
-        this._lineColorsContent.set(line, parseColor(config.content))
-      } else if (config.gutter) {
-        // If only gutter is specified, use a darker version for content
-        this._lineColorsContent.set(line, darkenColor(parseColor(config.gutter)))
+      if (color.content) {
+        this._lineColorsContent.set(line, parseColor(color.content))
+      } else if (color.gutter) {
+        // Only gutter specified: derive a darker content tint for visual hierarchy.
+        this._lineColorsContent.set(line, darkenColor(parseColor(color.gutter)))
       }
-      if (config.fg) {
-        this._lineColorsFg.set(line, parseColor(config.fg))
+      if (color.fg) {
+        this._lineColorsFg.set(line, parseColor(color.fg))
       }
     } else {
-      // Simple format - same color for both, but content is darker
-      const parsedColor = parseColor(color as string | RGBA)
+      const parsedColor = parseColor(color)
       this._lineColorsGutter.set(line, parsedColor)
       this._lineColorsContent.set(line, darkenColor(parsedColor))
     }


### PR DESCRIPTION
## Summary

Two small additions to the diff renderer, both motivated by real consumer pain:

### 1. Per-kind line-number foreground colors

Today every line-number digit in the gutter is painted with one `lineNumberFg` (default `#888`), even on `+` / `−` rows where the sign glyph is already tinted green/red. This adds three optional overrides:

- `addedLineNumberFg`
- `removedLineNumberFg`
- `contextLineNumberFg`

Each defaults to undefined (existing `lineNumberFg` remains the umbrella default), so behavior is unchanged unless a consumer opts in.

Underneath, `LineColorConfig` (the per-line override shape used by `LineNumberRenderable`) gains an optional `fg?: string | RGBA` so manual `setLineColor()` callers can also set the digit color, not just background.

```
before:                              after (with the new options set):
  41                                   41                       (gray)
  43 −  return greeting + name         43 −  return greeting…   (red)
  43 +  return `Hi, ${name}!`          43 +  return `Hi…`       (green)
  ↑                                    ↑
  digit always gray                    digit picks up kind color
```

### 2. Side-targeted line color API

The diff-level methods that paint individual lines now accept an optional `side` parameter:

```ts
type DiffSide = "left" | "right" | "both"

diff.setLineColor(line, color, side?)
diff.clearLineColor(line, side?)
diff.setLineColors(map, side?)
diff.clearAllLineColors(side?)
diff.highlightLines(start, end, color, side?)
diff.clearHighlightLines(start, end, side?)
```

Default is `"both"`, so existing callers are byte-identical. New capability is `"left"` / `"right"` for split-view consumers — e.g. ghui, which currently has to do `diff as unknown as DiffRenderableRuntimeSides` and reach into the private `leftSide` / `rightSide` fields to highlight a single side for a PR comment anchor. With this PR, that hack collapses to a single public call.

## Test plan

- [ ] CI typecheck (local `tsc --noEmit` is clean for the modified files; pre-existing errors in unrelated tests/dev files remain unchanged)
- [ ] `bun run test src/renderables/Diff.test.ts src/renderables/__tests__/LineNumberRenderable.test.ts` — could not run locally; my checkout's prebuilt `@opentui/core-darwin-arm64` is missing the `setClearOnShutdown` symbol added in recent `main`, and a from-source rebuild fails with libc symbol errors (Zig 0.15.2 toolchain mismatch). Both predate this PR; CI / a fresh `bun install` should be fine.
- [ ] Manual visual check via `packages/examples/src/diff-demo.ts` with the new options set, confirming digits in the `+` / `−` rows pick up their tinted colors and that `setLineColor(..., "left")` only paints the left side in split view.

Marking as draft pending those last two checks.