### PR TITLE
build: add macOS SDK discovery and host builds

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -15,7 +15,7 @@ jobs:
       (contains(github.event.comment.body, ' /pkg-preview') ||
         startsWith(github.event.comment.body, '/pkg-preview')) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
@@ -46,7 +46,12 @@ jobs:
       - name: Get native package directories
         id: native-packages
         run: |
-          NATIVE_DIRS=$(find ./packages/core/node_modules/@opentui -maxdepth 1 -type d -name 'core-*' -printf '%p ' | sed 's/ $//')
+          NATIVE_DIRS=""
+          for dir in ./packages/core/node_modules/@opentui/core-*; do
+            if [ -d "$dir" ]; then
+              NATIVE_DIRS="${NATIVE_DIRS}${NATIVE_DIRS:+ }$dir"
+            fi
+          done
           echo "dirs=$NATIVE_DIRS" >> $GITHUB_OUTPUT
           echo "Found native packages: $NATIVE_DIRS"
 

--- a/bun.lock
+++ b/bun.lock
@@ -439,6 +439,18 @@
 
     "@opentui/core": ["@opentui/core@workspace:packages/core"],
 
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.2.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CAy6cL3byz2Xf6gFiJHBpcnsp/2ADEWLLOUokVypOyPLcy8GY3sPzlA4pkAjVGQMYQhDj+Y3+SXz4uTLt4AETg=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.2.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-K06h333rMkC9cyMJr/VvcRK3ik81Admd8ZsES5uf5YXWPdYhXGf75I1T8mKIThhUmoFLb8R5xqfuPmoocsjM7Q=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.2.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-iYWGTztbdG9yYSB5Alxuo0dWAmkWQR0+/paNWUyPOocjigmKgMmACDtHgYqa7sxkIcWgmXljt/f8rgXDG4wdMg=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.2.7", "", { "os": "linux", "cpu": "x64" }, "sha512-tymBCfYbsDRfHQNXsolkFfaTEIDhemD4+1ZovUztQd7i+0Ggnu9WbPN1SNCiRz6PjrlaNeQzZE3Wl8FfVdw/cw=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.2.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-XLPJWdT8QOukrYDkpIng6+uNUlF66ByXcQlC3qA9JbrUTBetZhgXs8Q2jEjRfc+Ty3uh1iRSA6PgJGbbOK/f4Q=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.2.7", "", { "os": "win32", "cpu": "x64" }, "sha512-CzVGEfqysVk8Hxcj0RDv/DtXIM6iZmbmr23kW7y8CJMPtmV1gmKI4D9abVjynWJnGbaSBnDi43mgZnGMgOdyEg=="],
+
     "@opentui/examples": ["@opentui/examples@workspace:packages/examples"],
 
     "@opentui/keymap": ["@opentui/keymap@workspace:packages/keymap"],

--- a/packages/core/scripts/build.ts
+++ b/packages/core/scripts/build.ts
@@ -52,6 +52,15 @@ const variants: Variant[] = [
   { platform: "win32", arch: "arm64" },
 ]
 
+const getHostVariant = (): Variant => {
+  const hostVariant = variants.find((variant) => variant.platform === process.platform && variant.arch === process.arch)
+  if (!hostVariant) {
+    console.error(`Error: Unsupported host platform for native builds: ${process.platform}-${process.arch}`)
+    process.exit(1)
+  }
+  return hostVariant
+}
+
 if (!buildLib && !buildNative) {
   console.error("Error: Please specify --lib, --native, or both")
   process.exit(1)
@@ -105,7 +114,9 @@ if (buildNative) {
     process.exit(1)
   }
 
-  for (const { platform, arch } of variants) {
+  const variantsToPackage = buildAll ? variants : [getHostVariant()]
+
+  for (const { platform, arch } of variantsToPackage) {
     const nativeName = `${packageJson.name}-${platform}-${arch}`
     const nativeDir = join(rootDir, "node_modules", nativeName)
     const libDir = join(rootDir, "src", "zig", "lib", getZigTarget(platform, arch))

--- a/packages/core/src/zig/build.zig
+++ b/packages/core/src/zig/build.zig
@@ -31,6 +31,20 @@ const DEFAULT_MACOS_SDK_PATH = "/Library/Developer/CommandLineTools/SDKs/MacOSX.
 const LIB_NAME = "opentui";
 const ROOT_SOURCE_FILE = "lib.zig";
 
+fn nativeExecutableTarget(b: *std.Build) std.Build.ResolvedTarget {
+    if (builtin.os.tag != .linux) {
+        return b.resolveTargetQuery(.{});
+    }
+
+    // Zig 0.15.2's ELF linker currently fails on newer glibc startup objects
+    // that ship .sframe relocations. Keep shipped libraries on linux-gnu, but
+    // use musl for local native executables so test/debug/bench still work.
+    var query = b.graph.host.query;
+    query.abi = .musl;
+    query.glibc_version = null;
+    return b.resolveTargetQuery(query);
+}
+
 fn pathExists(path: []const u8) bool {
     if (path.len == 0) return false;
     std.fs.cwd().access(path, .{}) catch return false;
@@ -227,7 +241,7 @@ pub fn build(b: *std.Build) void {
 
     // Test step (native only)
     const test_step = b.step("test", "Run unit tests");
-    const native_target = b.resolveTargetQuery(.{});
+    const native_target = nativeExecutableTarget(b);
     const test_mod = b.createModule(.{
         .root_source_file = b.path("test.zig"),
         .target = native_target,

--- a/packages/core/src/zig/build.zig
+++ b/packages/core/src/zig/build.zig
@@ -31,6 +31,109 @@ const DEFAULT_MACOS_SDK_PATH = "/Library/Developer/CommandLineTools/SDKs/MacOSX.
 const LIB_NAME = "opentui";
 const ROOT_SOURCE_FILE = "lib.zig";
 
+fn pathExists(path: []const u8) bool {
+    if (path.len == 0) return false;
+    std.fs.cwd().access(path, .{}) catch return false;
+    return true;
+}
+
+fn isMacOSSDKPath(path: []const u8) bool {
+    const trimmed_path = std.mem.trimRight(u8, path, "/");
+    if (trimmed_path.len == 0) return false;
+
+    const base_name = std.fs.path.basename(trimmed_path);
+    return std.mem.startsWith(u8, base_name, "MacOSX") and std.mem.endsWith(u8, base_name, ".sdk");
+}
+
+fn macOSSDKHasFramework(b: *std.Build, sdk_path: []const u8, framework: []const u8) bool {
+    return pathExists(b.pathJoin(&.{ sdk_path, "System", "Library", "Frameworks", b.fmt("{s}.framework", .{framework}) }));
+}
+
+fn isMacOSSDKAvailable(b: *std.Build, sdk_path: []const u8) bool {
+    return isMacOSSDKPath(sdk_path) and
+        pathExists(b.pathJoin(&.{ sdk_path, "usr", "lib" })) and
+        macOSSDKHasFramework(b, sdk_path, "CoreFoundation") and
+        macOSSDKHasFramework(b, sdk_path, "CoreAudio") and
+        macOSSDKHasFramework(b, sdk_path, "AudioToolbox");
+}
+
+fn resolveMacOSSDKPath(b: *std.Build) ?[]const u8 {
+    if (b.option([]const u8, "macos-sdk", "Path to a macOS SDK for CoreAudio headers and framework linking")) |sdk_path| {
+        if (isMacOSSDKAvailable(b, sdk_path)) return sdk_path;
+        std.debug.print("macOS SDK path '{s}' must be a MacOSX*.sdk with the required frameworks\n", .{sdk_path});
+        return null;
+    }
+
+    const env_vars = [_][]const u8{ "SDKROOT", "MACOS_SDK_PATH", "MACOSX_SDK_PATH" };
+    for (env_vars) |env_var| {
+        if (b.graph.env_map.get(env_var)) |sdk_path| {
+            if (isMacOSSDKAvailable(b, sdk_path)) return sdk_path;
+        }
+    }
+
+    if (builtin.os.tag == .macos and std.zig.system.darwin.isSdkInstalled(b.allocator)) {
+        const sdk_target = b.resolveTargetQuery(.{ .cpu_arch = .aarch64, .os_tag = .macos });
+        if (std.zig.system.darwin.getSdk(b.allocator, &sdk_target.result)) |sdk_path| {
+            if (isMacOSSDKAvailable(b, sdk_path)) return sdk_path;
+        }
+    }
+
+    if (isMacOSSDKAvailable(b, DEFAULT_MACOS_SDK_PATH)) return DEFAULT_MACOS_SDK_PATH;
+    return null;
+}
+
+fn printMissingMacOSSDK(target_description: []const u8) void {
+    std.debug.print(
+        "macOS SDK not found for {s}. Set SDKROOT, MACOS_SDK_PATH, or -Dmacos-sdk=/path/to/MacOSX.sdk.\n",
+        .{target_description},
+    );
+}
+
+fn addMiniaudioShim(
+    b: *std.Build,
+    artifact: *std.Build.Step.Compile,
+    target: std.Build.ResolvedTarget,
+    macos_sdk_path: ?[]const u8,
+) void {
+    const c_flags: []const []const u8 = switch (target.result.os.tag) {
+        .macos => blk: {
+            const flags = b.allocator.alloc([]const u8, 4) catch @panic("OOM");
+            flags[0] = "-std=c99";
+            flags[1] = "-DMA_NO_RUNTIME_LINKING";
+            flags[2] = "-isysroot";
+            flags[3] = macos_sdk_path.?;
+            break :blk flags;
+        },
+        else => &.{ "-std=c99" },
+    };
+
+    artifact.addIncludePath(b.path("."));
+    artifact.linkLibC();
+    artifact.addCSourceFile(.{
+        .file = b.path("miniaudio_shim.c"),
+        .flags = c_flags,
+    });
+}
+
+fn addMacOSSDKSearchPaths(b: *std.Build, artifact: *std.Build.Step.Compile, sdk_path: []const u8) void {
+    const include_path = b.pathJoin(&.{ sdk_path, "usr", "include" });
+    const framework_path = b.pathJoin(&.{ sdk_path, "System", "Library", "Frameworks" });
+    const lib_path = b.pathJoin(&.{ sdk_path, "usr", "lib" });
+
+    artifact.addSystemIncludePath(.{ .cwd_relative = include_path });
+    artifact.addSystemFrameworkPath(.{ .cwd_relative = framework_path });
+    artifact.addFrameworkPath(.{ .cwd_relative = framework_path });
+    artifact.addLibraryPath(.{ .cwd_relative = lib_path });
+}
+
+fn addMacOSSystemLibraries(b: *std.Build, artifact: *std.Build.Step.Compile, sdk_path: []const u8) void {
+    artifact.linkFramework("CoreFoundation");
+    artifact.linkFramework("CoreAudio");
+    artifact.linkFramework("AudioToolbox");
+    artifact.linkSystemLibrary("pthread");
+    addMacOSSDKSearchPaths(b, artifact, sdk_path);
+}
+
 /// Apply dependencies to a module
 fn applyDependencies(
     b: *std.Build,
@@ -98,21 +201,28 @@ pub fn build(b: *std.Build) void {
     const target_option = b.option([]const u8, "target", "Build for specific target (e.g., 'x86_64-linux-gnu').");
     const build_all = b.option(bool, "all", "Build for all supported targets") orelse false;
     const gpa_safe_stats = b.option(bool, "gpa-safe-stats", "Enable GPA safety checks for trustworthy allocator stats") orelse false;
+    const macos_sdk_path = resolveMacOSSDKPath(b);
     const build_options = b.addOptions();
     build_options.addOption(bool, "gpa_safe_stats", gpa_safe_stats);
 
     if (target_option) |target_str| {
         // Build single target
-        buildSingleTarget(b, target_str, optimize, build_options) catch |err| {
+        buildSingleTarget(b, target_str, optimize, build_options, macos_sdk_path) catch |err| {
             std.debug.print("Error building target '{s}': {}\n", .{ target_str, err });
             std.process.exit(1);
         };
     } else if (build_all) {
         // Build all supported targets
-        buildAllTargets(b, optimize, build_options);
+        buildAllTargets(b, optimize, build_options, macos_sdk_path) catch |err| {
+            std.debug.print("Error building all targets: {}\n", .{err});
+            std.process.exit(1);
+        };
     } else {
         // Build for native target only (default)
-        buildNativeTarget(b, optimize, build_options);
+        buildNativeTarget(b, optimize, build_options, macos_sdk_path) catch |err| {
+            std.debug.print("Error building native target: {}\n", .{err});
+            std.process.exit(1);
+        };
     }
 
     // Test step (native only)
@@ -130,27 +240,16 @@ pub fn build(b: *std.Build) void {
         .use_llvm = debug_use_llvm,
     });
 
-    const test_c_flags: []const []const u8 = if (native_target.result.os.tag == .macos)
-        &.{ "-std=c99", "-DMA_NO_RUNTIME_LINKING" }
-    else
-        &.{"-std=c99"};
-
-    test_artifact.addIncludePath(b.path("."));
-    test_artifact.linkLibC();
-    test_artifact.addCSourceFile(.{
-        .file = b.path("miniaudio_shim.c"),
-        .flags = test_c_flags,
-    });
+    addMiniaudioShim(b, test_artifact, native_target, macos_sdk_path);
 
     switch (native_target.result.os.tag) {
         .macos => {
-            test_artifact.linkFramework("CoreFoundation");
-            test_artifact.linkFramework("CoreAudio");
-            test_artifact.linkFramework("AudioToolbox");
-            test_artifact.linkSystemLibrary("pthread");
-            test_artifact.addFrameworkPath(.{ .cwd_relative = DEFAULT_MACOS_SDK_PATH });
-            test_artifact.addFrameworkPath(.{ .cwd_relative = b.fmt("{s}/System/Library/Frameworks", .{DEFAULT_MACOS_SDK_PATH}) });
-            test_artifact.addLibraryPath(.{ .cwd_relative = b.fmt("{s}/usr/lib", .{DEFAULT_MACOS_SDK_PATH}) });
+            if (macos_sdk_path) |sdk_path| {
+                addMacOSSystemLibraries(b, test_artifact, sdk_path);
+            } else {
+                printMissingMacOSSDK("native macOS tests");
+                std.process.exit(1);
+            }
         },
         .linux => {
             test_artifact.linkSystemLibrary("dl");
@@ -213,23 +312,31 @@ pub fn build(b: *std.Build) void {
     debug_step.dependOn(&run_debug.step);
 }
 
-fn buildAllTargets(b: *std.Build, optimize: std.builtin.OptimizeMode, build_options: *std.Build.Step.Options) void {
+fn buildAllTargets(
+    b: *std.Build,
+    optimize: std.builtin.OptimizeMode,
+    build_options: *std.Build.Step.Options,
+    macos_sdk_path: ?[]const u8,
+) !void {
     for (SUPPORTED_TARGETS) |supported_target| {
-        buildTarget(
+        try buildTarget(
             b,
             supported_target.zig_target,
             supported_target.output_name,
             supported_target.description,
             optimize,
             build_options,
-        ) catch |err| {
-            std.debug.print("Failed to build target {s}: {}\n", .{ supported_target.description, err });
-            continue;
-        };
+            macos_sdk_path,
+        );
     }
 }
 
-fn buildNativeTarget(b: *std.Build, optimize: std.builtin.OptimizeMode, build_options: *std.Build.Step.Options) void {
+fn buildNativeTarget(
+    b: *std.Build,
+    optimize: std.builtin.OptimizeMode,
+    build_options: *std.Build.Step.Options,
+    macos_sdk_path: ?[]const u8,
+) !void {
     // Find the matching supported target for the native platform
     const native_arch = @tagName(builtin.cpu.arch);
     const native_os = @tagName(builtin.os.tag);
@@ -239,21 +346,21 @@ fn buildNativeTarget(b: *std.Build, optimize: std.builtin.OptimizeMode, build_op
         if (std.mem.indexOf(u8, supported_target.zig_target, native_arch) != null and
             std.mem.indexOf(u8, supported_target.zig_target, native_os) != null)
         {
-            buildTarget(
+            try buildTarget(
                 b,
                 supported_target.zig_target,
                 supported_target.output_name,
                 supported_target.description,
                 optimize,
                 build_options,
-            ) catch |err| {
-                std.debug.print("Failed to build native target {s}: {}\n", .{ supported_target.description, err });
-            };
+                macos_sdk_path,
+            );
             return;
         }
     }
 
     std.debug.print("No matching supported target for native platform ({s}-{s})\n", .{ native_arch, native_os });
+    return error.UnsupportedNativeTarget;
 }
 
 fn buildSingleTarget(
@@ -261,6 +368,7 @@ fn buildSingleTarget(
     target_str: []const u8,
     optimize: std.builtin.OptimizeMode,
     build_options: *std.Build.Step.Options,
+    macos_sdk_path: ?[]const u8,
 ) !void {
     // Check if it matches a known target, use its output_name
     for (SUPPORTED_TARGETS) |supported_target| {
@@ -272,13 +380,14 @@ fn buildSingleTarget(
                 supported_target.description,
                 optimize,
                 build_options,
+                macos_sdk_path,
             );
             return;
         }
     }
     // Custom target - use target string as output name
     const description = try std.fmt.allocPrint(b.allocator, "Custom target: {s}", .{target_str});
-    try buildTarget(b, target_str, target_str, description, optimize, build_options);
+    try buildTarget(b, target_str, target_str, description, optimize, build_options, macos_sdk_path);
 }
 
 fn buildTarget(
@@ -288,13 +397,15 @@ fn buildTarget(
     description: []const u8,
     optimize: std.builtin.OptimizeMode,
     build_options: *std.Build.Step.Options,
+    macos_sdk_path: ?[]const u8,
 ) !void {
     const target_query = try std.Target.Query.parse(.{ .arch_os_abi = zig_target });
     const target = b.resolveTargetQuery(target_query);
-    const c_flags: []const []const u8 = if (target.result.os.tag == .macos)
-        &.{ "-std=c99", "-DMA_NO_RUNTIME_LINKING" }
-    else
-        &.{"-std=c99"};
+
+    if (target.result.os.tag == .macos and macos_sdk_path == null) {
+        printMissingMacOSSDK(description);
+        return error.MissingMacOSSDK;
+    }
 
     const module = b.createModule(.{
         .root_source_file = b.path(ROOT_SOURCE_FILE),
@@ -310,22 +421,11 @@ fn buildTarget(
         .linkage = .dynamic,
     });
 
-    lib.addIncludePath(b.path("."));
-    lib.linkLibC();
-    lib.addCSourceFile(.{
-        .file = b.path("miniaudio_shim.c"),
-        .flags = c_flags,
-    });
+    addMiniaudioShim(b, lib, target, macos_sdk_path);
 
     switch (target.result.os.tag) {
         .macos => {
-            lib.linkFramework("CoreFoundation");
-            lib.linkFramework("CoreAudio");
-            lib.linkFramework("AudioToolbox");
-            lib.linkSystemLibrary("pthread");
-            lib.addFrameworkPath(.{ .cwd_relative = DEFAULT_MACOS_SDK_PATH });
-            lib.addFrameworkPath(.{ .cwd_relative = b.fmt("{s}/System/Library/Frameworks", .{DEFAULT_MACOS_SDK_PATH}) });
-            lib.addLibraryPath(.{ .cwd_relative = b.fmt("{s}/usr/lib", .{DEFAULT_MACOS_SDK_PATH}) });
+            addMacOSSystemLibraries(b, lib, macos_sdk_path.?);
         },
         .linux => {
             lib.linkSystemLibrary("dl");

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -14,7 +14,8 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "bun src/index.ts",
-    "build": "bun scripts/build.ts"
+    "build": "bun scripts/build.ts",
+    "build:host": "bun scripts/build.ts --host"
   },
   "dependencies": {
     "@dimforge/rapier2d-simd-compat": "^0.17.3",

--- a/packages/examples/scripts/build.ts
+++ b/packages/examples/scripts/build.ts
@@ -82,7 +82,13 @@ function getNativePackageDir(platform: string, arch: string): string {
 
 function getHostBuildTarget(): BuildTarget {
   const hostPlatform =
-    process.platform === "win32" ? "windows" : process.platform === "darwin" ? "darwin" : process.platform === "linux" ? "linux" : null
+    process.platform === "win32"
+      ? "windows"
+      : process.platform === "darwin"
+        ? "darwin"
+        : process.platform === "linux"
+          ? "linux"
+          : null
 
   if (!hostPlatform || (process.arch !== "x64" && process.arch !== "arm64")) {
     throw new Error(`Unsupported host platform for examples build: ${process.platform}-${process.arch}`)

--- a/packages/examples/scripts/build.ts
+++ b/packages/examples/scripts/build.ts
@@ -25,8 +25,11 @@ const coreRoot = join(repoRoot, "packages", "core")
 const keymapRoot = join(repoRoot, "packages", "keymap")
 const threeRoot = join(repoRoot, "packages", "three")
 const examplesDir = join(packageRoot, "src")
+const args = process.argv.slice(2)
 const usePrebuiltArtifacts = process.env.OPENTUI_EXAMPLES_USE_PREBUILT_ARTIFACTS === "true"
 const skipBunWebgpuInstall = process.env.OPENTUI_EXAMPLES_SKIP_BUN_WEBGPU_INSTALL === "true"
+const buildHostOnly = args.includes("--host")
+const canBuildLocalNativePackagesForAllTargets = process.platform === "darwin"
 
 // Supported platforms and architectures based on bun-webgpu and opentui native binaries.
 const targets: BuildTarget[] = [
@@ -77,6 +80,28 @@ function getNativePackageDir(platform: string, arch: string): string {
   return join(coreRoot, "node_modules", "@opentui", `core-${packagePlatform}-${arch}`)
 }
 
+function getHostBuildTarget(): BuildTarget {
+  const hostPlatform =
+    process.platform === "win32" ? "windows" : process.platform === "darwin" ? "darwin" : process.platform === "linux" ? "linux" : null
+
+  if (!hostPlatform || (process.arch !== "x64" && process.arch !== "arm64")) {
+    throw new Error(`Unsupported host platform for examples build: ${process.platform}-${process.arch}`)
+  }
+
+  return { platform: hostPlatform, arch: process.arch }
+}
+
+function verifyNativePackages(buildTargets: BuildTarget[]): void {
+  for (const { platform, arch } of buildTargets) {
+    const packageDir = getNativePackageDir(platform, arch)
+    if (!existsSync(packageDir)) {
+      throw new Error(`Missing native package for ${platform}-${arch}: ${packageDir}`)
+    }
+  }
+}
+
+const buildTargets = buildHostOnly ? [getHostBuildTarget()] : targets
+
 if (skipBunWebgpuInstall) {
   console.log(`Skipping bun-webgpu install; assuming bun-webgpu@${bunWebgpuVersion} is already prepared`)
 } else {
@@ -87,19 +112,22 @@ if (skipBunWebgpuInstall) {
 
 if (usePrebuiltArtifacts) {
   console.log("Using prebuilt native opentui packages from CI artifacts...")
-
-  for (const { platform, arch } of targets) {
-    const packageDir = getNativePackageDir(platform, arch)
-    if (!existsSync(packageDir)) {
-      throw new Error(`Missing prebuilt native package for ${platform}-${arch}: ${packageDir}`)
-    }
-  }
-
+  verifyNativePackages(buildTargets)
   console.log("✅ Prebuilt native opentui packages verified")
-} else {
+} else if (buildHostOnly) {
+  console.log("Refreshing the host native opentui package...")
+  await Bun.$`bun ${join(coreRoot, "scripts", "build.ts")} --native`
+  verifyNativePackages(buildTargets)
+  console.log("✅ Host native package refreshed")
+} else if (canBuildLocalNativePackagesForAllTargets) {
   console.log("Building local native opentui packages for all platforms...")
   await Bun.$`bun ${join(coreRoot, "scripts", "build.ts")} --native --all`
+  verifyNativePackages(buildTargets)
   console.log("✅ Local native opentui packages refreshed")
+} else {
+  throw new Error(
+    "Full examples builds require macOS so current-source darwin native packages can be built. Use `bun run build:host` for a local host-only build.",
+  )
 }
 console.log()
 
@@ -110,7 +138,7 @@ console.log()
 let successCount = 0
 let failCount = 0
 
-for (const { platform: targetPlatform, arch: targetArch } of targets) {
+for (const { platform: targetPlatform, arch: targetArch } of buildTargets) {
   const exeName = targetPlatform === "windows" ? "opentui-examples.exe" : "opentui-examples"
   const outfile = join(distDir, `${targetPlatform}-${targetArch}`, exeName)
   const outDir = dirname(outfile)


### PR DESCRIPTION
Replace hardcoded macOS SDK paths with runtime discovery that
checks -Dmacos-sdk, SDKROOT/MACOS_SDK_PATH env vars, system
SDK detection, and the default CommandLineTools path as fallback.

Add host-only build mode so non-macOS developers can build and
test native packages for their own platform without needing to
cross-compile all targets.

Use musl for native executables on Linux to work around Zig
0.15.2 failing on newer glibc startup objects that contain
.sframe relocations. I think this is basically what it did before
the audio libs linked libc.

Move the CI preview workflow to macos-latest so it can build
darwin native packages from source.