### PR TITLE
examples: add Node.js 26 runtime support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # caches
 .eslintcache
 .cache
+.node
 *.tsbuildinfo
 
 # IntelliJ based IDEs

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "cd packages/core && bun run build && cd ../qrcode && bun run build && cd ../three && bun run build && cd ../solid && bun run build && cd ../react && bun run build && cd ../keymap && bun run build",
     "build:examples": "cd packages/examples && bun run build",
     "clean": "bun scripts/clean.ts",
+    "examples:node": "node packages/examples/scripts/run-node26.mjs",
     "fmt": "oxfmt --write .",
     "fmt:check": "oxfmt --check .",
     "lint": "oxlint .",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "cd packages/core && bun run build && cd ../three && bun run build && cd ../solid && bun run build && cd ../react && bun run build && cd ../keymap && bun run build",
     "build:examples": "cd packages/examples && bun run build",
     "clean": "bun scripts/clean.ts",
+    "examples:node": "node packages/examples/scripts/run-node26.mjs",
     "fmt": "oxfmt --write .",
     "fmt:check": "oxfmt --check .",
     "lint": "oxlint .",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -15,7 +15,9 @@
   "scripts": {
     "dev": "bun src/index.ts",
     "build": "bun scripts/build.ts",
-    "build:host": "bun scripts/build.ts --host"
+    "build:host": "bun scripts/build.ts --host",
+    "download:node26": "node scripts/download-node26.mjs",
+    "dev:node": "node scripts/run-node26.mjs"
   },
   "dependencies": {
     "@dimforge/rapier2d-simd-compat": "^0.17.3",

--- a/packages/examples/scripts/download-node26.mjs
+++ b/packages/examples/scripts/download-node26.mjs
@@ -1,0 +1,3 @@
+import { ensureNode26 } from "./node26.mjs"
+
+console.log(ensureNode26())

--- a/packages/examples/scripts/node26.mjs
+++ b/packages/examples/scripts/node26.mjs
@@ -1,0 +1,102 @@
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdirSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+export const NODE26_VERSION = "v26.1.0"
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, "..")
+const cacheDir = resolve(packageRoot, ".cache/node26")
+
+function getTarget() {
+  if (process.arch !== "x64") {
+    throw new Error(`This examples runner downloads the x64 Node 26 builds, not ${process.platform}-${process.arch}.`)
+  }
+
+  switch (process.platform) {
+    case "linux":
+      return {
+        archiveName: `node-${NODE26_VERSION}-linux-x64.tar.xz`,
+        directoryName: `node-${NODE26_VERSION}-linux-x64`,
+        nodeRelativePath: "bin/node",
+        url: `https://nodejs.org/dist/${NODE26_VERSION}/node-${NODE26_VERSION}-linux-x64.tar.xz`,
+      }
+    case "darwin":
+      return {
+        archiveName: `node-${NODE26_VERSION}-darwin-x64.tar.gz`,
+        directoryName: `node-${NODE26_VERSION}-darwin-x64`,
+        nodeRelativePath: "bin/node",
+        url: `https://nodejs.org/dist/${NODE26_VERSION}/node-${NODE26_VERSION}-darwin-x64.tar.gz`,
+      }
+    case "win32":
+      return {
+        archiveName: `node-${NODE26_VERSION}-win-x64.zip`,
+        directoryName: `node-${NODE26_VERSION}-win-x64`,
+        nodeRelativePath: "node.exe",
+        url: `https://nodejs.org/dist/${NODE26_VERSION}/node-${NODE26_VERSION}-win-x64.zip`,
+      }
+    default:
+      throw new Error(`This examples runner does not have a Node 26 download for ${process.platform}-${process.arch}.`)
+  }
+}
+
+export function getNode26Path() {
+  const target = getTarget()
+  return resolve(cacheDir, target.directoryName, target.nodeRelativePath)
+}
+
+export function ensureNode26() {
+  const target = getTarget()
+  const archivePath = resolve(cacheDir, target.archiveName)
+  const nodeDir = resolve(cacheDir, target.directoryName)
+  const nodePath = resolve(nodeDir, target.nodeRelativePath)
+
+  if (existsSync(nodePath)) {
+    return nodePath
+  }
+
+  mkdirSync(cacheDir, { recursive: true })
+
+  if (!existsSync(archivePath)) {
+    run("curl", ["-L", target.url, "-o", archivePath])
+  }
+
+  extractArchive(archivePath, cacheDir)
+
+  if (!existsSync(nodePath)) {
+    throw new Error(`Downloaded Node 26 archive did not produce ${nodePath}`)
+  }
+
+  return nodePath
+}
+
+function extractArchive(archivePath, outputDir) {
+  if (archivePath.endsWith(".zip")) {
+    if (process.platform === "win32") {
+      run("powershell", [
+        "-NoProfile",
+        "-Command",
+        `Expand-Archive -Path '${archivePath}' -DestinationPath '${outputDir}' -Force`,
+      ])
+      return
+    }
+
+    run("unzip", ["-q", archivePath, "-d", outputDir])
+    return
+  }
+
+  run("tar", ["-xf", archivePath, "-C", outputDir])
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { stdio: "inherit" })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}

--- a/packages/examples/scripts/run-node26.mjs
+++ b/packages/examples/scripts/run-node26.mjs
@@ -1,0 +1,76 @@
+import { spawnSync } from "node:child_process"
+import { cpSync, mkdirSync, rmSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { ensureNode26 } from "./node26.mjs"
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, "..")
+const repoRoot = resolve(packageRoot, "../..")
+const coreRoot = resolve(repoRoot, "packages/core")
+const nodePath = ensureNode26()
+const bundleDir = resolve(packageRoot, ".node")
+const bundleEntry = resolve(bundleDir, "index.js")
+
+ensureNativePackage()
+buildNodeExamples()
+
+const result = spawnSync(nodePath, ["--experimental-ffi", "--no-warnings", bundleEntry], {
+  cwd: packageRoot,
+  stdio: "inherit",
+  env: process.env,
+})
+
+if (result.error) {
+  throw result.error
+}
+
+process.exit(result.status ?? 0)
+
+function buildNodeExamples() {
+  rmSync(bundleDir, { recursive: true, force: true })
+
+  run(
+    "bun",
+    [
+      "build",
+      "src/index.ts",
+      "--target=node",
+      "--format=esm",
+      "--splitting",
+      "--outdir",
+      ".node",
+      "--define",
+      "OPENTUI_BUN_ONLY_EXAMPLES=false",
+    ],
+    packageRoot,
+  )
+}
+
+function ensureNativePackage() {
+  const nativePackageName = `core-${process.platform === "win32" ? "win32" : process.platform}-${process.arch}`
+  const sourceNativeDir = resolve(coreRoot, "node_modules", "@opentui", nativePackageName)
+  const targetNativeDir = resolve(packageRoot, "node_modules", "@opentui", nativePackageName)
+
+  run("bun", ["run", "build:native"], coreRoot)
+
+  mkdirSync(resolve(packageRoot, "node_modules", "@opentui"), { recursive: true })
+  rmSync(targetNativeDir, { recursive: true, force: true })
+  cpSync(sourceNativeDir, targetNativeDir, { recursive: true, dereference: true })
+}
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, {
+    cwd,
+    stdio: "inherit",
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}

--- a/packages/examples/src/hast-syntax-highlighting-demo.ts
+++ b/packages/examples/src/hast-syntax-highlighting-demo.ts
@@ -3,8 +3,9 @@ import { setupCommonDemoKeys } from "./lib/standalone-keys.js"
 import { parseColor } from "@opentui/core"
 import { hastToStyledText, type HASTElement } from "@opentui/core"
 import { SyntaxStyle } from "@opentui/core"
+import exampleHAST from "./assets/hast-example.json" with { type: "json" }
 
-const exampleHAST: HASTElement = (await import("./assets/hast-example.json", { with: { type: "json" } })) as HASTElement
+const typedExampleHAST = exampleHAST as HASTElement
 
 let renderer: CliRenderer | null = null
 let keyboardHandler: ((key: KeyEvent) => void) | null = null
@@ -67,7 +68,7 @@ export function run(rendererInstance: CliRenderer): void {
     default: { fg: parseColor("#FFFFFF") },
   })
   const transformStart = performance.now()
-  const styledText = hastToStyledText(exampleHAST, syntaxStyle)
+  const styledText = hastToStyledText(typedExampleHAST, syntaxStyle)
   const transformEnd = performance.now()
   const transformTime = (transformEnd - transformStart).toFixed(2)
 
@@ -93,7 +94,7 @@ export function run(rendererInstance: CliRenderer): void {
       syntaxStyle.clearCache()
 
       const retransformStart = performance.now()
-      const newStyledText = hastToStyledText(exampleHAST, syntaxStyle)
+      const newStyledText = hastToStyledText(typedExampleHAST, syntaxStyle)
       const retransformEnd = performance.now()
       const newTransformTime = (retransformEnd - retransformStart).toFixed(2)
 

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -17,25 +17,14 @@ import {
   type ThemeMode,
 } from "@opentui/core"
 import { measureText } from "@opentui/core"
-import * as goldenStarDemo from "./golden-star-demo.js"
 import * as boxExample from "./fonts.js"
-import * as fractalShaderExample from "./fractal-shader-demo.js"
 import * as framebufferExample from "./framebuffer-demo.js"
-import * as lightsPhongExample from "./lights-phong-demo.js"
-import * as physxPlanckExample from "./physx-planck-2d-demo.js"
-import * as physxRapierExample from "./physx-rapier-2d-demo.js"
 import * as opentuiDemo from "./opentui-demo.js"
 import * as nestedZIndexDemo from "./nested-zindex-demo.js"
 import * as relativePositioningDemo from "./relative-positioning-demo.js"
 import * as transparencyDemo from "./transparency-demo.js"
-import * as draggableThreeDemo from "./draggable-three-demo.js"
 import * as scrollExample from "./scroll-example.js"
 import * as stickyScrollExample from "./sticky-scroll-example.js"
-import * as shaderCubeExample from "./shader-cube-demo.js"
-import * as spriteAnimationExample from "./sprite-animation-demo.js"
-import * as spriteParticleExample from "./sprite-particle-generator-demo.js"
-import * as staticSpriteExample from "./static-sprite-demo.js"
-import * as textureLoadingExample from "./texture-loading-demo.js"
 import * as timelineExample from "./timeline-example.js"
 import * as tabSelectExample from "./tab-select-demo.js"
 import * as selectExample from "./select-demo.js"
@@ -81,9 +70,16 @@ import * as nativeAudioDemo from "./native-audio-demo.js"
 interface Example {
   name: string
   description: string
-  run?: (renderer: CliRenderer) => void
+  run?: (renderer: CliRenderer) => void | Promise<void>
   destroy?: (renderer: CliRenderer) => void
 }
+
+interface ExampleModule {
+  run?: (renderer: CliRenderer) => void | Promise<void>
+  destroy?: (renderer: CliRenderer) => void
+}
+
+declare const OPENTUI_BUN_ONLY_EXAMPLES: boolean | undefined
 
 interface ExampleTheme {
   titleColor: RGBA
@@ -103,6 +99,36 @@ interface ExampleTheme {
 }
 
 const DEFAULT_THEME_MODE: ThemeMode = "dark"
+const isBunRuntime = typeof process !== "undefined" && typeof process.versions?.bun === "string"
+const includeBunOnlyExamples = typeof OPENTUI_BUN_ONLY_EXAMPLES === "boolean" ? OPENTUI_BUN_ONLY_EXAMPLES : isBunRuntime
+
+function bunOnlyExample(name: string, description: string, load: () => Promise<ExampleModule>): Example {
+  if (!includeBunOnlyExamples) {
+    return {
+      name,
+      description: `${description} (Bun-only for now)`,
+    }
+  }
+
+  let loaded: ExampleModule | null = null
+
+  async function loadModule(): Promise<ExampleModule> {
+    loaded ??= await load()
+    return loaded
+  }
+
+  return {
+    name,
+    description,
+    async run(renderer) {
+      const module = await loadModule()
+      return module.run?.(renderer)
+    },
+    destroy(renderer) {
+      loaded?.destroy?.(renderer)
+    },
+  }
+}
 
 const MENU_THEMES: Record<ThemeMode, ExampleTheme> = {
   dark: {
@@ -139,13 +165,12 @@ const MENU_THEMES: Record<ThemeMode, ExampleTheme> = {
   },
 }
 
-const examples: Example[] = [
-  {
-    name: "Golden Star Demo",
-    description: "3D golden star with particle effects and animated text celebrating 5000 stars",
-    run: goldenStarDemo.run,
-    destroy: goldenStarDemo.destroy,
-  },
+export const examples: Example[] = [
+  bunOnlyExample(
+    "Golden Star Demo",
+    "3D golden star with particle effects and animated text celebrating 5000 stars",
+    () => import("./golden-star-demo.js"),
+  ),
   {
     name: "Mouse Interaction Demo",
     description: "Interactive mouse trails and clickable cells demonstration",
@@ -303,42 +328,25 @@ const examples: Example[] = [
     run: transparencyDemo.run,
     destroy: transparencyDemo.destroy,
   },
-  {
-    name: "Draggable ThreeRenderable",
-    description: "Draggable WebGPU cube with live animation",
-    run: draggableThreeDemo.run,
-    destroy: draggableThreeDemo.destroy,
-  },
-  {
-    name: "Static Sprite",
-    description: "Static sprite rendering demo",
-    run: staticSpriteExample.run,
-    destroy: staticSpriteExample.destroy,
-  },
-  {
-    name: "Sprite Animation",
-    description: "Animated sprite sequences",
-    run: spriteAnimationExample.run,
-    destroy: spriteAnimationExample.destroy,
-  },
-  {
-    name: "Sprite Particles",
-    description: "Particle system with sprites",
-    run: spriteParticleExample.run,
-    destroy: spriteParticleExample.destroy,
-  },
+  bunOnlyExample(
+    "Draggable ThreeRenderable",
+    "Draggable WebGPU cube with live animation",
+    () => import("./draggable-three-demo.js"),
+  ),
+  bunOnlyExample("Static Sprite", "Static sprite rendering demo", () => import("./static-sprite-demo.js")),
+  bunOnlyExample("Sprite Animation", "Animated sprite sequences", () => import("./sprite-animation-demo.js")),
+  bunOnlyExample(
+    "Sprite Particles",
+    "Particle system with sprites",
+    () => import("./sprite-particle-generator-demo.js"),
+  ),
   {
     name: "Framebuffer Demo",
     description: "Framebuffer rendering techniques",
     run: framebufferExample.run,
     destroy: framebufferExample.destroy,
   },
-  {
-    name: "Texture Loading",
-    description: "Loading and displaying textures",
-    run: textureLoadingExample.run,
-    destroy: textureLoadingExample.destroy,
-  },
+  bunOnlyExample("Texture Loading", "Loading and displaying textures", () => import("./texture-loading-demo.js")),
   {
     name: "ScrollBox Demo",
     description: "Scrollable container with customization",
@@ -363,36 +371,11 @@ const examples: Example[] = [
     run: scrollboxOverlayHitTest.run,
     destroy: scrollboxOverlayHitTest.destroy,
   },
-  {
-    name: "Shader Cube",
-    description: "3D cube with custom shaders",
-    run: shaderCubeExample.run,
-    destroy: shaderCubeExample.destroy,
-  },
-  {
-    name: "Fractal Shader",
-    description: "Fractal rendering with shaders",
-    run: fractalShaderExample.run,
-    destroy: fractalShaderExample.destroy,
-  },
-  {
-    name: "Phong Lighting",
-    description: "Phong lighting model demo",
-    run: lightsPhongExample.run,
-    destroy: lightsPhongExample.destroy,
-  },
-  {
-    name: "Physics Planck",
-    description: "2D physics with Planck.js",
-    run: physxPlanckExample.run,
-    destroy: physxPlanckExample.destroy,
-  },
-  {
-    name: "Physics Rapier",
-    description: "2D physics with Rapier",
-    run: physxRapierExample.run,
-    destroy: physxRapierExample.destroy,
-  },
+  bunOnlyExample("Shader Cube", "3D cube with custom shaders", () => import("./shader-cube-demo.js")),
+  bunOnlyExample("Fractal Shader", "Fractal rendering with shaders", () => import("./fractal-shader-demo.js")),
+  bunOnlyExample("Phong Lighting", "Phong lighting model demo", () => import("./lights-phong-demo.js")),
+  bunOnlyExample("Physics Planck", "2D physics with Planck.js", () => import("./physx-planck-2d-demo.js")),
+  bunOnlyExample("Physics Rapier", "2D physics with Rapier", () => import("./physx-rapier-2d-demo.js")),
   {
     name: "Timeline Example",
     description: "Animation timeline system",
@@ -538,7 +521,7 @@ class ExampleSelector {
     const theme = MENU_THEMES[this.themeMode]
 
     // Menu container with column layout
-    this.menuContainer = new BoxRenderable(renderer, {
+    this.menuContainer = new BoxRenderable(this.renderer, {
       id: "example-menu-container",
       flexDirection: "column",
       width: "100%",
@@ -552,7 +535,7 @@ class ExampleSelector {
     const { width: titleWidth } = measureText({ text: titleText, font: titleFont })
     const centerX = Math.floor(width / 2) - Math.floor(titleWidth / 2)
 
-    this.title = new ASCIIFontRenderable(renderer, {
+    this.title = new ASCIIFontRenderable(this.renderer, {
       id: "example-index-title",
       left: centerX,
       margin: 1,
@@ -564,7 +547,7 @@ class ExampleSelector {
     this.menuContainer.add(this.title)
 
     // Filter box with border (grows with content)
-    this.filterBox = new BoxRenderable(renderer, {
+    this.filterBox = new BoxRenderable(this.renderer, {
       id: "example-index-filter-box",
       marginLeft: 1,
       marginRight: 1,
@@ -577,7 +560,7 @@ class ExampleSelector {
     this.menuContainer.add(this.filterBox)
 
     // Filter input inside the box (transparent bg so box bg shows through)
-    this.filterInput = new TextareaRenderable(renderer, {
+    this.filterInput = new TextareaRenderable(this.renderer, {
       id: "example-index-filter-input",
       width: "100%",
       height: 1,
@@ -598,7 +581,7 @@ class ExampleSelector {
     this.filterInput.focus()
 
     // Select box (grows to fill remaining space)
-    this.selectBox = new BoxRenderable(renderer, {
+    this.selectBox = new BoxRenderable(this.renderer, {
       id: "example-selector-box",
       marginLeft: 1,
       marginRight: 1,
@@ -622,7 +605,7 @@ class ExampleSelector {
       value: example,
     }))
 
-    this.selectElement = new SelectRenderable(renderer, {
+    this.selectElement = new SelectRenderable(this.renderer, {
       id: "example-selector",
       height: "100%",
       options: selectOptions,
@@ -641,17 +624,17 @@ class ExampleSelector {
     this.selectBox.add(this.selectElement)
 
     this.selectElement.on(SelectRenderableEvents.ITEM_SELECTED, (index: number, option: SelectOption) => {
-      this.runSelected(option.value as Example)
+      void this.runSelected(option.value as Example)
     })
 
-    this.timeToFirstDrawText = new TimeToFirstDrawRenderable(renderer, {
+    this.timeToFirstDrawText = new TimeToFirstDrawRenderable(this.renderer, {
       id: "example-index-time-to-first-draw",
       fg: theme.instructionsColor,
     })
     this.menuContainer.add(this.timeToFirstDrawText)
 
     // Instructions at the bottom
-    this.instructions = new TextRenderable(renderer, {
+    this.instructions = new TextRenderable(this.renderer, {
       id: "example-index-instructions",
       height: 1,
       flexShrink: 0,
@@ -825,17 +808,17 @@ class ExampleSelector {
     setupCommonDemoKeys(this.renderer)
   }
 
-  private runSelected(selected: Example): void {
+  private async runSelected(selected: Example): Promise<void> {
     this.inMenu = false
     this.hideMenuElements()
 
     if (selected.run) {
       this.currentExample = selected
-      selected.run(this.renderer)
+      await selected.run(this.renderer)
     } else {
       if (!this.notImplementedText) {
         const theme = MENU_THEMES[this.themeMode]
-        this.notImplementedText = new TextRenderable(renderer, {
+        this.notImplementedText = new TextRenderable(this.renderer, {
           id: "not-implemented",
           position: "absolute",
           left: 10,

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -17,25 +17,14 @@ import {
   type ThemeMode,
 } from "@opentui/core"
 import { measureText } from "@opentui/core"
-import * as goldenStarDemo from "./golden-star-demo.js"
 import * as boxExample from "./fonts.js"
-import * as fractalShaderExample from "./fractal-shader-demo.js"
 import * as framebufferExample from "./framebuffer-demo.js"
-import * as lightsPhongExample from "./lights-phong-demo.js"
-import * as physxPlanckExample from "./physx-planck-2d-demo.js"
-import * as physxRapierExample from "./physx-rapier-2d-demo.js"
 import * as opentuiDemo from "./opentui-demo.js"
 import * as nestedZIndexDemo from "./nested-zindex-demo.js"
 import * as relativePositioningDemo from "./relative-positioning-demo.js"
 import * as transparencyDemo from "./transparency-demo.js"
-import * as draggableThreeDemo from "./draggable-three-demo.js"
 import * as scrollExample from "./scroll-example.js"
 import * as stickyScrollExample from "./sticky-scroll-example.js"
-import * as shaderCubeExample from "./shader-cube-demo.js"
-import * as spriteAnimationExample from "./sprite-animation-demo.js"
-import * as spriteParticleExample from "./sprite-particle-generator-demo.js"
-import * as staticSpriteExample from "./static-sprite-demo.js"
-import * as textureLoadingExample from "./texture-loading-demo.js"
 import * as timelineExample from "./timeline-example.js"
 import * as tabSelectExample from "./tab-select-demo.js"
 import * as selectExample from "./select-demo.js"
@@ -83,9 +72,16 @@ import * as nativeAudioDemo from "./native-audio-demo.js"
 interface Example {
   name: string
   description: string
-  run?: (renderer: CliRenderer) => void
+  run?: (renderer: CliRenderer) => void | Promise<void>
   destroy?: (renderer: CliRenderer) => void
 }
+
+interface ExampleModule {
+  run?: (renderer: CliRenderer) => void | Promise<void>
+  destroy?: (renderer: CliRenderer) => void
+}
+
+declare const OPENTUI_BUN_ONLY_EXAMPLES: boolean | undefined
 
 interface ExampleTheme {
   titleColor: RGBA
@@ -105,6 +101,36 @@ interface ExampleTheme {
 }
 
 const DEFAULT_THEME_MODE: ThemeMode = "dark"
+const isBunRuntime = typeof process !== "undefined" && typeof process.versions?.bun === "string"
+const includeBunOnlyExamples = typeof OPENTUI_BUN_ONLY_EXAMPLES === "boolean" ? OPENTUI_BUN_ONLY_EXAMPLES : isBunRuntime
+
+function bunOnlyExample(name: string, description: string, load: () => Promise<ExampleModule>): Example {
+  if (!includeBunOnlyExamples) {
+    return {
+      name,
+      description: `${description} (Bun-only for now)`,
+    }
+  }
+
+  let loaded: ExampleModule | null = null
+
+  async function loadModule(): Promise<ExampleModule> {
+    loaded ??= await load()
+    return loaded
+  }
+
+  return {
+    name,
+    description,
+    async run(renderer) {
+      const module = await loadModule()
+      return module.run?.(renderer)
+    },
+    destroy(renderer) {
+      loaded?.destroy?.(renderer)
+    },
+  }
+}
 
 const MENU_THEMES: Record<ThemeMode, ExampleTheme> = {
   dark: {
@@ -141,13 +167,12 @@ const MENU_THEMES: Record<ThemeMode, ExampleTheme> = {
   },
 }
 
-const examples: Example[] = [
-  {
-    name: "Golden Star Demo",
-    description: "3D golden star with particle effects and animated text celebrating 5000 stars",
-    run: goldenStarDemo.run,
-    destroy: goldenStarDemo.destroy,
-  },
+export const examples: Example[] = [
+  bunOnlyExample(
+    "Golden Star Demo",
+    "3D golden star with particle effects and animated text celebrating 5000 stars",
+    () => import("./golden-star-demo.js"),
+  ),
   {
     name: "Mouse Interaction Demo",
     description: "Interactive mouse trails and clickable cells demonstration",
@@ -317,42 +342,25 @@ const examples: Example[] = [
     run: transparencyDemo.run,
     destroy: transparencyDemo.destroy,
   },
-  {
-    name: "Draggable ThreeRenderable",
-    description: "Draggable WebGPU cube with live animation",
-    run: draggableThreeDemo.run,
-    destroy: draggableThreeDemo.destroy,
-  },
-  {
-    name: "Static Sprite",
-    description: "Static sprite rendering demo",
-    run: staticSpriteExample.run,
-    destroy: staticSpriteExample.destroy,
-  },
-  {
-    name: "Sprite Animation",
-    description: "Animated sprite sequences",
-    run: spriteAnimationExample.run,
-    destroy: spriteAnimationExample.destroy,
-  },
-  {
-    name: "Sprite Particles",
-    description: "Particle system with sprites",
-    run: spriteParticleExample.run,
-    destroy: spriteParticleExample.destroy,
-  },
+  bunOnlyExample(
+    "Draggable ThreeRenderable",
+    "Draggable WebGPU cube with live animation",
+    () => import("./draggable-three-demo.js"),
+  ),
+  bunOnlyExample("Static Sprite", "Static sprite rendering demo", () => import("./static-sprite-demo.js")),
+  bunOnlyExample("Sprite Animation", "Animated sprite sequences", () => import("./sprite-animation-demo.js")),
+  bunOnlyExample(
+    "Sprite Particles",
+    "Particle system with sprites",
+    () => import("./sprite-particle-generator-demo.js"),
+  ),
   {
     name: "Framebuffer Demo",
     description: "Framebuffer rendering techniques",
     run: framebufferExample.run,
     destroy: framebufferExample.destroy,
   },
-  {
-    name: "Texture Loading",
-    description: "Loading and displaying textures",
-    run: textureLoadingExample.run,
-    destroy: textureLoadingExample.destroy,
-  },
+  bunOnlyExample("Texture Loading", "Loading and displaying textures", () => import("./texture-loading-demo.js")),
   {
     name: "ScrollBox Demo",
     description: "Scrollable container with customization",
@@ -377,36 +385,11 @@ const examples: Example[] = [
     run: scrollboxOverlayHitTest.run,
     destroy: scrollboxOverlayHitTest.destroy,
   },
-  {
-    name: "Shader Cube",
-    description: "3D cube with custom shaders",
-    run: shaderCubeExample.run,
-    destroy: shaderCubeExample.destroy,
-  },
-  {
-    name: "Fractal Shader",
-    description: "Fractal rendering with shaders",
-    run: fractalShaderExample.run,
-    destroy: fractalShaderExample.destroy,
-  },
-  {
-    name: "Phong Lighting",
-    description: "Phong lighting model demo",
-    run: lightsPhongExample.run,
-    destroy: lightsPhongExample.destroy,
-  },
-  {
-    name: "Physics Planck",
-    description: "2D physics with Planck.js",
-    run: physxPlanckExample.run,
-    destroy: physxPlanckExample.destroy,
-  },
-  {
-    name: "Physics Rapier",
-    description: "2D physics with Rapier",
-    run: physxRapierExample.run,
-    destroy: physxRapierExample.destroy,
-  },
+  bunOnlyExample("Shader Cube", "3D cube with custom shaders", () => import("./shader-cube-demo.js")),
+  bunOnlyExample("Fractal Shader", "Fractal rendering with shaders", () => import("./fractal-shader-demo.js")),
+  bunOnlyExample("Phong Lighting", "Phong lighting model demo", () => import("./lights-phong-demo.js")),
+  bunOnlyExample("Physics Planck", "2D physics with Planck.js", () => import("./physx-planck-2d-demo.js")),
+  bunOnlyExample("Physics Rapier", "2D physics with Rapier", () => import("./physx-rapier-2d-demo.js")),
   {
     name: "Timeline Example",
     description: "Animation timeline system",
@@ -552,7 +535,7 @@ class ExampleSelector {
     const theme = MENU_THEMES[this.themeMode]
 
     // Menu container with column layout
-    this.menuContainer = new BoxRenderable(renderer, {
+    this.menuContainer = new BoxRenderable(this.renderer, {
       id: "example-menu-container",
       flexDirection: "column",
       width: "100%",
@@ -566,7 +549,7 @@ class ExampleSelector {
     const { width: titleWidth } = measureText({ text: titleText, font: titleFont })
     const centerX = Math.floor(width / 2) - Math.floor(titleWidth / 2)
 
-    this.title = new ASCIIFontRenderable(renderer, {
+    this.title = new ASCIIFontRenderable(this.renderer, {
       id: "example-index-title",
       left: centerX,
       margin: 1,
@@ -578,7 +561,7 @@ class ExampleSelector {
     this.menuContainer.add(this.title)
 
     // Filter box with border (grows with content)
-    this.filterBox = new BoxRenderable(renderer, {
+    this.filterBox = new BoxRenderable(this.renderer, {
       id: "example-index-filter-box",
       marginLeft: 1,
       marginRight: 1,
@@ -591,7 +574,7 @@ class ExampleSelector {
     this.menuContainer.add(this.filterBox)
 
     // Filter input inside the box (transparent bg so box bg shows through)
-    this.filterInput = new TextareaRenderable(renderer, {
+    this.filterInput = new TextareaRenderable(this.renderer, {
       id: "example-index-filter-input",
       width: "100%",
       height: 1,
@@ -612,7 +595,7 @@ class ExampleSelector {
     this.filterInput.focus()
 
     // Select box (grows to fill remaining space)
-    this.selectBox = new BoxRenderable(renderer, {
+    this.selectBox = new BoxRenderable(this.renderer, {
       id: "example-selector-box",
       marginLeft: 1,
       marginRight: 1,
@@ -636,7 +619,7 @@ class ExampleSelector {
       value: example,
     }))
 
-    this.selectElement = new SelectRenderable(renderer, {
+    this.selectElement = new SelectRenderable(this.renderer, {
       id: "example-selector",
       height: "100%",
       options: selectOptions,
@@ -655,17 +638,17 @@ class ExampleSelector {
     this.selectBox.add(this.selectElement)
 
     this.selectElement.on(SelectRenderableEvents.ITEM_SELECTED, (index: number, option: SelectOption) => {
-      this.runSelected(option.value as Example)
+      void this.runSelected(option.value as Example)
     })
 
-    this.timeToFirstDrawText = new TimeToFirstDrawRenderable(renderer, {
+    this.timeToFirstDrawText = new TimeToFirstDrawRenderable(this.renderer, {
       id: "example-index-time-to-first-draw",
       fg: theme.instructionsColor,
     })
     this.menuContainer.add(this.timeToFirstDrawText)
 
     // Instructions at the bottom
-    this.instructions = new TextRenderable(renderer, {
+    this.instructions = new TextRenderable(this.renderer, {
       id: "example-index-instructions",
       height: 1,
       flexShrink: 0,
@@ -839,17 +822,17 @@ class ExampleSelector {
     setupCommonDemoKeys(this.renderer)
   }
 
-  private runSelected(selected: Example): void {
+  private async runSelected(selected: Example): Promise<void> {
     this.inMenu = false
     this.hideMenuElements()
 
     if (selected.run) {
       this.currentExample = selected
-      selected.run(this.renderer)
+      await selected.run(this.renderer)
     } else {
       if (!this.notImplementedText) {
         const theme = MENU_THEMES[this.themeMode]
-        this.notImplementedText = new TextRenderable(renderer, {
+        this.notImplementedText = new TextRenderable(this.renderer, {
           id: "not-implemented",
           position: "absolute",
           left: 10,

--- a/packages/examples/src/keypress-debug-demo.ts
+++ b/packages/examples/src/keypress-debug-demo.ts
@@ -12,6 +12,7 @@ import {
 import { ScrollBoxRenderable } from "@opentui/core"
 import { setupCommonDemoKeys } from "./lib/standalone-keys.js"
 import { env, registerEnvVar } from "@opentui/core"
+import { writeFile } from "node:fs/promises"
 
 registerEnvVar({
   name: "OTUI_KEYPRESS_DEBUG_SHOW_JSON",
@@ -471,7 +472,7 @@ async function saveToFile(renderer: CliRenderer): Promise<void> {
   }
 
   try {
-    await Bun.write(filename, JSON.stringify(data, null, 2))
+    await writeFile(filename, JSON.stringify(data, null, 2))
     lastSavedFile = filename
     lastSaveError = null
   } catch (error) {

--- a/packages/examples/src/physx-rapier-2d-demo.ts
+++ b/packages/examples/src/physx-rapier-2d-demo.ts
@@ -15,7 +15,9 @@ import { SpriteAnimator, TiledSprite, type SpriteDefinition, type AnimationDefin
 import { SpriteResourceManager, type ResourceConfig } from "@opentui/three"
 import { PhysicsExplosionManager, type PhysicsExplosionHandle } from "@opentui/three"
 import { RapierPhysicsWorld } from "@opentui/three"
-import RAPIER from "@dimforge/rapier2d-simd-compat"
+import type { Collider, RigidBody, World } from "@dimforge/rapier2d-simd-compat"
+// @ts-expect-error Rapier does not publish types for its ESM subpath.
+import * as RAPIER from "@dimforge/rapier2d-simd-compat/rapier.es.js"
 import { MeshLambertNodeMaterial } from "three/webgpu"
 import { ThreeCliRenderer } from "@opentui/three"
 
@@ -29,7 +31,7 @@ const EXPLOSION_FORCE_VARIATION = 0.2
 const TORQUE_STRENGTH = 2.0
 
 interface PhysicsBox {
-  rigidBody: RAPIER.RigidBody
+  rigidBody: RigidBody
   sprite: TiledSprite
   width: number
   height: number
@@ -37,8 +39,8 @@ interface PhysicsBox {
 }
 
 interface PhysicsWorld {
-  world: RAPIER.World
-  ground: RAPIER.Collider
+  world: World
+  ground: Collider
   boxes: PhysicsBox[]
 }
 

--- a/packages/examples/src/text-wrap.ts
+++ b/packages/examples/src/text-wrap.ts
@@ -17,7 +17,7 @@ import { TextNodeRenderable } from "@opentui/core"
 import { ScrollBoxRenderable } from "@opentui/core"
 import { InputRenderable, InputRenderableEvents } from "@opentui/core"
 import { setupCommonDemoKeys } from "./lib/standalone-keys.js"
-import { readFile, stat } from "node:fs/promises"
+import { readFile, stat, writeFile } from "node:fs/promises"
 
 let mainContainer: BoxRenderable | null = null
 let contentBox: BoxRenderable | null = null
@@ -696,7 +696,7 @@ export function run(renderer: CliRenderer): void {
           const fileName = `babylon-${Date.now()}.js`
           const filePath = `${tempDir}/${fileName}`
 
-          await Bun.write(filePath, content)
+          await writeFile(filePath, content)
 
           // Load it back from disk
           const loadedContent = await readFile(filePath, "utf8")

--- a/packages/three/src/canvas.ts
+++ b/packages/three/src/canvas.ts
@@ -1,7 +1,6 @@
 import { GPUCanvasContextMock } from "bun-webgpu"
 import { RGBA, type OptimizedBuffer } from "@opentui/core"
 import { SuperSampleType } from "./WGPURenderer.js"
-import { toArrayBuffer } from "bun:ffi"
 import { Jimp } from "jimp"
 
 // @ts-ignore
@@ -422,7 +421,7 @@ export class CLICanvas {
         this.superSampleDrawTimeMs = performance.now() - ssStart
       } else {
         this.superSampleDrawTimeMs = 0
-        const pixelData = new Uint8Array(toArrayBuffer(bufPtr, 0, textureBuffer.size))
+        const pixelData = new Uint8Array(textureBuffer.getMappedRange())
         const isBGRA = contextFormat === "bgra8unorm"
         const backgroundColor = RGBA.fromValues(0, 0, 0, 1)
 

--- a/packages/three/src/physics/RapierPhysicsAdapter.ts
+++ b/packages/three/src/physics/RapierPhysicsAdapter.ts
@@ -1,4 +1,6 @@
-import RAPIER from "@dimforge/rapier2d-simd-compat"
+import type { RigidBody, World } from "@dimforge/rapier2d-simd-compat"
+// @ts-expect-error Rapier does not publish types for its ESM subpath.
+import * as RAPIER from "@dimforge/rapier2d-simd-compat/rapier.es.js"
 import type {
   PhysicsVector2,
   PhysicsRigidBodyDesc,
@@ -8,7 +10,7 @@ import type {
 } from "./physics-interface.js"
 
 export class RapierRigidBody implements PhysicsRigidBody {
-  constructor(private rapierBody: RAPIER.RigidBody) {}
+  constructor(private rapierBody: RigidBody) {}
 
   applyImpulse(force: PhysicsVector2): void {
     this.rapierBody.applyImpulse(force, true)
@@ -27,13 +29,13 @@ export class RapierRigidBody implements PhysicsRigidBody {
     return this.rapierBody.rotation()
   }
 
-  get nativeBody(): RAPIER.RigidBody {
+  get nativeBody(): RigidBody {
     return this.rapierBody
   }
 }
 
 export class RapierPhysicsWorld implements PhysicsWorld {
-  constructor(private rapierWorld: RAPIER.World) {}
+  constructor(private rapierWorld: World) {}
 
   createRigidBody(desc: PhysicsRigidBodyDesc): PhysicsRigidBody {
     const rigidBodyDesc = RAPIER.RigidBodyDesc.dynamic()
@@ -60,7 +62,7 @@ export class RapierPhysicsWorld implements PhysicsWorld {
     this.rapierWorld.removeRigidBody(rapierRigidBody)
   }
 
-  static createFromRapierWorld(rapierWorld: RAPIER.World): RapierPhysicsWorld {
+  static createFromRapierWorld(rapierWorld: World): RapierPhysicsWorld {
     return new RapierPhysicsWorld(rapierWorld)
   }
 }


### PR DESCRIPTION
Allow examples to run under Node 26 with --experimental-ffi in addition to Bun. Replace some Bun-specific APIs with standard Node equivalents, lazy-load demos that still require Bun (WebGPU, sprites, shaders), and import Rapier via its ESM subpath.