### PR TITLE
fix: markdown table aligment

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -10,6 +10,7 @@ import { CodeRenderable, type OnChunksCallback } from "./Code.js"
 import {
   TextTableRenderable,
   type TextTableCellContent,
+  type TextTableColumnAlignment,
   type TextTableColumnFitter,
   type TextTableColumnWidthMode,
   type TextTableContent,
@@ -124,6 +125,7 @@ export interface RenderNodeContext {
 interface TableContentCache {
   content: TextTableContent
   cellKeys: Uint32Array[]
+  columnAlignments: TextTableColumnAlignment[]
 }
 
 interface ResolvedTableRenderableOptions {
@@ -663,6 +665,32 @@ export class MarkdownRenderable extends Renderable {
     return table.rows
   }
 
+  private resolveTableColumnAlignment(value: Tokens.TableCell["align"] | undefined): TextTableColumnAlignment {
+    if (value === "center" || value === "right") {
+      return value
+    }
+
+    return "left"
+  }
+
+  private getTableColumnAlignments(table: Tokens.Table): TextTableColumnAlignment[] {
+    const alignments = Array.isArray(table.align) ? table.align : []
+    return table.header.map((cell, colIndex) => this.resolveTableColumnAlignment(alignments[colIndex] ?? cell.align))
+  }
+
+  private tableColumnAlignmentsEqual(
+    left: readonly TextTableColumnAlignment[],
+    right: readonly TextTableColumnAlignment[],
+  ): boolean {
+    if (left.length !== right.length) return false
+
+    for (let idx = 0; idx < left.length; idx += 1) {
+      if (left[idx] !== right[idx]) return false
+    }
+
+    return true
+  }
+
   private hashString(value: string, seed: number): number {
     let hash = seed >>> 0
     for (let i = 0; i < value.length; i += 1) {
@@ -759,9 +787,11 @@ export class MarkdownRenderable extends Renderable {
 
     const content: TextTableContent = []
     const cellKeys: Uint32Array[] = []
+    const columnAlignments = this.getTableColumnAlignments(table)
     const totalRows = rowsToRender.length + 1
 
-    let changed = forceRegenerate || !previous
+    let changed =
+      forceRegenerate || !previous || !this.tableColumnAlignmentsEqual(previous.columnAlignments, columnAlignments)
 
     for (let rowIndex = 0; rowIndex < totalRows; rowIndex += 1) {
       const rowContent: TextTableCellContent[] = []
@@ -808,6 +838,7 @@ export class MarkdownRenderable extends Renderable {
       cache: {
         content,
         cellKeys,
+        columnAlignments,
       },
       changed,
     }
@@ -888,11 +919,13 @@ export class MarkdownRenderable extends Renderable {
     content: TextTableContent,
     id: string,
     marginBottom: number = 0,
+    columnAlignments: readonly TextTableColumnAlignment[] = [],
   ): TextTableRenderable {
     const options = this.resolveTableRenderableOptions()
     return new TextTableRenderable(this.ctx, {
       id,
       content,
+      columnAlignments,
       width: "100%",
       marginBottom,
       columnWidthMode: options.columnWidthMode,
@@ -925,7 +958,7 @@ export class MarkdownRenderable extends Renderable {
     }
 
     return {
-      renderable: this.createTextTableRenderable(cache.content, id, marginBottom),
+      renderable: this.createTextTableRenderable(cache.content, id, marginBottom, cache.columnAlignments),
       tableContentCache: cache,
     }
   }
@@ -1082,6 +1115,7 @@ export class MarkdownRenderable extends Renderable {
         if (changed) {
           state.renderable.content = cache.content
         }
+        state.renderable.columnAlignments = cache.columnAlignments
         this.applyTableRenderableOptions(state.renderable, this.resolveTableRenderableOptions())
         state.renderable.marginBottom = marginBottom
         state.tableContentCache = cache
@@ -1089,7 +1123,12 @@ export class MarkdownRenderable extends Renderable {
       }
 
       state.renderable.destroyRecursively()
-      const tableRenderable = this.createTextTableRenderable(cache.content, `${this.id}-block-${index}`, marginBottom)
+      const tableRenderable = this.createTextTableRenderable(
+        cache.content,
+        `${this.id}-block-${index}`,
+        marginBottom,
+        cache.columnAlignments,
+      )
       this.add(tableRenderable)
       state.renderable = tableRenderable
       state.tableContentCache = cache
@@ -1353,7 +1392,12 @@ export class MarkdownRenderable extends Renderable {
         }
 
         state.renderable.destroyRecursively()
-        const tableRenderable = this.createTextTableRenderable(cache.content, `${this.id}-block-${i}`, marginBottom)
+        const tableRenderable = this.createTextTableRenderable(
+          cache.content,
+          `${this.id}-block-${i}`,
+          marginBottom,
+          cache.columnAlignments,
+        )
         this.add(tableRenderable)
         state.renderable = tableRenderable
         state.tableContentCache = cache

--- a/packages/core/src/renderables/TextTable.test.ts
+++ b/packages/core/src/renderables/TextTable.test.ts
@@ -316,6 +316,43 @@ describe("TextTableRenderable", () => {
     expect(borderXs).toEqual([0, 11, 23])
   })
 
+  test("applies column alignments when drawing cells", async () => {
+    const table = new TextTableRenderable(renderer, {
+      left: 0,
+      top: 0,
+      columnWidthMode: "content",
+      columnAlignments: ["left", "center", "right"],
+      content: [
+        [cell("Left"), cell("Center"), cell("Right")],
+        [cell("A"), cell("B"), cell("C")],
+        [cell("Long text"), cell("X"), cell("Y")],
+      ],
+    })
+
+    renderer.root.add(table)
+    await renderOnce()
+
+    let rendered = captureFrame()
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .join("\n")
+
+    expect(rendered).toContain("│A        │  B   │    C│")
+    expect(rendered).toContain("│Long text│  X   │    Y│")
+    expect(table.columnAlignments).toEqual(["left", "center", "right"])
+
+    table.columnAlignments = ["right", "left", "center"]
+    await renderOnce()
+
+    rendered = captureFrame()
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .join("\n")
+
+    expect(rendered).toContain("│        A│B     │  C  │")
+    expect(rendered).toContain("│Long text│X     │  Y  │")
+  })
+
   test("preserves bordered layout when border glyphs are hidden", async () => {
     const table = new TextTableRenderable(renderer, {
       left: 0,

--- a/packages/core/src/renderables/TextTable.ts
+++ b/packages/core/src/renderables/TextTable.ts
@@ -19,6 +19,7 @@ export type TextTableCellContent = TextChunk[] | null | undefined
 export type TextTableContent = TextTableCellContent[][]
 export type TextTableColumnWidthMode = "content" | "full"
 export type TextTableColumnFitter = "proportional" | "balanced"
+export type TextTableColumnAlignment = "left" | "center" | "right"
 
 interface ResolvedTableBorderLayout {
   left: boolean
@@ -76,6 +77,7 @@ export interface TextTableOptions extends RenderableOptions<TextTableRenderable>
   wrapMode?: "none" | "char" | "word"
   columnWidthMode?: TextTableColumnWidthMode
   columnFitter?: TextTableColumnFitter
+  columnAlignments?: readonly TextTableColumnAlignment[]
   cellPadding?: number
   columnGap?: number
   showBorders?: boolean
@@ -98,6 +100,7 @@ export class TextTableRenderable extends Renderable {
   private _wrapMode: "none" | "char" | "word"
   private _columnWidthMode: TextTableColumnWidthMode
   private _columnFitter: TextTableColumnFitter
+  private _columnAlignments: TextTableColumnAlignment[]
   private _cellPadding: number
   private _columnGap: number
   private _showBorders: boolean
@@ -133,6 +136,7 @@ export class TextTableRenderable extends Renderable {
     wrapMode: "word" as "none" | "char" | "word",
     columnWidthMode: "full" as TextTableColumnWidthMode,
     columnFitter: "proportional" as TextTableColumnFitter,
+    columnAlignments: [] as TextTableColumnAlignment[],
     cellPadding: 0,
     columnGap: 0,
     showBorders: true,
@@ -157,6 +161,7 @@ export class TextTableRenderable extends Renderable {
     this._wrapMode = options.wrapMode ?? this._defaultOptions.wrapMode
     this._columnWidthMode = options.columnWidthMode ?? this._defaultOptions.columnWidthMode
     this._columnFitter = this.resolveColumnFitter(options.columnFitter)
+    this._columnAlignments = this.resolveColumnAlignments(options.columnAlignments)
     this._cellPadding = this.resolveCellPadding(options.cellPadding)
     this._columnGap = this.resolveColumnGap(options.columnGap)
     this._showBorders = options.showBorders ?? this._defaultOptions.showBorders
@@ -223,6 +228,18 @@ export class TextTableRenderable extends Renderable {
     if (this._columnFitter === next) return
     this._columnFitter = next
     this.invalidateLayoutAndRaster()
+  }
+
+  public get columnAlignments(): TextTableColumnAlignment[] {
+    return [...this._columnAlignments]
+  }
+
+  public set columnAlignments(value: readonly TextTableColumnAlignment[] | undefined) {
+    const next = this.resolveColumnAlignments(value)
+    if (this.columnAlignmentsEqual(this._columnAlignments, next)) return
+
+    this._columnAlignments = next
+    this.invalidateRasterOnly()
   }
 
   public get cellPadding(): number {
@@ -1031,18 +1048,55 @@ export class TextTableRenderable extends Renderable {
 
   private drawCellRange(buffer: OptimizedBuffer, firstRow: number, lastRow: number): void {
     const colOffsets = this._layout.columnOffsets
+    const colWidths = this._layout.columnWidths
     const rowOffsets = this._layout.rowOffsets
+    const rowHeights = this._layout.rowHeights
     const cellPadding = this._cellPadding
+    const horizontalPadding = this.getHorizontalCellPadding()
+    const verticalPadding = this.getVerticalCellPadding()
 
     for (let rowIdx = firstRow; rowIdx <= lastRow; rowIdx++) {
       const cellY = (rowOffsets[rowIdx] ?? 0) + 1 + cellPadding
+      const rowHeight = rowHeights[rowIdx] ?? 1
+      const contentHeight = Math.max(1, rowHeight - verticalPadding)
 
       for (let colIdx = 0; colIdx < this._columnCount; colIdx++) {
         const cell = this._cells[rowIdx]?.[colIdx]
         if (!cell) continue
-        buffer.drawTextBuffer(cell.textBufferView, (colOffsets[colIdx] ?? 0) + 1 + cellPadding, cellY)
+
+        const colWidth = colWidths[colIdx] ?? 1
+        const contentWidth = Math.max(1, colWidth - horizontalPadding)
+        const cellX = (colOffsets[colIdx] ?? 0) + 1 + cellPadding
+        const alignment = this.getColumnAlignment(colIdx)
+        this.drawCell(buffer, cell, cellX, cellY, contentWidth, contentHeight, alignment)
       }
     }
+  }
+
+  private drawCell(
+    buffer: OptimizedBuffer,
+    cell: TextTableCellState,
+    cellX: number,
+    cellY: number,
+    contentWidth: number,
+    contentHeight: number,
+    alignment: TextTableColumnAlignment,
+  ): void {
+    if (alignment === "left") {
+      buffer.drawTextBuffer(cell.textBufferView, cellX, cellY)
+      return
+    }
+
+    const lineWidths = cell.textBufferView.lineInfo.lineWidthCols
+    const visibleLineCount = Math.min(contentHeight, lineWidths.length)
+
+    for (let lineIdx = 0; lineIdx < visibleLineCount; lineIdx += 1) {
+      const offset = this.getAlignmentOffset(alignment, contentWidth, lineWidths[lineIdx] ?? 0)
+      cell.textBufferView.setViewport(0, lineIdx, contentWidth, 1)
+      buffer.drawTextBuffer(cell.textBufferView, cellX + offset, cellY + lineIdx)
+    }
+
+    cell.textBufferView.setViewport(0, 0, contentWidth, contentHeight)
   }
 
   private redrawSelectionRows(firstRow: number, lastRow: number): void {
@@ -1366,6 +1420,53 @@ export class TextTableRenderable extends Renderable {
     }
 
     return value === "balanced" ? "balanced" : "proportional"
+  }
+
+  private resolveColumnAlignments(value: readonly TextTableColumnAlignment[] | undefined): TextTableColumnAlignment[] {
+    if (!value) {
+      return this._defaultOptions.columnAlignments
+    }
+
+    return value.map((alignment) => this.resolveColumnAlignment(alignment))
+  }
+
+  private resolveColumnAlignment(value: string | undefined): TextTableColumnAlignment {
+    if (value === "center" || value === "right") {
+      return value
+    }
+
+    return "left"
+  }
+
+  private columnAlignmentsEqual(
+    left: readonly TextTableColumnAlignment[],
+    right: readonly TextTableColumnAlignment[],
+  ): boolean {
+    if (left.length !== right.length) return false
+
+    for (let idx = 0; idx < left.length; idx += 1) {
+      if (left[idx] !== right[idx]) return false
+    }
+
+    return true
+  }
+
+  private getColumnAlignment(colIdx: number): TextTableColumnAlignment {
+    return this._columnAlignments[colIdx] ?? "left"
+  }
+
+  private getAlignmentOffset(alignment: TextTableColumnAlignment, contentWidth: number, lineWidth: number): number {
+    const availableWidth = Math.max(0, contentWidth - Math.max(0, Math.floor(lineWidth)))
+
+    if (alignment === "right") {
+      return availableWidth
+    }
+
+    if (alignment === "center") {
+      return Math.floor(availableWidth / 2)
+    }
+
+    return 0
   }
 
   private resolveCellPadding(value: number | undefined): number {

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -365,11 +365,37 @@ test("table with alignment markers (left, center, right)", async () => {
     ┌─────────┬──────┬─────┐
     │Left     │Center│Right│
     ├─────────┼──────┼─────┤
-    │A        │B     │C    │
+    │A        │  B   │    C│
     ├─────────┼──────┼─────┤
-    │Long text│X     │Y    │
+    │Long text│  X   │    Y│
     └─────────┴──────┴─────┘"
   `)
+})
+
+test("full-width table with alignment markers positions text within expanded columns", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-full-width-table-alignment",
+    content: `| L | C | R |
+|:---|:---:|---:|
+| a | b | c |`,
+    syntaxStyle,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const dataRow = captureFrame()
+    .split("\n")
+    .find((line) => line.includes("a") && line.includes("b") && line.includes("c"))
+
+  expect(dataRow).toBeDefined()
+
+  const borderXs = [...dataRow!].map((char, index) => (char === "│" ? index : -1)).filter((index) => index >= 0)
+  const centerColumnWidth = borderXs[2]! - borderXs[1]! - 1
+
+  expect(dataRow!.indexOf("a")).toBe(borderXs[0]! + 1)
+  expect(dataRow!.indexOf("b")).toBe(borderXs[1]! + 1 + Math.floor((centerColumnWidth - 1) / 2))
+  expect(dataRow!.indexOf("c")).toBe(borderXs[3]! - 1)
 })
 
 test("table with empty cells", async () => {


### PR DESCRIPTION
Content alignment in tables was broken

<img width="1093" height="391" alt="image" src="https://github.com/user-attachments/assets/b29be5ef-5f38-4755-acdd-6e66b0e282e2" />
