### PR TITLE
markdown: preserve spacing before code blocks

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -579,11 +579,38 @@ export class MarkdownRenderable extends Renderable {
     return raw.replace(TRAILING_MARKDOWN_BLOCK_NEWLINES_RE, "")
   }
 
-  private buildRenderableTokens(tokens: MarkedToken[]): MarkedToken[] {
-    if (this._renderNode) {
-      return tokens.filter((token) => token.type !== "space")
+  private shouldPreserveCoalescedGapBefore(nextToken: MarkedToken | undefined): boolean {
+    return nextToken?.type === "code"
+  }
+
+  private withPreservedCoalescedGap(token: MarkedToken, gapRaw: string): MarkedToken {
+    if (!token.raw) {
+      return token
     }
 
+    return {
+      ...token,
+      raw: this.normalizeMarkdownBlockRaw(token.raw + gapRaw),
+    } as MarkedToken
+  }
+
+  private getNextNonSpaceToken(tokens: MarkedToken[], startIndex: number): MarkedToken | undefined {
+    for (let i = startIndex; i < tokens.length; i += 1) {
+      const token = tokens[i]
+      if (token.type !== "space") {
+        return token
+      }
+    }
+
+    return undefined
+  }
+
+  private shouldKeepCoalescedGap(nextToken: MarkedToken | undefined): boolean {
+    return !!nextToken && (!this.shouldRenderSeparately(nextToken) || this.shouldPreserveCoalescedGapBefore(nextToken))
+  }
+
+  private buildRenderableTokens(tokens: MarkedToken[]): MarkedToken[] {
+    const hasCustomRenderer = !!this._renderNode
     const renderTokens: MarkedToken[] = []
     let markdownRaw = ""
 
@@ -600,19 +627,28 @@ export class MarkdownRenderable extends Renderable {
       const token = tokens[i]
 
       if (token.type === "space") {
-        if (markdownRaw.length === 0) {
+        const nextToken = this.getNextNonSpaceToken(tokens, i + 1)
+
+        if (hasCustomRenderer) {
+          const previousToken = renderTokens[renderTokens.length - 1]
+          if (
+            previousToken &&
+            !this.shouldRenderSeparately(previousToken) &&
+            this.shouldPreserveCoalescedGapBefore(nextToken)
+          ) {
+            renderTokens[renderTokens.length - 1] = this.withPreservedCoalescedGap(previousToken, token.raw)
+          }
           continue
         }
 
-        let nextIndex = i + 1
-        while (nextIndex < tokens.length && tokens[nextIndex].type === "space") {
-          nextIndex += 1
-        }
-
-        const nextToken = tokens[nextIndex]
-        if (nextToken && !this.shouldRenderSeparately(nextToken)) {
+        if (markdownRaw.length > 0 && this.shouldKeepCoalescedGap(nextToken)) {
           markdownRaw += token.raw
         }
+        continue
+      }
+
+      if (hasCustomRenderer) {
+        renderTokens.push(token)
         continue
       }
 

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -1281,16 +1281,23 @@ export class MarkdownRenderable extends Renderable {
       let tableContentCache: TableContentCache | undefined
 
       if (this._renderNode) {
+        let defaultRenderable: Renderable | null = null
         const context: RenderNodeContext = {
           syntaxStyle: this._syntaxStyle,
           conceal: this._conceal,
           concealCode: this._concealCode,
           treeSitterClient: this._treeSitterClient,
-          defaultRender: () => this.createDefaultRenderable(token, blockIndex, hasNextToken),
+          defaultRender: () => {
+            defaultRenderable = this.createDefaultRenderable(token, blockIndex, hasNextToken)
+            return defaultRenderable
+          },
         }
         const custom = this._renderNode(token, context)
         if (custom) {
           renderable = custom
+          if (custom !== defaultRenderable && token.raw.endsWith("\n") && blockTokens[i + 1]?.type === "code") {
+            custom.marginBottom = 1
+          }
         }
       }
 

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -152,6 +152,8 @@ export interface BlockState {
   token: MarkedToken
   tokenRaw: string // Cache raw for comparison
   marginTop?: number
+  customRenderNode?: boolean
+  customGapBeforeCode?: boolean
   renderable: Renderable
   tableContentCache?: TableContentCache
 }
@@ -1238,9 +1240,23 @@ export class MarkdownRenderable extends Renderable {
     const blockTokens = this.buildRenderableTokens(tokens)
     const lastBlockIndex = blockTokens.length - 1
 
+    const updateCustomGapBeforeCode = (
+      state: BlockState,
+      token: MarkedToken,
+      nextToken: MarkedToken | undefined,
+    ): void => {
+      if (!state.customRenderNode) return
+      const hasGap = token.raw.endsWith("\n") && nextToken?.type === "code"
+      if (hasGap || state.customGapBeforeCode) {
+        state.renderable.marginBottom = hasGap ? 1 : 0
+      }
+      state.customGapBeforeCode = hasGap
+    }
+
     let blockIndex = 0
     for (let i = 0; i < blockTokens.length; i++) {
       const token = blockTokens[i]
+      const nextToken = blockTokens[i + 1]
       const hasNextToken = i < lastBlockIndex
       const existing = this._blockStates[blockIndex]
 
@@ -1251,6 +1267,7 @@ export class MarkdownRenderable extends Renderable {
           this.updateBlockRenderable(existing, token, blockIndex, hasNextToken)
           existing.tokenRaw = token.raw
         }
+        updateCustomGapBeforeCode(existing, token, nextToken)
         blockIndex++
         continue
       }
@@ -1261,6 +1278,7 @@ export class MarkdownRenderable extends Renderable {
           this.updateBlockRenderable(existing, token, blockIndex, hasNextToken)
           existing.tokenRaw = token.raw
         }
+        updateCustomGapBeforeCode(existing, token, nextToken)
         blockIndex++
         continue
       }
@@ -1269,6 +1287,8 @@ export class MarkdownRenderable extends Renderable {
         this.updateBlockRenderable(existing, token, blockIndex, hasNextToken)
         existing.token = token
         existing.tokenRaw = token.raw
+        existing.customRenderNode = undefined
+        existing.customGapBeforeCode = undefined
         blockIndex++
         continue
       }
@@ -1279,6 +1299,8 @@ export class MarkdownRenderable extends Renderable {
 
       let renderable: Renderable | undefined
       let tableContentCache: TableContentCache | undefined
+      let customRenderNode: boolean | undefined
+      let customGapBeforeCode: boolean | undefined
 
       if (this._renderNode) {
         let defaultRenderable: Renderable | null = null
@@ -1295,7 +1317,9 @@ export class MarkdownRenderable extends Renderable {
         const custom = this._renderNode(token, context)
         if (custom) {
           renderable = custom
-          if (custom !== defaultRenderable && token.raw.endsWith("\n") && blockTokens[i + 1]?.type === "code") {
+          customRenderNode = custom !== defaultRenderable
+          customGapBeforeCode = customRenderNode && token.raw.endsWith("\n") && nextToken?.type === "code"
+          if (customGapBeforeCode) {
             custom.marginBottom = 1
           }
         }
@@ -1326,6 +1350,8 @@ export class MarkdownRenderable extends Renderable {
           token,
           tokenRaw: token.raw,
           renderable,
+          customRenderNode,
+          customGapBeforeCode,
           tableContentCache,
         }
       }

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -153,7 +153,7 @@ export interface BlockState {
   tokenRaw: string // Cache raw for comparison
   marginTop?: number
   customRenderNode?: boolean
-  customGapBeforeCode?: boolean
+  customMarginBottom?: number
   renderable: Renderable
   tableContentCache?: TableContentCache
 }
@@ -609,6 +609,18 @@ export class MarkdownRenderable extends Renderable {
 
   private shouldKeepCoalescedGap(nextToken: MarkedToken | undefined): boolean {
     return !!nextToken && (!this.shouldRenderSeparately(nextToken) || this.shouldPreserveCoalescedGapBefore(nextToken))
+  }
+
+  private getCustomRenderMarginBottom(
+    token: MarkedToken,
+    nextToken: MarkedToken | undefined,
+    hasNextToken: boolean,
+  ): number {
+    if (token.raw?.endsWith("\n") && nextToken?.type === "code") {
+      return 1
+    }
+
+    return this.getInterBlockMargin(token, hasNextToken)
   }
 
   private buildRenderableTokens(tokens: MarkedToken[]): MarkedToken[] {
@@ -1240,17 +1252,18 @@ export class MarkdownRenderable extends Renderable {
     const blockTokens = this.buildRenderableTokens(tokens)
     const lastBlockIndex = blockTokens.length - 1
 
-    const updateCustomGapBeforeCode = (
+    const updateCustomMarginBottom = (
       state: BlockState,
       token: MarkedToken,
       nextToken: MarkedToken | undefined,
+      hasNextToken: boolean,
     ): void => {
       if (!state.customRenderNode) return
-      const hasGap = token.raw.endsWith("\n") && nextToken?.type === "code"
-      if (hasGap || state.customGapBeforeCode) {
-        state.renderable.marginBottom = hasGap ? 1 : 0
+      const marginBottom = this.getCustomRenderMarginBottom(token, nextToken, hasNextToken)
+      if (marginBottom !== state.customMarginBottom) {
+        state.renderable.marginBottom = marginBottom
+        state.customMarginBottom = marginBottom
       }
-      state.customGapBeforeCode = hasGap
     }
 
     let blockIndex = 0
@@ -1267,7 +1280,7 @@ export class MarkdownRenderable extends Renderable {
           this.updateBlockRenderable(existing, token, blockIndex, hasNextToken)
           existing.tokenRaw = token.raw
         }
-        updateCustomGapBeforeCode(existing, token, nextToken)
+        updateCustomMarginBottom(existing, token, nextToken, hasNextToken)
         blockIndex++
         continue
       }
@@ -1278,7 +1291,7 @@ export class MarkdownRenderable extends Renderable {
           this.updateBlockRenderable(existing, token, blockIndex, hasNextToken)
           existing.tokenRaw = token.raw
         }
-        updateCustomGapBeforeCode(existing, token, nextToken)
+        updateCustomMarginBottom(existing, token, nextToken, hasNextToken)
         blockIndex++
         continue
       }
@@ -1288,7 +1301,7 @@ export class MarkdownRenderable extends Renderable {
         existing.token = token
         existing.tokenRaw = token.raw
         existing.customRenderNode = undefined
-        existing.customGapBeforeCode = undefined
+        existing.customMarginBottom = undefined
         blockIndex++
         continue
       }
@@ -1300,7 +1313,7 @@ export class MarkdownRenderable extends Renderable {
       let renderable: Renderable | undefined
       let tableContentCache: TableContentCache | undefined
       let customRenderNode: boolean | undefined
-      let customGapBeforeCode: boolean | undefined
+      let customMarginBottom: number | undefined
 
       if (this._renderNode) {
         let defaultRenderable: Renderable | null = null
@@ -1318,9 +1331,9 @@ export class MarkdownRenderable extends Renderable {
         if (custom) {
           renderable = custom
           customRenderNode = custom !== defaultRenderable
-          customGapBeforeCode = customRenderNode && token.raw.endsWith("\n") && nextToken?.type === "code"
-          if (customGapBeforeCode) {
-            custom.marginBottom = 1
+          if (customRenderNode) {
+            customMarginBottom = this.getCustomRenderMarginBottom(token, nextToken, hasNextToken)
+            custom.marginBottom = customMarginBottom
           }
         }
       }
@@ -1351,7 +1364,7 @@ export class MarkdownRenderable extends Renderable {
           tokenRaw: token.raw,
           renderable,
           customRenderNode,
-          customGapBeforeCode,
+          customMarginBottom,
           tableContentCache,
         }
       }

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -152,8 +152,6 @@ export interface BlockState {
   token: MarkedToken
   tokenRaw: string // Cache raw for comparison
   marginTop?: number
-  customRenderNode?: boolean
-  customMarginBottom?: number
   renderable: Renderable
   tableContentCache?: TableContentCache
 }
@@ -164,6 +162,11 @@ interface MarkdownRenderBlock {
   token: MarkedToken
   sourceTokenEnd: number
   marginTop: number
+}
+
+interface CoalescedRenderBlock {
+  token: MarkedToken
+  marginBottom: number
 }
 
 export class MarkdownRenderable extends Renderable {
@@ -585,17 +588,6 @@ export class MarkdownRenderable extends Renderable {
     return nextToken?.type === "code"
   }
 
-  private withPreservedCoalescedGap(token: MarkedToken, gapRaw: string): MarkedToken {
-    if (!token.raw) {
-      return token
-    }
-
-    return {
-      ...token,
-      raw: this.normalizeMarkdownBlockRaw(token.raw + gapRaw),
-    } as MarkedToken
-  }
-
   private getNextNonSpaceToken(tokens: MarkedToken[], startIndex: number): MarkedToken | undefined {
     for (let i = startIndex; i < tokens.length; i += 1) {
       const token = tokens[i]
@@ -611,20 +603,14 @@ export class MarkdownRenderable extends Renderable {
     return !!nextToken && (!this.shouldRenderSeparately(nextToken) || this.shouldPreserveCoalescedGapBefore(nextToken))
   }
 
-  private getCustomRenderMarginBottom(
-    token: MarkedToken,
-    nextToken: MarkedToken | undefined,
-    hasNextToken: boolean,
-  ): number {
-    if (token.raw?.endsWith("\n") && nextToken?.type === "code") {
-      return 1
-    }
-
-    return this.getInterBlockMargin(token, hasNextToken)
+  private shouldApplyInterBlockGap(previousToken: MarkedToken, gapRaw: string): boolean {
+    return (
+      this.shouldRenderSeparately(previousToken) ||
+      TRAILING_MARKDOWN_BLOCK_BREAKS_RE.test(`${previousToken.raw ?? ""}${gapRaw}`)
+    )
   }
 
   private buildRenderableTokens(tokens: MarkedToken[]): MarkedToken[] {
-    const hasCustomRenderer = !!this._renderNode
     const renderTokens: MarkedToken[] = []
     let markdownRaw = ""
 
@@ -641,28 +627,9 @@ export class MarkdownRenderable extends Renderable {
       const token = tokens[i]
 
       if (token.type === "space") {
-        const nextToken = this.getNextNonSpaceToken(tokens, i + 1)
-
-        if (hasCustomRenderer) {
-          const previousToken = renderTokens[renderTokens.length - 1]
-          if (
-            previousToken &&
-            !this.shouldRenderSeparately(previousToken) &&
-            this.shouldPreserveCoalescedGapBefore(nextToken)
-          ) {
-            renderTokens[renderTokens.length - 1] = this.withPreservedCoalescedGap(previousToken, token.raw)
-          }
-          continue
-        }
-
-        if (markdownRaw.length > 0 && this.shouldKeepCoalescedGap(nextToken)) {
+        if (markdownRaw.length > 0 && this.shouldKeepCoalescedGap(this.getNextNonSpaceToken(tokens, i + 1))) {
           markdownRaw += token.raw
         }
-        continue
-      }
-
-      if (hasCustomRenderer) {
-        renderTokens.push(token)
         continue
       }
 
@@ -680,6 +647,38 @@ export class MarkdownRenderable extends Renderable {
     return renderTokens
   }
 
+  private buildCoalescedRenderBlocks(tokens: MarkedToken[]): CoalescedRenderBlock[] {
+    const renderTokens = this.buildRenderableTokens(tokens)
+    const lastBlockIndex = renderTokens.length - 1
+
+    return renderTokens.map((token, index) => ({
+      token,
+      marginBottom: this.getInterBlockMargin(token, index < lastBlockIndex),
+    }))
+  }
+
+  private buildRenderNodeBlocks(tokens: MarkedToken[]): CoalescedRenderBlock[] {
+    const blocks: CoalescedRenderBlock[] = []
+    let gapAfterPrevious = ""
+
+    for (const token of tokens) {
+      if (token.type === "space") {
+        gapAfterPrevious += token.raw
+        continue
+      }
+
+      const previousBlock = blocks[blocks.length - 1]
+      if (previousBlock) {
+        previousBlock.marginBottom = this.shouldApplyInterBlockGap(previousBlock.token, gapAfterPrevious) ? 1 : 0
+      }
+
+      blocks.push({ token, marginBottom: 0 })
+      gapAfterPrevious = ""
+    }
+
+    return blocks
+  }
+
   private buildTopLevelRenderBlocks(tokens: MarkedToken[]): MarkdownRenderBlock[] {
     const blocks: MarkdownRenderBlock[] = []
     let gapBefore = ""
@@ -692,11 +691,7 @@ export class MarkdownRenderable extends Renderable {
       }
 
       const prev = blocks[blocks.length - 1]
-      const marginTop =
-        prev &&
-        (this.shouldRenderSeparately(prev.token) || TRAILING_MARKDOWN_BLOCK_BREAKS_RE.test(prev.token.raw + gapBefore))
-          ? 1
-          : 0
+      const marginTop = prev && this.shouldApplyInterBlockGap(prev.token, gapBefore) ? 1 : 0
 
       blocks.push({
         token,
@@ -1009,7 +1004,7 @@ export class MarkdownRenderable extends Renderable {
     state.tableContentCache = tableContentCache
   }
 
-  private getTopLevelBlockRaw(token: MarkedToken): string | undefined {
+  private getStandaloneBlockRaw(token: MarkedToken): string | undefined {
     if (!token.raw) {
       return undefined
     }
@@ -1036,7 +1031,7 @@ export class MarkdownRenderable extends Renderable {
       return next
     }
 
-    const markdownRaw = this.getTopLevelBlockRaw(token)
+    const markdownRaw = this.getStandaloneBlockRaw(token)
     if (!markdownRaw) {
       return { renderable: undefined }
     }
@@ -1074,9 +1069,13 @@ export class MarkdownRenderable extends Renderable {
     return next ?? this.createTopLevelDefaultRenderable(block, index)
   }
 
-  private createDefaultRenderable(token: MarkedToken, index: number, hasNextToken: boolean = false): Renderable | null {
+  private createDefaultRenderable(
+    token: MarkedToken,
+    index: number,
+    marginBottom: number = 0,
+    standalone: boolean = false,
+  ): Renderable | null {
     const id = `${this.id}-block-${index}`
-    const marginBottom = this.getInterBlockMargin(token, hasNextToken)
 
     if (token.type === "code") {
       return this.createCodeRenderable(token, id, marginBottom)
@@ -1090,16 +1089,21 @@ export class MarkdownRenderable extends Renderable {
       return null
     }
 
-    if (!token.raw) {
+    const markdownRaw = standalone ? this.getStandaloneBlockRaw(token) : token.raw
+    if (!markdownRaw) {
       return null
     }
 
-    return this.createMarkdownCodeRenderable(token.raw, id, marginBottom)
+    return this.createMarkdownCodeRenderable(markdownRaw, id, marginBottom)
   }
 
-  private updateBlockRenderable(state: BlockState, token: MarkedToken, index: number, hasNextToken: boolean): void {
-    const marginBottom = this.getInterBlockMargin(token, hasNextToken)
-
+  private updateBlockRenderable(
+    state: BlockState,
+    token: MarkedToken,
+    index: number,
+    marginBottom: number,
+    standalone: boolean,
+  ): void {
     if (token.type === "code") {
       this.applyCodeBlockRenderable(state.renderable as CodeRenderable, token as Tokens.Code, marginBottom)
       return
@@ -1146,13 +1150,18 @@ export class MarkdownRenderable extends Renderable {
       return
     }
 
+    const markdownRaw = standalone ? this.getStandaloneBlockRaw(token) : token.raw
+    if (!markdownRaw) {
+      return
+    }
+
     if (state.renderable instanceof CodeRenderable) {
-      this.applyMarkdownCodeRenderable(state.renderable, token.raw, marginBottom)
+      this.applyMarkdownCodeRenderable(state.renderable, markdownRaw, marginBottom)
       return
     }
 
     state.renderable.destroyRecursively()
-    const markdownRenderable = this.createMarkdownCodeRenderable(token.raw, `${this.id}-block-${index}`, marginBottom)
+    const markdownRenderable = this.createMarkdownCodeRenderable(markdownRaw, `${this.id}-block-${index}`, marginBottom)
     this.add(markdownRenderable)
     state.renderable = markdownRenderable
   }
@@ -1249,59 +1258,38 @@ export class MarkdownRenderable extends Renderable {
     }
 
     this._stableBlockCount = 0
-    const blockTokens = this.buildRenderableTokens(tokens)
-    const lastBlockIndex = blockTokens.length - 1
-
-    const updateCustomMarginBottom = (
-      state: BlockState,
-      token: MarkedToken,
-      nextToken: MarkedToken | undefined,
-      hasNextToken: boolean,
-    ): void => {
-      if (!state.customRenderNode) return
-      const marginBottom = this.getCustomRenderMarginBottom(token, nextToken, hasNextToken)
-      if (marginBottom !== state.customMarginBottom) {
-        state.renderable.marginBottom = marginBottom
-        state.customMarginBottom = marginBottom
-      }
-    }
+    const standaloneBlocks = !!this._renderNode
+    const blocks = standaloneBlocks ? this.buildRenderNodeBlocks(tokens) : this.buildCoalescedRenderBlocks(tokens)
 
     let blockIndex = 0
-    for (let i = 0; i < blockTokens.length; i++) {
-      const token = blockTokens[i]
-      const nextToken = blockTokens[i + 1]
-      const hasNextToken = i < lastBlockIndex
+    for (let i = 0; i < blocks.length; i++) {
+      const block = blocks[i]
+      const { token, marginBottom } = block
       const existing = this._blockStates[blockIndex]
 
       const shouldForceRefresh = forceTableRefresh
 
-      if (existing && existing.token === token) {
-        if (shouldForceRefresh) {
-          this.updateBlockRenderable(existing, token, blockIndex, hasNextToken)
-          existing.tokenRaw = token.raw
+      if (existing && existing.token === token && !shouldForceRefresh) {
+        if (existing.renderable.marginBottom !== marginBottom) {
+          existing.renderable.marginBottom = marginBottom
         }
-        updateCustomMarginBottom(existing, token, nextToken, hasNextToken)
         blockIndex++
         continue
       }
 
-      if (existing && existing.tokenRaw === token.raw && existing.token.type === token.type) {
+      if (existing && existing.tokenRaw === token.raw && existing.token.type === token.type && !shouldForceRefresh) {
         existing.token = token
-        if (shouldForceRefresh) {
-          this.updateBlockRenderable(existing, token, blockIndex, hasNextToken)
-          existing.tokenRaw = token.raw
+        if (existing.renderable.marginBottom !== marginBottom) {
+          existing.renderable.marginBottom = marginBottom
         }
-        updateCustomMarginBottom(existing, token, nextToken, hasNextToken)
         blockIndex++
         continue
       }
 
-      if (existing && existing.token.type === token.type) {
-        this.updateBlockRenderable(existing, token, blockIndex, hasNextToken)
+      if (!standaloneBlocks && existing && existing.token.type === token.type) {
+        this.updateBlockRenderable(existing, token, blockIndex, marginBottom, standaloneBlocks)
         existing.token = token
         existing.tokenRaw = token.raw
-        existing.customRenderNode = undefined
-        existing.customMarginBottom = undefined
         blockIndex++
         continue
       }
@@ -1312,44 +1300,44 @@ export class MarkdownRenderable extends Renderable {
 
       let renderable: Renderable | undefined
       let tableContentCache: TableContentCache | undefined
-      let customRenderNode: boolean | undefined
-      let customMarginBottom: number | undefined
+      const createDefaultBlock = (): { renderable: Renderable | undefined; tableContentCache?: TableContentCache } => {
+        if (token.type === "table") {
+          return this.createTableBlock(token, `${this.id}-block-${blockIndex}`, marginBottom)
+        }
+
+        return {
+          renderable: this.createDefaultRenderable(token, blockIndex, marginBottom, standaloneBlocks) ?? undefined,
+        }
+      }
 
       if (this._renderNode) {
-        let defaultRenderable: Renderable | null = null
+        let defaultBlock: { renderable: Renderable | undefined; tableContentCache?: TableContentCache } | undefined
+        let usedDefaultRender = false
         const context: RenderNodeContext = {
           syntaxStyle: this._syntaxStyle,
           conceal: this._conceal,
           concealCode: this._concealCode,
           treeSitterClient: this._treeSitterClient,
           defaultRender: () => {
-            defaultRenderable = this.createDefaultRenderable(token, blockIndex, hasNextToken)
-            return defaultRenderable
+            usedDefaultRender = true
+            defaultBlock ??= createDefaultBlock()
+            return defaultBlock.renderable ?? null
           },
         }
         const custom = this._renderNode(token, context)
         if (custom) {
           renderable = custom
-          customRenderNode = custom !== defaultRenderable
-          if (customRenderNode) {
-            customMarginBottom = this.getCustomRenderMarginBottom(token, nextToken, hasNextToken)
-            custom.marginBottom = customMarginBottom
-          }
+          custom.marginBottom = marginBottom
+        } else if (usedDefaultRender) {
+          renderable = defaultBlock?.renderable
+          tableContentCache = defaultBlock?.tableContentCache
         }
       }
 
       if (!renderable) {
-        if (token.type === "table") {
-          const tableBlock = this.createTableBlock(
-            token,
-            `${this.id}-block-${blockIndex}`,
-            this.getInterBlockMargin(token, hasNextToken),
-          )
-          renderable = tableBlock.renderable
-          tableContentCache = tableBlock.tableContentCache
-        } else {
-          renderable = this.createDefaultRenderable(token, blockIndex, hasNextToken) ?? undefined
-        }
+        const defaultBlock = createDefaultBlock()
+        renderable = defaultBlock.renderable
+        tableContentCache = defaultBlock.tableContentCache
       }
 
       if (token.type === "table" && !tableContentCache && renderable instanceof TextTableRenderable) {
@@ -1363,8 +1351,6 @@ export class MarkdownRenderable extends Renderable {
           token,
           tokenRaw: token.raw,
           renderable,
-          customRenderNode,
-          customMarginBottom,
           tableContentCache,
         }
       }
@@ -1395,17 +1381,29 @@ export class MarkdownRenderable extends Renderable {
       return
     }
 
+    const standaloneBlocks = !!this._renderNode
+
     for (let i = 0; i < this._blockStates.length; i++) {
       const state = this._blockStates[i]
-      const hasNextToken = i < this._blockStates.length - 1
-      const marginBottom = this.getInterBlockMargin(state.token, hasNextToken)
+      const marginBottom = typeof state.renderable.marginBottom === "number" ? state.renderable.marginBottom : 0
 
       if (state.token.type === "code") {
+        if (standaloneBlocks && !(state.renderable instanceof CodeRenderable)) {
+          continue
+        }
+
         this.applyCodeBlockRenderable(state.renderable as CodeRenderable, state.token as Tokens.Code, marginBottom)
         continue
       }
 
       if (state.token.type === "table") {
+        if (
+          standaloneBlocks &&
+          !(state.renderable instanceof TextTableRenderable || state.renderable instanceof CodeRenderable)
+        ) {
+          continue
+        }
+
         const tableToken = state.token as Tokens.Table
         const { cache } = this.buildTableContentCache(tableToken, state.tableContentCache, true)
 
@@ -1442,14 +1440,23 @@ export class MarkdownRenderable extends Renderable {
         continue
       }
 
+      const markdownRaw = standaloneBlocks ? this.getStandaloneBlockRaw(state.token) : state.token.raw
+      if (!markdownRaw) {
+        continue
+      }
+
       if (state.renderable instanceof CodeRenderable) {
-        this.applyMarkdownCodeRenderable(state.renderable, state.token.raw, marginBottom)
+        this.applyMarkdownCodeRenderable(state.renderable, markdownRaw, marginBottom)
+        continue
+      }
+
+      if (standaloneBlocks) {
         continue
       }
 
       state.renderable.destroyRecursively()
       const markdownRenderable = this.createMarkdownCodeRenderable(
-        state.token.raw,
+        markdownRaw,
         `${this.id}-block-${i}`,
         marginBottom,
       )

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1356,6 +1356,75 @@ test("custom renderNode override clears spacing when following code changes", as
   `)
 })
 
+test("custom renderNode override preserves spacing after custom code", async () => {
+  const md = createMarkdownRenderable({
+    id: "custom-code-spacing-after",
+    content: ["```ts", 'console.log("Hello, world!")', "```", "", "After code"].join("\n"),
+    syntaxStyle,
+    renderNode: (node, ctx) => {
+      if (node.type === "code") {
+        return new TextRenderable(renderer, {
+          id: "custom-code-spacing-after-text",
+          content: "CUSTOM CODE",
+          width: "100%",
+        })
+      }
+
+      return ctx.defaultRender()
+    },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    CUSTOM CODE
+
+    After code"
+  `)
+})
+
+test("custom renderNode override clears spacing when custom code becomes last block", async () => {
+  const md = createMarkdownRenderable({
+    id: "custom-code-spacing-update",
+    content: ["```ts", 'console.log("Hello, world!")', "```", "", "After code"].join("\n"),
+    syntaxStyle,
+    renderNode: (node, ctx) => {
+      if (node.type === "code") {
+        return new TextRenderable(renderer, {
+          id: "custom-code-spacing-update-text",
+          content: "CUSTOM CODE",
+          width: "100%",
+        })
+      }
+
+      return ctx.defaultRender()
+    },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates[0]?.customMarginBottom).toBe(1)
+
+  md.content = ["```ts", 'console.log("Hello, world!")', "```"].join("\n")
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates[0]?.customMarginBottom).toBe(0)
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    CUSTOM CODE"
+  `)
+})
+
 test("custom renderNode output survives top-level spacing updates", async () => {
   const md = createMarkdownRenderable({
     id: "custom-spacing-update",

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1322,6 +1322,40 @@ test("custom renderNode override preserves coalesced spacing before default code
   `)
 })
 
+test("custom renderNode override clears spacing when following code changes", async () => {
+  const md = createMarkdownRenderable({
+    id: "custom-overridden-spacing-update",
+    content: ["Example", "```ts", 'console.log("Hello, world!")', "```"].join("\n"),
+    syntaxStyle,
+    renderNode: (node, ctx) => {
+      if (node.type === "paragraph") {
+        return new TextRenderable(renderer, {
+          id: "custom-overridden-spacing-update-text",
+          content: "CUSTOM",
+          width: "100%",
+        })
+      }
+
+      return ctx.defaultRender()
+    },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  md.content = ["Example", "# Heading"].join("\n")
+  await renderMarkdownRenderable(md)
+
+  const updatedLines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+  expect("\n" + updatedLines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    CUSTOM
+    Heading"
+  `)
+})
+
 test("custom renderNode output survives top-level spacing updates", async () => {
   const md = createMarkdownRenderable({
     id: "custom-spacing-update",

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1290,6 +1290,38 @@ test("custom renderNode using defaultRender preserves coalesced spacing before c
   `)
 })
 
+test("custom renderNode override preserves coalesced spacing before default code", async () => {
+  const md = createMarkdownRenderable({
+    id: "custom-overridden-spacing",
+    content: ["Example", "", "```ts", 'console.log("Hello, world!")', "```"].join("\n"),
+    syntaxStyle,
+    renderNode: (node, ctx) => {
+      if (node.type === "paragraph") {
+        return new TextRenderable(renderer, {
+          id: "custom-overridden-spacing-text",
+          content: "CUSTOM",
+          width: "100%",
+        })
+      }
+
+      return ctx.defaultRender()
+    },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    CUSTOM
+
+    console.log(\"Hello, world!\")"
+  `)
+})
+
 test("custom renderNode output survives top-level spacing updates", async () => {
   const md = createMarkdownRenderable({
     id: "custom-spacing-update",

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -811,6 +811,7 @@ And here is more text after.`
   expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
     "
     Here is some code:
+
     function hello() {
       return "world";
     }
@@ -835,9 +836,11 @@ fn main() {}
   expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
     "
     First block:
+
     print("hello")
 
     Second block:
+
     fn main() {}"
   `)
 })
@@ -1265,6 +1268,28 @@ const x = 1;
   `)
 })
 
+test("custom renderNode using defaultRender preserves coalesced spacing before code", async () => {
+  const md = createMarkdownRenderable({
+    id: "custom-default-spacing",
+    content: ["Example", "", "```ts", 'console.log("Hello, world!")', "```"].join("\n"),
+    syntaxStyle,
+    renderNode: (_node, ctx) => ctx.defaultRender(),
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    Example
+
+    console.log(\"Hello, world!\")"
+  `)
+})
+
 test("custom renderNode output survives top-level spacing updates", async () => {
   const md = createMarkdownRenderable({
     id: "custom-spacing-update",
@@ -1341,6 +1366,7 @@ console.log(x);`
   expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
     "
     Here is some code:
+
     const x = 1;
     console.log(x);"
   `)
@@ -1485,6 +1511,7 @@ const x = 1;
   expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
     "
     Text before
+
     const x = 1;"
   `)
 })

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1221,6 +1221,7 @@ Regular paragraph.`,
   expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
     "
     [CUSTOM] Custom Heading
+
     Regular paragraph."
   `)
 })
@@ -1290,6 +1291,28 @@ test("custom renderNode using defaultRender preserves coalesced spacing before c
   `)
 })
 
+test("custom renderNode receives the original marked token raw", async () => {
+  const seenRaw: string[] = []
+
+  const md = createMarkdownRenderable({
+    id: "custom-original-raw",
+    content: ["Example", "", "```ts", 'console.log("Hello, world!")', "```"].join("\n"),
+    syntaxStyle,
+    renderNode: (node, ctx) => {
+      if (node.type === "paragraph") {
+        seenRaw.push(node.raw)
+      }
+
+      return ctx.defaultRender()
+    },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  expect(seenRaw).toEqual(["Example"])
+})
+
 test("custom renderNode override preserves coalesced spacing before default code", async () => {
   const md = createMarkdownRenderable({
     id: "custom-overridden-spacing",
@@ -1356,6 +1379,41 @@ test("custom renderNode override clears spacing when following code changes", as
   `)
 })
 
+test("custom renderNode reevaluates paragraph overrides on same-type updates", async () => {
+  const md = createMarkdownRenderable({
+    id: "custom-overridden-same-type-update",
+    content: "plain",
+    syntaxStyle,
+    renderNode: (node, ctx) => {
+      if (node.type === "paragraph" && node.raw.startsWith("custom")) {
+        return new TextRenderable(renderer, {
+          id: "custom-overridden-same-type-update-text",
+          content: "CUSTOM",
+          width: "100%",
+        })
+      }
+
+      return ctx.defaultRender()
+    },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  md.content = "custom now"
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates[0]?.renderable).toBeInstanceOf(TextRenderable)
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    CUSTOM"
+  `)
+})
+
 test("custom renderNode override preserves spacing after custom code", async () => {
   const md = createMarkdownRenderable({
     id: "custom-code-spacing-after",
@@ -1409,12 +1467,8 @@ test("custom renderNode override clears spacing when custom code becomes last bl
   renderer.root.add(md)
   await renderMarkdownRenderable(md)
 
-  expect(md._blockStates[0]?.customMarginBottom).toBe(1)
-
   md.content = ["```ts", 'console.log("Hello, world!")', "```"].join("\n")
   await renderMarkdownRenderable(md)
-
-  expect(md._blockStates[0]?.customMarginBottom).toBe(0)
 
   const lines = captureFrame()
     .split("\n")
@@ -1422,6 +1476,50 @@ test("custom renderNode override clears spacing when custom code becomes last bl
   expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
     "
     CUSTOM CODE"
+  `)
+})
+
+test("custom renderNode re-renders custom code blocks on same-type updates", async () => {
+  const { BoxRenderable } = await import("../Box.js")
+
+  const md = createMarkdownRenderable({
+    id: "custom-code-same-type-update",
+    content: ["```ts", "const a = 1", "```"].join("\n"),
+    syntaxStyle,
+    renderNode: (node, ctx) => {
+      if (node.type === "code") {
+        const box = new BoxRenderable(renderer, {
+          id: "custom-code-same-type-update-box",
+          border: true,
+          borderStyle: "single",
+        })
+        box.add(
+          new TextRenderable(renderer, {
+            id: "custom-code-same-type-update-text",
+            content: `CODE: ${node.text}`,
+          }),
+        )
+        return box
+      }
+
+      return ctx.defaultRender()
+    },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  md.content = ["```ts", "const a = 2", "```"].join("\n")
+  await renderMarkdownRenderable(md)
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    ┌──────────────────────────────────────────────────────────┐
+    │CODE: const a = 2                                         │
+    └──────────────────────────────────────────────────────────┘"
   `)
 })
 
@@ -1483,7 +1581,6 @@ Paragraph text.`,
   expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
     "
     Heading
-
 
     Paragraph text."
   `)


### PR DESCRIPTION
The token coalescing logic dropped blank lines preceding code
blocks, causing text and code to render without visual separation.
Preserve the gap in both the default and custom renderNode paths.
