### PR TITLE
build: target Node.js for portable dist output

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       "name": "@opentui/core",
       "version": "0.3.2",
       "dependencies": {
-        "bun-ffi-structs": "0.2.2",
+        "bun-ffi-structs": "0.2.3",
         "diff": "9.0.0",
         "marked": "17.0.1",
         "string-width": "7.2.0",
@@ -741,7 +741,7 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "bun-ffi-structs": ["bun-ffi-structs@0.2.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w=="],
+    "bun-ffi-structs": ["bun-ffi-structs@0.2.3", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-pgJiXP+hEgFo9qG51J6ItfY4ocs3vniwNzJ9WhoakB3QB2GdzQxX2EXssentPYlB2hOfJrTjO6iIQkWYzUodpg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       "name": "@opentui/core",
       "version": "0.2.14",
       "dependencies": {
-        "bun-ffi-structs": "0.2.2",
+        "bun-ffi-structs": "0.2.3",
         "diff": "9.0.0",
         "marked": "17.0.1",
         "string-width": "7.2.0",
@@ -713,7 +713,7 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "bun-ffi-structs": ["bun-ffi-structs@0.2.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-N/ZWtyN0piZlrXQT7TO0V+q952orYqkfhXRXM1Hcbb+R3QSiBH4vLnib187Mrs1H7pWIYECAmPeapGYDOMCl+w=="],
+    "bun-ffi-structs": ["bun-ffi-structs@0.2.3", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-pgJiXP+hEgFo9qG51J6ItfY4ocs3vniwNzJ9WhoakB3QB2GdzQxX2EXssentPYlB2hOfJrTjO6iIQkWYzUodpg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,9 @@
     "bench:text-table": "bun src/benchmark/text-table-benchmark.ts",
     "bench:ts": "bun src/benchmark/native-span-feed-benchmark.ts --suite=quick --json=src/benchmark/latest-quick-bench-run.json && bun src/benchmark/native-span-feed-benchmark.ts --suite=default --json=src/benchmark/latest-default-bench-run.json && bun src/benchmark/native-span-feed-benchmark.ts --suite=large --json=src/benchmark/latest-large-bench-run.json && bun src/benchmark/native-span-feed-benchmark.ts --suite=all --json=src/benchmark/latest-all-bench-run.json && bun src/benchmark/native-span-feed-async-benchmark.ts --json=src/benchmark/latest-async-bench-run.json",
     "publish": "bun scripts/publish.ts",
+    "test:dist": "bun scripts/dist-test.ts",
     "test:js": "bun test",
+    "test:js:node": "bun scripts/test-node.ts",
     "test": "bun run test:native && bun run test:js"
   },
   "license": "MIT",
@@ -36,7 +38,7 @@
     "web-tree-sitter": "0.25.10"
   },
   "dependencies": {
-    "bun-ffi-structs": "0.2.2",
+    "bun-ffi-structs": "0.2.3",
     "diff": "9.0.0",
     "marked": "17.0.1",
     "string-width": "7.2.0",

--- a/packages/core/scripts/build.ts
+++ b/packages/core/scripts/build.ts
@@ -1,6 +1,7 @@
 import { spawnSync, type SpawnSyncReturns } from "node:child_process"
 import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs"
 import { dirname, join, resolve } from "path"
+import { ModuleKind, ScriptTarget, transpileModule } from "typescript"
 import { fileURLToPath } from "url"
 import process from "process"
 import path from "path"
@@ -29,6 +30,13 @@ interface PackageJson {
   devDependencies?: Record<string, string>
   optionalDependencies?: Record<string, string>
   peerDependencies?: Record<string, string>
+}
+
+interface BunBuildOptions {
+  entryPoints: string[]
+  externalPatterns?: string[]
+  splitting?: boolean
+  target: "bun" | "node"
 }
 
 const __filename = fileURLToPath(import.meta.url)
@@ -92,6 +100,55 @@ if (missingRequired.length > 0) {
   process.exit(1)
 }
 
+const runCommand = (command: string, commandArgs: string[], cwd: string, errorMessage: string): void => {
+  const result: SpawnSyncReturns<Buffer> = spawnSync(command, commandArgs, {
+    cwd,
+    stdio: "inherit",
+  })
+
+  if (result.error) {
+    console.error(`${errorMessage}: ${result.error.message}`)
+    process.exit(1)
+  }
+
+  if (result.status !== 0) {
+    console.error(errorMessage)
+    process.exit(1)
+  }
+}
+
+const runBunBuild = ({ entryPoints, externalPatterns = [], splitting = false, target }: BunBuildOptions): void => {
+  const buildArgs = [
+    "build",
+    `--target=${target}`,
+    "--outdir=dist",
+    "--sourcemap",
+    ...(splitting ? ["--splitting"] : []),
+    ...externalPatterns.flatMap((pattern) => ["--external", pattern]),
+    ...entryPoints,
+  ]
+
+  runCommand("bun", buildArgs, rootDir, `Error: Bun ${target} build failed for ${entryPoints.join(", ")}`)
+}
+
+const transpileEntryPoint = (entryPoint: string, outputPath: string): void => {
+  const sourcePath = join(rootDir, entryPoint)
+  const sourceText = readFileSync(sourcePath, "utf8")
+  const result = transpileModule(sourceText, {
+    compilerOptions: {
+      module: ModuleKind.ESNext,
+      sourceMap: true,
+      target: ScriptTarget.ES2022,
+    },
+    fileName: sourcePath,
+  })
+
+  writeFileSync(outputPath, result.outputText)
+  if (result.sourceMapText) {
+    writeFileSync(`${outputPath}.map`, result.sourceMapText)
+  }
+}
+
 if (buildNative) {
   console.log(`Building native ${isDev ? "dev" : "prod"} binaries${buildAll ? " for all platforms" : ""}...`)
 
@@ -103,20 +160,7 @@ if (buildNative) {
     zigArgs.push("-Dgpa-safe-stats=true")
   }
 
-  const zigBuild: SpawnSyncReturns<Buffer> = spawnSync("zig", zigArgs, {
-    cwd: join(rootDir, "src", "zig"),
-    stdio: "inherit",
-  })
-
-  if (zigBuild.error) {
-    console.error("Error: Zig is not installed or not in PATH")
-    process.exit(1)
-  }
-
-  if (zigBuild.status !== 0) {
-    console.error("Error: Zig build failed")
-    process.exit(1)
-  }
+  runCommand("zig", zigArgs, join(rootDir, "src", "zig"), "Error: Zig build failed")
 
   const variantsToPackage = buildAll ? variants : [getHostVariant()]
 
@@ -228,12 +272,21 @@ if (buildLib) {
     process.exit(1)
   }
 
-  const entryPoints: string[] = [
-    packageJson.module,
-    "src/testing.ts",
-    "src/runtime-plugin.ts",
-    "src/runtime-plugin-support.ts",
-    "src/runtime-plugin-support-configure.ts",
+  const portableEntryPoints: string[] = [packageJson.module, "src/testing.ts"]
+
+  const bunOnlyEntryPoints = [
+    {
+      entryPoint: "src/runtime-plugin.ts",
+      outputFile: "runtime-plugin.js",
+    },
+    {
+      entryPoint: "src/runtime-plugin-support-configure.ts",
+      outputFile: "runtime-plugin-support-configure.js",
+    },
+    {
+      entryPoint: "src/runtime-plugin-support.ts",
+      outputFile: "runtime-plugin-support.js",
+    },
   ]
 
   // Build main entry points with code splitting
@@ -248,25 +301,19 @@ if (buildLib) {
     "./lib/tree-sitter/default-parsers.ts",
   ]
 
-  spawnSync(
-    "bun",
-    [
-      "build",
-      "--target=bun",
-      "--splitting",
-      "--outdir=dist",
-      "--sourcemap",
-      ...externalPatterns.flatMap((dep) => ["--external", dep]),
-      ...entryPoints,
-    ],
-    {
-      cwd: rootDir,
-      stdio: "inherit",
-    },
-  )
+  runBunBuild({
+    entryPoints: portableEntryPoints,
+    externalPatterns,
+    splitting: true,
+    target: "node",
+  })
+
+  for (const { entryPoint, outputFile } of bunOnlyEntryPoints) {
+    transpileEntryPoint(entryPoint, join(distDir, outputFile))
+  }
 
   // Build updater as a separate entry so generator code stays out of the core runtime bundle.
-  spawnSync(
+  runCommand(
     "bun",
     [
       "build",
@@ -276,31 +323,17 @@ if (buildLib) {
       ...externalDeps.flatMap((dep) => ["--external", dep]),
       "src/lib/tree-sitter/update-assets.ts",
     ],
-    {
-      cwd: rootDir,
-      stdio: "inherit",
-    },
+    rootDir,
+    "Error: Bun build failed for src/lib/tree-sitter/update-assets.ts",
   )
 
   // Build parser worker as standalone bundle (no splitting) so it can be loaded as a Worker
   // Make web-tree-sitter external so it loads from node_modules with its WASM file
-  spawnSync(
-    "bun",
-    [
-      "build",
-      "--target=bun",
-      "--outdir=dist",
-      "--sourcemap",
-      ...externalDeps.flatMap((dep) => ["--external", dep]),
-      "--external",
-      "web-tree-sitter",
-      "src/lib/tree-sitter/parser.worker.ts",
-    ],
-    {
-      cwd: rootDir,
-      stdio: "inherit",
-    },
-  )
+  runBunBuild({
+    entryPoints: ["src/lib/tree-sitter/parser.worker.ts"],
+    externalPatterns: [...externalDeps, "web-tree-sitter"],
+    target: "node",
+  })
 
   // Post-process to fix Bun's duplicate export issue
   // See: https://github.com/oven-sh/bun/issues/5344
@@ -313,7 +346,7 @@ if (buildLib) {
     "dist/runtime-plugin-support.js",
     "dist/runtime-plugin-support-configure.js",
     "dist/lib/tree-sitter/update-assets.js",
-    "dist/lib/tree-sitter/parser.worker.js",
+    "dist/parser.worker.js",
   ]
   for (const filePath of bundledFiles) {
     const fullPath = join(rootDir, filePath)
@@ -346,17 +379,8 @@ if (buildLib) {
 
   const tsconfigBuildPath = join(rootDir, "tsconfig.build.json")
 
-  const tscResult: SpawnSyncReturns<Buffer> = spawnSync("bunx", ["tsc", "-p", tsconfigBuildPath], {
-    cwd: rootDir,
-    stdio: "inherit",
-  })
-
-  if (tscResult.status !== 0) {
-    console.error("Error: TypeScript declaration generation failed")
-    process.exit(1)
-  } else {
-    console.log("TypeScript declarations generated")
-  }
+  runCommand("bunx", ["tsc", "-p", tsconfigBuildPath], rootDir, "Error: TypeScript declaration generation failed")
+  console.log("TypeScript declarations generated")
 
   const treeSitterSrcDir = join(rootDir, "src", "lib", "tree-sitter")
 
@@ -377,32 +401,63 @@ if (buildLib) {
   copyAssets(join(treeSitterSrcDir, "assets"), join(distDir, "assets"))
   console.log("  Copied tree-sitter assets (*.wasm, *.scm) to dist/assets/")
 
+  const writeBunOnlyStub = (fileName: string, specifier: string, exportNames: string[]): void => {
+    const errorMessage = `${specifier} is Bun-only and is not available in Node.js. Use Bun to import this entrypoint.`
+    const namedExports = exportNames
+      .map(
+        (exportName) => `export function ${exportName}() {\n  throw new Error(${JSON.stringify(errorMessage)})\n}`,
+      )
+      .join("\n\n")
+
+    writeFileSync(
+      join(distDir, fileName),
+      `const errorMessage = ${JSON.stringify(errorMessage)}\n\n${namedExports}\n\nthrow new Error(errorMessage)\n`,
+    )
+  }
+
+  writeBunOnlyStub("runtime-plugin.node.js", `${packageJson.name}/runtime-plugin`, [
+    "createRuntimePlugin",
+    "isCoreRuntimeModuleSpecifier",
+    "runtimeModuleIdForSpecifier",
+  ])
+  writeBunOnlyStub("runtime-plugin-support.node.js", `${packageJson.name}/runtime-plugin-support`, [
+    "ensureRuntimePluginSupport",
+    "createRuntimePlugin",
+    "runtimeModuleIdForSpecifier",
+  ])
+  writeBunOnlyStub("runtime-plugin-support-configure.node.js", `${packageJson.name}/runtime-plugin-support/configure`, [
+    "ensureRuntimePluginSupport",
+    "createRuntimePlugin",
+    "runtimeModuleIdForSpecifier",
+  ])
+
   // Configure exports for multiple entry points
   const exports = {
     ".": {
       import: "./index.js",
-      require: "./index.js",
       types: "./index.d.ts",
     },
     "./testing": {
       import: "./testing.js",
-      require: "./testing.js",
       types: "./testing.d.ts",
     },
     "./runtime-plugin": {
-      import: "./runtime-plugin.js",
-      require: "./runtime-plugin.js",
       types: "./runtime-plugin.d.ts",
+      bun: "./runtime-plugin.js",
+      node: "./runtime-plugin.node.js",
+      default: "./runtime-plugin.node.js",
     },
     "./runtime-plugin-support": {
-      import: "./runtime-plugin-support.js",
-      require: "./runtime-plugin-support.js",
       types: "./runtime-plugin-support.d.ts",
+      bun: "./runtime-plugin-support.js",
+      node: "./runtime-plugin-support.node.js",
+      default: "./runtime-plugin-support.node.js",
     },
     "./runtime-plugin-support/configure": {
-      import: "./runtime-plugin-support-configure.js",
-      require: "./runtime-plugin-support-configure.js",
       types: "./runtime-plugin-support-configure.d.ts",
+      bun: "./runtime-plugin-support-configure.js",
+      node: "./runtime-plugin-support-configure.node.js",
+      default: "./runtime-plugin-support-configure.node.js",
     },
     "./tree-sitter/update-assets": {
       import: "./lib/tree-sitter/update-assets.js",
@@ -410,8 +465,7 @@ if (buildLib) {
       types: "./lib/tree-sitter/update-assets.d.ts",
     },
     "./parser.worker": {
-      import: "./lib/tree-sitter/parser.worker.js",
-      require: "./lib/tree-sitter/parser.worker.js",
+      import: "./parser.worker.js",
       types: "./lib/tree-sitter/parser.worker.d.ts",
     },
   }
@@ -442,7 +496,6 @@ if (buildLib) {
         bugs: packageJson.bugs,
         exports,
         dependencies: packageJson.dependencies,
-        devDependencies: packageJson.devDependencies,
         peerDependencies: packageJson.peerDependencies,
         optionalDependencies: {
           ...packageJson.optionalDependencies,

--- a/packages/core/scripts/build.ts
+++ b/packages/core/scripts/build.ts
@@ -1,6 +1,7 @@
 import { spawnSync, type SpawnSyncReturns } from "node:child_process"
 import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs"
 import { dirname, join, resolve } from "path"
+import { ModuleKind, ScriptTarget, transpileModule } from "typescript"
 import { fileURLToPath } from "url"
 import process from "process"
 import path from "path"
@@ -28,6 +29,13 @@ interface PackageJson {
   devDependencies?: Record<string, string>
   optionalDependencies?: Record<string, string>
   peerDependencies?: Record<string, string>
+}
+
+interface BunBuildOptions {
+  entryPoints: string[]
+  externalPatterns?: string[]
+  splitting?: boolean
+  target: "bun" | "node"
 }
 
 const __filename = fileURLToPath(import.meta.url)
@@ -88,6 +96,55 @@ if (missingRequired.length > 0) {
   process.exit(1)
 }
 
+const runCommand = (command: string, commandArgs: string[], cwd: string, errorMessage: string): void => {
+  const result: SpawnSyncReturns<Buffer> = spawnSync(command, commandArgs, {
+    cwd,
+    stdio: "inherit",
+  })
+
+  if (result.error) {
+    console.error(`${errorMessage}: ${result.error.message}`)
+    process.exit(1)
+  }
+
+  if (result.status !== 0) {
+    console.error(errorMessage)
+    process.exit(1)
+  }
+}
+
+const runBunBuild = ({ entryPoints, externalPatterns = [], splitting = false, target }: BunBuildOptions): void => {
+  const buildArgs = [
+    "build",
+    `--target=${target}`,
+    "--outdir=dist",
+    "--sourcemap",
+    ...(splitting ? ["--splitting"] : []),
+    ...externalPatterns.flatMap((pattern) => ["--external", pattern]),
+    ...entryPoints,
+  ]
+
+  runCommand("bun", buildArgs, rootDir, `Error: Bun ${target} build failed for ${entryPoints.join(", ")}`)
+}
+
+const transpileEntryPoint = (entryPoint: string, outputPath: string): void => {
+  const sourcePath = join(rootDir, entryPoint)
+  const sourceText = readFileSync(sourcePath, "utf8")
+  const result = transpileModule(sourceText, {
+    compilerOptions: {
+      module: ModuleKind.ESNext,
+      sourceMap: true,
+      target: ScriptTarget.ES2022,
+    },
+    fileName: sourcePath,
+  })
+
+  writeFileSync(outputPath, result.outputText)
+  if (result.sourceMapText) {
+    writeFileSync(`${outputPath}.map`, result.sourceMapText)
+  }
+}
+
 if (buildNative) {
   console.log(`Building native ${isDev ? "dev" : "prod"} binaries${buildAll ? " for all platforms" : ""}...`)
 
@@ -99,20 +156,7 @@ if (buildNative) {
     zigArgs.push("-Dgpa-safe-stats=true")
   }
 
-  const zigBuild: SpawnSyncReturns<Buffer> = spawnSync("zig", zigArgs, {
-    cwd: join(rootDir, "src", "zig"),
-    stdio: "inherit",
-  })
-
-  if (zigBuild.error) {
-    console.error("Error: Zig is not installed or not in PATH")
-    process.exit(1)
-  }
-
-  if (zigBuild.status !== 0) {
-    console.error("Error: Zig build failed")
-    process.exit(1)
-  }
+  runCommand("zig", zigArgs, join(rootDir, "src", "zig"), "Error: Zig build failed")
 
   const variantsToPackage = buildAll ? variants : [getHostVariant()]
 
@@ -221,12 +265,21 @@ if (buildLib) {
     process.exit(1)
   }
 
-  const entryPoints: string[] = [
-    packageJson.module,
-    "src/testing.ts",
-    "src/runtime-plugin.ts",
-    "src/runtime-plugin-support.ts",
-    "src/runtime-plugin-support-configure.ts",
+  const portableEntryPoints: string[] = [packageJson.module, "src/testing.ts"]
+
+  const bunOnlyEntryPoints = [
+    {
+      entryPoint: "src/runtime-plugin.ts",
+      outputFile: "runtime-plugin.js",
+    },
+    {
+      entryPoint: "src/runtime-plugin-support-configure.ts",
+      outputFile: "runtime-plugin-support-configure.js",
+    },
+    {
+      entryPoint: "src/runtime-plugin-support.ts",
+      outputFile: "runtime-plugin-support.js",
+    },
   ]
 
   // Build main entry points with code splitting
@@ -241,25 +294,19 @@ if (buildLib) {
     "./lib/tree-sitter/default-parsers.ts",
   ]
 
-  spawnSync(
-    "bun",
-    [
-      "build",
-      "--target=bun",
-      "--splitting",
-      "--outdir=dist",
-      "--sourcemap",
-      ...externalPatterns.flatMap((dep) => ["--external", dep]),
-      ...entryPoints,
-    ],
-    {
-      cwd: rootDir,
-      stdio: "inherit",
-    },
-  )
+  runBunBuild({
+    entryPoints: portableEntryPoints,
+    externalPatterns,
+    splitting: true,
+    target: "node",
+  })
+
+  for (const { entryPoint, outputFile } of bunOnlyEntryPoints) {
+    transpileEntryPoint(entryPoint, join(distDir, outputFile))
+  }
 
   // Build updater as a separate entry so generator code stays out of the core runtime bundle.
-  spawnSync(
+  runCommand(
     "bun",
     [
       "build",
@@ -269,31 +316,17 @@ if (buildLib) {
       ...externalDeps.flatMap((dep) => ["--external", dep]),
       "src/lib/tree-sitter/update-assets.ts",
     ],
-    {
-      cwd: rootDir,
-      stdio: "inherit",
-    },
+    rootDir,
+    "Error: Bun build failed for src/lib/tree-sitter/update-assets.ts",
   )
 
   // Build parser worker as standalone bundle (no splitting) so it can be loaded as a Worker
   // Make web-tree-sitter external so it loads from node_modules with its WASM file
-  spawnSync(
-    "bun",
-    [
-      "build",
-      "--target=bun",
-      "--outdir=dist",
-      "--sourcemap",
-      ...externalDeps.flatMap((dep) => ["--external", dep]),
-      "--external",
-      "web-tree-sitter",
-      "src/lib/tree-sitter/parser.worker.ts",
-    ],
-    {
-      cwd: rootDir,
-      stdio: "inherit",
-    },
-  )
+  runBunBuild({
+    entryPoints: ["src/lib/tree-sitter/parser.worker.ts"],
+    externalPatterns: [...externalDeps, "web-tree-sitter"],
+    target: "node",
+  })
 
   // Post-process to fix Bun's duplicate export issue
   // See: https://github.com/oven-sh/bun/issues/5344
@@ -306,7 +339,7 @@ if (buildLib) {
     "dist/runtime-plugin-support.js",
     "dist/runtime-plugin-support-configure.js",
     "dist/lib/tree-sitter/update-assets.js",
-    "dist/lib/tree-sitter/parser.worker.js",
+    "dist/parser.worker.js",
   ]
   for (const filePath of bundledFiles) {
     const fullPath = join(rootDir, filePath)
@@ -339,17 +372,8 @@ if (buildLib) {
 
   const tsconfigBuildPath = join(rootDir, "tsconfig.build.json")
 
-  const tscResult: SpawnSyncReturns<Buffer> = spawnSync("bunx", ["tsc", "-p", tsconfigBuildPath], {
-    cwd: rootDir,
-    stdio: "inherit",
-  })
-
-  if (tscResult.status !== 0) {
-    console.error("Error: TypeScript declaration generation failed")
-    process.exit(1)
-  } else {
-    console.log("TypeScript declarations generated")
-  }
+  runCommand("bunx", ["tsc", "-p", tsconfigBuildPath], rootDir, "Error: TypeScript declaration generation failed")
+  console.log("TypeScript declarations generated")
 
   const treeSitterSrcDir = join(rootDir, "src", "lib", "tree-sitter")
 
@@ -370,32 +394,63 @@ if (buildLib) {
   copyAssets(join(treeSitterSrcDir, "assets"), join(distDir, "assets"))
   console.log("  Copied tree-sitter assets (*.wasm, *.scm) to dist/assets/")
 
+  const writeBunOnlyStub = (fileName: string, specifier: string, exportNames: string[]): void => {
+    const errorMessage = `${specifier} is Bun-only and is not available in Node.js. Use Bun to import this entrypoint.`
+    const namedExports = exportNames
+      .map(
+        (exportName) => `export function ${exportName}() {\n  throw new Error(${JSON.stringify(errorMessage)})\n}`,
+      )
+      .join("\n\n")
+
+    writeFileSync(
+      join(distDir, fileName),
+      `const errorMessage = ${JSON.stringify(errorMessage)}\n\n${namedExports}\n\nthrow new Error(errorMessage)\n`,
+    )
+  }
+
+  writeBunOnlyStub("runtime-plugin.node.js", `${packageJson.name}/runtime-plugin`, [
+    "createRuntimePlugin",
+    "isCoreRuntimeModuleSpecifier",
+    "runtimeModuleIdForSpecifier",
+  ])
+  writeBunOnlyStub("runtime-plugin-support.node.js", `${packageJson.name}/runtime-plugin-support`, [
+    "ensureRuntimePluginSupport",
+    "createRuntimePlugin",
+    "runtimeModuleIdForSpecifier",
+  ])
+  writeBunOnlyStub("runtime-plugin-support-configure.node.js", `${packageJson.name}/runtime-plugin-support/configure`, [
+    "ensureRuntimePluginSupport",
+    "createRuntimePlugin",
+    "runtimeModuleIdForSpecifier",
+  ])
+
   // Configure exports for multiple entry points
   const exports = {
     ".": {
       import: "./index.js",
-      require: "./index.js",
       types: "./index.d.ts",
     },
     "./testing": {
       import: "./testing.js",
-      require: "./testing.js",
       types: "./testing.d.ts",
     },
     "./runtime-plugin": {
-      import: "./runtime-plugin.js",
-      require: "./runtime-plugin.js",
       types: "./runtime-plugin.d.ts",
+      bun: "./runtime-plugin.js",
+      node: "./runtime-plugin.node.js",
+      default: "./runtime-plugin.node.js",
     },
     "./runtime-plugin-support": {
-      import: "./runtime-plugin-support.js",
-      require: "./runtime-plugin-support.js",
       types: "./runtime-plugin-support.d.ts",
+      bun: "./runtime-plugin-support.js",
+      node: "./runtime-plugin-support.node.js",
+      default: "./runtime-plugin-support.node.js",
     },
     "./runtime-plugin-support/configure": {
-      import: "./runtime-plugin-support-configure.js",
-      require: "./runtime-plugin-support-configure.js",
       types: "./runtime-plugin-support-configure.d.ts",
+      bun: "./runtime-plugin-support-configure.js",
+      node: "./runtime-plugin-support-configure.node.js",
+      default: "./runtime-plugin-support-configure.node.js",
     },
     "./tree-sitter/update-assets": {
       import: "./lib/tree-sitter/update-assets.js",
@@ -403,8 +458,7 @@ if (buildLib) {
       types: "./lib/tree-sitter/update-assets.d.ts",
     },
     "./parser.worker": {
-      import: "./lib/tree-sitter/parser.worker.js",
-      require: "./lib/tree-sitter/parser.worker.js",
+      import: "./parser.worker.js",
       types: "./lib/tree-sitter/parser.worker.d.ts",
     },
   }
@@ -432,7 +486,6 @@ if (buildLib) {
         bugs: packageJson.bugs,
         exports,
         dependencies: packageJson.dependencies,
-        devDependencies: packageJson.devDependencies,
         peerDependencies: packageJson.peerDependencies,
         optionalDependencies: {
           ...packageJson.optionalDependencies,

--- a/packages/core/scripts/dist-test.ts
+++ b/packages/core/scripts/dist-test.ts
@@ -1,0 +1,285 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process"
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, relative, resolve } from "node:path"
+import process from "node:process"
+import { fileURLToPath } from "node:url"
+
+interface PackageJson {
+  name: string
+  version: string
+}
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const rootDir = resolve(__dirname, "..")
+const distDir = join(rootDir, "dist")
+const args = new Set(process.argv.slice(2))
+const keepTemp = args.has("--keep-temp")
+const skipBuild = args.has("--skip-build")
+
+const packageJson = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8")) as PackageJson
+const nativePackageName = `${packageJson.name}-${process.platform}-${process.arch}`
+const nativePackageDir = join(rootDir, "node_modules", nativePackageName)
+
+const declarationPaths = ["index.d.ts", "testing.d.ts", "lib/tree-sitter/parser.worker.d.ts"]
+
+function runCommand(
+  command: string,
+  commandArgs: string[],
+  cwd: string,
+  errorMessage: string,
+  options: { stdio?: "inherit" | "pipe" } = {},
+): SpawnSyncReturns<Buffer> {
+  const result = spawnSync(command, commandArgs, {
+    cwd,
+    stdio: options.stdio ?? "inherit",
+  })
+
+  if (result.error) {
+    throw new Error(`${errorMessage}: ${result.error.message}`)
+  }
+
+  if (result.status !== 0) {
+    throw new Error(errorMessage)
+  }
+
+  return result
+}
+
+function runCommandExpectFailure(
+  command: string,
+  commandArgs: string[],
+  cwd: string,
+  errorMessage: string,
+): SpawnSyncReturns<Buffer> {
+  const result = spawnSync(command, commandArgs, {
+    cwd,
+    stdio: "pipe",
+  })
+
+  if (result.error) {
+    throw new Error(`${errorMessage}: ${result.error.message}`)
+  }
+
+  if (result.status === 0) {
+    throw new Error(errorMessage)
+  }
+
+  return result
+}
+
+function ensureBuildArtifacts(): void {
+  if (!skipBuild) {
+    runCommand("bun", ["run", "build"], rootDir, "Dist test build failed")
+  }
+
+  if (!existsSync(distDir)) {
+    throw new Error(`Missing dist directory at ${distDir}. Run bun run build first.`)
+  }
+
+  if (!existsSync(nativePackageDir)) {
+    throw new Error(`Missing native package directory at ${nativePackageDir}. Run bun run build first.`)
+  }
+}
+
+function assertPortableDeclarations(): void {
+  for (const declarationPath of declarationPaths) {
+    const fullPath = join(distDir, declarationPath)
+    const contents = readFileSync(fullPath, "utf8")
+    if (contents.includes("bun:ffi")) {
+      throw new Error(`Portable declaration ${declarationPath} still references bun:ffi`)
+    }
+  }
+}
+
+function packArtifact(packageDir: string, packDir: string): string {
+  const result = runCommand(
+    "npm",
+    ["pack", "--pack-destination", packDir],
+    packageDir,
+    `Failed to pack ${packageDir}`,
+    {
+      stdio: "pipe",
+    },
+  )
+
+  const tarballName = result.stdout.toString("utf8").trim().split(/\r?\n/).at(-1)
+
+  if (!tarballName) {
+    throw new Error(`Failed to determine tarball name for ${packageDir}`)
+  }
+
+  return join(packDir, tarballName)
+}
+
+function writeConsumerPackage(consumerDir: string, coreTarball: string, nativeTarball: string, name: string): void {
+  const coreDependency = `file:${relative(consumerDir, coreTarball).replaceAll("\\", "/")}`
+  const nativeDependency = `file:${relative(consumerDir, nativeTarball).replaceAll("\\", "/")}`
+
+  writeFileSync(
+    join(consumerDir, "package.json"),
+    JSON.stringify(
+      {
+        name,
+        private: true,
+        type: "module",
+        dependencies: {
+          [packageJson.name]: coreDependency,
+          [nativePackageName]: nativeDependency,
+        },
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+function writeNodeTest(nodeDir: string): void {
+  writeFileSync(
+    join(nodeDir, "index.mjs"),
+    `import assert from "node:assert/strict"
+
+const nativePackageName = ${JSON.stringify(nativePackageName)}
+
+const core = await import(${JSON.stringify(packageJson.name)})
+const testing = await import(${JSON.stringify(`${packageJson.name}/testing`)})
+const nativePackage = await import(nativePackageName)
+
+assert.equal(typeof core.createCliRenderer, "function")
+assert.equal(typeof testing.createTestRenderer, "function")
+assert.equal(typeof nativePackage.default, "string")
+
+const expectBunOnlyFailure = async (specifier, expectedMessage) => {
+  await assert.rejects(import(specifier), (error) => {
+    return error instanceof Error && error.message.includes(expectedMessage)
+  })
+}
+
+await expectBunOnlyFailure(${JSON.stringify(`${packageJson.name}/runtime-plugin`)}, ${JSON.stringify(`${packageJson.name}/runtime-plugin is Bun-only`)})
+await expectBunOnlyFailure(
+  ${JSON.stringify(`${packageJson.name}/runtime-plugin-support`)},
+  ${JSON.stringify(`${packageJson.name}/runtime-plugin-support is Bun-only`)},
+)
+await expectBunOnlyFailure(
+  ${JSON.stringify(`${packageJson.name}/runtime-plugin-support/configure`)},
+  ${JSON.stringify(`${packageJson.name}/runtime-plugin-support/configure is Bun-only`)},
+)
+
+console.log("Node dist smoke test passed")
+`,
+  )
+}
+
+function writeBunTest(bunDir: string): void {
+  writeFileSync(
+    join(bunDir, "index.test.ts"),
+    `import { describe, expect, test } from "bun:test"
+
+describe("${packageJson.name} dist smoke test", () => {
+  test("imports portable and Bun-only entrypoints", async () => {
+    const core = await import(${JSON.stringify(packageJson.name)})
+    const testing = await import(${JSON.stringify(`${packageJson.name}/testing`)})
+    const runtimePlugin = await import(${JSON.stringify(`${packageJson.name}/runtime-plugin`)})
+    const nativePackage = await import(${JSON.stringify(nativePackageName)})
+
+    expect(typeof core.createCliRenderer).toBe("function")
+    expect(typeof testing.createTestRenderer).toBe("function")
+    expect(typeof runtimePlugin.createRuntimePlugin).toBe("function")
+    expect(typeof nativePackage.default).toBe("string")
+  })
+})
+`,
+  )
+}
+
+function assertNodeStaticImportFailure(
+  nodeDir: string,
+  importedName: string,
+  specifier: string,
+  expectedMessage: string,
+): void {
+  const result = runCommandExpectFailure(
+    "node",
+    ["--input-type=module", "-e", `import { ${importedName} } from ${JSON.stringify(specifier)}`],
+    nodeDir,
+    `Expected static Node import of ${specifier} to fail`,
+  )
+
+  const output = `${result.stdout.toString("utf8")}\n${result.stderr.toString("utf8")}`
+
+  if (output.includes("does not provide an export named")) {
+    throw new Error(`Static Node import of ${specifier} failed before the Bun-only stub could run`)
+  }
+
+  if (!output.includes(expectedMessage)) {
+    throw new Error(`Static Node import of ${specifier} did not report the expected Bun-only error`)
+  }
+}
+
+function installAndTest(nodeDir: string, bunDir: string): void {
+  runCommand("npm", ["install", "--ignore-scripts", "--no-package-lock"], nodeDir, "Node dist test install failed")
+  runCommand("node", ["-e", `import(${JSON.stringify(packageJson.name)})`], nodeDir, "Node import smoke check failed")
+  runCommand("node", ["index.mjs"], nodeDir, "Node dist smoke tests failed")
+
+  assertNodeStaticImportFailure(
+    nodeDir,
+    "createRuntimePlugin",
+    `${packageJson.name}/runtime-plugin`,
+    `${packageJson.name}/runtime-plugin is Bun-only`,
+  )
+  assertNodeStaticImportFailure(
+    nodeDir,
+    "ensureRuntimePluginSupport",
+    `${packageJson.name}/runtime-plugin-support`,
+    `${packageJson.name}/runtime-plugin-support is Bun-only`,
+  )
+  assertNodeStaticImportFailure(
+    nodeDir,
+    "ensureRuntimePluginSupport",
+    `${packageJson.name}/runtime-plugin-support/configure`,
+    `${packageJson.name}/runtime-plugin-support/configure is Bun-only`,
+  )
+
+  runCommand("bun", ["install", "--ignore-scripts"], bunDir, "Bun dist test install failed")
+  runCommand("bun", ["test", "index.test.ts"], bunDir, "Bun dist smoke tests failed")
+}
+
+let tempRoot: string | undefined
+
+try {
+  ensureBuildArtifacts()
+  assertPortableDeclarations()
+
+  tempRoot = mkdtempSync(join(tmpdir(), "opentui-core-dist-test-"))
+  const packDir = join(tempRoot, "packs")
+  const nodeDir = join(tempRoot, "node")
+  const bunDir = join(tempRoot, "bun")
+
+  mkdirSync(packDir, { recursive: true })
+  mkdirSync(nodeDir, { recursive: true })
+  mkdirSync(bunDir, { recursive: true })
+
+  const coreTarball = packArtifact(distDir, packDir)
+  const nativeTarball = packArtifact(nativePackageDir, packDir)
+
+  writeConsumerPackage(nodeDir, coreTarball, nativeTarball, "opentui-core-dist-test-node")
+  writeConsumerPackage(bunDir, coreTarball, nativeTarball, "opentui-core-dist-test-bun")
+  writeNodeTest(nodeDir)
+  writeBunTest(bunDir)
+
+  installAndTest(nodeDir, bunDir)
+
+  if (!keepTemp) {
+    rmSync(tempRoot, { recursive: true, force: true })
+    tempRoot = undefined
+  }
+
+  console.log("Packed dist smoke tests passed")
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error)
+  if (tempRoot) {
+    console.error(`Dist test workspace kept at ${tempRoot}`)
+  }
+  process.exit(1)
+}

--- a/packages/core/src/lib/tree-sitter/assets/update.ts
+++ b/packages/core/src/lib/tree-sitter/assets/update.ts
@@ -6,6 +6,10 @@ import { DownloadUtils } from "../download-utils.js"
 import { parseArgs } from "util"
 import type { FiletypeParserOptions } from "../types.js"
 import { readdir } from "fs/promises"
+import { fileURLToPath } from "node:url"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 interface ParsersConfig {
   parsers: FiletypeParserOptions[]
@@ -300,7 +304,7 @@ async function main(options?: Partial<UpdateOptions>): Promise<void> {
 function parseCLIArgs(): Partial<UpdateOptions> | null {
   try {
     const { values } = parseArgs({
-      args: Bun.argv.slice(2),
+      args: process.argv.slice(2),
       options: {
         config: { type: "string" },
         assets: { type: "string" },


### PR DESCRIPTION
Add conditional exports (bun/node/default) so each runtime resolves the correct variant, and add a packed dist smoke test that verifies imports work in both Node.js and Bun.