### PR TITLE
split footer fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -438,6 +438,18 @@
 
     "@opentui/core": ["@opentui/core@workspace:packages/core"],
 
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tY5n3ZRQx+b0kyhQJJLsyJMeZ+0w4FV37YZc/Qqv3qvOqE9kZPw/7adR77FYwWDm/7fax94mLMrR8Y5bKUkDmw=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-W/R7OnqY30FXcTG0tiP2JkQFmgtYbIte5afQ5PC12TliRoee1RqG3iCG6kY1jxW+3Vg6jge88uiSjUEDpeV2gA=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-1pzTYFEZauYuw6AGycw2TYGtAlZVGjuUtSdxH1fP51kBPS3oVWduUY2j7GKREz3SU5NulvO2Wc6HWsm3feMqwQ=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ucVwUtUYeOYGVFPBLbPoxzbrPdhD0PDyKNQ2X4n1AJ9jlQX4gqBZRcXMEF8hiXDjFxsikZwef7De0ciCcWvAMg=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.2.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-MPhYdJNdxmC5Bqsq6sis/+VkjRgkEjm+bQ1Tl++NSKLuiTU32Re0ImcZlgHbe+LZtZoGMZHVSgZlkGd3oYXO2g=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-19BroLfn2h0RDYfJS5o96Fc8kYCDhRBcseIXtHIkoKIsKMxx62KiDLo/byVye6rp+yQRRB7Xkd2uWqsbdiWo9w=="],
+
     "@opentui/examples": ["@opentui/examples@workspace:packages/examples"],
 
     "@opentui/keymap": ["@opentui/keymap@workspace:packages/keymap"],

--- a/packages/core/src/lib/stdin-parser.test.ts
+++ b/packages/core/src/lib/stdin-parser.test.ts
@@ -1389,6 +1389,87 @@ describe("StdinParser", () => {
       }
     })
 
+    test("aborting a pending startup cursor CPR swallows a reply that finishes later", () => {
+      const parser = createParser({
+        protocolContext: { startupCursorCprActive: true },
+      })
+
+      try {
+        parser.push(Buffer.from("\x1b[24;80"))
+        expect(snap(parser)).toEqual([])
+
+        parser.abortPendingStartupCursorCpr()
+        parser.updateProtocolContext({ startupCursorCprActive: false })
+
+        expect(snap(parser)).toEqual([])
+
+        parser.push(Buffer.from("R"))
+        expect(snap(parser)).toEqual([])
+      } finally {
+        parser.destroy()
+      }
+    })
+
+    test("aborting a pending startup cursor CPR swallows a reply split after the CSI introducer", () => {
+      const parser = createParser({
+        protocolContext: { startupCursorCprActive: true },
+      })
+
+      try {
+        parser.push(Buffer.from("\x1b["))
+        expect(snap(parser)).toEqual([])
+
+        parser.abortPendingStartupCursorCpr()
+        parser.updateProtocolContext({ startupCursorCprActive: false })
+
+        parser.push(Buffer.from("24;80R"))
+        expect(snap(parser)).toEqual([])
+      } finally {
+        parser.destroy()
+      }
+    })
+
+    test("aborting a pending startup cursor CPR preserves explicit-width CPR replies", () => {
+      const parser = createParser({
+        protocolContext: {
+          startupCursorCprActive: true,
+          explicitWidthCprActive: true,
+        },
+      })
+
+      try {
+        parser.push(Buffer.from("\x1b["))
+        expect(snap(parser)).toEqual([])
+
+        parser.abortPendingStartupCursorCpr()
+        parser.updateProtocolContext({ startupCursorCprActive: false })
+
+        parser.push(Buffer.from("1;2R"))
+        expect(snap(parser)).toEqual([resp("cpr", "\x1b[1;2R")])
+      } finally {
+        parser.destroy()
+      }
+    })
+
+    test("aborting a pending startup cursor CPR preserves later non-CPR input", () => {
+      const parser = createParser({
+        protocolContext: { startupCursorCprActive: true },
+      })
+
+      try {
+        parser.push(Buffer.from("\x1b[24;80"))
+        expect(snap(parser)).toEqual([])
+
+        parser.abortPendingStartupCursorCpr()
+        parser.updateProtocolContext({ startupCursorCprActive: false })
+
+        parser.push(Buffer.from("a"))
+        expect(snap(parser)).toEqual([k("a")])
+      } finally {
+        parser.destroy()
+      }
+    })
+
     test("deferred explicit-width CPR flushes when probe context is cleared", () => {
       const { parser, clock } = createTimedParser({
         protocolContext: { explicitWidthCprActive: true },

--- a/packages/core/src/lib/stdin-parser.ts
+++ b/packages/core/src/lib/stdin-parser.ts
@@ -78,6 +78,17 @@ type ParserState =
       hasDigit: boolean
       firstParamValue: number | null
     }
+  | {
+      // Startup cursor CPR cancellation can happen before the parser has enough
+      // bytes to distinguish a stale reply from ordinary CSI input. This state
+      // keeps consuming that one pending reply until it is either discarded as
+      // CPR noise or handed back to normal CSI parsing.
+      tag: "csi_parametric_ignored"
+      semicolons: number
+      segments: number
+      hasDigit: boolean
+      firstParamValue: number | null
+    }
   | { tag: "csi_private_reply"; semicolons: number; hasDigit: boolean; sawDollar: boolean }
   | { tag: "csi_private_reply_deferred"; semicolons: number; hasDigit: boolean; sawDollar: boolean }
   | { tag: "osc"; sawEsc: boolean }
@@ -376,6 +387,10 @@ function canStillBeStartupCursorCpr(state: ParametricCsiLike): boolean {
   return state.semicolons === 1
 }
 
+function canStillBeStartupCursorCprPrefix(state: ParametricCsiLike): boolean {
+  return state.segments === 1 && state.semicolons <= 1
+}
+
 function canStillBePixelResolution(state: ParametricCsiLike): boolean {
   return state.firstParamValue === 4 && state.semicolons === 2
 }
@@ -598,6 +613,80 @@ export class StdinParser {
     this.ensureAlive()
     this.protocolContext = { ...this.protocolContext, ...patch }
     this.reconcileDeferredStateWithProtocolContext()
+    this.reconcileTimeoutState()
+  }
+
+  // A startup CPR can be split either after `ESC[` or after the first `;`.
+  // Normalize both shapes into one ignore-state so leaving split-footer can
+  // cancel the stale reply without also swallowing unrelated CSI sequences.
+  private getAbortableStartupCursorCprState(): Extract<ParserState, { tag: "csi_parametric_ignored" }> | null {
+    if (this.pending.length === 0) {
+      return null
+    }
+
+    switch (this.state.tag) {
+      case "csi": {
+        const bytes = this.pending.view()
+        const firstParamStart = this.unitStart + 2
+        if (this.cursor < firstParamStart) {
+          return null
+        }
+
+        let firstParamValue: number | null = null
+        for (let index = firstParamStart; index < this.cursor; index += 1) {
+          const byte = bytes[index]!
+          if (!isAsciiDigit(byte)) {
+            return null
+          }
+
+          firstParamValue = (firstParamValue ?? 0) * 10 + (byte - 0x30)
+        }
+
+        return {
+          tag: "csi_parametric_ignored",
+          semicolons: 0,
+          segments: 1,
+          hasDigit: this.cursor > firstParamStart,
+          firstParamValue,
+        }
+      }
+
+      case "csi_parametric":
+      case "csi_parametric_deferred":
+        if (
+          !canStillBeStartupCursorCprPrefix(this.state) ||
+          (this.protocolContext.explicitWidthCprActive && canStillBeExplicitWidthCpr(this.state))
+        ) {
+          return null
+        }
+
+        return {
+          tag: "csi_parametric_ignored",
+          semicolons: this.state.semicolons,
+          segments: this.state.segments,
+          hasDigit: this.state.hasDigit,
+          firstParamValue: this.state.firstParamValue,
+        }
+    }
+
+    return null
+  }
+
+  public abortPendingStartupCursorCpr(): void {
+    this.ensureAlive()
+
+    const nextState = this.getAbortableStartupCursorCprState()
+    if (!nextState) {
+      return
+    }
+
+    this.state = nextState
+
+    if (this.pendingSinceMs === null) {
+      this.markPending()
+    }
+
+    this.forceFlush = false
     this.reconcileTimeoutState()
   }
 
@@ -1291,6 +1380,74 @@ export class StdinParser {
           }
 
           this.emitOpaqueResponse("unknown", bytes.subarray(this.unitStart, this.cursor))
+          this.state = { tag: "ground" }
+          this.consumePrefix(this.cursor)
+          continue
+        }
+
+        case "csi_parametric_ignored": {
+          if (this.cursor >= bytes.length) {
+            if (!this.forceFlush) {
+              this.markPending()
+              return
+            }
+
+            this.state = { tag: "ground" }
+            this.consumePrefix(this.cursor)
+            continue
+          }
+
+          if (byte === ESC) {
+            this.state = { tag: "ground" }
+            this.consumePrefix(this.cursor)
+            continue
+          }
+
+          if (isAsciiDigit(byte)) {
+            this.cursor += 1
+            this.state = {
+              tag: "csi_parametric_ignored",
+              semicolons: this.state.semicolons,
+              segments: this.state.segments,
+              hasDigit: true,
+              firstParamValue:
+                this.state.semicolons === 0 ? (this.state.firstParamValue ?? 0) * 10 + (byte - 0x30) : this.state.firstParamValue,
+            }
+            continue
+          }
+
+          if (byte === 0x3b && this.state.semicolons === 0 && this.state.hasDigit) {
+            // `CSI 1;...R` is also used by the explicit-width probe, so once we
+            // learn that first param we must hand control back to normal CSI
+            // parsing instead of discarding the rest of the reply.
+            if (this.protocolContext.explicitWidthCprActive && this.state.firstParamValue === 1) {
+              this.state = { tag: "csi" }
+              continue
+            }
+
+            this.cursor += 1
+            this.state = {
+              tag: "csi_parametric_ignored",
+              semicolons: 1,
+              segments: 1,
+              hasDigit: false,
+              firstParamValue: this.state.firstParamValue,
+            }
+            continue
+          }
+
+          if (byte === 0x52 && this.state.semicolons === 1 && this.state.hasDigit) {
+            const end = this.cursor + 1
+            this.state = { tag: "ground" }
+            this.consumePrefix(end)
+            continue
+          }
+
+          if (this.state.semicolons === 0) {
+            this.state = { tag: "csi" }
+            continue
+          }
+
           this.state = { tag: "ground" }
           this.consumePrefix(this.cursor)
           continue

--- a/packages/core/src/lib/stdin-parser.ts
+++ b/packages/core/src/lib/stdin-parser.ts
@@ -1411,7 +1411,9 @@ export class StdinParser {
               segments: this.state.segments,
               hasDigit: true,
               firstParamValue:
-                this.state.semicolons === 0 ? (this.state.firstParamValue ?? 0) * 10 + (byte - 0x30) : this.state.firstParamValue,
+                this.state.semicolons === 0
+                  ? (this.state.firstParamValue ?? 0) * 10 + (byte - 0x30)
+                  : this.state.firstParamValue,
             }
             continue
           }

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1519,7 +1519,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     if (this.isSplitCursorSeedFrameBlocked() && this._controlState !== RendererControlState.EXPLICIT_SUSPENDED) {
-      this.clearSplitStartupCursorSeed()
+      this.abortSplitStartupCursorSeed()
     }
 
     this.flushPendingSplitOutputBeforeTransition()
@@ -2344,6 +2344,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.clock.clearTimeout(this.splitStartupSeedTimeoutId)
       this.splitStartupSeedTimeoutId = null
     }
+  }
+
+  private abortSplitStartupCursorSeed(): void {
+    this.clearSplitStartupCursorSeed()
+    this.updateStdinParserProtocolContext({ startupCursorCprActive: false })
   }
 
   private flushPendingSplitOutputBeforeTransition(

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -2348,6 +2348,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private abortSplitStartupCursorSeed(): void {
     this.clearSplitStartupCursorSeed()
+    this.stdinParser?.abortPendingStartupCursorCpr()
     this.updateStdinParserProtocolContext({ startupCursorCprActive: false })
   }
 

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -323,6 +323,7 @@ type PendingSplitFooterTransition = {
   sourceHeight: number
   targetTopLine: number
   targetHeight: number
+  scrollLines?: number
 }
 
 class ExternalOutputQueue {
@@ -2359,6 +2360,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.renderOffset = this.lib.syncSplitScrollback(this.rendererPtr, this.getSplitPinnedRenderOffset())
   }
 
+  private getSplitOutputOffset(surfaceOffset: number = this.renderOffset): number {
+    return this.lib.getSplitOutputOffset(this.rendererPtr, surfaceOffset)
+  }
+
   private clearPendingSplitFooterTransition(): void {
     if (this.pendingSplitFooterTransition === null) {
       return
@@ -2377,6 +2382,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       transition.sourceHeight,
       transition.targetTopLine,
       transition.targetHeight,
+      transition.scrollLines ?? 0,
     )
   }
 
@@ -2464,9 +2470,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     const previousSurfaceTopLine = this.renderOffset + 1
-    const previousPinnedRenderOffset = Math.max(this._terminalHeight - prevSplitHeight, 0)
-    const splitWasSettled = prevSplitHeight === 0 || this.renderOffset >= previousPinnedRenderOffset
-    const shouldUseViewportScrollTransitions = this._externalOutputMode !== "capture-stdout" || splitWasSettled
     const shouldDeferSplitFooterResizeTransition =
       this._terminalIsSetup &&
       prevScreenMode === "split-footer" &&
@@ -2479,8 +2482,36 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.pendingSplitStartupCursorSeed && this.splitStartupSeedTimeoutId !== null
     const splitTransitionSourceTopLine = this.pendingSplitFooterTransition?.sourceTopLine ?? previousSurfaceTopLine
     const splitTransitionSourceHeight = this.pendingSplitFooterTransition?.sourceHeight ?? prevSplitHeight
-    const splitTransitionMode =
-      this.pendingSplitFooterTransition?.mode ?? (splitWasSettled ? "viewport-scroll" : "clear-stale-rows")
+    const splitTransitionSourceSurfaceOffset = Math.max(splitTransitionSourceTopLine - 1, 0)
+    const splitTransitionSourceOutputOffset =
+      prevScreenMode === "split-footer" && prevSplitHeight > 0 && this._externalOutputMode === "capture-stdout"
+        ? this.getSplitOutputOffset(splitTransitionSourceSurfaceOffset)
+        : splitTransitionSourceSurfaceOffset
+    const nextPinnedRenderOffset = nextGeometry.renderOffset
+    const nextSplitOutputOffset =
+      screenMode === "split-footer" && nextSplitHeight > 0 && this._externalOutputMode === "capture-stdout"
+        ? this.getSplitOutputOffset(nextPinnedRenderOffset)
+        : nextPinnedRenderOffset
+    const shrinkingSplitFooter = nextSplitHeight > 0 && nextSplitHeight < splitTransitionSourceHeight
+    const growingSplitFooter = nextSplitHeight > splitTransitionSourceHeight && splitTransitionSourceHeight > 0
+    const nextSplitSurfaceOffset =
+      screenMode !== "split-footer" || nextSplitHeight === 0
+        ? 0
+        : shrinkingSplitFooter
+          ? Math.max(splitTransitionSourceSurfaceOffset, nextSplitOutputOffset)
+          : growingSplitFooter
+            ? Math.max(nextSplitOutputOffset, Math.min(splitTransitionSourceSurfaceOffset, nextPinnedRenderOffset))
+            : nextPinnedRenderOffset
+    const splitTransitionTargetTopLine = nextSplitSurfaceOffset + 1
+    const splitViewportScrollLines = nextSplitHeight > 0 ? Math.max(splitTransitionSourceOutputOffset - nextSplitOutputOffset, 0) : 0
+    const splitTransitionMode = !shrinkingSplitFooter && splitViewportScrollLines > 0 ? "viewport-scroll" : "clear-stale-rows"
+    const splitFooterSurfaceMovesDown = nextSplitSurfaceOffset > splitTransitionSourceSurfaceOffset
+    const shouldClearSplitSurfaceRowsImmediately =
+      terminalWritable &&
+      !terminalScreenModeChanged &&
+      !shouldDeferSplitFooterResizeTransition &&
+      splitFooterSurfaceMovesDown &&
+      nextSplitHeight > 0
 
     if (terminalWritable && leavingSplitFooter) {
       this.clearPendingSplitFooterTransition()
@@ -2491,19 +2522,14 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     if (
       terminalWritable &&
       !terminalScreenModeChanged &&
-      shouldUseViewportScrollTransitions &&
       !shouldDeferSplitFooterResizeTransition
     ) {
       if (prevSplitHeight === 0 && nextSplitHeight > 0) {
         const freedLines = this._terminalHeight - nextSplitHeight
         const scrollDown = ANSI.scrollDown(freedLines)
         this.writeOut(scrollDown)
-      } else if (prevSplitHeight > nextSplitHeight && nextSplitHeight > 0) {
-        const freedLines = prevSplitHeight - nextSplitHeight
-        const scrollDown = ANSI.scrollDown(freedLines)
-        this.writeOut(scrollDown)
-      } else if (prevSplitHeight < nextSplitHeight && prevSplitHeight > 0) {
-        const additionalLines = nextSplitHeight - prevSplitHeight
+      } else if (splitViewportScrollLines > 0) {
+        const additionalLines = splitViewportScrollLines
         const scrollUp = ANSI.scrollUp(additionalLines)
         this.writeOut(scrollUp)
       }
@@ -2520,7 +2546,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       if (prevScreenMode !== "split-footer") {
         this.resetSplitScrollback(this.getSplitCursorSeedRows())
       } else {
-        this.syncSplitScrollback()
+        this.renderOffset = nextSplitSurfaceOffset
+        this.lib.setRenderOffset(this.rendererPtr, this.renderOffset)
       }
 
       if (shouldDeferSplitFooterResizeTransition) {
@@ -2531,19 +2558,33 @@ export class CliRenderer extends EventEmitter implements RenderContext {
             mode: splitTransitionMode,
             sourceTopLine: splitTransitionSourceTopLine,
             sourceHeight: splitTransitionSourceHeight,
-            targetTopLine: this.renderOffset + 1,
+            targetTopLine: splitTransitionTargetTopLine,
             targetHeight: nextSplitHeight,
+            scrollLines: splitViewportScrollLines,
           })
         }
         this.forceFullRepaintRequested = true
-      } else if (!shouldUseViewportScrollTransitions && prevSplitHeight > 0 && nextSplitHeight > 0) {
+      } else if (shouldClearSplitSurfaceRowsImmediately) {
         this.clearPendingSplitFooterTransition()
-        this.clearStaleSplitSurfaceRows(previousSurfaceTopLine, prevSplitHeight, this.renderOffset + 1, nextSplitHeight)
+        this.clearStaleSplitSurfaceRows(
+          splitTransitionSourceTopLine,
+          splitTransitionSourceHeight,
+          splitTransitionTargetTopLine,
+          nextSplitHeight,
+        )
       } else {
         this.clearPendingSplitFooterTransition()
       }
     } else {
       this.syncSplitFooterState()
+      if (shouldClearSplitSurfaceRowsImmediately) {
+        this.clearStaleSplitSurfaceRows(
+          splitTransitionSourceTopLine,
+          splitTransitionSourceHeight,
+          this.renderOffset + 1,
+          nextSplitHeight,
+        )
+      }
     }
 
     this.nextRenderBuffer = this.lib.getNextBuffer(this.rendererPtr)

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -2513,38 +2513,37 @@ export class CliRenderer extends EventEmitter implements RenderContext {
         ? this.getSplitOutputOffset(nextPinnedRenderOffset)
         : nextPinnedRenderOffset
     const pendingSplitFooterTransition = this.pendingSplitFooterTransition
-    const returningSplitFooterToSource =
+    const pendingSplitFooterReturn =
       pendingSplitFooterTransition !== null && nextSplitHeight === splitTransitionSourceHeight
-    const returningSplitFooterToGrownTarget =
-      returningSplitFooterToSource &&
+    const pendingSplitFooterViewportReturn =
+      pendingSplitFooterReturn &&
       pendingSplitFooterTransition.mode === "viewport-scroll" &&
-      pendingSplitFooterTransition.targetTopLine < pendingSplitFooterTransition.sourceTopLine &&
       (pendingSplitFooterTransition.scrollLines ?? 0) > 0
     const shrinkingSplitFooter = nextSplitHeight > 0 && nextSplitHeight < splitTransitionSourceHeight
     const growingSplitFooter = nextSplitHeight > splitTransitionSourceHeight && splitTransitionSourceHeight > 0
     const nextSplitSurfaceOffset =
       screenMode !== "split-footer" || nextSplitHeight === 0
         ? 0
-        : returningSplitFooterToGrownTarget
+        : pendingSplitFooterViewportReturn
           ? pendingSplitFooterTransition.targetTopLine - 1
-          : returningSplitFooterToSource
+          : pendingSplitFooterReturn
+          ? splitTransitionSourceSurfaceOffset
+          : shrinkingSplitFooter && splitTransitionSourceSurfaceOffset > 0
           ? splitTransitionSourceSurfaceOffset
           : shrinkingSplitFooter
-          ? splitTransitionSourceSurfaceOffset === 0
-            ? nextSplitOutputOffset
-            : splitTransitionSourceSurfaceOffset
+          ? nextSplitOutputOffset
           : growingSplitFooter
             ? Math.max(nextSplitOutputOffset, Math.min(splitTransitionSourceSurfaceOffset, nextPinnedRenderOffset))
             : nextPinnedRenderOffset
     const splitTransitionTargetTopLine = nextSplitSurfaceOffset + 1
     const splitViewportScrollLines =
-      returningSplitFooterToGrownTarget
+      pendingSplitFooterViewportReturn
         ? (pendingSplitFooterTransition.scrollLines ?? 0)
-        : nextSplitHeight > 0 && !returningSplitFooterToSource
+        : nextSplitHeight > 0 && !pendingSplitFooterReturn
         ? Math.max(splitTransitionSourceOutputOffset - nextSplitOutputOffset, 0)
         : 0
     const splitTransitionMode =
-      (!shrinkingSplitFooter || returningSplitFooterToGrownTarget) && splitViewportScrollLines > 0
+      (!shrinkingSplitFooter || pendingSplitFooterViewportReturn) && splitViewportScrollLines > 0
         ? "viewport-scroll"
         : "clear-stale-rows"
     const splitFooterSurfaceMovesDown = nextSplitSurfaceOffset > splitTransitionSourceSurfaceOffset

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1458,8 +1458,28 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private afterExternalOutputModeChanged(previousMode: ExternalOutputMode, mode: ExternalOutputMode): void {
     if (this._screenMode === "split-footer" && this._splitHeight > 0 && mode === "capture-stdout") {
+      const previousSurfaceTopLine = this.renderOffset + 1
+      const previousSurfaceHeight = this._splitHeight
+
       this.clearPendingSplitFooterTransition()
       this.resetSplitScrollback(this.getSplitCursorSeedRows())
+
+      if (previousMode === "passthrough" && this._terminalIsSetup) {
+        const nextSurfaceTopLine = this.renderOffset + 1
+        if (previousSurfaceTopLine !== nextSurfaceTopLine) {
+          this.setPendingSplitFooterTransition({
+            mode: "clear-stale-rows",
+            sourceTopLine: previousSurfaceTopLine,
+            sourceHeight: previousSurfaceHeight,
+            targetTopLine: nextSurfaceTopLine,
+            targetHeight: this._splitHeight,
+            scrollLines: 0,
+          })
+          this.forceFullRepaintRequested = true
+        }
+      }
+
+      this.requestRender()
       return
     }
 
@@ -3993,6 +4013,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.pendingSplitFooterTransition = null
       this.lib.render(this.rendererPtr, force)
     }
+
     // this.dumpStdoutBuffer(Date.now())
     this.renderingNative = false
   }

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -2533,19 +2533,21 @@ export class CliRenderer extends EventEmitter implements RenderContext {
         : pendingSplitFooterViewportReturn
           ? pendingSplitFooterTransition.targetTopLine - 1
           : pendingSplitFooterReturn
-          ? splitTransitionSourceSurfaceOffset
-          : shrinkingSplitFooter && splitTransitionSourceSurfaceOffset > 0
-          ? splitTransitionSourceSurfaceOffset
-          : shrinkingSplitFooter
-          ? nextSplitOutputOffset
-          : growingSplitFooter
-            ? Math.max(nextSplitOutputOffset, Math.min(splitTransitionSourceSurfaceOffset, nextPinnedRenderOffset))
-            : nextPinnedRenderOffset
+            ? splitTransitionSourceSurfaceOffset
+            : shrinkingSplitFooter && splitTransitionSourceSurfaceOffset > 0
+              ? splitTransitionSourceSurfaceOffset
+              : shrinkingSplitFooter
+                ? nextSplitOutputOffset
+                : growingSplitFooter
+                  ? Math.max(
+                      nextSplitOutputOffset,
+                      Math.min(splitTransitionSourceSurfaceOffset, nextPinnedRenderOffset),
+                    )
+                  : nextPinnedRenderOffset
     const splitTransitionTargetTopLine = nextSplitSurfaceOffset + 1
-    const splitViewportScrollLines =
-      pendingSplitFooterViewportReturn
-        ? (pendingSplitFooterTransition.scrollLines ?? 0)
-        : nextSplitHeight > 0 && !pendingSplitFooterReturn
+    const splitViewportScrollLines = pendingSplitFooterViewportReturn
+      ? (pendingSplitFooterTransition.scrollLines ?? 0)
+      : nextSplitHeight > 0 && !pendingSplitFooterReturn
         ? Math.max(splitTransitionSourceOutputOffset - nextSplitOutputOffset, 0)
         : 0
     const splitTransitionMode =
@@ -2567,11 +2569,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.lib.setRenderOffset(this.rendererPtr, 0)
     }
 
-    if (
-      terminalWritable &&
-      !terminalScreenModeChanged &&
-      !shouldDeferSplitFooterResizeTransition
-    ) {
+    if (terminalWritable && !terminalScreenModeChanged && !shouldDeferSplitFooterResizeTransition) {
       if (prevSplitHeight === 0 && nextSplitHeight > 0) {
         const freedLines = this._terminalHeight - nextSplitHeight
         const scrollDown = ANSI.scrollDown(freedLines)

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -771,6 +771,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private clearOnShutdown: boolean = true
   private _suspendedMouseEnabled: boolean = false
   private _previousControlState: RendererControlState = RendererControlState.IDLE
+  private pendingSuspendedTerminalSetup: boolean = false
   private capturedRenderable?: Renderable
   private lastOverRenderableNum: number = 0
   private lastOverRenderable?: Renderable
@@ -1410,7 +1411,14 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       return
     }
 
-    if (previousMode === "capture-stdout" && mode === "passthrough" && this._splitHeight > 0) {
+    const canFlushSplitOutputBeforeTransition = this.canFlushSplitOutputBeforeTransition()
+
+    if (
+      previousMode === "capture-stdout" &&
+      mode === "passthrough" &&
+      this._splitHeight > 0 &&
+      canFlushSplitOutputBeforeTransition
+    ) {
       this.flushPendingSplitOutputBeforeTransition()
     }
 
@@ -1726,7 +1734,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
           snapshot: commitBuffer,
           rowColumns: commitOptions.rowColumns,
           startOnNewLine: nextCommitStartOnNewLine,
-          trailingNewline: commitOptions.trailingNewline ?? false,
+          trailingNewline: commitOptions.trailingNewline ?? true,
         })
 
         nextCommitStartOnNewLine = false
@@ -2114,11 +2122,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     return commits
   }
 
-  private flushPendingSplitCommits(forceFooterRepaint: boolean = false): void {
+  private flushPendingSplitCommits(forceFooterRepaint: boolean = false, drainAll: boolean = false): void {
     // Drain only a bounded prefix so one JS render pass maps to one native frame.
     // Remaining commits are intentionally left queued and rendered on subsequent
     // ticks to avoid giant multi-thousand-cell frames that can flicker.
-    const commits = this.externalOutputQueue.claim(this.maxSplitCommitsPerFrame)
+    const commits = this.externalOutputQueue.claim(drainAll ? Number.POSITIVE_INFINITY : this.maxSplitCommitsPerFrame)
     let hasCommittedOutput = false
     const lastCommitIndex = commits.length - 1
 
@@ -2205,12 +2213,46 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     return Math.min(cursorRow, Math.max(this._terminalHeight, 1))
   }
 
-  private flushPendingSplitOutputBeforeTransition(forceFooterRepaint: boolean = false): void {
+  private isSplitCursorSeedFrameBlocked(): boolean {
+    return (
+      this._screenMode === "split-footer" &&
+      this._externalOutputMode === "capture-stdout" &&
+      this._splitHeight > 0 &&
+      this.pendingSplitStartupCursorSeed &&
+      this.splitStartupSeedTimeoutId !== null
+    )
+  }
+
+  private canFlushSplitOutputBeforeTransition(allowSuspended: boolean = false): boolean {
+    return (
+      this._terminalIsSetup &&
+      (allowSuspended || this._controlState !== RendererControlState.EXPLICIT_SUSPENDED) &&
+      !this.isSplitCursorSeedFrameBlocked()
+    )
+  }
+
+  private clearSplitStartupCursorSeed(): void {
+    this.pendingSplitStartupCursorSeed = false
+    if (this.splitStartupSeedTimeoutId !== null) {
+      this.clock.clearTimeout(this.splitStartupSeedTimeoutId)
+      this.splitStartupSeedTimeoutId = null
+    }
+  }
+
+  private flushPendingSplitOutputBeforeTransition(
+    forceFooterRepaint: boolean = false,
+    options: { allowSuspended?: boolean; allowPassthrough?: boolean } = {},
+  ): void {
+    const hasDeferredCapturedOutput = this.externalOutputQueue.size > 0
     if (
       this._screenMode !== "split-footer" ||
       this._splitHeight <= 0 ||
-      this._externalOutputMode !== "capture-stdout"
+      (this._externalOutputMode !== "capture-stdout" && !(options.allowPassthrough && hasDeferredCapturedOutput))
     ) {
+      return
+    }
+
+    if (!this.canFlushSplitOutputBeforeTransition(options.allowSuspended ?? false)) {
       return
     }
 
@@ -2218,7 +2260,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       return
     }
 
-    this.flushPendingSplitCommits(forceFooterRepaint)
+    this.flushPendingSplitCommits(this._externalOutputMode === "capture-stdout" ? forceFooterRepaint : false, true)
   }
 
   private resetSplitScrollback(seedRows: number = 0): void {
@@ -2324,12 +2366,13 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       return
     }
 
+    const terminalWritable = this._terminalIsSetup && this._controlState !== RendererControlState.EXPLICIT_SUSPENDED
     const prevUseAlternateScreen = prevScreenMode === "alternate-screen"
     const nextUseAlternateScreen = screenMode === "alternate-screen"
     const terminalScreenModeChanged = this._terminalIsSetup && prevUseAlternateScreen !== nextUseAlternateScreen
     const leavingSplitFooter = prevSplitHeight > 0 && nextSplitHeight === 0
 
-    if (this._terminalIsSetup && prevSplitHeight > 0) {
+    if (terminalWritable && prevSplitHeight > 0) {
       this.flushPendingSplitOutputBeforeTransition()
     }
 
@@ -2352,14 +2395,14 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     const splitTransitionMode =
       this.pendingSplitFooterTransition?.mode ?? (splitWasSettled ? "viewport-scroll" : "clear-stale-rows")
 
-    if (this._terminalIsSetup && leavingSplitFooter) {
+    if (terminalWritable && leavingSplitFooter) {
       this.clearPendingSplitFooterTransition()
       this.renderOffset = 0
       this.lib.setRenderOffset(this.rendererPtr, 0)
     }
 
     if (
-      this._terminalIsSetup &&
+      terminalWritable &&
       !terminalScreenModeChanged &&
       shouldUseViewportScrollTransitions &&
       !shouldDeferSplitFooterResizeTransition
@@ -2423,10 +2466,15 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.root.resize(this.width, this.height)
 
     if (terminalScreenModeChanged) {
-      this.lib.suspendRenderer(this.rendererPtr)
-      this.lib.setupTerminal(this.rendererPtr, nextUseAlternateScreen)
+      if (terminalWritable) {
+        this.lib.suspendRenderer(this.rendererPtr)
+        this.lib.setupTerminal(this.rendererPtr, nextUseAlternateScreen)
+        this.pendingSuspendedTerminalSetup = false
+      } else {
+        this.pendingSuspendedTerminalSetup = true
+      }
 
-      if (this._useMouse) {
+      if (terminalWritable && this._useMouse) {
         this.enableMouse()
       }
     }
@@ -2530,12 +2578,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this.capabilityTimeoutId = this.clock.setTimeout(() => {
       this.capabilityTimeoutId = null
-      this.pendingSplitStartupCursorSeed = false
-
-      if (this.splitStartupSeedTimeoutId !== null) {
-        this.clock.clearTimeout(this.splitStartupSeedTimeoutId)
-        this.splitStartupSeedTimeoutId = null
-      }
+      this.clearSplitStartupCursorSeed()
 
       if (this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout") {
         this.requestRender()
@@ -2576,6 +2619,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
         if (this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout") {
           this.requestRender()
         }
+
+        this.flushPendingSplitOutputBeforeTransition(false, { allowPassthrough: true })
       }, 120)
     }
 
@@ -2652,13 +2697,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     ) {
       this.resetSplitScrollback(this.getSplitCursorSeedRows())
       this.clearPendingSplitFooterTransition()
-      this.pendingSplitStartupCursorSeed = false
+      this.clearSplitStartupCursorSeed()
       this.updateStdinParserProtocolContext({ startupCursorCprActive: false })
-
-      if (this.splitStartupSeedTimeoutId !== null) {
-        this.clock.clearTimeout(this.splitStartupSeedTimeoutId)
-        this.splitStartupSeedTimeoutId = null
-      }
 
       this.requestRender()
     }
@@ -3129,7 +3169,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private processResize(width: number, height: number): void {
     if (width === this._terminalWidth && height === this._terminalHeight) return
 
-    if (this._terminalIsSetup && this._controlState !== RendererControlState.EXPLICIT_SUSPENDED) {
+    if (
+      this._terminalIsSetup &&
+      this._controlState !== RendererControlState.EXPLICIT_SUSPENDED &&
+      !this.isSplitCursorSeedFrameBlocked()
+    ) {
       this.flushPendingSplitOutputBeforeTransition()
     }
 
@@ -3394,7 +3438,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.internalPause()
 
     if (this._terminalIsSetup) {
-      this.flushPendingSplitOutputBeforeTransition(true)
+      this.clearSplitStartupCursorSeed()
+      this.flushPendingSplitOutputBeforeTransition(true, { allowSuspended: true })
     }
 
     this._suspendedMouseEnabled = this._useMouse
@@ -3436,7 +3481,15 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.stdin.resume()
     this.addExitListeners()
 
-    this.lib.resumeRenderer(this.rendererPtr)
+    if (this.pendingSuspendedTerminalSetup) {
+      this.pendingSuspendedTerminalSetup = false
+      this.lib.setupTerminal(this.rendererPtr, this._screenMode === "alternate-screen")
+    } else {
+      this.lib.resumeRenderer(this.rendererPtr)
+    }
+
+    this.flushPendingSplitOutputBeforeTransition(false, { allowSuspended: true, allowPassthrough: true })
+
     if (this._screenMode === "split-footer" && this._splitHeight > 0) {
       this.syncSplitFooterState()
     }
@@ -3534,10 +3587,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.capabilityTimeoutId = null
     }
 
-    if (this.splitStartupSeedTimeoutId !== null) {
-      this.clock.clearTimeout(this.splitStartupSeedTimeoutId)
-      this.splitStartupSeedTimeoutId = null
-    }
+    this.clearSplitStartupCursorSeed()
 
     if (this.memorySnapshotTimer) {
       this.clock.clearInterval(this.memorySnapshotTimer)
@@ -3777,12 +3827,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this.renderingNative = true
 
-    if (
-      this.pendingSplitStartupCursorSeed &&
-      this.splitStartupSeedTimeoutId !== null &&
-      this._splitHeight > 0 &&
-      this._externalOutputMode === "capture-stdout"
-    ) {
+    if (this.isSplitCursorSeedFrameBlocked()) {
       this.renderingNative = false
       return
     }

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -2512,25 +2512,48 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       screenMode === "split-footer" && nextSplitHeight > 0 && this._externalOutputMode === "capture-stdout"
         ? this.getSplitOutputOffset(nextPinnedRenderOffset)
         : nextPinnedRenderOffset
+    const pendingSplitFooterTransition = this.pendingSplitFooterTransition
+    const returningSplitFooterToSource =
+      pendingSplitFooterTransition !== null && nextSplitHeight === splitTransitionSourceHeight
+    const returningSplitFooterToGrownTarget =
+      returningSplitFooterToSource &&
+      pendingSplitFooterTransition.mode === "viewport-scroll" &&
+      pendingSplitFooterTransition.targetTopLine < pendingSplitFooterTransition.sourceTopLine &&
+      (pendingSplitFooterTransition.scrollLines ?? 0) > 0
     const shrinkingSplitFooter = nextSplitHeight > 0 && nextSplitHeight < splitTransitionSourceHeight
     const growingSplitFooter = nextSplitHeight > splitTransitionSourceHeight && splitTransitionSourceHeight > 0
     const nextSplitSurfaceOffset =
       screenMode !== "split-footer" || nextSplitHeight === 0
         ? 0
-        : shrinkingSplitFooter
-          ? Math.max(splitTransitionSourceSurfaceOffset, nextSplitOutputOffset)
+        : returningSplitFooterToGrownTarget
+          ? pendingSplitFooterTransition.targetTopLine - 1
+          : returningSplitFooterToSource
+          ? splitTransitionSourceSurfaceOffset
+          : shrinkingSplitFooter
+          ? splitTransitionSourceSurfaceOffset === 0
+            ? nextSplitOutputOffset
+            : splitTransitionSourceSurfaceOffset
           : growingSplitFooter
             ? Math.max(nextSplitOutputOffset, Math.min(splitTransitionSourceSurfaceOffset, nextPinnedRenderOffset))
             : nextPinnedRenderOffset
     const splitTransitionTargetTopLine = nextSplitSurfaceOffset + 1
-    const splitViewportScrollLines = nextSplitHeight > 0 ? Math.max(splitTransitionSourceOutputOffset - nextSplitOutputOffset, 0) : 0
-    const splitTransitionMode = !shrinkingSplitFooter && splitViewportScrollLines > 0 ? "viewport-scroll" : "clear-stale-rows"
+    const splitViewportScrollLines =
+      returningSplitFooterToGrownTarget
+        ? (pendingSplitFooterTransition.scrollLines ?? 0)
+        : nextSplitHeight > 0 && !returningSplitFooterToSource
+        ? Math.max(splitTransitionSourceOutputOffset - nextSplitOutputOffset, 0)
+        : 0
+    const splitTransitionMode =
+      (!shrinkingSplitFooter || returningSplitFooterToGrownTarget) && splitViewportScrollLines > 0
+        ? "viewport-scroll"
+        : "clear-stale-rows"
     const splitFooterSurfaceMovesDown = nextSplitSurfaceOffset > splitTransitionSourceSurfaceOffset
+    const splitFooterSurfaceLeavesStaleRows = splitFooterSurfaceMovesDown || shrinkingSplitFooter
     const shouldClearSplitSurfaceRowsImmediately =
       terminalWritable &&
       !terminalScreenModeChanged &&
       !shouldDeferSplitFooterResizeTransition &&
-      splitFooterSurfaceMovesDown &&
+      splitFooterSurfaceLeavesStaleRows &&
       nextSplitHeight > 0
 
     if (terminalWritable && leavingSplitFooter) {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -336,6 +336,10 @@ class ExternalOutputQueue {
     this.commits.push(commit)
   }
 
+  peek(): readonly ExternalOutputCommit[] {
+    return this.commits
+  }
+
   claim(limit: number = Number.POSITIVE_INFINITY): ExternalOutputCommit[] {
     if (this.commits.length === 0) {
       return []
@@ -772,6 +776,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private _suspendedMouseEnabled: boolean = false
   private _previousControlState: RendererControlState = RendererControlState.IDLE
   private pendingSuspendedTerminalSetup: boolean = false
+  private suspendedNonAltSurfacePreserved: boolean = false
   private capturedRenderable?: Renderable
   private lastOverRenderableNum: number = 0
   private lastOverRenderable?: Renderable
@@ -797,6 +802,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private _terminalIsSetup: boolean = false
 
   private externalOutputQueue = new ExternalOutputQueue()
+  private pendingExternalOutputMode: ExternalOutputMode | null = null
   private realStdoutWrite: (chunk: any, encoding?: any, callback?: any) => boolean
 
   private _useConsole: boolean = true
@@ -1375,6 +1381,15 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   public set screenMode(mode: ScreenMode) {
     if (this.externalOutputMode === "capture-stdout" && mode !== "split-footer") {
+      if (this.pendingExternalOutputMode === "passthrough") {
+        this.flushPendingSplitOutputBeforeLeavingSplitFooter()
+      }
+
+      if (this.externalOutputMode !== "capture-stdout") {
+        this.applyScreenMode(mode)
+        return
+      }
+
       throw new Error('externalOutputMode "capture-stdout" requires screenMode "split-footer"')
     }
 
@@ -1408,23 +1423,39 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     const previousMode = this._externalOutputMode
     if (previousMode === mode) {
+      if (this.pendingExternalOutputMode !== null && this.pendingExternalOutputMode !== mode) {
+        this.pendingExternalOutputMode = null
+      }
       return
     }
 
     const canFlushSplitOutputBeforeTransition = this.canFlushSplitOutputBeforeTransition()
-
-    if (
+    const isSplitCaptureToPassthrough =
       previousMode === "capture-stdout" &&
       mode === "passthrough" &&
-      this._splitHeight > 0 &&
-      canFlushSplitOutputBeforeTransition
-    ) {
+      this._screenMode === "split-footer" &&
+      this._splitHeight > 0
+
+    if (isSplitCaptureToPassthrough && this.externalOutputQueue.size > 0 && !canFlushSplitOutputBeforeTransition) {
+      this.pendingExternalOutputMode = "passthrough"
+      return
+    }
+
+    if (isSplitCaptureToPassthrough && canFlushSplitOutputBeforeTransition) {
       this.flushPendingSplitOutputBeforeTransition()
     }
 
+    this.pendingExternalOutputMode = null
+    this.applyExternalOutputMode(mode)
+    this.afterExternalOutputModeChanged(previousMode, mode)
+  }
+
+  private applyExternalOutputMode(mode: ExternalOutputMode): void {
     this._externalOutputMode = mode
     this.stdout.write = mode === "capture-stdout" ? this.interceptStdoutWrite : this.realStdoutWrite
+  }
 
+  private afterExternalOutputModeChanged(previousMode: ExternalOutputMode, mode: ExternalOutputMode): void {
     if (this._screenMode === "split-footer" && this._splitHeight > 0 && mode === "capture-stdout") {
       this.clearPendingSplitFooterTransition()
       this.resetSplitScrollback(this.getSplitCursorSeedRows())
@@ -1442,6 +1473,39 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     this.syncSplitFooterState()
+  }
+
+  private applyPendingExternalOutputModeIfReady(): void {
+    const pendingMode = this.pendingExternalOutputMode
+    if (pendingMode === null || this.externalOutputQueue.size > 0) {
+      return
+    }
+
+    const previousMode = this._externalOutputMode
+    this.pendingExternalOutputMode = null
+
+    if (previousMode === pendingMode) {
+      return
+    }
+
+    this.applyExternalOutputMode(pendingMode)
+    this.afterExternalOutputModeChanged(previousMode, pendingMode)
+  }
+
+  private flushPendingSplitOutputBeforeLeavingSplitFooter(): void {
+    if (this.pendingExternalOutputMode !== "passthrough") {
+      return
+    }
+
+    if (this.isSplitCursorSeedFrameBlocked() && this._controlState !== RendererControlState.EXPLICIT_SUSPENDED) {
+      this.clearSplitStartupCursorSeed()
+    }
+
+    this.flushPendingSplitOutputBeforeTransition()
+
+    if (this.pendingExternalOutputMode !== null) {
+      throw new Error("Cannot leave split-footer while captured output is pending")
+    }
   }
 
   public get liveRequestCount(): number {
@@ -1491,10 +1555,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     const renderer = this
     const surfaceId = scrollbackSurfaceCounter++
     const startOnNewLine = options.startOnNewLine ?? true
-    const firstLineOffset =
-      !startOnNewLine && renderer.splitTailColumn > 0 && renderer.splitTailColumn < renderer.width
-        ? renderer.splitTailColumn
-        : 0
+    const tailColumn = renderer.getPendingSplitTailColumn()
+    const firstLineOffset = !startOnNewLine && tailColumn > 0 && tailColumn < renderer.width ? tailColumn : 0
 
     const snapshotContext = new ScrollbackSnapshotRenderContext(renderer.width, 1, renderer.widthMethod)
     let firstLineOffsetOwner: Renderable | null = null
@@ -1834,7 +1896,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     const snapshot = write({
       width: this.width,
       widthMethod: this.widthMethod,
-      tailColumn: this.splitTailColumn,
+      tailColumn: this.getPendingSplitTailColumn(),
       renderContext: snapshotContext,
     })
 
@@ -1945,13 +2007,12 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     return widths
   }
 
-  private publishSplitTailColumns(columns: number): void {
+  private advanceSplitTailColumn(tailColumn: number, columns: number, width: number): number {
     if (columns <= 0) {
-      return
+      return tailColumn
     }
 
-    const width = Math.max(this.width, 1)
-    let tail = this.splitTailColumn
+    let tail = tailColumn
     let remaining = columns
 
     while (remaining > 0) {
@@ -1968,21 +2029,44 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       }
     }
 
-    this.splitTailColumn = tail
+    return tail
   }
 
-  private recordSplitCommit(commit: ExternalOutputCommit): void {
-    if (commit.startOnNewLine && this.splitTailColumn > 0) {
-      this.splitTailColumn = 0
+  private getSplitTailColumnAfterCommit(
+    commit: ExternalOutputCommit,
+    initialTailColumn: number,
+    width: number,
+  ): number {
+    let tailColumn = initialTailColumn
+
+    if (commit.startOnNewLine && tailColumn > 0) {
+      tailColumn = 0
     }
 
     const rowWidths = this.getSnapshotRowWidths(commit.snapshot, commit.rowColumns)
     for (const [index, rowWidth] of rowWidths.entries()) {
-      this.publishSplitTailColumns(rowWidth)
+      tailColumn = this.advanceSplitTailColumn(tailColumn, rowWidth, width)
       if (index < rowWidths.length - 1 || commit.trailingNewline) {
-        this.splitTailColumn = 0
+        tailColumn = 0
       }
     }
+
+    return tailColumn
+  }
+
+  private recordSplitCommit(commit: ExternalOutputCommit): void {
+    this.splitTailColumn = this.getSplitTailColumnAfterCommit(commit, this.splitTailColumn, Math.max(this.width, 1))
+  }
+
+  private getPendingSplitTailColumn(): number {
+    const width = Math.max(this.width, 1)
+    let tailColumn = this.splitTailColumn
+
+    for (const commit of this.externalOutputQueue.peek()) {
+      tailColumn = this.getSplitTailColumnAfterCommit(commit, tailColumn, width)
+    }
+
+    return tailColumn
   }
 
   private enqueueRenderedScrollbackCommit(options: {
@@ -2011,7 +2095,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   private enqueueSplitCommit(commit: ExternalOutputCommit): void {
-    this.recordSplitCommit(commit)
     this.externalOutputQueue.writeSnapshot(commit)
   }
 
@@ -2153,6 +2236,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
           beginFrame,
           finalizeFrame,
         )
+        this.recordSplitCommit(commit)
         hasCommittedOutput = true
       } finally {
         commit.snapshot.destroy()
@@ -2173,6 +2257,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       // Preserve FIFO ordering without doing unbounded work in one tick.
       // This keeps sustained stdout bursts smooth instead of blocking on one frame.
       this.requestRender()
+    } else {
+      this.applyPendingExternalOutputModeIfReady()
     }
   }
 
@@ -2243,7 +2329,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     forceFooterRepaint: boolean = false,
     options: { allowSuspended?: boolean; allowPassthrough?: boolean } = {},
   ): void {
-    const hasDeferredCapturedOutput = this.externalOutputQueue.size > 0
+    const hasDeferredCapturedOutput = this.externalOutputQueue.size > 0 || this.pendingExternalOutputMode !== null
     if (
       this._screenMode !== "split-footer" ||
       this._splitHeight <= 0 ||
@@ -2257,6 +2343,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     if (this.externalOutputQueue.size === 0 && !forceFooterRepaint) {
+      this.applyPendingExternalOutputModeIfReady()
       return
     }
 
@@ -2701,6 +2788,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.updateStdinParserProtocolContext({ startupCursorCprActive: false })
 
       this.requestRender()
+      if (this.pendingExternalOutputMode === "passthrough") {
+        this.flushPendingSplitOutputBeforeTransition()
+      }
     }
 
     const consumeStartupCursorReport =
@@ -3440,6 +3530,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     if (this._terminalIsSetup) {
       this.clearSplitStartupCursorSeed()
       this.flushPendingSplitOutputBeforeTransition(true, { allowSuspended: true })
+      this.suspendedNonAltSurfacePreserved = this._screenMode !== "alternate-screen" && this.renderOffset > 0
+    } else {
+      this.suspendedNonAltSurfacePreserved = false
     }
 
     this._suspendedMouseEnabled = this._useMouse
@@ -3481,12 +3574,24 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.stdin.resume()
     this.addExitListeners()
 
+    const resumePreservedNonAltSurface =
+      this.pendingSuspendedTerminalSetup &&
+      this._screenMode !== "alternate-screen" &&
+      this.suspendedNonAltSurfacePreserved &&
+      this.renderOffset > 0
+
     if (this.pendingSuspendedTerminalSetup) {
       this.pendingSuspendedTerminalSetup = false
-      this.lib.setupTerminal(this.rendererPtr, this._screenMode === "alternate-screen")
+      if (resumePreservedNonAltSurface) {
+        this.lib.resumeRenderer(this.rendererPtr)
+      } else {
+        this.lib.setupTerminal(this.rendererPtr, this._screenMode === "alternate-screen")
+      }
     } else {
       this.lib.resumeRenderer(this.rendererPtr)
     }
+
+    this.suspendedNonAltSurfacePreserved = false
 
     this.flushPendingSplitOutputBeforeTransition(false, { allowSuspended: true, allowPassthrough: true })
 
@@ -3681,6 +3786,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     this._externalOutputMode = "passthrough"
+    this.pendingExternalOutputMode = null
     this.stdout.write = this.realStdoutWrite
     this.externalOutputQueue.clear()
 
@@ -3838,7 +3944,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       // capture path keeps using diff-based repainting.
       const forceSplitRepaint = this.forceFullRepaintRequested
       this.forceFullRepaintRequested = false
-      this.flushPendingSplitCommits(forceSplitRepaint)
+      this.flushPendingSplitCommits(forceSplitRepaint, this.pendingExternalOutputMode === "passthrough")
       this.pendingSplitFooterTransition = null
     } else {
       const force = this.forceFullRepaintRequested

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -584,6 +584,59 @@ test("CliRenderer drains deferred passthrough output before leaving split-footer
   }
 })
 
+test("CliRenderer leaving split-footer clears startup CPR parser mode for deferred passthrough", async () => {
+  const clock = new ManualClock()
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+    clock,
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  ;(renderer as any).pendingSplitStartupCursorSeed = true
+  ;(renderer as any).splitStartupSeedTimeoutId = clock.setTimeout(() => {}, 120)
+  ;(renderer as any).capabilityTimeoutId = clock.setTimeout(() => {}, 5000)
+  ;(renderer as any).updateStdinParserProtocolContext({ startupCursorCprActive: true })
+
+  const keypresses: string[] = []
+  renderer.keyInput.on("keypress", (event) => {
+    keypresses.push(event.name)
+  })
+
+  try {
+    ;(renderer as any).stdout.write("before-leave\n")
+    renderer.externalOutputMode = "passthrough"
+
+    expect(renderer.externalOutputMode).toBe("capture-stdout")
+
+    renderer.screenMode = "main-screen"
+
+    expect((renderer as any).pendingSplitStartupCursorSeed).toBe(false)
+    expect((renderer as any).splitStartupSeedTimeoutId).toBeNull()
+    expect((renderer as any).stdinParser.protocolContext.startupCursorCprActive).toBe(false)
+
+    renderer.stdin.emit("data", Buffer.from("\x1b[24;80"))
+    clock.advance(20)
+    renderer.stdin.emit("data", Buffer.from("R"))
+    clock.advance(20)
+
+    expect(keypresses).toEqual(["r"])
+  } finally {
+    if ((renderer as any).capabilityTimeoutId !== null) {
+      clock.clearTimeout((renderer as any).capabilityTimeoutId)
+      ;(renderer as any).capabilityTimeoutId = null
+    }
+
+    if ((renderer as any).splitStartupSeedTimeoutId !== null) {
+      clock.clearTimeout((renderer as any).splitStartupSeedTimeoutId)
+      ;(renderer as any).splitStartupSeedTimeoutId = null
+    }
+  }
+})
+
 test("CliRenderer preserves split render offset when switching to passthrough", async () => {
   const result = await createTestRenderer({
     width: 40,

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -1476,16 +1476,6 @@ test("CliRenderer split-footer grow then shrink back before frame keeps grown to
   renderer.footerHeight = 8
   renderer.footerHeight = 4
 
-  expect((renderer as any).renderOffset).toBe(2)
-  expect((renderer as any).pendingSplitFooterTransition).toEqual({
-    mode: "viewport-scroll",
-    sourceTopLine: 4,
-    sourceHeight: 4,
-    targetTopLine: 3,
-    targetHeight: 4,
-    scrollLines: 1,
-  })
-
   await result.renderOnce()
 
   expect((renderer as any).renderOffset).toBe(2)
@@ -1536,58 +1526,6 @@ test("CliRenderer split-footer pinned footerHeight shrink defers clear-stale-row
 
   writeOutSpy.mockRestore()
   repaintSpy.mockRestore()
-})
-
-test("CliRenderer split-footer settling footerHeight shrink keeps footer top line", async () => {
-  const result = await createTestRenderer({
-    width: 40,
-    height: 10,
-    screenMode: "split-footer",
-    footerHeight: 4,
-    externalOutputMode: "capture-stdout",
-    consoleMode: "disabled",
-  })
-
-  renderer = result.renderer
-  ;(renderer as any)._terminalIsSetup = true
-
-  ;(renderer as any).stdout.write("a\n")
-  await result.renderOnce()
-  ;(renderer as any).stdout.write("b\n")
-  await result.renderOnce()
-
-  expect((renderer as any).renderOffset).toBe(3)
-
-  renderer.footerHeight = 8
-  await result.renderOnce()
-
-  expect((renderer as any).renderOffset).toBe(2)
-
-  renderer.footerHeight = 4
-
-  expect((renderer as any).pendingSplitFooterTransition).toEqual({
-    mode: "clear-stale-rows",
-    sourceTopLine: 3,
-    sourceHeight: 8,
-    targetTopLine: 3,
-    targetHeight: 4,
-    scrollLines: 0,
-  })
-
-  await result.renderOnce()
-
-  expect((renderer as any).renderOffset).toBe(2)
-
-  renderer.footerHeight = 6
-
-  expect((renderer as any).pendingSplitFooterTransition).toEqual({
-    mode: "clear-stale-rows",
-    sourceTopLine: 3,
-    sourceHeight: 4,
-    targetTopLine: 3,
-    targetHeight: 6,
-    scrollLines: 0,
-  })
 })
 
 test("CliRenderer split-footer reuses the reserved gap when reopening the footer before new output arrives", async () => {

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -1453,7 +1453,7 @@ test("CliRenderer split-footer footerHeight changes coalesce while settling befo
   repaintSpy.mockRestore()
 })
 
-test("CliRenderer split-footer footerHeight changes defer pinned viewport transitions to the next native frame", async () => {
+test("CliRenderer split-footer pinned footerHeight shrink defers clear-stale-row cleanup to the next native frame", async () => {
   const result = await createTestRenderer({
     width: 40,
     height: 10,
@@ -1478,16 +1478,109 @@ test("CliRenderer split-footer footerHeight changes defer pinned viewport transi
 
   renderer.footerHeight = 3
 
+  expect((renderer as any).renderOffset).toBe(6)
+  expect((renderer as any).pendingSplitFooterTransition).toEqual({
+    mode: "clear-stale-rows",
+    sourceTopLine: 7,
+    sourceHeight: 4,
+    targetTopLine: 7,
+    targetHeight: 3,
+    scrollLines: 0,
+  })
   expect(writeOutSpy).toHaveBeenCalledTimes(0)
 
   await result.renderOnce()
 
+  expect((renderer as any).renderOffset).toBe(6)
   expect(repaintSpy).toHaveBeenCalledTimes(1)
   expect(repaintSpy.mock.calls[0]?.[1]).toBe(7)
   expect(repaintSpy.mock.calls[0]?.[2]).toBe(true)
 
   writeOutSpy.mockRestore()
   repaintSpy.mockRestore()
+})
+
+test("CliRenderer split-footer reuses the reserved gap when reopening the footer before new output arrives", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  for (let i = 0; i < 12; i += 1) {
+    ;(renderer as any).stdout.write(`line-${i}\n`)
+    await result.renderOnce()
+  }
+
+  expect((renderer as any).renderOffset).toBe(6)
+
+  renderer.footerHeight = 8
+
+  expect((renderer as any).pendingSplitFooterTransition).toEqual({
+    mode: "viewport-scroll",
+    sourceTopLine: 7,
+    sourceHeight: 4,
+    targetTopLine: 3,
+    targetHeight: 8,
+    scrollLines: 4,
+  })
+
+  await result.renderOnce()
+
+  renderer.footerHeight = 4
+
+  expect((renderer as any).pendingSplitFooterTransition).toEqual({
+    mode: "clear-stale-rows",
+    sourceTopLine: 3,
+    sourceHeight: 8,
+    targetTopLine: 3,
+    targetHeight: 4,
+    scrollLines: 0,
+  })
+
+  await result.renderOnce()
+
+  expect((renderer as any).renderOffset).toBe(2)
+
+  renderer.footerHeight = 7
+
+  expect((renderer as any).pendingSplitFooterTransition).toEqual({
+    mode: "clear-stale-rows",
+    sourceTopLine: 3,
+    sourceHeight: 4,
+    targetTopLine: 3,
+    targetHeight: 7,
+    scrollLines: 0,
+  })
+})
+
+test("CliRenderer split-footer passthrough footerHeight shrink clears stale rows without reverse scrolling", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "passthrough",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const writeOutSpy = spyOn(renderer as any, "writeOut")
+
+  renderer.footerHeight = 3
+
+  expect(writeOutSpy).toHaveBeenCalledTimes(1)
+  expect(writeOutSpy.mock.calls[0]?.[0]).toBe(`${ANSI.moveCursor(7, 1)}\x1b[2K`)
+
+  writeOutSpy.mockRestore()
 })
 
 test("CliRenderer split-footer resize cleanup uses the visible footer surface while a deferred footer transition is pending", async () => {
@@ -1513,6 +1606,7 @@ test("CliRenderer split-footer resize cleanup uses the visible footer surface wh
     sourceHeight: 4,
     targetTopLine: 2,
     targetHeight: 3,
+    scrollLines: 0,
   })
 
   result.resize(20, 10)
@@ -1547,6 +1641,7 @@ test("CliRenderer split-footer resize cleanup uses the visible source top line a
     sourceHeight: 4,
     targetTopLine: 2,
     targetHeight: 3,
+    scrollLines: 0,
   })
 
   result.resize(20, 12)

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -1724,6 +1724,39 @@ test("CliRenderer entering split capture seeds from current terminal cursor row"
   expect((renderer as any).renderOffset).toBe(4)
 })
 
+test("CliRenderer entering split capture after a committed main-screen frame clears the old pinned footer surface", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  await result.renderOnce()
+
+  renderer.externalOutputMode = "passthrough"
+  renderer.screenMode = "main-screen"
+  await result.renderOnce()
+
+  renderer.screenMode = "split-footer"
+  renderer.externalOutputMode = "capture-stdout"
+
+  expect((renderer as any).pendingSplitFooterTransition).toEqual({
+    mode: "clear-stale-rows",
+    sourceTopLine: 7,
+    sourceHeight: 4,
+    targetTopLine: 2,
+    targetHeight: 4,
+    scrollLines: 0,
+  })
+  expect((renderer as any).forceFullRepaintRequested).toBe(true)
+})
+
 test("CliRenderer reseeds split startup offset from non-home CPR capability response", async () => {
   const result = await createTestRenderer({
     width: 40,

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -584,7 +584,7 @@ test("CliRenderer drains deferred passthrough output before leaving split-footer
   }
 })
 
-test("CliRenderer leaving split-footer clears startup CPR parser mode for deferred passthrough", async () => {
+test("CliRenderer leaving split-footer aborts an in-flight startup CPR reply", async () => {
   const clock = new ManualClock()
   const result = await createTestRenderer({
     screenMode: "split-footer",
@@ -607,6 +607,8 @@ test("CliRenderer leaving split-footer clears startup CPR parser mode for deferr
   })
 
   try {
+    renderer.stdin.emit("data", Buffer.from("\x1b["))
+
     ;(renderer as any).stdout.write("before-leave\n")
     renderer.externalOutputMode = "passthrough"
 
@@ -618,12 +620,10 @@ test("CliRenderer leaving split-footer clears startup CPR parser mode for deferr
     expect((renderer as any).splitStartupSeedTimeoutId).toBeNull()
     expect((renderer as any).stdinParser.protocolContext.startupCursorCprActive).toBe(false)
 
-    renderer.stdin.emit("data", Buffer.from("\x1b[24;80"))
-    clock.advance(20)
-    renderer.stdin.emit("data", Buffer.from("R"))
+    renderer.stdin.emit("data", Buffer.from("24;80R"))
     clock.advance(20)
 
-    expect(keypresses).toEqual(["r"])
+    expect(keypresses).toEqual([])
   } finally {
     if ((renderer as any).capabilityTimeoutId !== null) {
       clock.clearTimeout((renderer as any).capabilityTimeoutId)

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -47,6 +47,20 @@ function textScrollbackWrite(data: string) {
   }
 }
 
+function blockSplitStartupCursorSeed(target: TestRenderer): () => void {
+  ;(target as any).pendingSplitStartupCursorSeed = true
+  ;(target as any).splitStartupSeedTimeoutId = setTimeout(() => {}, 10)
+
+  return () => {
+    if ((target as any).splitStartupSeedTimeoutId !== null) {
+      clearTimeout((target as any).splitStartupSeedTimeoutId)
+      ;(target as any).splitStartupSeedTimeoutId = null
+    }
+
+    ;(target as any).pendingSplitStartupCursorSeed = false
+  }
+}
+
 beforeEach(() => {
   previousShowConsole = process.env.SHOW_CONSOLE
   previousUseAlternateScreen = process.env.OTUI_USE_ALTERNATE_SCREEN
@@ -493,6 +507,83 @@ test("CliRenderer drains all pending split commits before switching to passthrou
   splitCommitSpy.mockRestore()
 })
 
+test("CliRenderer keeps stdout captured until a deferred passthrough switch drains", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  const unblockStartupSeed = blockSplitStartupCursorSeed(renderer)
+
+  const committedOutput: string[] = []
+  const lib = (renderer as any).lib
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    committedOutput.push(new TextDecoder().decode(args[1].getRealCharBytes(true)))
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+
+  try {
+    ;(renderer as any).stdout.write("older\n")
+    renderer.externalOutputMode = "passthrough"
+
+    expect(renderer.externalOutputMode).toBe("capture-stdout")
+
+    ;(renderer as any).stdout.write("newer\n")
+
+    expect((renderer as any).externalOutputQueue.size).toBe(2)
+
+    unblockStartupSeed()
+    await result.renderOnce()
+
+    expect(committedOutput[0]).toContain("older")
+    expect(committedOutput[1]).toContain("newer")
+    expect((renderer as any).externalOutputQueue.size).toBe(0)
+    expect(renderer.externalOutputMode).toBe("passthrough")
+  } finally {
+    unblockStartupSeed()
+    lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+  }
+})
+
+test("CliRenderer drains deferred passthrough output before leaving split-footer", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  const unblockStartupSeed = blockSplitStartupCursorSeed(renderer)
+
+  const lib = (renderer as any).lib
+  const splitCommitSpy = spyOn(lib, "commitSplitFooterSnapshot")
+
+  try {
+    ;(renderer as any).stdout.write("before-leave\n")
+    renderer.externalOutputMode = "passthrough"
+
+    expect(renderer.externalOutputMode).toBe("capture-stdout")
+
+    renderer.screenMode = "main-screen"
+
+    expect(splitCommitSpy).toHaveBeenCalledTimes(1)
+    expect((renderer as any).externalOutputQueue.size).toBe(0)
+    expect(renderer.externalOutputMode).toBe("passthrough")
+    expect(renderer.screenMode).toBe("main-screen")
+  } finally {
+    unblockStartupSeed()
+    splitCommitSpy.mockRestore()
+  }
+})
+
 test("CliRenderer preserves split render offset when switching to passthrough", async () => {
   const result = await createTestRenderer({
     width: 40,
@@ -711,6 +802,48 @@ test("CliRenderer applies suspended screen mode changes on resume", async () => 
   }
 })
 
+test("CliRenderer resumes preserved split-footer reservation after suspended screen roundtrip", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "passthrough",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const lib = (renderer as any).lib
+  const originalSetupTerminal = lib.setupTerminal.bind(lib)
+  const originalResumeRenderer = lib.resumeRenderer.bind(lib)
+  let setupTerminalCalls = 0
+  let resumeRendererCalls = 0
+
+  lib.setupTerminal = (...args: any[]) => {
+    setupTerminalCalls += 1
+    return originalSetupTerminal(...args)
+  }
+  lib.resumeRenderer = (...args: any[]) => {
+    resumeRendererCalls += 1
+    return originalResumeRenderer(...args)
+  }
+
+  try {
+    renderer.suspend()
+    renderer.screenMode = "alternate-screen"
+    renderer.screenMode = "split-footer"
+    renderer.resume()
+
+    expect(setupTerminalCalls).toBe(0)
+    expect(resumeRendererCalls).toBe(1)
+  } finally {
+    lib.setupTerminal = originalSetupTerminal
+    lib.resumeRenderer = originalResumeRenderer
+  }
+})
+
 test("CliRenderer does not flush captured split output during resize while suspended", async () => {
   const result = await createTestRenderer({
     width: 40,
@@ -735,6 +868,49 @@ test("CliRenderer does not flush captured split output during resize while suspe
   splitCommitSpy.mockRestore()
 })
 
+test("CliRenderer recomputes queued split tail after a blocked resize", async () => {
+  const result = await createTestRenderer({
+    width: 10,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  const unblockStartupSeed = blockSplitStartupCursorSeed(renderer)
+
+  try {
+    ;(renderer as any).stdout.write("123456789012345")
+    ;(renderer as any).processResize(20, 10)
+
+    let tailColumn = -1
+    renderer.writeToScrollback((ctx) => {
+      tailColumn = ctx.tailColumn
+      const root = new TextRenderable(ctx.renderContext, {
+        id: "tail-after-resize-probe",
+        content: "x",
+        width: 1,
+        height: 1,
+      })
+
+      return {
+        root,
+        width: 1,
+        height: 1,
+        startOnNewLine: false,
+        trailingNewline: false,
+      }
+    })
+
+    expect(tailColumn).toBe(15)
+  } finally {
+    unblockStartupSeed()
+  }
+})
+
 test("CliRenderer preserves captured split output when switching output mode while suspended", async () => {
   const result = await createTestRenderer({
     width: 40,
@@ -757,6 +933,7 @@ test("CliRenderer preserves captured split output when switching output mode whi
 
   expect(splitCommitSpy.mock.calls.length).toBe(commitCallsAfterSuspend)
   expect((renderer as any).externalOutputQueue.size).toBe(1)
+  expect(renderer.externalOutputMode).toBe("capture-stdout")
 
   renderer.resume()
 
@@ -794,6 +971,7 @@ test("CliRenderer preserves captured split output until startup cursor seed unbl
 
     expect(splitCommitSpy).toHaveBeenCalledTimes(0)
     expect((renderer as any).externalOutputQueue.size).toBe(1)
+    expect(renderer.externalOutputMode).toBe("capture-stdout")
 
     clock.advance(120)
 
@@ -818,8 +996,7 @@ test("CliRenderer flushes pending split output on suspend even when startup curs
 
   renderer = result.renderer
   ;(renderer as any)._terminalIsSetup = true
-  ;(renderer as any).pendingSplitStartupCursorSeed = true
-  ;(renderer as any).splitStartupSeedTimeoutId = setTimeout(() => {}, 10)
+  const unblockStartupSeed = blockSplitStartupCursorSeed(renderer)
 
   const order: string[] = []
   const lib = (renderer as any).lib
@@ -844,10 +1021,7 @@ test("CliRenderer flushes pending split output on suspend even when startup curs
     expect(order.indexOf("split-commit")).toBeLessThan(order.indexOf("suspend"))
     expect((renderer as any).externalOutputQueue.size).toBe(0)
   } finally {
-    if ((renderer as any).splitStartupSeedTimeoutId !== null) {
-      clearTimeout((renderer as any).splitStartupSeedTimeoutId)
-      ;(renderer as any).splitStartupSeedTimeoutId = null
-    }
+    unblockStartupSeed()
     lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
     lib.suspendRenderer = originalSuspendRenderer
   }
@@ -1170,22 +1344,21 @@ test("CliRenderer split-footer defers first native frame while startup cursor se
   })
 
   renderer = result.renderer
-  ;(renderer as any).pendingSplitStartupCursorSeed = true
-  ;(renderer as any).splitStartupSeedTimeoutId = setTimeout(() => {}, 10)
+  const unblockStartupSeed = blockSplitStartupCursorSeed(renderer)
 
   const repaintSpy = spyOn((renderer as any).lib, "repaintSplitFooter")
   const commitSpy = spyOn((renderer as any).lib, "commitSplitFooterSnapshot")
 
-  await result.renderOnce()
+  try {
+    await result.renderOnce()
 
-  expect(repaintSpy).toHaveBeenCalledTimes(0)
-  expect(commitSpy).toHaveBeenCalledTimes(0)
-
-  clearTimeout((renderer as any).splitStartupSeedTimeoutId)
-  ;(renderer as any).splitStartupSeedTimeoutId = null
-
-  repaintSpy.mockRestore()
-  commitSpy.mockRestore()
+    expect(repaintSpy).toHaveBeenCalledTimes(0)
+    expect(commitSpy).toHaveBeenCalledTimes(0)
+  } finally {
+    unblockStartupSeed()
+    repaintSpy.mockRestore()
+    commitSpy.mockRestore()
+  }
 })
 
 test("CliRenderer split-footer starts in settling phase and then pins as output grows", async () => {
@@ -1421,8 +1594,7 @@ test("CliRenderer split-footer footerHeight changes do not queue deferred transi
 
   renderer = result.renderer
   ;(renderer as any)._terminalIsSetup = true
-  ;(renderer as any).pendingSplitStartupCursorSeed = true
-  ;(renderer as any).splitStartupSeedTimeoutId = setTimeout(() => {}, 10)
+  const unblockStartupSeed = blockSplitStartupCursorSeed(renderer)
 
   const setPendingTransitionSpy = spyOn((renderer as any).lib, "setPendingSplitFooterTransition")
 
@@ -1433,8 +1605,7 @@ test("CliRenderer split-footer footerHeight changes do not queue deferred transi
     expect((renderer as any).pendingSplitFooterTransition).toBeNull()
     expect((renderer as any).forceFullRepaintRequested).toBe(true)
   } finally {
-    clearTimeout((renderer as any).splitStartupSeedTimeoutId)
-    ;(renderer as any).splitStartupSeedTimeoutId = null
+    unblockStartupSeed()
     setPendingTransitionSpy.mockRestore()
   }
 })

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -1453,6 +1453,44 @@ test("CliRenderer split-footer footerHeight changes coalesce while settling befo
   repaintSpy.mockRestore()
 })
 
+test("CliRenderer split-footer grow then shrink back before frame keeps grown top line", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  ;(renderer as any).stdout.write("a\n")
+  await result.renderOnce()
+  ;(renderer as any).stdout.write("b\n")
+  await result.renderOnce()
+
+  expect((renderer as any).renderOffset).toBe(3)
+
+  renderer.footerHeight = 8
+  renderer.footerHeight = 4
+
+  expect((renderer as any).renderOffset).toBe(2)
+  expect((renderer as any).pendingSplitFooterTransition).toEqual({
+    mode: "viewport-scroll",
+    sourceTopLine: 4,
+    sourceHeight: 4,
+    targetTopLine: 3,
+    targetHeight: 4,
+    scrollLines: 1,
+  })
+
+  await result.renderOnce()
+
+  expect((renderer as any).renderOffset).toBe(2)
+})
+
 test("CliRenderer split-footer pinned footerHeight shrink defers clear-stale-row cleanup to the next native frame", async () => {
   const result = await createTestRenderer({
     width: 40,
@@ -1498,6 +1536,58 @@ test("CliRenderer split-footer pinned footerHeight shrink defers clear-stale-row
 
   writeOutSpy.mockRestore()
   repaintSpy.mockRestore()
+})
+
+test("CliRenderer split-footer settling footerHeight shrink keeps footer top line", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  ;(renderer as any).stdout.write("a\n")
+  await result.renderOnce()
+  ;(renderer as any).stdout.write("b\n")
+  await result.renderOnce()
+
+  expect((renderer as any).renderOffset).toBe(3)
+
+  renderer.footerHeight = 8
+  await result.renderOnce()
+
+  expect((renderer as any).renderOffset).toBe(2)
+
+  renderer.footerHeight = 4
+
+  expect((renderer as any).pendingSplitFooterTransition).toEqual({
+    mode: "clear-stale-rows",
+    sourceTopLine: 3,
+    sourceHeight: 8,
+    targetTopLine: 3,
+    targetHeight: 4,
+    scrollLines: 0,
+  })
+
+  await result.renderOnce()
+
+  expect((renderer as any).renderOffset).toBe(2)
+
+  renderer.footerHeight = 6
+
+  expect((renderer as any).pendingSplitFooterTransition).toEqual({
+    mode: "clear-stale-rows",
+    sourceTopLine: 3,
+    sourceHeight: 4,
+    targetTopLine: 3,
+    targetHeight: 6,
+    scrollLines: 0,
+  })
 })
 
 test("CliRenderer split-footer reuses the reserved gap when reopening the footer before new output arrives", async () => {

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -442,6 +442,7 @@ test("CliRenderer flushes captured output before switching to passthrough in spl
   })
 
   renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
   const lib = (renderer as any).lib
   const splitCommitSpy = spyOn(lib, "commitSplitFooterSnapshot")
   const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
@@ -462,6 +463,33 @@ test("CliRenderer flushes captured output before switching to passthrough in spl
   expect(committedOutput).toContain("pending output")
   expect((renderer as any).externalOutputQueue.size).toBe(0)
   lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+  splitCommitSpy.mockRestore()
+})
+
+test("CliRenderer drains all pending split commits before switching to passthrough", async () => {
+  const result = await createTestRenderer({
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  const lib = (renderer as any).lib
+  const splitCommitSpy = spyOn(lib, "commitSplitFooterSnapshot")
+
+  for (let i = 0; i < 10; i += 1) {
+    ;(renderer as any).stdout.write(`pending-${i}\n`)
+  }
+
+  expect((renderer as any).externalOutputQueue.size).toBe(10)
+
+  renderer.externalOutputMode = "passthrough"
+
+  expect(splitCommitSpy).toHaveBeenCalledTimes(10)
+  expect((renderer as any).externalOutputQueue.size).toBe(0)
+
   splitCommitSpy.mockRestore()
 })
 
@@ -639,6 +667,50 @@ test("CliRenderer split-footer resume forces the next footer repaint", async () 
   repaintSpy.mockRestore()
 })
 
+test("CliRenderer applies suspended screen mode changes on resume", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "main-screen",
+    externalOutputMode: "passthrough",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const lib = (renderer as any).lib
+  const originalSetupTerminal = lib.setupTerminal.bind(lib)
+  const originalResumeRenderer = lib.resumeRenderer.bind(lib)
+  const setupTerminalCalls: any[][] = []
+  let resumeRendererCalls = 0
+
+  lib.setupTerminal = (...args: any[]) => {
+    setupTerminalCalls.push(args)
+  }
+  lib.resumeRenderer = (...args: any[]) => {
+    resumeRendererCalls += 1
+    return originalResumeRenderer(...args)
+  }
+
+  try {
+    renderer.suspend()
+    const setupCallsAfterSuspend = setupTerminalCalls.length
+    renderer.screenMode = "alternate-screen"
+
+    expect(setupTerminalCalls.length).toBe(setupCallsAfterSuspend)
+
+    renderer.resume()
+
+    expect(setupTerminalCalls.length).toBe(setupCallsAfterSuspend + 1)
+    expect(setupTerminalCalls.at(-1)?.[1]).toBe(true)
+    expect(resumeRendererCalls).toBe(0)
+  } finally {
+    lib.setupTerminal = originalSetupTerminal
+    lib.resumeRenderer = originalResumeRenderer
+  }
+})
+
 test("CliRenderer does not flush captured split output during resize while suspended", async () => {
   const result = await createTestRenderer({
     width: 40,
@@ -661,6 +733,124 @@ test("CliRenderer does not flush captured split output during resize while suspe
   expect(splitCommitSpy).toHaveBeenCalledTimes(0)
 
   splitCommitSpy.mockRestore()
+})
+
+test("CliRenderer preserves captured split output when switching output mode while suspended", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const splitCommitSpy = spyOn((renderer as any).lib, "commitSplitFooterSnapshot")
+
+  renderer.suspend()
+  const commitCallsAfterSuspend = splitCommitSpy.mock.calls.length
+  ;(renderer as any).stdout.write("during-suspend\n")
+  renderer.externalOutputMode = "passthrough"
+
+  expect(splitCommitSpy.mock.calls.length).toBe(commitCallsAfterSuspend)
+  expect((renderer as any).externalOutputQueue.size).toBe(1)
+
+  renderer.resume()
+
+  expect(splitCommitSpy.mock.calls.length).toBe(commitCallsAfterSuspend + 1)
+  expect((renderer as any).externalOutputQueue.size).toBe(0)
+  expect(renderer.externalOutputMode).toBe("passthrough")
+
+  splitCommitSpy.mockRestore()
+})
+
+test("CliRenderer preserves captured split output until startup cursor seed unblocks passthrough switch", async () => {
+  const clock = new ManualClock()
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+    clock,
+  })
+
+  renderer = result.renderer
+  const lib = (renderer as any).lib
+  const originalSetupTerminal = lib.setupTerminal.bind(lib)
+  lib.setupTerminal = () => {}
+
+  const splitCommitSpy = spyOn(lib, "commitSplitFooterSnapshot")
+
+  try {
+    await renderer.setupTerminal()
+
+    ;(renderer as any).stdout.write("during-startup\n")
+    renderer.externalOutputMode = "passthrough"
+
+    expect(splitCommitSpy).toHaveBeenCalledTimes(0)
+    expect((renderer as any).externalOutputQueue.size).toBe(1)
+
+    clock.advance(120)
+
+    expect(splitCommitSpy).toHaveBeenCalledTimes(1)
+    expect((renderer as any).externalOutputQueue.size).toBe(0)
+    expect(renderer.externalOutputMode).toBe("passthrough")
+  } finally {
+    lib.setupTerminal = originalSetupTerminal
+    splitCommitSpy.mockRestore()
+  }
+})
+
+test("CliRenderer flushes pending split output on suspend even when startup cursor seeding is pending", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  ;(renderer as any).pendingSplitStartupCursorSeed = true
+  ;(renderer as any).splitStartupSeedTimeoutId = setTimeout(() => {}, 10)
+
+  const order: string[] = []
+  const lib = (renderer as any).lib
+  const originalCommitSplitFooterSnapshot = lib.commitSplitFooterSnapshot.bind(lib)
+  const originalSuspendRenderer = lib.suspendRenderer.bind(lib)
+
+  lib.commitSplitFooterSnapshot = (...args: any[]) => {
+    order.push("split-commit")
+    return originalCommitSplitFooterSnapshot(...args)
+  }
+  lib.suspendRenderer = (...args: any[]) => {
+    order.push("suspend")
+    return originalSuspendRenderer(...args)
+  }
+
+  try {
+    ;(renderer as any).stdout.write("before-suspend\n")
+    renderer.suspend()
+
+    expect(order.indexOf("split-commit")).toBeGreaterThanOrEqual(0)
+    expect(order.indexOf("suspend")).toBeGreaterThanOrEqual(0)
+    expect(order.indexOf("split-commit")).toBeLessThan(order.indexOf("suspend"))
+    expect((renderer as any).externalOutputQueue.size).toBe(0)
+  } finally {
+    if ((renderer as any).splitStartupSeedTimeoutId !== null) {
+      clearTimeout((renderer as any).splitStartupSeedTimeoutId)
+      ;(renderer as any).splitStartupSeedTimeoutId = null
+    }
+    lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
+    lib.suspendRenderer = originalSuspendRenderer
+  }
 })
 
 test("CliRenderer flushes pending writeToScrollback output before suspend", async () => {

--- a/packages/core/src/tests/renderer.scrollback-surface.test.ts
+++ b/packages/core/src/tests/renderer.scrollback-surface.test.ts
@@ -288,6 +288,46 @@ test("ScrollbackSurface captures inline first-line offset at creation", async ()
   expect(text.height).toBe(2)
 })
 
+test("ScrollbackSurface.commitRows defaults to closing committed row chunks", async () => {
+  const { renderer } = await createSplitFooterRenderer({
+    width: 20,
+    height: 6,
+    footerHeight: 3,
+  })
+
+  const surface = renderer.createScrollbackSurface()
+  const text = new TextRenderable(surface.renderContext, {
+    id: "surface-default-newline",
+    content: "closed-row",
+    width: "100%",
+  })
+
+  surface.root.add(text)
+  surface.render()
+  surface.commitRows(0, 1)
+
+  let tailColumn = -1
+  renderer.writeToScrollback((ctx) => {
+    tailColumn = ctx.tailColumn
+    const root = new TextRenderable(ctx.renderContext, {
+      id: "tail-column-probe",
+      content: "next",
+      width: 4,
+      height: 1,
+    })
+
+    return {
+      root,
+      width: 4,
+      height: 1,
+    }
+  })
+
+  expect(tailColumn).toBe(0)
+
+  destroyClaimedCommits(claimCommits(renderer))
+})
+
 test("ScrollbackSurface preserves inline first-line offset when the first markdown block is replaced", async () => {
   const { renderer } = await createSplitFooterRenderer({
     width: 10,

--- a/packages/core/src/tests/renderer.scrollback-surface.test.ts
+++ b/packages/core/src/tests/renderer.scrollback-surface.test.ts
@@ -245,7 +245,7 @@ test("ScrollbackSurface commitRows respects top-level block margins from custom 
 })
 
 test("ScrollbackSurface captures inline first-line offset at creation", async () => {
-  const { renderer } = await createSplitFooterRenderer({
+  const { renderer, renderOnce } = await createSplitFooterRenderer({
     width: 10,
     height: 6,
     footerHeight: 3,
@@ -271,8 +271,7 @@ test("ScrollbackSurface captures inline first-line offset at creation", async ()
     }
   })
 
-  const seededCommits = claimCommits(renderer)
-  destroyClaimedCommits(seededCommits)
+  await renderOnce()
 
   const surface = renderer.createScrollbackSurface({ startOnNewLine: false })
   const text = new TextRenderable(surface.renderContext, {
@@ -329,7 +328,7 @@ test("ScrollbackSurface.commitRows defaults to closing committed row chunks", as
 })
 
 test("ScrollbackSurface preserves inline first-line offset when the first markdown block is replaced", async () => {
-  const { renderer } = await createSplitFooterRenderer({
+  const { renderer, renderOnce } = await createSplitFooterRenderer({
     width: 10,
     height: 6,
     footerHeight: 3,
@@ -355,7 +354,7 @@ test("ScrollbackSurface preserves inline first-line offset when the first markdo
     }
   })
 
-  destroyClaimedCommits(claimCommits(renderer))
+  await renderOnce()
 
   const surface = renderer.createScrollbackSurface({ startOnNewLine: false })
   const mockTreeSitterClient = new MockTreeSitterClient({ autoResolveTimeout: 0 })

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -169,8 +169,12 @@ function getOpenTUILib(libPath?: string) {
       args: ["ptr", "u32"],
       returns: "u32",
     },
+    getSplitOutputOffset: {
+      args: ["ptr", "u32"],
+      returns: "u32",
+    },
     setPendingSplitFooterTransition: {
-      args: ["ptr", "u8", "u32", "u32", "u32", "u32"],
+      args: ["ptr", "u8", "u32", "u32", "u32", "u32", "u32"],
       returns: "void",
     },
     clearPendingSplitFooterTransition: {
@@ -1433,6 +1437,7 @@ export interface RenderLib {
   setRenderOffset: (renderer: Pointer, offset: number) => void
   resetSplitScrollback: (renderer: Pointer, seedRows: number, pinnedRenderOffset: number) => number
   syncSplitScrollback: (renderer: Pointer, pinnedRenderOffset: number) => number
+  getSplitOutputOffset: (renderer: Pointer, surfaceOffset: number) => number
   setPendingSplitFooterTransition: (
     renderer: Pointer,
     mode: number,
@@ -1440,6 +1445,7 @@ export interface RenderLib {
     sourceHeight: number,
     targetTopLine: number,
     targetHeight: number,
+    scrollLines: number,
   ) => void
   clearPendingSplitFooterTransition: (renderer: Pointer) => void
   updateStats: (renderer: Pointer, time: number, fps: number, frameCallbackTime: number) => void
@@ -2120,6 +2126,10 @@ class FFIRenderLib implements RenderLib {
     return this.opentui.symbols.syncSplitScrollback(renderer, pinnedRenderOffset)
   }
 
+  public getSplitOutputOffset(renderer: Pointer, surfaceOffset: number): number {
+    return this.opentui.symbols.getSplitOutputOffset(renderer, surfaceOffset)
+  }
+
   public setPendingSplitFooterTransition(
     renderer: Pointer,
     mode: number,
@@ -2127,6 +2137,7 @@ class FFIRenderLib implements RenderLib {
     sourceHeight: number,
     targetTopLine: number,
     targetHeight: number,
+    scrollLines: number,
   ): void {
     this.opentui.symbols.setPendingSplitFooterTransition(
       renderer,
@@ -2135,6 +2146,7 @@ class FFIRenderLib implements RenderLib {
       sourceHeight,
       targetTopLine,
       targetHeight,
+      scrollLines,
     )
   }
 

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -252,6 +252,10 @@ export fn syncSplitScrollback(rendererPtr: *renderer.CliRenderer, pinnedRenderOf
     return rendererPtr.syncSplitScrollback(pinnedRenderOffset);
 }
 
+export fn getSplitOutputOffset(rendererPtr: *renderer.CliRenderer, surfaceOffset: u32) u32 {
+    return rendererPtr.getSplitOutputOffset(surfaceOffset);
+}
+
 export fn setPendingSplitFooterTransition(
     rendererPtr: *renderer.CliRenderer,
     mode: u8,
@@ -259,6 +263,7 @@ export fn setPendingSplitFooterTransition(
     sourceHeight: u32,
     targetTopLine: u32,
     targetHeight: u32,
+    scrollLines: u32,
 ) void {
     rendererPtr.setPendingSplitFooterTransition(
         @enumFromInt(mode),
@@ -266,6 +271,7 @@ export fn setPendingSplitFooterTransition(
         sourceHeight,
         targetTopLine,
         targetHeight,
+        scrollLines,
     );
 }
 

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -75,6 +75,7 @@ const SplitFooterTransition = struct {
     source_height: u32 = 0,
     target_top_line: u32 = 0,
     target_height: u32 = 0,
+    scroll_lines: u32 = 0,
 
     fn clear(self: *SplitFooterTransition) void {
         self.* = .{};
@@ -694,6 +695,15 @@ pub const CliRenderer = struct {
         self.renderOffset = offset;
     }
 
+    fn splitOutputOffset(self: *const CliRenderer, surface_offset: u32) u32 {
+        return self.splitScrollback.renderOffset(surface_offset);
+    }
+
+    fn clampSplitSurfaceOffset(self: *const CliRenderer, surface_offset: u32, pinned_render_offset: u32) u32 {
+        const output_offset = self.splitOutputOffset(pinned_render_offset);
+        return std.math.clamp(surface_offset, output_offset, pinned_render_offset);
+    }
+
     pub fn resetSplitScrollback(self: *CliRenderer, seed_rows: u32, pinned_render_offset: u32) u32 {
         self.splitScrollback.reset(seed_rows);
         self.renderOffset = self.splitScrollback.renderOffset(pinned_render_offset);
@@ -701,8 +711,12 @@ pub const CliRenderer = struct {
     }
 
     pub fn syncSplitScrollback(self: *CliRenderer, pinned_render_offset: u32) u32 {
-        self.renderOffset = self.splitScrollback.renderOffset(pinned_render_offset);
+        self.renderOffset = self.clampSplitSurfaceOffset(self.renderOffset, pinned_render_offset);
         return self.renderOffset;
+    }
+
+    pub fn getSplitOutputOffset(self: *CliRenderer, surface_offset: u32) u32 {
+        return self.splitOutputOffset(surface_offset);
     }
 
     pub fn setPendingSplitFooterTransition(
@@ -712,6 +726,7 @@ pub const CliRenderer = struct {
         source_height: u32,
         target_top_line: u32,
         target_height: u32,
+        scroll_lines: u32,
     ) void {
         self.pendingSplitFooterTransition = .{
             .mode = mode,
@@ -719,6 +734,7 @@ pub const CliRenderer = struct {
             .source_height = source_height,
             .target_top_line = target_top_line,
             .target_height = target_height,
+            .scroll_lines = scroll_lines,
         };
     }
 
@@ -741,10 +757,16 @@ pub const CliRenderer = struct {
 
         switch (transition.mode) {
             .viewport_scroll => {
-                if (transition.source_height > transition.target_height) {
-                    writer.print("\x1b[{d}T", .{transition.source_height - transition.target_height}) catch {};
-                } else if (transition.source_height < transition.target_height) {
-                    writer.print("\x1b[{d}S", .{transition.target_height - transition.source_height}) catch {};
+                if (transition.scroll_lines == 0) {
+                    return;
+                }
+
+                self.splitScrollback.noteViewportScroll(transition.scroll_lines);
+
+                if (transition.source_top_line < transition.target_top_line) {
+                    writer.print("\x1b[{d}T", .{transition.scroll_lines}) catch {};
+                } else if (transition.source_top_line > transition.target_top_line) {
+                    writer.print("\x1b[{d}S", .{transition.scroll_lines}) catch {};
                 }
             },
             .clear_stale_rows => {
@@ -993,7 +1015,7 @@ pub const CliRenderer = struct {
         force: bool,
     ) void {
         const previousRenderOffset = self.renderOffset;
-        const next_render_offset = self.splitScrollback.renderOffset(pinned_render_offset);
+        const next_render_offset = self.clampSplitSurfaceOffset(previousRenderOffset, pinned_render_offset);
         const redraw_footer = force or previousRenderOffset != next_render_offset;
 
         self.renderOffset = next_render_offset;
@@ -1142,13 +1164,14 @@ pub const CliRenderer = struct {
         pinned_render_offset: u32,
         force: bool,
     ) bool {
-        const previousRenderOffset = self.renderOffset;
+        const previousSurfaceOffset = self.renderOffset;
+        const previousOutputOffset = self.splitOutputOffset(previousSurfaceOffset);
         const previousOutputColumn = self.splitScrollback.tail_column;
         const snapshot_has_content = snapshot.width > 0 and snapshot.height > 0;
         const normalized_row_columns = @min(row_columns, snapshot.width);
         const starts_mid_line = previousOutputColumn > 0 and start_on_new_line;
         const starts_wrapped_line = previousOutputColumn >= self.width;
-        const previousFooterTopLine: u32 = @max(previousRenderOffset + 1, @as(u32, 1));
+        const previousFooterTopLine: u32 = @max(previousSurfaceOffset + 1, @as(u32, 1));
 
         if (snapshot_has_content) {
             // First update logical split scrollback state, then emit terminal I/O.
@@ -1165,19 +1188,23 @@ pub const CliRenderer = struct {
                     row + 1 < snapshot.height or trailing_newline,
                 );
             }
+
+            self.splitScrollback.published_rows = @min(self.splitScrollback.published_rows, pinned_render_offset);
         }
 
-        const next_render_offset = self.splitScrollback.renderOffset(pinned_render_offset);
+        const next_output_offset = self.splitScrollback.renderOffset(pinned_render_offset);
+        const next_render_offset = self.clampSplitSurfaceOffset(previousSurfaceOffset, pinned_render_offset);
         const targetFooterTopLine: u32 = @max(next_render_offset + 1, @as(u32, 1));
         // Footer redraw is only needed when offset changes (settling/pinning) or
         // when an explicit force was requested by the caller.
-        const redraw_footer = force or previousRenderOffset != next_render_offset;
+        const redraw_footer = force or previousSurfaceOffset != next_render_offset;
         // When split scrollback is settled at the pinned boundary, newlines/wraps from
         // appended output must scroll only the upper pane. Without a temporary DECSTBM
         // region, terminals advance into the footer rows and overwrite them in place.
         const use_bounded_scroll_region = snapshot_has_content and
             pinned_render_offset > 0 and
-            next_render_offset == pinned_render_offset;
+            next_render_offset == pinned_render_offset and
+            next_output_offset == next_render_offset;
 
         if (snapshot_has_content or force) {
             if (snapshot_has_content) {
@@ -1199,7 +1226,7 @@ pub const CliRenderer = struct {
                     writer.print("\x1b[1;{d}r", .{pinned_render_offset}) catch {};
                 }
 
-                moveToSplitOutputCursor(writer, previousRenderOffset, previousOutputColumn, self.width);
+                moveToSplitOutputCursor(writer, previousOutputOffset, previousOutputColumn, self.width);
                 if (starts_mid_line or starts_wrapped_line) {
                     // The prior commit left output cursor mid-row and caller asked
                     // for newline anchoring. When the prior commit exactly filled the

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -1014,8 +1014,15 @@ pub const CliRenderer = struct {
         pinned_render_offset: u32,
         force: bool,
     ) void {
+        const transition = self.pendingSplitFooterTransition;
+        const hasPendingViewportTarget = transition.mode == .viewport_scroll and
+            transition.target_top_line > 0 and
+            transition.scroll_lines > 0;
         const previousRenderOffset = self.renderOffset;
-        const next_render_offset = self.clampSplitSurfaceOffset(previousRenderOffset, pinned_render_offset);
+        const next_render_offset = if (hasPendingViewportTarget)
+            transition.target_top_line - 1
+        else
+            self.clampSplitSurfaceOffset(previousRenderOffset, pinned_render_offset);
         const redraw_footer = force or previousRenderOffset != next_render_offset;
 
         self.renderOffset = next_render_offset;

--- a/packages/core/src/zig/split-scrollback.zig
+++ b/packages/core/src/zig/split-scrollback.zig
@@ -7,12 +7,19 @@ pub const SplitScrollback = struct {
         self.tail_column = 0;
     }
 
-    pub fn renderOffset(self: *const SplitScrollback, pinned_render_offset: u32) u32 {
-        if (pinned_render_offset == 0) {
+    pub fn renderOffset(self: *const SplitScrollback, surface_offset: u32) u32 {
+        if (surface_offset == 0) {
             return 0;
         }
 
-        return @min(self.published_rows, pinned_render_offset);
+        return @min(self.published_rows, surface_offset);
+    }
+
+    pub fn noteViewportScroll(self: *SplitScrollback, lines: u32) void {
+        self.published_rows = self.published_rows - @min(lines, self.published_rows);
+        if (self.published_rows == 0) {
+            self.tail_column = 0;
+        }
     }
 
     pub fn noteNewline(self: *SplitScrollback) void {

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -1642,7 +1642,7 @@ test "renderer - repaintSplitFooter applies pending viewport scroll transition i
 
     _ = cli_renderer.resetSplitScrollback(4, 4);
     cli_renderer.setRenderOffset(3);
-    cli_renderer.setPendingSplitFooterTransition(.viewport_scroll, 4, 2, 5, 1);
+    cli_renderer.setPendingSplitFooterTransition(.viewport_scroll, 4, 2, 5, 1, 1);
 
     const next_buffer = cli_renderer.getNextBuffer();
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
@@ -1668,6 +1668,39 @@ test "renderer - repaintSplitFooter applies pending viewport scroll transition i
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, output, ansi.ANSI.syncReset));
 }
 
+test "renderer - repaintSplitFooter viewport scroll uses explicit split scroll delta when gap already exists" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var cli_renderer = try CliRenderer.create(
+        std.testing.allocator,
+        12,
+        8,
+        pool,
+        true,
+    );
+    defer cli_renderer.destroy();
+
+    _ = cli_renderer.resetSplitScrollback(6, 6);
+    cli_renderer.splitScrollback.noteViewportScroll(2);
+    cli_renderer.setRenderOffset(6);
+    cli_renderer.setPendingSplitFooterTransition(.viewport_scroll, 7, 4, 3, 8, 2);
+
+    const next_buffer = cli_renderer.getNextBuffer();
+    const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
+    const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
+    try next_buffer.drawText("FOOT", 0, 0, fg, bg, 0);
+
+    _ = cli_renderer.repaintSplitFooter(2, true);
+
+    const output = cli_renderer.getLastOutputForTest();
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[2S") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "\x1b[4S") == null);
+    try std.testing.expectEqual(@as(u32, 2), cli_renderer.getSplitOutputOffset(2));
+}
+
 test "renderer - repaintSplitFooter applies pending stale row clear transition in one frame" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
@@ -1684,7 +1717,7 @@ test "renderer - repaintSplitFooter applies pending stale row clear transition i
     defer cli_renderer.destroy();
 
     _ = cli_renderer.resetSplitScrollback(1, 7);
-    cli_renderer.setPendingSplitFooterTransition(.clear_stale_rows, 2, 4, 2, 3);
+    cli_renderer.setPendingSplitFooterTransition(.clear_stale_rows, 2, 4, 2, 3, 0);
 
     const next_buffer = cli_renderer.getNextBuffer();
     const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);

--- a/packages/core/src/zig/tests/split-scrollback_test.zig
+++ b/packages/core/src/zig/tests/split-scrollback_test.zig
@@ -22,6 +22,21 @@ test "split scrollback reset seeds pinned rows" {
     try std.testing.expectEqual(@as(u32, 1), scrollback.tail_column);
 }
 
+test "split scrollback render offset preserves growth-created gap until output fills it" {
+    var scrollback: split_scrollback.SplitScrollback = .{};
+
+    scrollback.reset(7);
+    scrollback.noteViewportScroll(5);
+
+    try std.testing.expectEqual(@as(u32, 2), scrollback.renderOffset(2));
+    try std.testing.expectEqual(@as(u32, 2), scrollback.renderOffset(7));
+
+    scrollback.noteNewline();
+    scrollback.noteNewline();
+
+    try std.testing.expectEqual(@as(u32, 4), scrollback.renderOffset(7));
+}
+
 test "split scrollback snapshot rows start at line boundary" {
     var scrollback: split_scrollback.SplitScrollback = .{};
 

--- a/packages/solid/src/elements/slot.ts
+++ b/packages/solid/src/elements/slot.ts
@@ -61,13 +61,29 @@ export class TextSlotRenderable extends TextNodeRenderable {
     this.slotParent = parent
   }
 
+  public detachFromSlot(): void {
+    this.slotParent = undefined
+  }
+
+  public disposeWithoutSlotCascade(): void {
+    if (this.destroyed) {
+      return
+    }
+
+    this.destroyed = true
+    this.detachFromSlot()
+  }
+
   public override destroy(): void {
     if (this.destroyed) {
       return
     }
     this.destroyed = true
 
-    this.slotParent?.destroy()
+    const slotParent = this.slotParent
+    this.slotParent = undefined
+
+    slotParent?.destroy()
     super.destroy()
   }
 }
@@ -77,6 +93,7 @@ export class LayoutSlotRenderable extends SlotBaseRenderable {
   protected slotParent?: SlotRenderable
   protected destroyed: boolean = false
   private yogaNodeConstructor: LayoutNodeConstructor
+  private yogaNodeFreed: boolean = false
 
   constructor(id: string, parent?: SlotRenderable, layoutParent?: BaseRenderable) {
     super(id)
@@ -102,10 +119,30 @@ export class LayoutSlotRenderable extends SlotBaseRenderable {
     return this.yogaNodeConstructor === getLayoutNodeConstructor(layoutParent)
   }
 
-  public disposeDetachedLayoutNode(): void {
+  public detachFromSlot(): void {
+    this.slotParent = undefined
+  }
+
+  private freeYogaNode(): void {
+    if (this.yogaNodeFreed) {
+      return
+    }
+
+    this.yogaNodeFreed = true
+
     try {
       this.yogaNode.free()
     } catch {}
+  }
+
+  public disposeWithoutSlotCascade(): void {
+    if (this.destroyed) {
+      return
+    }
+
+    this.destroyed = true
+    this.detachFromSlot()
+    this.freeYogaNode()
   }
 
   public override destroy(): void {
@@ -114,15 +151,20 @@ export class LayoutSlotRenderable extends SlotBaseRenderable {
     }
     this.destroyed = true
 
-    super.destroy()
-    this.slotParent?.destroy()
+    const slotParent = this.slotParent
+    this.slotParent = undefined
+
+    this.freeYogaNode()
+    slotParent?.destroy()
   }
 }
 
 export class SlotRenderable extends SlotBaseRenderable {
-  layoutNode?: LayoutSlotRenderable
-  textNode?: TextSlotRenderable
   protected destroyed: boolean = false
+  private readonly layoutNodesByParent = new Map<BaseRenderable, LayoutSlotRenderable>()
+  private readonly textNodesByParent = new Map<BaseRenderable, TextSlotRenderable>()
+  private layoutNodeCount: number = 0
+  private textNodeCount: number = 0
 
   constructor(id: string) {
     super(id)
@@ -130,23 +172,192 @@ export class SlotRenderable extends SlotBaseRenderable {
     this._visible = false
   }
 
-  getSlotChild(parent: BaseRenderable) {
-    if (isTextNodeRenderable(parent) || parent instanceof TextRenderable) {
-      if (!this.textNode) {
-        this.textNode = new TextSlotRenderable(`slot-text-${this.id}`, this)
+  public get layoutNode(): LayoutSlotRenderable | undefined {
+    return this.getCurrentSlotChild(this.layoutNodesByParent)
+  }
+
+  public get textNode(): TextSlotRenderable | undefined {
+    return this.getCurrentSlotChild(this.textNodesByParent)
+  }
+
+  private isTextSlotParent(parent: BaseRenderable): boolean {
+    return isTextNodeRenderable(parent) || parent instanceof TextRenderable
+  }
+
+  private getCurrentSlotChild<T extends BaseRenderable>(nodesByParent: Map<BaseRenderable, T>): T | undefined {
+    for (const node of nodesByParent.values()) {
+      if (node.parent) {
+        return node
       }
-      return this.textNode
     }
 
-    if (this.layoutNode && !this.layoutNode.parent && !this.layoutNode.isCompatibleWith(parent)) {
-      this.layoutNode.disposeDetachedLayoutNode()
-      this.layoutNode = undefined
+    return nodesByParent.values().next().value
+  }
+
+  private getTextNodeForParent(parent: BaseRenderable): TextSlotRenderable | undefined {
+    const mappedNode = this.textNodesByParent.get(parent)
+    if (mappedNode) {
+      return mappedNode
     }
 
-    if (!this.layoutNode) {
-      this.layoutNode = new LayoutSlotRenderable(`slot-layout-${this.id}`, this, parent)
+    for (const [mappedParent, textNode] of this.textNodesByParent) {
+      if (textNode.parent !== parent) {
+        continue
+      }
+
+      this.textNodesByParent.delete(mappedParent)
+      this.textNodesByParent.set(parent, textNode)
+      return textNode
     }
-    return this.layoutNode
+  }
+
+  private getLayoutNodeForParent(parent: BaseRenderable): LayoutSlotRenderable | undefined {
+    const mappedNode = this.layoutNodesByParent.get(parent)
+    if (mappedNode) {
+      return mappedNode
+    }
+
+    for (const [mappedParent, layoutNode] of this.layoutNodesByParent) {
+      if (layoutNode.parent !== parent) {
+        continue
+      }
+
+      this.layoutNodesByParent.delete(mappedParent)
+      this.layoutNodesByParent.set(parent, layoutNode)
+      return layoutNode
+    }
+  }
+
+  private takeReusableTextNode(parent: BaseRenderable): TextSlotRenderable | undefined {
+    for (const [mappedParent, textNode] of this.textNodesByParent) {
+      if (textNode.parent) {
+        continue
+      }
+
+      this.textNodesByParent.delete(mappedParent)
+      this.textNodesByParent.set(parent, textNode)
+      return textNode
+    }
+  }
+
+  private takeReusableLayoutNode(parent: BaseRenderable): LayoutSlotRenderable | undefined {
+    for (const [mappedParent, layoutNode] of this.layoutNodesByParent) {
+      if (layoutNode.parent) {
+        continue
+      }
+
+      if (!layoutNode.isCompatibleWith(parent)) {
+        continue
+      }
+
+      this.layoutNodesByParent.delete(mappedParent)
+      this.layoutNodesByParent.set(parent, layoutNode)
+      return layoutNode
+    }
+  }
+
+  private disposeDetachedTextNodes(): void {
+    for (const [parent, textNode] of this.textNodesByParent) {
+      if (textNode.parent) {
+        continue
+      }
+
+      this.textNodesByParent.delete(parent)
+      textNode.disposeWithoutSlotCascade()
+    }
+  }
+
+  private disposeDetachedIncompatibleLayoutNodes(parent: BaseRenderable): void {
+    for (const [mappedParent, layoutNode] of this.layoutNodesByParent) {
+      if (layoutNode.parent || layoutNode.isCompatibleWith(parent)) {
+        continue
+      }
+
+      this.layoutNodesByParent.delete(mappedParent)
+      layoutNode.disposeWithoutSlotCascade()
+    }
+  }
+
+  private hasOtherAttachedSlotChildren(excludedNode: BaseRenderable): boolean {
+    for (const textNode of this.textNodesByParent.values()) {
+      if (textNode !== excludedNode && textNode.parent) {
+        return true
+      }
+    }
+
+    for (const layoutNode of this.layoutNodesByParent.values()) {
+      if (layoutNode !== excludedNode && layoutNode.parent) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  getSlotChild(parent: BaseRenderable) {
+    if (this.isTextSlotParent(parent)) {
+      const existingTextNode = this.getTextNodeForParent(parent)
+      if (existingTextNode) {
+        return existingTextNode
+      }
+
+      const reusableTextNode = this.takeReusableTextNode(parent)
+      if (reusableTextNode) {
+        return reusableTextNode
+      }
+
+      this.disposeDetachedIncompatibleLayoutNodes(parent)
+
+      const textNode = new TextSlotRenderable(`slot-text-${this.id}-${++this.textNodeCount}`, this)
+      this.textNodesByParent.set(parent, textNode)
+      return textNode
+    }
+
+    const existingLayoutNode = this.getLayoutNodeForParent(parent)
+    if (existingLayoutNode) {
+      return existingLayoutNode
+    }
+
+    const reusableLayoutNode = this.takeReusableLayoutNode(parent)
+    if (reusableLayoutNode) {
+      return reusableLayoutNode
+    }
+
+    this.disposeDetachedTextNodes()
+    this.disposeDetachedIncompatibleLayoutNodes(parent)
+
+    const layoutNode = new LayoutSlotRenderable(`slot-layout-${this.id}-${++this.layoutNodeCount}`, this, parent)
+    this.layoutNodesByParent.set(parent, layoutNode)
+    return layoutNode
+  }
+
+  getSlotChildForRemoval(parent: BaseRenderable): BaseRenderable | undefined {
+    if (this.isTextSlotParent(parent)) {
+      return this.getTextNodeForParent(parent)
+    }
+
+    return this.getLayoutNodeForParent(parent)
+  }
+
+  didRemoveSlotChild(parent: BaseRenderable, child: BaseRenderable): void {
+    if (this.parent === parent) {
+      this.parent = null
+    }
+
+    if (!this.hasOtherAttachedSlotChildren(child)) {
+      return
+    }
+
+    if (child instanceof TextSlotRenderable && this.getTextNodeForParent(parent) === child) {
+      this.textNodesByParent.delete(parent)
+      child.disposeWithoutSlotCascade()
+      return
+    }
+
+    if (child instanceof LayoutSlotRenderable && this.getLayoutNodeForParent(parent) === child) {
+      this.layoutNodesByParent.delete(parent)
+      child.disposeWithoutSlotCascade()
+    }
   }
 
   public override destroy(): void {
@@ -155,14 +366,15 @@ export class SlotRenderable extends SlotBaseRenderable {
     }
     this.destroyed = true
 
-    if (this.layoutNode) {
-      const layoutNode = this.layoutNode
-      this.layoutNode = undefined
+    const layoutNodes = new Set(this.layoutNodesByParent.values())
+    this.layoutNodesByParent.clear()
+    for (const layoutNode of layoutNodes) {
       layoutNode.destroy()
     }
-    if (this.textNode) {
-      const textNode = this.textNode
-      this.textNode = undefined
+
+    const textNodes = new Set(this.textNodesByParent.values())
+    this.textNodesByParent.clear()
+    for (const textNode of textNodes) {
       textNode.destroy()
     }
   }

--- a/packages/solid/src/elements/slot.ts
+++ b/packages/solid/src/elements/slot.ts
@@ -4,10 +4,14 @@ type LayoutNodeProvider = {
   getLayoutNode?: () => Yoga.Node
 }
 
-function createLayoutSlotYogaNode(parent?: BaseRenderable): Yoga.Node {
-  const parentLayoutNode = (parent as LayoutNodeProvider | undefined)?.getLayoutNode?.()
-  const parentNodeConstructor = parentLayoutNode?.constructor as { create?: () => Yoga.Node } | undefined
+type LayoutNodeConstructor = { create?: () => Yoga.Node } | undefined
 
+function getLayoutNodeConstructor(parent?: BaseRenderable): LayoutNodeConstructor {
+  const parentLayoutNode = (parent as LayoutNodeProvider | undefined)?.getLayoutNode?.()
+  return parentLayoutNode?.constructor as LayoutNodeConstructor
+}
+
+function createLayoutSlotYogaNode(parentNodeConstructor?: LayoutNodeConstructor): Yoga.Node {
   return parentNodeConstructor?.create?.() ?? Yoga.default.Node.create()
 }
 
@@ -72,13 +76,15 @@ export class LayoutSlotRenderable extends SlotBaseRenderable {
   protected yogaNode: Yoga.Node
   protected slotParent?: SlotRenderable
   protected destroyed: boolean = false
+  private yogaNodeConstructor: LayoutNodeConstructor
 
   constructor(id: string, parent?: SlotRenderable, layoutParent?: BaseRenderable) {
     super(id)
 
     this._visible = false
     this.slotParent = parent
-    this.yogaNode = createLayoutSlotYogaNode(layoutParent)
+    this.yogaNodeConstructor = getLayoutNodeConstructor(layoutParent)
+    this.yogaNode = createLayoutSlotYogaNode(this.yogaNodeConstructor)
     this.yogaNode.setDisplay(Yoga.Display.None)
   }
 
@@ -91,6 +97,16 @@ export class LayoutSlotRenderable extends SlotBaseRenderable {
   public updateLayout() {}
 
   public onRemove() {}
+
+  public isCompatibleWith(layoutParent?: BaseRenderable): boolean {
+    return this.yogaNodeConstructor === getLayoutNodeConstructor(layoutParent)
+  }
+
+  public disposeDetachedLayoutNode(): void {
+    try {
+      this.yogaNode.free()
+    } catch {}
+  }
 
   public override destroy(): void {
     if (this.destroyed) {
@@ -122,6 +138,11 @@ export class SlotRenderable extends SlotBaseRenderable {
       return this.textNode
     }
 
+    if (this.layoutNode && !this.layoutNode.parent && !this.layoutNode.isCompatibleWith(parent)) {
+      this.layoutNode.disposeDetachedLayoutNode()
+      this.layoutNode = undefined
+    }
+
     if (!this.layoutNode) {
       this.layoutNode = new LayoutSlotRenderable(`slot-layout-${this.id}`, this, parent)
     }
@@ -135,10 +156,14 @@ export class SlotRenderable extends SlotBaseRenderable {
     this.destroyed = true
 
     if (this.layoutNode) {
-      this.layoutNode.destroy()
+      const layoutNode = this.layoutNode
+      this.layoutNode = undefined
+      layoutNode.destroy()
     }
     if (this.textNode) {
-      this.textNode.destroy()
+      const textNode = this.textNode
+      this.textNode = undefined
+      textNode.destroy()
     }
   }
 }

--- a/packages/solid/src/elements/slot.ts
+++ b/packages/solid/src/elements/slot.ts
@@ -278,20 +278,27 @@ export class SlotRenderable extends SlotBaseRenderable {
     }
   }
 
-  private hasOtherAttachedSlotChildren(excludedNode: BaseRenderable): boolean {
+  // A slot can have multiple placeholder children attached transiently while a
+  // move is in flight. Portal host tracking relies on `slot.parent` pointing at
+  // one of the still-live hosts, not necessarily the most recently inserted one.
+  private getAttachedSlotParent(excludedNode?: BaseRenderable): BaseRenderable | null {
     for (const textNode of this.textNodesByParent.values()) {
       if (textNode !== excludedNode && textNode.parent) {
-        return true
+        return textNode.parent
       }
     }
 
     for (const layoutNode of this.layoutNodesByParent.values()) {
       if (layoutNode !== excludedNode && layoutNode.parent) {
-        return true
+        return layoutNode.parent
       }
     }
 
-    return false
+    return null
+  }
+
+  private hasOtherAttachedSlotChildren(excludedNode: BaseRenderable): boolean {
+    return this.getAttachedSlotParent(excludedNode) !== null
   }
 
   getSlotChild(parent: BaseRenderable) {
@@ -340,23 +347,20 @@ export class SlotRenderable extends SlotBaseRenderable {
   }
 
   didRemoveSlotChild(parent: BaseRenderable, child: BaseRenderable): void {
-    if (this.parent === parent) {
-      this.parent = null
-    }
+    const hasOtherAttachedSlotChildren = this.hasOtherAttachedSlotChildren(child)
 
-    if (!this.hasOtherAttachedSlotChildren(child)) {
-      return
-    }
-
-    if (child instanceof TextSlotRenderable && this.getTextNodeForParent(parent) === child) {
+    if (hasOtherAttachedSlotChildren && child instanceof TextSlotRenderable && this.getTextNodeForParent(parent) === child) {
       this.textNodesByParent.delete(parent)
       child.disposeWithoutSlotCascade()
-      return
     }
 
-    if (child instanceof LayoutSlotRenderable && this.getLayoutNodeForParent(parent) === child) {
+    if (hasOtherAttachedSlotChildren && child instanceof LayoutSlotRenderable && this.getLayoutNodeForParent(parent) === child) {
       this.layoutNodesByParent.delete(parent)
       child.disposeWithoutSlotCascade()
+    }
+
+    if (this.parent === parent) {
+      this.parent = this.getAttachedSlotParent(child)
     }
   }
 

--- a/packages/solid/src/elements/slot.ts
+++ b/packages/solid/src/elements/slot.ts
@@ -1,5 +1,16 @@
 import { BaseRenderable, isTextNodeRenderable, TextNodeRenderable, TextRenderable, Yoga } from "@opentui/core"
 
+type LayoutNodeProvider = {
+  getLayoutNode?: () => Yoga.Node
+}
+
+function createLayoutSlotYogaNode(parent?: BaseRenderable): Yoga.Node {
+  const parentLayoutNode = (parent as LayoutNodeProvider | undefined)?.getLayoutNode?.()
+  const parentNodeConstructor = parentLayoutNode?.constructor as { create?: () => Yoga.Node } | undefined
+
+  return parentNodeConstructor?.create?.() ?? Yoga.default.Node.create()
+}
+
 class SlotBaseRenderable extends BaseRenderable {
   constructor(id: string) {
     super({
@@ -62,12 +73,12 @@ export class LayoutSlotRenderable extends SlotBaseRenderable {
   protected slotParent?: SlotRenderable
   protected destroyed: boolean = false
 
-  constructor(id: string, parent?: SlotRenderable) {
+  constructor(id: string, parent?: SlotRenderable, layoutParent?: BaseRenderable) {
     super(id)
 
     this._visible = false
     this.slotParent = parent
-    this.yogaNode = Yoga.default.Node.create()
+    this.yogaNode = createLayoutSlotYogaNode(layoutParent)
     this.yogaNode.setDisplay(Yoga.Display.None)
   }
 
@@ -112,7 +123,7 @@ export class SlotRenderable extends SlotBaseRenderable {
     }
 
     if (!this.layoutNode) {
-      this.layoutNode = new LayoutSlotRenderable(`slot-layout-${this.id}`, this)
+      this.layoutNode = new LayoutSlotRenderable(`slot-layout-${this.id}`, this, parent)
     }
     return this.layoutNode
   }

--- a/packages/solid/src/elements/slot.ts
+++ b/packages/solid/src/elements/slot.ts
@@ -349,12 +349,20 @@ export class SlotRenderable extends SlotBaseRenderable {
   didRemoveSlotChild(parent: BaseRenderable, child: BaseRenderable): void {
     const hasOtherAttachedSlotChildren = this.hasOtherAttachedSlotChildren(child)
 
-    if (hasOtherAttachedSlotChildren && child instanceof TextSlotRenderable && this.getTextNodeForParent(parent) === child) {
+    if (
+      hasOtherAttachedSlotChildren &&
+      child instanceof TextSlotRenderable &&
+      this.getTextNodeForParent(parent) === child
+    ) {
       this.textNodesByParent.delete(parent)
       child.disposeWithoutSlotCascade()
     }
 
-    if (hasOtherAttachedSlotChildren && child instanceof LayoutSlotRenderable && this.getLayoutNodeForParent(parent) === child) {
+    if (
+      hasOtherAttachedSlotChildren &&
+      child instanceof LayoutSlotRenderable &&
+      this.getLayoutNodeForParent(parent) === child
+    ) {
       this.layoutNodesByParent.delete(parent)
       child.disposeWithoutSlotCascade()
     }

--- a/packages/solid/src/reconciler.ts
+++ b/packages/solid/src/reconciler.ts
@@ -111,12 +111,24 @@ function _insertNode(parent: DomNode, node: DomNode, anchor?: DomNode): void {
 function _removeNode(parent: DomNode, node: DomNode): void {
   log("Removing node:", logId(node), "from parent:", logId(parent))
 
+  let slotParent: SlotRenderable | undefined
+
   if (node instanceof SlotRenderable) {
-    node.parent = null
-    node = node.getSlotChild(parent)
+    slotParent = node
+    const slotChild = slotParent.getSlotChildForRemoval(parent)
+    if (!slotChild) {
+      if (slotParent.parent === parent) {
+        slotParent.parent = null
+      }
+      return
+    }
+
+    node = slotChild
   }
 
   parent.remove(node.id)
+
+  slotParent?.didRemoveSlotChild(parent, node)
 
   process.nextTick(() => {
     if (node instanceof BaseRenderable && !node.parent) {

--- a/packages/solid/tests/slot-reconciler-move.test.ts
+++ b/packages/solid/tests/slot-reconciler-move.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "bun:test"
+import { BoxRenderable, Yoga } from "@opentui/core"
+import { createTestRenderer } from "@opentui/core/testing"
+import { batch, createRoot, createSignal } from "solid-js"
+import { createSlotNode, insert } from "../index.js"
+
+type MoveOrder = "remove-then-insert" | "insert-then-remove"
+
+function assignDistinctLayoutConstructor(parent: BoxRenderable): void {
+  const layoutNode = parent.getLayoutNode() as Yoga.Node & { constructor?: { create?: () => Yoga.Node } }
+
+  Object.defineProperty(layoutNode, "constructor", {
+    value: { create: () => Yoga.default.Node.create() },
+    configurable: true,
+  })
+}
+
+async function runMoveScenario(order: MoveOrder) {
+  const setup = await createTestRenderer({ width: 40, height: 10 })
+  const parentA = new BoxRenderable(setup.renderer, {
+    id: `slot-parent-a-${order}`,
+    width: 10,
+    height: 1,
+  })
+  const parentB = new BoxRenderable(setup.renderer, {
+    id: `slot-parent-b-${order}`,
+    width: 10,
+    height: 1,
+  })
+
+  setup.renderer.root.add(parentA)
+  setup.renderer.root.add(parentB)
+  assignDistinctLayoutConstructor(parentA)
+  assignDistinctLayoutConstructor(parentB)
+
+  const slot = createSlotNode()
+  const controls = createRoot((dispose) => {
+    const [inParentA, setInParentA] = createSignal(true)
+    const [inParentB, setInParentB] = createSignal(false)
+
+    const mountInParentA = () => (inParentA() ? slot : null)
+    const mountInParentB = () => (inParentB() ? slot : null)
+
+    if (order === "remove-then-insert") {
+      insert(parentA, mountInParentA)
+      insert(parentB, mountInParentB)
+    } else {
+      insert(parentB, mountInParentB)
+      insert(parentA, mountInParentA)
+    }
+
+    return {
+      dispose,
+      move(): void {
+        batch(() => {
+          setInParentB(true)
+          setInParentA(false)
+        })
+      },
+    }
+  })
+
+  const originalChild = parentA.getChildren()[0]
+  if (!originalChild) {
+    throw new Error(`Expected slot child in parent A for ${order}`)
+  }
+
+  controls.move()
+
+  const movedChild = parentB.getChildren()[0]
+  if (!movedChild) {
+    throw new Error(`Expected slot child in parent B for ${order}`)
+  }
+
+  await Bun.sleep(0)
+
+  return {
+    controls,
+    movedChild,
+    originalChild,
+    parentA,
+    parentB,
+    setup,
+    slot,
+  }
+}
+
+describe("slot placeholder moves", () => {
+  it("recreates incompatible layout placeholders for remove-then-insert moves", async () => {
+    const { controls, movedChild, originalChild, parentA, parentB, setup, slot } = await runMoveScenario(
+      "remove-then-insert",
+    )
+
+    try {
+      expect(movedChild).not.toBe(originalChild)
+      expect(parentA.getChildren()).toHaveLength(0)
+      expect(parentB.getChildren()).toHaveLength(1)
+      expect(parentB.getChildren()[0]).toBe(movedChild)
+      expect(movedChild.parent).toBe(parentB)
+      expect((movedChild as any).destroyed).toBe(false)
+      expect((slot as any).destroyed).toBe(false)
+    } finally {
+      controls.dispose()
+      setup.renderer.destroy()
+    }
+  })
+
+  it("recreates incompatible layout placeholders for insert-then-remove moves", async () => {
+    const { controls, movedChild, originalChild, parentA, parentB, setup, slot } = await runMoveScenario(
+      "insert-then-remove",
+    )
+
+    try {
+      expect(movedChild).not.toBe(originalChild)
+      expect(parentA.getChildren()).toHaveLength(0)
+      expect(parentB.getChildren()).toHaveLength(1)
+      expect(parentB.getChildren()[0]).toBe(movedChild)
+      expect(movedChild.parent).toBe(parentB)
+      expect((movedChild as any).destroyed).toBe(false)
+      expect((slot as any).destroyed).toBe(false)
+    } finally {
+      controls.dispose()
+      setup.renderer.destroy()
+    }
+  })
+})

--- a/packages/solid/tests/slot-reconciler-move.test.ts
+++ b/packages/solid/tests/slot-reconciler-move.test.ts
@@ -123,4 +123,44 @@ describe("slot placeholder moves", () => {
       setup.renderer.destroy()
     }
   })
+
+  it("promotes slot.parent back to another attached host when the newest placeholder is removed", async () => {
+    const setup = await createTestRenderer({ width: 40, height: 10 })
+    const parentA = new BoxRenderable(setup.renderer, {
+      id: "slot-parent-host-a",
+      width: 10,
+      height: 1,
+    })
+    const parentB = new BoxRenderable(setup.renderer, {
+      id: "slot-parent-host-b",
+      width: 10,
+      height: 1,
+    })
+
+    setup.renderer.root.add(parentA)
+    setup.renderer.root.add(parentB)
+
+    const slot = createSlotNode()
+
+    try {
+      slot.parent = parentA
+      const childA = slot.getSlotChild(parentA)
+      parentA.add(childA)
+
+      slot.parent = parentB
+      const childB = slot.getSlotChild(parentB)
+      parentB.add(childB)
+
+      expect(slot.parent).toBe(parentB)
+
+      parentB.remove(childB.id)
+      slot.didRemoveSlotChild(parentB, childB)
+
+      expect(slot.parent).toBe(parentA)
+      expect(parentA.getChildren()[0]).toBe(childA)
+      expect(parentB.getChildren()).toHaveLength(0)
+    } finally {
+      setup.renderer.destroy()
+    }
+  })
 })

--- a/packages/solid/tests/slot-reconciler-move.test.ts
+++ b/packages/solid/tests/slot-reconciler-move.test.ts
@@ -87,9 +87,8 @@ async function runMoveScenario(order: MoveOrder) {
 
 describe("slot placeholder moves", () => {
   it("recreates incompatible layout placeholders for remove-then-insert moves", async () => {
-    const { controls, movedChild, originalChild, parentA, parentB, setup, slot } = await runMoveScenario(
-      "remove-then-insert",
-    )
+    const { controls, movedChild, originalChild, parentA, parentB, setup, slot } =
+      await runMoveScenario("remove-then-insert")
 
     try {
       expect(movedChild).not.toBe(originalChild)
@@ -106,9 +105,8 @@ describe("slot placeholder moves", () => {
   })
 
   it("recreates incompatible layout placeholders for insert-then-remove moves", async () => {
-    const { controls, movedChild, originalChild, parentA, parentB, setup, slot } = await runMoveScenario(
-      "insert-then-remove",
-    )
+    const { controls, movedChild, originalChild, parentA, parentB, setup, slot } =
+      await runMoveScenario("insert-then-remove")
 
     try {
       expect(movedChild).not.toBe(originalChild)

--- a/packages/solid/tests/slot.test.tsx
+++ b/packages/solid/tests/slot.test.tsx
@@ -97,6 +97,61 @@ describe("Solid Slot System", () => {
     slot.destroy()
   })
 
+  it("recreates a detached layout placeholder when the parent Yoga factory changes", () => {
+    let displayA: number | undefined
+    let displayB: number | undefined
+    const layoutNodeA = {
+      setDisplay(value: number) {
+        displayA = value
+      },
+      free() {},
+    }
+    const layoutNodeB = {
+      setDisplay(value: number) {
+        displayB = value
+      },
+      free() {},
+    }
+    const parentA = {
+      getLayoutNode() {
+        return {
+          constructor: {
+            create() {
+              return layoutNodeA
+            },
+          },
+        }
+      },
+    } as unknown as BaseRenderable
+    const parentB = {
+      getLayoutNode() {
+        return {
+          constructor: {
+            create() {
+              return layoutNodeB
+            },
+          },
+        }
+      },
+    } as unknown as BaseRenderable
+
+    const slot = new SlotRenderable("moving-slot")
+    const firstChild = slot.getSlotChild(parentA)
+
+    expect(firstChild.getLayoutNode()).toBe(layoutNodeA)
+    expect(displayA).toBe(Yoga.Display.None)
+
+    firstChild.parent = null
+
+    const secondChild = slot.getSlotChild(parentB)
+
+    expect(secondChild).not.toBe(firstChild)
+    expect(secondChild.getLayoutNode()).toBe(layoutNodeB)
+    expect(displayB).toBe(Yoga.Display.None)
+
+    slot.destroy()
+  })
+
   it("reuses one registry per renderer and rejects different context", async () => {
     const setup = await createTestRenderer({ width: 20, height: 4 })
     testSetup = setup

--- a/packages/solid/tests/slot.test.tsx
+++ b/packages/solid/tests/slot.test.tsx
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { Yoga, type BaseRenderable } from "@opentui/core"
 import { createTestRenderer, type TestRendererOptions } from "@opentui/core/testing"
 import { createContext, createComponent, createSignal, onCleanup, onMount, useContext, type JSX } from "solid-js"
 import { createSlot, createSolidSlotRegistry, Slot, type SolidPlugin } from "../src/plugins/slot.js"
 import { _render as renderInternal } from "../src/reconciler.js"
 import { RendererContext } from "../src/elements/index.js"
+import { SlotRenderable } from "../src/elements/slot.js"
 
 interface AppSlots {
   statusbar: { user: string }
@@ -64,6 +66,35 @@ describe("Solid Slot System", () => {
     if (testSetup) {
       testSetup.renderer.destroy()
     }
+  })
+
+  it("creates layout placeholders with the parent Yoga node factory", () => {
+    let display: number | undefined
+    const layoutNode = {
+      setDisplay(value: number) {
+        display = value
+      },
+    }
+    const parentLayoutNode = {
+      constructor: {
+        create() {
+          return layoutNode
+        },
+      },
+    }
+    const parent = {
+      getLayoutNode() {
+        return parentLayoutNode
+      },
+    } as unknown as BaseRenderable
+
+    const slot = new SlotRenderable("factory-slot")
+    const child = slot.getSlotChild(parent)
+
+    expect(child.getLayoutNode()).toBe(layoutNode)
+    expect(display).toBe(Yoga.Display.None)
+
+    slot.destroy()
   })
 
   it("reuses one registry per renderer and rejects different context", async () => {


### PR DESCRIPTION
- **bun lock**
- **core/renderer: fix split-footer suspend handling**
- **fix split-footer transition ordering and slot Yoga ownership**
- **core/renderer: reuse gap on split-footer shrink**
- **core/renderer: clear stale split-footer rows after capture re-entry**
- **renderer: fix split-footer offset on shrink-back**
- **fixup! renderer: fix split-footer offset on shrink-back**
- **slot: fix placeholder lifecycle during moves**
- **fix stale CPR abort and slot parent promotion**
