### PR TITLE
refactor(core): replace Bun import attributes with URL constructor

### DIFF
--- a/packages/core/scripts/build.ts
+++ b/packages/core/scripts/build.ts
@@ -136,9 +136,9 @@ if (buildNative) {
       continue
     }
 
-    const indexTsContent = `const module = await import("./${libraryFileName}", { with: { type: "file" } })
-const path = module.default
-export default path;
+    const indexTsContent = `import { fileURLToPath } from "node:url"
+const module = new URL("./${libraryFileName}", import.meta.url)
+export default fileURLToPath(module)
 `
     writeFileSync(join(nativeDir, "index.ts"), indexTsContent)
 

--- a/packages/core/src/lib/KeyHandler.ts
+++ b/packages/core/src/lib/KeyHandler.ts
@@ -134,42 +134,35 @@ export class KeyHandler extends EventEmitter<KeyHandlerEventMap> {
 export class InternalKeyHandler extends KeyHandler {
   private renderableHandlers: Map<keyof KeyHandlerEventMap, Set<Function>> = new Map()
 
-  public emit<K extends keyof KeyHandlerEventMap>(event: K, ...args: KeyHandlerEventMap[K]): boolean {
+  public override emit<K extends keyof KeyHandlerEventMap>(event: K, ...args: KeyHandlerEventMap[K]): boolean {
     return this.emitWithPriority(event, ...args)
   }
 
   private emitWithPriority<K extends keyof KeyHandlerEventMap>(event: K, ...args: KeyHandlerEventMap[K]): boolean {
     let hasGlobalListeners = false
+    let hasRenderableListeners = false
 
-    // Check if we should emit to global handlers
-    // Global handlers are emitted using the parent EventEmitter which calls all listeners
-    // We need to manually iterate to check for stopPropagation between handlers
     const globalListeners = this.listeners(event as any)
     if (globalListeners.length > 0) {
       hasGlobalListeners = true
-
-      for (const listener of globalListeners) {
+      for (let gi = 0; gi < globalListeners.length; gi++) {
         try {
-          listener(...args)
+          ;(globalListeners[gi] as Function)(...args)
         } catch (error) {
           console.error(`[KeyHandler] Error in global ${event} handler:`, error)
         }
 
-        // Check if propagation was stopped after this handler
         if (event === "keypress" || event === "keyrelease" || event === "paste") {
           const keyEvent = args[0]
           if (keyEvent.propagationStopped) {
-            return hasGlobalListeners
+            return hasGlobalListeners || hasRenderableListeners
           }
         }
       }
     }
 
     const renderableSet = this.renderableHandlers.get(event)
-    // Snapshot the handler list so listeners added during dispatch (e.g., via focus changes)
-    // do not receive the in-flight key event.
     const renderableHandlers = renderableSet && renderableSet.size > 0 ? [...renderableSet] : []
-    let hasRenderableListeners = false
 
     if (renderableSet && renderableSet.size > 0) {
       hasRenderableListeners = true
@@ -187,7 +180,6 @@ export class InternalKeyHandler extends KeyHandler {
           console.error(`[KeyHandler] Error in renderable ${event} handler:`, error)
         }
 
-        // Check if propagation was stopped after this handler
         if (event === "keypress" || event === "keyrelease" || event === "paste") {
           const keyEvent = args[0]
           if (keyEvent.propagationStopped) {

--- a/packages/core/src/lib/tree-sitter/assets/update.ts
+++ b/packages/core/src/lib/tree-sitter/assets/update.ts
@@ -146,15 +146,15 @@ async function downloadAndCombineQueries(
 }
 
 async function generateDefaultParsersFile(parsers: GeneratedParser[], outputPath: string): Promise<void> {
-  const imports = parsers
+  const urlDeclarations = parsers
     .map((parser) => {
       const safeFiletype = parser.filetype.replace(/[^a-zA-Z0-9]/g, "_")
       const lines = [
-        `import ${safeFiletype}_highlights from "${parser.highlightsPath}" with { type: "file" }`,
-        `import ${safeFiletype}_language from "${parser.languagePath}" with { type: "file" }`,
+        `const ${safeFiletype}_highlights = new URL("${parser.highlightsPath}", import.meta.url)`,
+        `const ${safeFiletype}_language = new URL("${parser.languagePath}", import.meta.url)`,
       ]
       if (parser.injectionsPath) {
-        lines.push(`import ${safeFiletype}_injections from "${parser.injectionsPath}" with { type: "file" }`)
+        lines.push(`const ${safeFiletype}_injections = new URL("${parser.injectionsPath}", import.meta.url)`)
       }
       return lines.join("\n")
     })
@@ -164,11 +164,11 @@ async function generateDefaultParsersFile(parsers: GeneratedParser[], outputPath
     .map((parser) => {
       const safeFiletype = parser.filetype.replace(/[^a-zA-Z0-9]/g, "_")
       const queriesLines = [
-        `          highlights: [resolve(dirname(fileURLToPath(import.meta.url)), ${safeFiletype}_highlights)],`,
+        `          highlights: [toFilePath(${safeFiletype}_highlights)],`,
       ]
       if (parser.injectionsPath) {
         queriesLines.push(
-          `          injections: [resolve(dirname(fileURLToPath(import.meta.url)), ${safeFiletype}_injections)],`,
+          `          injections: [toFilePath(${safeFiletype}_injections)],`,
         )
       }
 
@@ -182,7 +182,7 @@ async function generateDefaultParsersFile(parsers: GeneratedParser[], outputPath
 ${aliasesLine ? aliasesLine + "\n" : ""}        queries: {
 ${queriesLines.join("\n")}
         },
-        wasm: resolve(dirname(fileURLToPath(import.meta.url)), ${safeFiletype}_language),${injectionMappingLine ? "\n" + injectionMappingLine : ""}
+        wasm: toFilePath(${safeFiletype}_language),${injectionMappingLine ? "\n" + injectionMappingLine : ""}
       }`
     })
     .join(",\n")
@@ -192,10 +192,13 @@ ${queriesLines.join("\n")}
 // Last generated: ${new Date().toISOString()}
 
 import type { FiletypeParserOptions } from "./types"
-import { resolve, dirname } from "path"
 import { fileURLToPath } from "url"
 
-${imports}
+${urlDeclarations}
+
+function toFilePath(url: URL): string {
+  return fileURLToPath(url)
+}
 
 // Cached parsers to avoid re-resolving paths on every call
 let _cachedParsers: FiletypeParserOptions[] | undefined

--- a/packages/core/src/lib/tree-sitter/default-parsers.ts
+++ b/packages/core/src/lib/tree-sitter/default-parsers.ts
@@ -3,20 +3,23 @@
 // Last generated: 2026-03-20T21:07:24.696Z
 
 import type { FiletypeParserOptions } from "./types.js"
-import { resolve, dirname } from "path"
 import { fileURLToPath } from "url"
 
-import javascript_highlights from "./assets/javascript/highlights.scm" with { type: "file" }
-import javascript_language from "./assets/javascript/tree-sitter-javascript.wasm" with { type: "file" }
-import typescript_highlights from "./assets/typescript/highlights.scm" with { type: "file" }
-import typescript_language from "./assets/typescript/tree-sitter-typescript.wasm" with { type: "file" }
-import markdown_highlights from "./assets/markdown/highlights.scm" with { type: "file" }
-import markdown_language from "./assets/markdown/tree-sitter-markdown.wasm" with { type: "file" }
-import markdown_injections from "./assets/markdown/injections.scm" with { type: "file" }
-import markdown_inline_highlights from "./assets/markdown_inline/highlights.scm" with { type: "file" }
-import markdown_inline_language from "./assets/markdown_inline/tree-sitter-markdown_inline.wasm" with { type: "file" }
-import zig_highlights from "./assets/zig/highlights.scm" with { type: "file" }
-import zig_language from "./assets/zig/tree-sitter-zig.wasm" with { type: "file" }
+const javascript_highlights = new URL("./assets/javascript/highlights.scm", import.meta.url)
+const javascript_language = new URL("./assets/javascript/tree-sitter-javascript.wasm", import.meta.url)
+const typescript_highlights = new URL("./assets/typescript/highlights.scm", import.meta.url)
+const typescript_language = new URL("./assets/typescript/tree-sitter-typescript.wasm", import.meta.url)
+const markdown_highlights = new URL("./assets/markdown/highlights.scm", import.meta.url)
+const markdown_language = new URL("./assets/markdown/tree-sitter-markdown.wasm", import.meta.url)
+const markdown_injections = new URL("./assets/markdown/injections.scm", import.meta.url)
+const markdown_inline_highlights = new URL("./assets/markdown_inline/highlights.scm", import.meta.url)
+const markdown_inline_language = new URL("./assets/markdown_inline/tree-sitter-markdown_inline.wasm", import.meta.url)
+const zig_highlights = new URL("./assets/zig/highlights.scm", import.meta.url)
+const zig_language = new URL("./assets/zig/tree-sitter-zig.wasm", import.meta.url)
+
+function toFilePath(url: URL): string {
+  return fileURLToPath(url)
+}
 
 // Cached parsers to avoid re-resolving paths on every call
 let _cachedParsers: FiletypeParserOptions[] | undefined
@@ -28,25 +31,25 @@ export function getParsers(): FiletypeParserOptions[] {
         filetype: "javascript",
         aliases: ["javascriptreact"],
         queries: {
-          highlights: [resolve(dirname(fileURLToPath(import.meta.url)), javascript_highlights)],
+          highlights: [toFilePath(javascript_highlights)],
         },
-        wasm: resolve(dirname(fileURLToPath(import.meta.url)), javascript_language),
+        wasm: toFilePath(javascript_language),
       },
       {
         filetype: "typescript",
         aliases: ["typescriptreact"],
         queries: {
-          highlights: [resolve(dirname(fileURLToPath(import.meta.url)), typescript_highlights)],
+          highlights: [toFilePath(typescript_highlights)],
         },
-        wasm: resolve(dirname(fileURLToPath(import.meta.url)), typescript_language),
+        wasm: toFilePath(typescript_language),
       },
       {
         filetype: "markdown",
         queries: {
-          highlights: [resolve(dirname(fileURLToPath(import.meta.url)), markdown_highlights)],
-          injections: [resolve(dirname(fileURLToPath(import.meta.url)), markdown_injections)],
+          highlights: [toFilePath(markdown_highlights)],
+          injections: [toFilePath(markdown_injections)],
         },
-        wasm: resolve(dirname(fileURLToPath(import.meta.url)), markdown_language),
+        wasm: toFilePath(markdown_language),
         injectionMapping: {
           "nodeTypes": {
                     "inline": "markdown_inline",
@@ -69,16 +72,16 @@ export function getParsers(): FiletypeParserOptions[] {
       {
         filetype: "markdown_inline",
         queries: {
-          highlights: [resolve(dirname(fileURLToPath(import.meta.url)), markdown_inline_highlights)],
+          highlights: [toFilePath(markdown_inline_highlights)],
         },
-        wasm: resolve(dirname(fileURLToPath(import.meta.url)), markdown_inline_language),
+        wasm: toFilePath(markdown_inline_language),
       },
       {
         filetype: "zig",
         queries: {
-          highlights: [resolve(dirname(fileURLToPath(import.meta.url)), zig_highlights)],
+          highlights: [toFilePath(zig_highlights)],
         },
-        wasm: resolve(dirname(fileURLToPath(import.meta.url)), zig_language),
+        wasm: toFilePath(zig_language),
       },
     ]
   }

--- a/packages/core/src/renderables/EditBufferRenderable.ts
+++ b/packages/core/src/renderables/EditBufferRenderable.ts
@@ -647,7 +647,6 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
     if (this.hasSelection()) {
       this.deleteSelectedText()
     }
-
     this.editBuffer.insertText(text)
     this.requestRender()
   }

--- a/packages/core/src/renderables/Textarea.ts
+++ b/packages/core/src/renderables/Textarea.ts
@@ -280,7 +280,6 @@ export class TextareaRenderable extends EditBufferRenderable {
 
       if (key.sequence) {
         const firstCharCode = key.sequence.charCodeAt(0)
-
         if (firstCharCode < 32) {
           return false
         }


### PR DESCRIPTION
## Summary
- Replace `import ... with { type: "file" }` with `new URL(path, import.meta.url)` + `fileURLToPath` in tree-sitter asset resolution and generated native package index.ts
- Minor cleanups in KeyHandler, EditBufferRenderable, and Textarea

The `with { type: "file" }` import attribute is a Bun-specific extension not part of the TC39 Import Attributes spec (which only defines `type: "json"`). Using `new URL()` + `fileURLToPath` produces the same resolved file paths and works across all runtimes.

## Test plan
- [x] `bun test` passes (58 tests across RGBA, border, clipboard, tree-sitter client)
- [x] Native build (`bun run build --native`) produces correct artifacts
- [x] Generated `@opentui/core-{platform}-{arch}/index.ts` uses the new format