### PR TITLE
core: replace Bun globals with platform runtime

### DIFF
--- a/packages/core/src/lib/extmarks.ts
+++ b/packages/core/src/lib/extmarks.ts
@@ -1,5 +1,6 @@
 import type { EditBuffer } from "../edit-buffer.js"
 import type { EditorView } from "../editor-view.js"
+import { stringWidth } from "../platform/runtime.js"
 import { ExtmarksHistory, type ExtmarksSnapshot } from "./extmarks-history.js"
 
 export interface Extmark {
@@ -614,7 +615,7 @@ export class ExtmarksController {
           j++
         }
         const chunk = text.substring(i, j)
-        const chunkWidth = Bun.stringWidth(chunk)
+        const chunkWidth = stringWidth(chunk)
 
         if (displayWidthSoFar + chunkWidth < offset) {
           // Entire chunk fits before offset
@@ -624,7 +625,7 @@ export class ExtmarksController {
           // Offset is within this chunk - need to find exact position
           // Walk character by character
           for (let k = i; k < j && displayWidthSoFar < offset; k++) {
-            const charWidth = Bun.stringWidth(text[k])
+            const charWidth = stringWidth(text[k])
             displayWidthSoFar += charWidth
           }
           break

--- a/packages/core/src/lib/paste.ts
+++ b/packages/core/src/lib/paste.ts
@@ -1,3 +1,5 @@
+import { stripANSI } from "../platform/runtime.js"
+
 export type PasteKind = "text" | "binary" | "unknown"
 
 export interface PasteMetadata {
@@ -12,5 +14,5 @@ export function decodePasteBytes(bytes: Uint8Array): string {
 }
 
 export function stripAnsiSequences(text: string): string {
-  return Bun.stripANSI(text)
+  return stripANSI(text)
 }

--- a/packages/core/src/renderables/LineNumberRenderable.ts
+++ b/packages/core/src/renderables/LineNumberRenderable.ts
@@ -2,6 +2,7 @@ import { Renderable, type RenderableOptions } from "../Renderable.js"
 import { OptimizedBuffer } from "../buffer.js"
 import type { RenderContext, LineInfoProvider } from "../types.js"
 import { RGBA, parseColor } from "../lib/RGBA.js"
+import { stringWidth } from "../platform/runtime.js"
 import { MeasureMode } from "yoga-layout"
 
 export interface LineSign {
@@ -158,11 +159,11 @@ class GutterRenderable extends Renderable {
 
     for (const sign of this._lineSigns.values()) {
       if (sign.before) {
-        const width = Bun.stringWidth(sign.before)
+        const width = stringWidth(sign.before)
         this._maxBeforeWidth = Math.max(this._maxBeforeWidth, width)
       }
       if (sign.after) {
-        const width = Bun.stringWidth(sign.after)
+        const width = stringWidth(sign.after)
         this._maxAfterWidth = Math.max(this._maxAfterWidth, width)
       }
     }
@@ -302,7 +303,7 @@ class GutterRenderable extends Renderable {
         // Draw 'before' sign if present
         const sign = this._lineSigns.get(logicalLine)
         if (sign?.before) {
-          const beforeWidth = Bun.stringWidth(sign.before)
+          const beforeWidth = stringWidth(sign.before)
           // Pad to max before width for alignment
           const padding = this._maxBeforeWidth - beforeWidth
           currentX += padding

--- a/packages/core/src/renderables/ScrollBar.ts
+++ b/packages/core/src/renderables/ScrollBar.ts
@@ -1,6 +1,7 @@
 import type { OptimizedBuffer } from "../buffer.js"
 import { parseColor, RGBA, type ColorInput } from "../lib/index.js"
 import type { KeyEvent } from "../lib/KeyHandler.js"
+import { stringWidth } from "../platform/runtime.js"
 import { Renderable, type RenderableOptions } from "../Renderable.js"
 import type { RenderContext, Timeout } from "../types.js"
 import { type BoxOptions } from "./Box.js"
@@ -344,7 +345,7 @@ export class ArrowRenderable extends Renderable {
     }
 
     if (!options.width) {
-      this.width = Bun.stringWidth(this.getArrowChar())
+      this.width = stringWidth(this.getArrowChar())
     }
   }
 

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -14,6 +14,7 @@ import {
 } from "./types.js"
 import { RGBA, parseColor, type ColorInput } from "./lib/RGBA.js"
 import type { Pointer } from "./platform/ffi.js"
+import { sleep } from "./platform/runtime.js"
 import { OptimizedBuffer } from "./buffer.js"
 import { resolveRenderLib, type RenderLib } from "./zig.js"
 import { TerminalConsole, type ConsoleOptions, capture } from "./console.js"
@@ -882,7 +883,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private exitHandler: () => void = (() => {
     this.destroy()
     if (env.OTUI_DUMP_CAPTURES) {
-      Bun.sleep(100).then(() => {
+      sleep(100).then(() => {
         this.dumpOutputCache("=== CAPTURED OUTPUT ===\n")
       })
     }

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -1,4 +1,5 @@
 import { dlopen, ffiBool, toArrayBuffer, ptr, type FFICallbackInstance, type Pointer } from "./platform/ffi.js"
+import { writeFile } from "./platform/runtime.js"
 import { existsSync, writeFileSync } from "fs"
 import { EventEmitter } from "events"
 import {
@@ -1370,7 +1371,9 @@ function convertToDebugSymbols<T extends Record<string, any>>(symbols: T): T {
           const now = new Date()
           const timestamp = now.toISOString().replace(/[:.]/g, "-").replace(/T/, "_").split("Z")[0]
           const traceFilePath = `ffi_otui_trace_${timestamp}.log`
-          Bun.write(traceFilePath, output)
+          void writeFile(traceFilePath, output).catch((error) => {
+            console.error("Failed to write FFI trace file:", error)
+          })
         } catch (e) {
           console.error("Failed to write FFI trace file:", e)
         }


### PR DESCRIPTION
Direct Bun.* calls (stringWidth, stripANSI, sleep, write) prevent
running on Node.js. Route them through the platform/runtime
abstraction so the core package stays runtime-agnostic.
