### PR TITLE
feat(core): wire MouseLevel through setMouseMode + CliRendererConfig

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -144,10 +144,26 @@ export interface CliRendererConfig {
   postProcessFns?: ((buffer: OptimizedBuffer, deltaTime: number) => void)[]
 
   // Track mouse move events. Defaults to true.
+  // Legacy. Prefer `mouseLevel`. When `mouseLevel` is set, this is ignored.
   enableMouseMovement?: boolean
 
   // Enable mouse input. Defaults to true.
+  // Legacy. Prefer `mouseLevel`. When `mouseLevel` is set, this is ignored.
   useMouse?: boolean
+
+  // Choose how much of the xterm mouse protocol to subscribe to.
+  //
+  //   "none"   - all tracking off
+  //   "basic"  - press/release only (?1000h ?1006h). Drag events stay with
+  //              the host terminal so the user's native drag-to-select
+  //              highlighter is undisturbed.
+  //   "drag"   - clicks + button-drag (?1000h ?1002h ?1006h). Default.
+  //   "motion" - clicks + button-drag + all motion (?1003h)
+  //
+  // When `mouseLevel` is unset, the renderer falls back to the legacy
+  // `useMouse` + `enableMouseMovement` shim (false => "none";
+  // true,false => "drag"; true,true => "motion").
+  mouseLevel?: MouseLevel | "none" | "basic" | "drag" | "motion"
 
   // Focus the nearest focusable renderable on left click. Defaults to true.
   autoFocus?: boolean
@@ -194,6 +210,51 @@ export interface CliRendererConfig {
 //
 // - "split-footer": Keep the renderer in a reserved footer on the main screen.
 export type ScreenMode = "alternate-screen" | "main-screen" | "split-footer"
+
+// Mouse-protocol subscription level. Numeric values match the Zig-side
+// `MouseLevel` enum order (terminal.zig); changes here MUST stay in sync
+// with `setMouseLevel` in lib.zig.
+export enum MouseLevel {
+  None = 0,
+  // Press/release only (?1000h ?1006h). Drag events flow back to the host
+  // terminal — needed for native drag-to-select with terminals that don't
+  // implement OSC 52 (e.g. Warp).
+  Basic = 1,
+  // Clicks + button-drag (?1000h ?1002h ?1006h). Historical default.
+  Drag = 2,
+  // Clicks + button-drag + all motion (adds ?1003h).
+  Motion = 3,
+  // Reserved for future pixel-coordinate decoding.
+  Pixels = 4,
+}
+
+const MOUSE_LEVEL_BY_NAME: Record<string, MouseLevel> = {
+  none: MouseLevel.None,
+  basic: MouseLevel.Basic,
+  drag: MouseLevel.Drag,
+  motion: MouseLevel.Motion,
+}
+
+export function resolveMouseLevel(
+  mouseLevel: MouseLevel | "none" | "basic" | "drag" | "motion" | undefined,
+  legacyUseMouse: boolean | undefined,
+  legacyEnableMovement: boolean | undefined,
+): MouseLevel {
+  if (mouseLevel !== undefined) {
+    if (typeof mouseLevel === "string") {
+      return MOUSE_LEVEL_BY_NAME[mouseLevel] ?? MouseLevel.Drag
+    }
+    return mouseLevel
+  }
+  // Legacy fallback. Defaults preserve the historical 0.2.x behavior:
+  //   useMouse undefined or true + enableMouseMovement undefined or true => Motion
+  //   useMouse true + enableMouseMovement false                          => Drag
+  //   useMouse false                                                     => None
+  const useMouse = legacyUseMouse ?? true
+  if (!useMouse) return MouseLevel.None
+  const enableMovement = legacyEnableMovement ?? true
+  return enableMovement ? MouseLevel.Motion : MouseLevel.Drag
+}
 
 // Controls writes that go through the configured `stdout.write`.
 //
@@ -769,6 +830,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private enableMouseMovement: boolean = false
   private _useMouse: boolean = true
+  private _mouseLevel: MouseLevel = MouseLevel.Drag
   private autoFocus: boolean = true
   private _screenMode: ScreenMode = "alternate-screen"
   private _footerHeight: number = DEFAULT_FOOTER_HEIGHT
@@ -989,6 +1051,12 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.maxStatSamples = config.maxStatSamples || 300
     this.enableMouseMovement = config.enableMouseMovement ?? true
     this._useMouse = config.useMouse ?? true
+    this._mouseLevel = resolveMouseLevel(config.mouseLevel, config.useMouse, config.enableMouseMovement)
+    // Keep the legacy projection consistent so callers reading
+    // `enableMouseMovement` / `useMouse` after-the-fact see a value that
+    // matches the resolved level.
+    this._useMouse = this._mouseLevel !== MouseLevel.None
+    this.enableMouseMovement = this._mouseLevel === MouseLevel.Motion
     this.autoFocus = config.autoFocus ?? true
     this.nextRenderBuffer = this.lib.getNextBuffer(this.rendererPtr)
     this.currentRenderBuffer = this.lib.getCurrentBuffer(this.rendererPtr)
@@ -2701,7 +2769,34 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private enableMouse(): void {
     this._useMouse = true
-    this.lib.enableMouse(this.rendererPtr, this.enableMouseMovement)
+    // Use the level-aware FFI when the resolved level isn't the historical
+    // default (Drag with movement). Falling through to enableMouse(bool)
+    // keeps behavior bit-identical for legacy callers that never set
+    // `mouseLevel` and never call `setMouseLevel(...)`.
+    if (this._mouseLevel === MouseLevel.Motion || this._mouseLevel === MouseLevel.Drag) {
+      this.lib.enableMouse(this.rendererPtr, this._mouseLevel === MouseLevel.Motion)
+      return
+    }
+    this.lib.setMouseLevel(this.rendererPtr, this._mouseLevel)
+  }
+
+  public get mouseLevel(): MouseLevel {
+    return this._mouseLevel
+  }
+
+  public set mouseLevel(level: MouseLevel | "none" | "basic" | "drag" | "motion") {
+    const resolved = resolveMouseLevel(level, undefined, undefined)
+    if (resolved === this._mouseLevel) return
+    this._mouseLevel = resolved
+    this._useMouse = resolved !== MouseLevel.None
+    this.enableMouseMovement = resolved === MouseLevel.Motion
+    if (resolved === MouseLevel.None) {
+      this.setCapturedRenderable(undefined)
+      this.stdinParser?.resetMouseState()
+      this.lib.disableMouse(this.rendererPtr)
+      return
+    }
+    this.lib.setMouseLevel(this.rendererPtr, resolved)
   }
 
   private disableMouse(): void {

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -489,6 +489,10 @@ function getOpenTUILib(libPath?: string) {
       args: ["ptr", "bool"],
       returns: "void",
     },
+    setMouseLevel: {
+      args: ["ptr", "u8"],
+      returns: "void",
+    },
     disableMouse: {
       args: ["ptr"],
       returns: "void",
@@ -1634,6 +1638,7 @@ export interface RenderLib {
   dumpStdoutBuffer: (renderer: Pointer, timestamp?: number) => void
   restoreTerminalModes: (renderer: Pointer) => void
   enableMouse: (renderer: Pointer, enableMovement: boolean) => void
+  setMouseLevel: (renderer: Pointer, level: number) => void
   disableMouse: (renderer: Pointer) => void
   enableKittyKeyboard: (renderer: Pointer, flags: number) => void
   disableKittyKeyboard: (renderer: Pointer) => void
@@ -2726,6 +2731,10 @@ class FFIRenderLib implements RenderLib {
 
   public enableMouse(renderer: Pointer, enableMovement: boolean): void {
     this.opentui.symbols.enableMouse(renderer, ffiBool(enableMovement))
+  }
+
+  public setMouseLevel(renderer: Pointer, level: number): void {
+    this.opentui.symbols.setMouseLevel(renderer, level)
   }
 
   public disableMouse(renderer: Pointer): void {

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -901,6 +901,21 @@ export fn enableMouse(rendererPtr: *renderer.CliRenderer, enableMovement: bool) 
     rendererPtr.enableMouse(enableMovement);
 }
 
+// `level` is a u8 corresponding to the MouseLevel enum order:
+//   0 = none, 1 = basic, 2 = drag, 3 = motion, 4 = pixels.
+// Out-of-range values fall back to .none for safety.
+export fn setMouseLevel(rendererPtr: *renderer.CliRenderer, level: u8) void {
+    const ml: terminal.MouseLevel = switch (level) {
+        0 => .none,
+        1 => .basic,
+        2 => .drag,
+        3 => .motion,
+        4 => .pixels,
+        else => .none,
+    };
+    rendererPtr.setMouseLevel(ml);
+}
+
 export fn disableMouse(rendererPtr: *renderer.CliRenderer) void {
     rendererPtr.disableMouse();
 }

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -1905,7 +1905,13 @@ pub const CliRenderer = struct {
 
     pub fn enableMouse(self: *CliRenderer, enableMovement: bool) void {
         var stream = std.io.fixedBufferStream(&self.writeOutBuf);
-        self.terminal.setMouseMode(stream.writer(), true, enableMovement) catch {};
+        self.terminal.setMouseModeLegacy(stream.writer(), true, enableMovement) catch {};
+        self.writeOut(stream.getWritten());
+    }
+
+    pub fn setMouseLevel(self: *CliRenderer, level: Terminal.MouseLevel) void {
+        var stream = std.io.fixedBufferStream(&self.writeOutBuf);
+        self.terminal.setMouseMode(stream.writer(), level) catch {};
         self.writeOut(stream.getWritten());
     }
 
@@ -1921,7 +1927,7 @@ pub const CliRenderer = struct {
 
     pub fn disableMouse(self: *CliRenderer) void {
         var stream = std.io.fixedBufferStream(&self.writeOutBuf);
-        self.terminal.setMouseMode(stream.writer(), false, self.terminal.state.mouse_movement) catch {};
+        self.terminal.setMouseMode(stream.writer(), .none) catch {};
         self.writeOut(stream.getWritten());
     }
 

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -118,6 +118,10 @@ state: struct {
     mouse: bool = false,
     mouse_movement: bool = true,
     mouse_was_enabled: bool = false,
+    // Effective mouse mode. `mouse` and `mouse_movement` above remain a
+    // backward-compatible projection (`.none` => mouse=false; `.motion` =>
+    // mouse_movement=true; everything else => mouse=true, movement=false).
+    mouse_level: MouseLevel = .none,
     pixel_mouse: bool = false,
     color_scheme_updates: bool = false,
     theme_queries_sent: bool = false,
@@ -569,38 +573,71 @@ fn writeMouseDisableSequences(tty: anytype) !void {
     try tty.writeAll(ansi.ANSI.disableSGRMouseMode);
 }
 
-// TODO: Allow pixel mouse mode to be enabled,
-// currently does not make sense and is not supported by higher levels
-pub fn setMouseMode(self: *Terminal, tty: anytype, enable: bool, enable_movement: bool) !void {
-    if (enable) {
-        if (self.state.mouse and self.state.mouse_movement == enable_movement) return;
-    } else if (!self.state.mouse) {
+// Set mouse tracking to the requested level.
+//
+//   .none    - all tracking off (?1000l ?1002l ?1003l ?1006l)
+//   .basic   - press/release only      (?1000h ?1006h)
+//   .drag    - clicks + drag           (?1000h ?1002h ?1006h)
+//   .motion  - clicks + drag + motion  (?1000h ?1002h ?1003h ?1006h)
+//   .pixels  - reserved for future; currently treated as .drag
+//
+// The legacy two-bool API (`enable`, `enable_movement`) maps onto this via
+// `setMouseModeLegacy`, which preserves the prior default (drag tracking on
+// when mouse is enabled and movement is off).
+//
+// Some terminals treat ?1000 / ?1002 / ?1003 as one family and let the last
+// sequence win — when downgrading to a lower level we explicitly emit the
+// disable sequences for the higher tiers before re-arming.
+//
+// TODO: pixel-coordinate mouse mode (?1016h) is not yet decoded by higher
+// layers; once decoding lands, .pixels will gain a distinct emit path.
+pub fn setMouseMode(self: *Terminal, tty: anytype, level: MouseLevel) !void {
+    if (self.state.mouse_level == level) return;
+
+    self.state.mouse_level = level;
+    self.state.mouse = (level != .none);
+    self.state.mouse_movement = (level == .motion);
+
+    if (level == .none) {
+        self.state.pixel_mouse = false;
+        try writeMouseDisableSequences(tty);
         return;
     }
 
-    if (enable) {
-        self.state.mouse = true;
-        self.state.mouse_movement = enable_movement;
-        // Arms the shutdown cleanup path so resetState() will still emit mouse
-        // disable sequences even if a later best-effort disable silently fails.
-        self.state.mouse_was_enabled = true;
-        if (!enable_movement) {
-            // Some terminals treat ?1000/?1002/?1003 as one family and let the
-            // last sequence win. Reset any-event tracking first, then enable
-            // click/drag modes so they remain active.
-            try tty.writeAll(ansi.ANSI.disableAnyEventTracking);
-        }
-        try tty.writeAll(ansi.ANSI.enableMouseTracking);
-        try tty.writeAll(ansi.ANSI.enableButtonEventTracking);
-        if (enable_movement) {
-            try tty.writeAll(ansi.ANSI.enableAnyEventTracking);
-        }
-        try tty.writeAll(ansi.ANSI.enableSGRMouseMode);
-    } else {
-        self.state.mouse = false;
-        self.state.pixel_mouse = false;
-        try writeMouseDisableSequences(tty);
+    // Arms the shutdown cleanup path so resetState() will still emit mouse
+    // disable sequences even if a later best-effort disable silently fails.
+    self.state.mouse_was_enabled = true;
+
+    // Downgrade higher tiers before re-arming the requested ones.
+    if (level != .motion) {
+        try tty.writeAll(ansi.ANSI.disableAnyEventTracking);
     }
+    if (level == .basic) {
+        try tty.writeAll(ansi.ANSI.disableButtonEventTracking);
+    }
+
+    try tty.writeAll(ansi.ANSI.enableMouseTracking);
+    if (level == .drag or level == .motion or level == .pixels) {
+        try tty.writeAll(ansi.ANSI.enableButtonEventTracking);
+    }
+    if (level == .motion) {
+        try tty.writeAll(ansi.ANSI.enableAnyEventTracking);
+    }
+    try tty.writeAll(ansi.ANSI.enableSGRMouseMode);
+}
+
+// Backward-compat shim for the old two-bool signature. Maps to:
+//   enable=false        => .none
+//   enable=true, mv=false => .drag   (preserves the prior default)
+//   enable=true, mv=true  => .motion
+pub fn setMouseModeLegacy(self: *Terminal, tty: anytype, enable: bool, enable_movement: bool) !void {
+    const level: MouseLevel = if (!enable)
+        .none
+    else if (enable_movement)
+        .motion
+    else
+        .drag;
+    return self.setMouseMode(tty, level);
 }
 
 // Best-effort shutdown path: emit the reset sequences even if tracked state

--- a/packages/core/src/zig/tests/terminal_test.zig
+++ b/packages/core/src/zig/tests/terminal_test.zig
@@ -844,12 +844,12 @@ test "enableDetectedFeatures - sends initial theme queries" {
     try testing.expect(term.state.theme_queries_sent);
 }
 
-test "setMouseMode - enable without movement keeps click/drag only" {
+test "setMouseMode - .drag emits ?1000h ?1002h ?1006h, no any-event" {
     var term = Terminal.init(.{});
     var writer = TestWriter.init(testing.allocator);
     defer writer.deinit();
 
-    try term.setMouseMode(&writer, true, false);
+    try term.setMouseMode(&writer, .drag);
 
     const output = writer.getWritten();
     const idx_disable_any = std.mem.indexOf(u8, output, ansi.ANSI.disableAnyEventTracking).?;
@@ -861,16 +861,17 @@ test "setMouseMode - enable without movement keeps click/drag only" {
     try testing.expect(idx_enable_mouse < idx_enable_button);
     try testing.expect(idx_enable_button < idx_enable_sgr);
 
+    try testing.expectEqual(Terminal.MouseLevel.drag, term.state.mouse_level);
     try testing.expect(term.state.mouse);
     try testing.expect(!term.state.mouse_movement);
 }
 
-test "setMouseMode - enable with movement enables any-event tracking" {
+test "setMouseMode - .motion emits any-event tracking" {
     var term = Terminal.init(.{});
     var writer = TestWriter.init(testing.allocator);
     defer writer.deinit();
 
-    try term.setMouseMode(&writer, true, true);
+    try term.setMouseMode(&writer, .motion);
 
     const output = writer.getWritten();
     const idx_enable_mouse = std.mem.indexOf(u8, output, ansi.ANSI.enableMouseTracking).?;
@@ -882,8 +883,108 @@ test "setMouseMode - enable with movement enables any-event tracking" {
     try testing.expect(idx_enable_any < idx_enable_sgr);
     try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.disableAnyEventTracking) == null);
 
+    try testing.expectEqual(Terminal.MouseLevel.motion, term.state.mouse_level);
     try testing.expect(term.state.mouse);
     try testing.expect(term.state.mouse_movement);
+}
+
+test "setMouseMode - .basic emits ?1000h + ?1006h only, drag disabled" {
+    var term = Terminal.init(.{});
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.setMouseMode(&writer, .basic);
+
+    const output = writer.getWritten();
+    // basic must downgrade button-event tracking — emit ?1002l before
+    // re-arming click tracking.
+    const idx_disable_button = std.mem.indexOf(u8, output, ansi.ANSI.disableButtonEventTracking).?;
+    const idx_enable_mouse = std.mem.indexOf(u8, output, ansi.ANSI.enableMouseTracking).?;
+    const idx_enable_sgr = std.mem.indexOf(u8, output, ansi.ANSI.enableSGRMouseMode).?;
+    try testing.expect(idx_disable_button < idx_enable_mouse);
+    try testing.expect(idx_enable_mouse < idx_enable_sgr);
+    // Drag and motion must NOT be enabled.
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.enableButtonEventTracking) == null);
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.enableAnyEventTracking) == null);
+
+    try testing.expectEqual(Terminal.MouseLevel.basic, term.state.mouse_level);
+    try testing.expect(term.state.mouse);
+    try testing.expect(!term.state.mouse_movement);
+}
+
+test "setMouseMode - .none disables all tracking" {
+    var term = Terminal.init(.{});
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    // Drive into a non-none state first so the disable path is exercised.
+    try term.setMouseMode(&writer, .drag);
+    writer.reset();
+
+    try term.setMouseMode(&writer, .none);
+
+    const output = writer.getWritten();
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.disableAnyEventTracking) != null);
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.disableButtonEventTracking) != null);
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.disableMouseTracking) != null);
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.disableSGRMouseMode) != null);
+
+    try testing.expectEqual(Terminal.MouseLevel.none, term.state.mouse_level);
+    try testing.expect(!term.state.mouse);
+}
+
+test "setMouseMode - same-level call is a no-op" {
+    var term = Terminal.init(.{});
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.setMouseMode(&writer, .drag);
+    writer.reset();
+    try term.setMouseMode(&writer, .drag);
+
+    try testing.expectEqual(@as(usize, 0), writer.getWritten().len);
+}
+
+test "setMouseModeLegacy - maps (true, false) to .drag" {
+    var term = Terminal.init(.{});
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.setMouseModeLegacy(&writer, true, false);
+
+    try testing.expectEqual(Terminal.MouseLevel.drag, term.state.mouse_level);
+    try testing.expect(term.state.mouse);
+    try testing.expect(!term.state.mouse_movement);
+    const output = writer.getWritten();
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.enableButtonEventTracking) != null);
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.enableAnyEventTracking) == null);
+}
+
+test "setMouseModeLegacy - maps (true, true) to .motion" {
+    var term = Terminal.init(.{});
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.setMouseModeLegacy(&writer, true, true);
+
+    try testing.expectEqual(Terminal.MouseLevel.motion, term.state.mouse_level);
+    try testing.expect(term.state.mouse);
+    try testing.expect(term.state.mouse_movement);
+    const output = writer.getWritten();
+    try testing.expect(std.mem.indexOf(u8, output, ansi.ANSI.enableAnyEventTracking) != null);
+}
+
+test "setMouseModeLegacy - maps (false, _) to .none" {
+    var term = Terminal.init(.{});
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.setMouseModeLegacy(&writer, true, true);
+    writer.reset();
+    try term.setMouseModeLegacy(&writer, false, true);
+
+    try testing.expectEqual(Terminal.MouseLevel.none, term.state.mouse_level);
+    try testing.expect(!term.state.mouse);
 }
 
 test "restoreTerminalModes - respects mouse movement setting" {


### PR DESCRIPTION
Closes #1038.

### What

Wires the existing-but-dormant `MouseLevel` enum (`packages/core/src/zig/terminal.zig:33-39`) through `setMouseMode` and surfaces it on `CliRendererConfig` as `mouseLevel?: MouseLevel | "none" | "basic" | "drag" | "motion"`.

`useMouse` + `enableMouseMovement` keep working as a back-compat shim so every existing consumer continues to produce identical output bytes.

### Why

`MouseLevel.basic` ("click only") is declared in source but unreachable today — `setMouseMode` always emits `?1000h ?1002h ?1006h` whenever mouse is enabled. There's no way to subscribe to clicks-only and let the host terminal own drag events natively.

The motivating use case is downstream in `automagik-dev/genie`: when the TUI runs over SSH from terminals that don't implement OSC 52 (notably Warp on macOS), the active `?1002h` subscription captures drag events that the user wanted to use for native text selection. A genie-side override (`\e[?1002l` after `createCliRenderer()`) ships in v5 day-one as a workaround. The long-term plan is to drop that override once `mouseLevel: "basic"` lands here.

Full discussion in #1038.

### Changes

#### Zig
- **`terminal.zig`** — `setMouseMode` now takes `(level: MouseLevel)`. Emits per level:
  - `.none`   → disable all four (`?1000l ?1002l ?1003l ?1006l`)
  - `.basic`  → `?1002l` (downgrade) + `?1000h + ?1006h`
  - `.drag`   → `?1003l` (downgrade) + `?1000h + ?1002h + ?1006h` (matches the prior `(true, false)` output)
  - `.motion` → `?1000h + ?1002h + ?1003h + ?1006h` (matches the prior `(true, true)` output)
  - `.pixels` → currently treated as `.drag`; reserved for future pixel-coordinate decoding
  - New `state.mouse_level` field records the canonical level. Existing `state.mouse` and `state.mouse_movement` remain a derived projection so `restoreTerminalModes`, `resetState`, and any external callers reading those fields keep working.
  - Same-level calls early-return (no-op).
- **`setMouseModeLegacy(enable, movement)`** — new shim mapping the prior two-bool contract onto a `MouseLevel`.
- **`renderer.zig`** — `enableMouse(bool)` routes through the legacy shim (zero behavior change). New `setMouseLevel(level)` exposes the canonical API. `disableMouse` calls `setMouseMode(.none)` directly.
- **`lib.zig`** — new `setMouseLevel(rendererPtr, u8)` FFI export.

#### TypeScript
- **`zig.ts`** — matching FFI binding + RenderLib method.
- **`renderer.ts`** — `MouseLevel` enum exported (numeric values match the Zig enum order). `mouseLevel` added to `CliRendererConfig` with a `resolveMouseLevel()` helper centralizing the legacy back-compat shim. CliRenderer gains a public `mouseLevel` getter/setter that drives the new FFI; the private `enableMouse()` falls through to the level-aware path only when the resolved level isn't `.drag` or `.motion`, so legacy callers stay on the original code path bit-for-bit.

#### Tests (Zig)
- Replaced the two existing `setMouseMode(true, ...)` tests with level-based equivalents; both also assert `state.mouse_level`.
- Added coverage for `.basic`, `.none` (drives through `.drag` first), and same-level no-op.
- Added `setMouseModeLegacy` round-trip tests for all three legacy combinations to guarantee behavior preservation.

### Back-compat / API surface

| Old call                              | Maps to                  | Bytes emitted        |
|---------------------------------------|--------------------------|----------------------|
| `setMouseMode(true,  false)`          | _removed_, see below     | _was_ ?1000h+?1002h+?1006h |
| `setMouseMode(true,  true)`           | _removed_, see below     | _was_ +?1003h        |
| `setMouseMode(false, _)`              | _removed_, see below     | _was_ disable-all    |
| `setMouseModeLegacy(true,  false)`    | `setMouseMode(.drag)`    | identical            |
| `setMouseModeLegacy(true,  true)`     | `setMouseMode(.motion)`  | identical            |
| `setMouseModeLegacy(false, _)`        | `setMouseMode(.none)`    | identical            |
| _new_ `setMouseMode(.basic)`          | —                        | ?1000h + ?1006h      |

The TypeScript surface is fully back-compat: existing `useMouse` / `enableMouseMovement` callers see no behavior change.

### Validation

- `bun test` (TS) — N/A in this draft until reviewer confirms preferred test wiring; happy to add `renderer.mouse.test.ts` covering `resolveMouseLevel()` if useful.
- Zig tests added in `tests/terminal_test.zig` cover all five level transitions plus the legacy shim.

### Open questions for reviewers

1. **Naming**: `setMouseMode(level)` reuses the old name; alternative is to keep old `setMouseMode(enable, movement)` and add a fresh `setMouseLevel(level)`. I went with the former because the wish from the downstream user explicitly asked for a signature change, but I'm happy to flip if you prefer additive-only.
2. **`.pixels`**: reserved but treated as `.drag` for now (matches the existing TODO at line 572). Should I add a `?1016h` emit path now or leave it for a follow-up?
3. **`useMouse` deprecation**: I left both `useMouse` and `enableMouseMovement` as `?: boolean` in `CliRendererConfig` with a comment pointing at `mouseLevel`. Want a JSDoc `@deprecated` annotation, or keep them first-class?

### Refs

- Downstream wish: [`automagik-dev/genie` — wish `tui-native-selection`](https://github.com/automagik-dev/genie) (filed by [@namastex888](https://github.com/namastex888) / [namastex.ai](https://namastex.ai))
- Branch: [`namastex888:feat/mouse-level-config-surface`](https://github.com/namastex888/opentui/tree/feat/mouse-level-config-surface)

Marking draft pending #1038 discussion.