### PR TITLE
fix: reuse streaming markdown list renderables

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -184,12 +184,6 @@ interface ListItemRenderInput {
   id: string
 }
 
-interface ListChildRenderInput {
-  token: MarkedToken
-  id: string
-  marginTop: number
-}
-
 export class MarkdownRenderable extends Renderable {
   private _content: string = ""
   private _syntaxStyle: SyntaxStyle
@@ -689,38 +683,25 @@ export class MarkdownRenderable extends Renderable {
     })
     row.add(content)
 
-    for (const child of this.getListChildInputs(input.item, input.id)) {
-      const renderable = this.createListChildRenderable(child.token, child.id)
-      if (!renderable) continue
-      renderable.marginTop = child.marginTop
-      content.add(renderable)
-    }
-
-    return row
-  }
-
-  private getListChildInputs(item: Tokens.ListItem, id: string): ListChildRenderInput[] {
-    const children: ListChildRenderInput[] = []
     let pendingMarginTop = 0
-
-    for (let index = 0; index < item.tokens.length; index += 1) {
-      const child = item.tokens[index] as MarkedToken | undefined
+    for (let index = 0; index < input.item.tokens.length; index += 1) {
+      const child = input.item.tokens[index] as MarkedToken | undefined
       if (!child) continue
       if (child.type === "checkbox") continue
       if (child.type === "space") {
         pendingMarginTop = Math.max(pendingMarginTop, 1)
         continue
       }
-
-      children.push({
-        token: child,
-        id: `${id}-child-${index}`,
-        marginTop: pendingMarginTop,
-      })
-      pendingMarginTop = 0
+      const renderable = this.createListChildRenderable(child, `${input.id}-child-${index}`)
+      if (!renderable) continue
+      if (pendingMarginTop > 0) {
+        renderable.marginTop = pendingMarginTop
+        pendingMarginTop = 0
+      }
+      content.add(renderable)
     }
 
-    return children
+    return row
   }
 
   private applyListItemRenderable(
@@ -733,100 +714,48 @@ export class MarkdownRenderable extends Renderable {
     const content = row.getChildren()[1]
     if (!(content instanceof BoxRenderable)) return false
 
-    const inputs = this.getListChildInputs(input.item, input.id)
-    const previousInputs = previousItem ? this.getListChildInputs(previousItem, input.id) : []
     const children = content.getChildren()
+    const markdownRaw = this.getSingleListItemMarkdownRaw(input.item)
 
-    for (let index = 0; index < inputs.length; index += 1) {
-      const childInput = inputs[index]
-      const existing = children[index]
-
-      if (
-        existing &&
-        this.canUpdateListChildRenderable(existing, childInput.token) &&
-        this.applyListChildRenderable(existing, childInput.token, previousInputs[index]?.token, childInput.id)
-      ) {
-        existing.marginTop = childInput.marginTop
-        continue
+    if (markdownRaw !== undefined) {
+      const child = children[0]
+      if (child instanceof CodeRenderable) {
+        this.applyMarkdownCodeRenderable(child, markdownRaw, 0)
+        child.marginTop = 0
+      } else if (markdownRaw.length > 0) {
+        content.add(this.createMarkdownCodeRenderable(markdownRaw, `${input.id}-child-0`), 0)
       }
 
-      existing?.destroyRecursively()
-      const renderable = this.createListChildRenderable(childInput.token, childInput.id)
-      if (!renderable) continue
-      renderable.marginTop = childInput.marginTop
-      content.add(renderable, index)
-    }
-
-    for (let index = children.length - 1; index >= inputs.length; index -= 1) {
-      children[index]?.destroyRecursively()
-    }
-
-    return true
-  }
-
-  private canUpdateListChildRenderable(renderable: Renderable, token: MarkedToken): boolean {
-    if (token.type === "text" || token.type === "paragraph") return renderable instanceof CodeRenderable
-    if (token.type === "code") return renderable instanceof CodeRenderable
-    if (token.type === "list") return renderable instanceof BoxRenderable
-    if (token.type === "blockquote") return renderable instanceof BoxRenderable
-    if (token.type === "hr") return renderable instanceof BoxRenderable
-    if (token.type === "table") return renderable instanceof TextTableRenderable || renderable instanceof CodeRenderable
-    return renderable instanceof CodeRenderable
-  }
-
-  private applyListChildRenderable(
-    renderable: Renderable,
-    token: MarkedToken,
-    previousToken: MarkedToken | undefined,
-    id: string,
-  ): boolean {
-    if ((token.type === "text" || token.type === "paragraph") && renderable instanceof CodeRenderable) {
-      this.applyMarkdownCodeRenderable(renderable, this.getListChildMarkdownRaw(token), 0)
+      this.destroyListItemChildrenAfter(content, 1)
       return true
     }
 
-    if (token.type === "code" && renderable instanceof CodeRenderable) {
-      this.applyCodeBlockRenderable(renderable, token as Tokens.Code, 0)
-      return true
-    }
-
-    if (token.type === "list") {
-      return this.applyListRenderable(renderable, token as Tokens.List, previousToken as Tokens.List | undefined, id)
-    }
-
-    if (token.type === "blockquote" && renderable instanceof BoxRenderable) {
-      this.applyBlockquoteRenderable(renderable, token, 0)
-      return true
-    }
-
-    if (token.type === "hr" && renderable instanceof BoxRenderable) {
-      renderable.marginBottom = 0
-      return true
-    }
-
-    if (token.type === "table") {
-      const tableToken = token as Tokens.Table
-      const { cache } = this.buildTableContentCache(tableToken)
-
-      if (!cache) {
-        if (!(renderable instanceof CodeRenderable)) return false
-        this.applyMarkdownCodeRenderable(renderable, tableToken.raw, 0)
-        return true
-      }
-
-      if (!(renderable instanceof TextTableRenderable)) return false
-      renderable.content = cache.content
-      this.applyTableRenderableOptions(renderable, this.resolveTableRenderableOptions())
-      renderable.marginBottom = 0
-      return true
-    }
-
-    if (renderable instanceof CodeRenderable && token.raw) {
-      this.applyMarkdownCodeRenderable(renderable, token.raw, 0)
+    if (previousItem && previousItem.raw === input.item.raw) {
       return true
     }
 
     return false
+  }
+
+  private getSingleListItemMarkdownRaw(item: Tokens.ListItem): string | undefined {
+    let raw = ""
+
+    for (const child of item.tokens as MarkedToken[]) {
+      if (child.type === "checkbox") continue
+      if (child.type === "space") continue
+      if (child.type !== "text" && child.type !== "paragraph") return undefined
+      if (raw.length > 0) return undefined
+      raw = this.getListChildMarkdownRaw(child)
+    }
+
+    return raw
+  }
+
+  private destroyListItemChildrenAfter(content: BoxRenderable, index: number): void {
+    const children = content.getChildren()
+    for (let i = children.length - 1; i >= index; i -= 1) {
+      children[i]?.destroyRecursively()
+    }
   }
 
   private getListChildMarkdownRaw(token: MarkedToken): string {

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -184,6 +184,12 @@ interface ListItemRenderInput {
   id: string
 }
 
+interface ListChildRenderInput {
+  token: MarkedToken
+  id: string
+  marginTop: number
+}
+
 export class MarkdownRenderable extends Renderable {
   private _content: string = ""
   private _syntaxStyle: SyntaxStyle
@@ -643,12 +649,7 @@ export class MarkdownRenderable extends Renderable {
       const input = inputs[index]
       const existing = rows[index]
 
-      if (
-        existing instanceof BoxRenderable &&
-        previousItems[index] &&
-        this.canReuseListItem(previousItems[index], input.item)
-      ) {
-        this.applyListItemMarker(existing, input)
+      if (existing instanceof BoxRenderable && this.applyListItemRenderable(existing, input, previousItems[index])) {
         continue
       }
 
@@ -661,14 +662,6 @@ export class MarkdownRenderable extends Renderable {
     }
 
     return true
-  }
-
-  private canReuseListItem(previous: Tokens.ListItem, next: Tokens.ListItem): boolean {
-    return previous.raw === next.raw || this.getListItemReuseKey(previous) === this.getListItemReuseKey(next)
-  }
-
-  private getListItemReuseKey(item: Tokens.ListItem): string {
-    return this.normalizeScrollbackMarkdownBlockRaw(item.raw)
   }
 
   private createListItemRenderable(input: ListItemRenderInput): BoxRenderable {
@@ -696,25 +689,148 @@ export class MarkdownRenderable extends Renderable {
     })
     row.add(content)
 
+    for (const child of this.getListChildInputs(input.item, input.id)) {
+      const renderable = this.createListChildRenderable(child.token, child.id)
+      if (!renderable) continue
+      renderable.marginTop = child.marginTop
+      content.add(renderable)
+    }
+
+    return row
+  }
+
+  private getListChildInputs(item: Tokens.ListItem, id: string): ListChildRenderInput[] {
+    const children: ListChildRenderInput[] = []
     let pendingMarginTop = 0
-    for (let index = 0; index < input.item.tokens.length; index += 1) {
-      const child = input.item.tokens[index] as MarkedToken | undefined
+
+    for (let index = 0; index < item.tokens.length; index += 1) {
+      const child = item.tokens[index] as MarkedToken | undefined
       if (!child) continue
       if (child.type === "checkbox") continue
       if (child.type === "space") {
         pendingMarginTop = Math.max(pendingMarginTop, 1)
         continue
       }
-      const renderable = this.createListChildRenderable(child, `${input.id}-child-${index}`)
-      if (!renderable) continue
-      if (pendingMarginTop > 0) {
-        renderable.marginTop = pendingMarginTop
-        pendingMarginTop = 0
-      }
-      content.add(renderable)
+
+      children.push({
+        token: child,
+        id: `${id}-child-${index}`,
+        marginTop: pendingMarginTop,
+      })
+      pendingMarginTop = 0
     }
 
-    return row
+    return children
+  }
+
+  private applyListItemRenderable(
+    row: BoxRenderable,
+    input: ListItemRenderInput,
+    previousItem: Tokens.ListItem | undefined,
+  ): boolean {
+    this.applyListItemMarker(row, input)
+
+    const content = row.getChildren()[1]
+    if (!(content instanceof BoxRenderable)) return false
+
+    const inputs = this.getListChildInputs(input.item, input.id)
+    const previousInputs = previousItem ? this.getListChildInputs(previousItem, input.id) : []
+    const children = content.getChildren()
+
+    for (let index = 0; index < inputs.length; index += 1) {
+      const childInput = inputs[index]
+      const existing = children[index]
+
+      if (
+        existing &&
+        this.canUpdateListChildRenderable(existing, childInput.token) &&
+        this.applyListChildRenderable(existing, childInput.token, previousInputs[index]?.token, childInput.id)
+      ) {
+        existing.marginTop = childInput.marginTop
+        continue
+      }
+
+      existing?.destroyRecursively()
+      const renderable = this.createListChildRenderable(childInput.token, childInput.id)
+      if (!renderable) continue
+      renderable.marginTop = childInput.marginTop
+      content.add(renderable, index)
+    }
+
+    for (let index = children.length - 1; index >= inputs.length; index -= 1) {
+      children[index]?.destroyRecursively()
+    }
+
+    return true
+  }
+
+  private canUpdateListChildRenderable(renderable: Renderable, token: MarkedToken): boolean {
+    if (token.type === "text" || token.type === "paragraph") return renderable instanceof CodeRenderable
+    if (token.type === "code") return renderable instanceof CodeRenderable
+    if (token.type === "list") return renderable instanceof BoxRenderable
+    if (token.type === "blockquote") return renderable instanceof BoxRenderable
+    if (token.type === "hr") return renderable instanceof BoxRenderable
+    if (token.type === "table") return renderable instanceof TextTableRenderable || renderable instanceof CodeRenderable
+    return renderable instanceof CodeRenderable
+  }
+
+  private applyListChildRenderable(
+    renderable: Renderable,
+    token: MarkedToken,
+    previousToken: MarkedToken | undefined,
+    id: string,
+  ): boolean {
+    if ((token.type === "text" || token.type === "paragraph") && renderable instanceof CodeRenderable) {
+      this.applyMarkdownCodeRenderable(renderable, this.getListChildMarkdownRaw(token), 0)
+      return true
+    }
+
+    if (token.type === "code" && renderable instanceof CodeRenderable) {
+      this.applyCodeBlockRenderable(renderable, token as Tokens.Code, 0)
+      return true
+    }
+
+    if (token.type === "list") {
+      return this.applyListRenderable(renderable, token as Tokens.List, previousToken as Tokens.List | undefined, id)
+    }
+
+    if (token.type === "blockquote" && renderable instanceof BoxRenderable) {
+      this.applyBlockquoteRenderable(renderable, token, 0)
+      return true
+    }
+
+    if (token.type === "hr" && renderable instanceof BoxRenderable) {
+      renderable.marginBottom = 0
+      return true
+    }
+
+    if (token.type === "table") {
+      const tableToken = token as Tokens.Table
+      const { cache } = this.buildTableContentCache(tableToken)
+
+      if (!cache) {
+        if (!(renderable instanceof CodeRenderable)) return false
+        this.applyMarkdownCodeRenderable(renderable, tableToken.raw, 0)
+        return true
+      }
+
+      if (!(renderable instanceof TextTableRenderable)) return false
+      renderable.content = cache.content
+      this.applyTableRenderableOptions(renderable, this.resolveTableRenderableOptions())
+      renderable.marginBottom = 0
+      return true
+    }
+
+    if (renderable instanceof CodeRenderable && token.raw) {
+      this.applyMarkdownCodeRenderable(renderable, token.raw, 0)
+      return true
+    }
+
+    return false
+  }
+
+  private getListChildMarkdownRaw(token: MarkedToken): string {
+    return token.type === "paragraph" ? this.normalizeScrollbackMarkdownBlockRaw(token.raw) : token.raw
   }
 
   private applyListItemMarker(row: BoxRenderable, input: ListItemRenderInput): void {
@@ -732,9 +848,9 @@ export class MarkdownRenderable extends Renderable {
   }
 
   private createListChildRenderable(token: MarkedToken, id: string): Renderable | null {
-    if (token.type === "text") return this.createMarkdownCodeRenderable(token.raw, id)
-    if (token.type === "paragraph")
-      return this.createMarkdownCodeRenderable(this.normalizeScrollbackMarkdownBlockRaw(token.raw), id)
+    if (token.type === "text" || token.type === "paragraph") {
+      return this.createMarkdownCodeRenderable(this.getListChildMarkdownRaw(token), id)
+    }
     if (token.type === "list") return this.createListRenderable(token as Tokens.List, id)
     if (token.type === "code") return this.createCodeRenderable(token as Tokens.Code, id)
     if (token.type === "blockquote") return this.createBlockquoteRenderable(token, id)

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -616,6 +616,62 @@ export class MarkdownRenderable extends Renderable {
     return list
   }
 
+  private applyListRenderable(
+    renderable: Renderable,
+    token: Tokens.List,
+    id: string,
+    marginBottom: number = 0,
+  ): boolean {
+    if (!this.isListRenderable(renderable)) return false
+
+    renderable.marginBottom = marginBottom
+
+    const items = token.items ?? []
+    const start = token.start === "" || token.start === undefined || token.start === null ? 1 : Number(token.start)
+    const markerWidth = Math.max(1, ...items.map((_, index) => (token.ordered ? `${start + index}.` : "-").length))
+    const rows = renderable.getChildren()
+
+    for (let index = 0; index < items.length; index += 1) {
+      const item = items[index]
+      if (!item) continue
+
+      const input = {
+        item,
+        marker: token.ordered ? `${start + index}.` : "-",
+        markerWidth,
+        id: `${id}-item-${index}`,
+      }
+      const existing = rows[index]
+
+      if (existing instanceof BoxRenderable && this.applyListItemRenderable(existing, input)) {
+        continue
+      }
+
+      existing?.destroyRecursively()
+      renderable.add(this.createListItemRenderable(input), index)
+    }
+
+    for (let index = rows.length - 1; index >= items.length; index -= 1) {
+      rows[index]?.destroyRecursively()
+    }
+
+    return true
+  }
+
+  private isListRenderable(renderable: Renderable): renderable is BoxRenderable {
+    if (!(renderable instanceof BoxRenderable)) return false
+
+    const rows = renderable.getChildren()
+    return (
+      rows.length > 0 &&
+      rows.every((row) => {
+        if (!(row instanceof BoxRenderable)) return false
+        const [marker, content] = row.getChildren()
+        return marker instanceof TextRenderable && content instanceof BoxRenderable
+      })
+    )
+  }
+
   private createListItemRenderable(input: {
     item: Tokens.ListItem
     marker: string
@@ -667,6 +723,57 @@ export class MarkdownRenderable extends Renderable {
     return row
   }
 
+  private applyListItemRenderable(
+    row: BoxRenderable,
+    input: {
+      item: Tokens.ListItem
+      marker: string
+      markerWidth: number
+      id: string
+    },
+  ): boolean {
+    const [marker, content] = row.getChildren()
+    if (!(marker instanceof TextRenderable) || !(content instanceof BoxRenderable)) return false
+
+    row.marginBottom = /\n[ \t]*\n$/.test(input.item.raw) ? 1 : 0
+    marker.content = new StyledText([this.createChunk(input.marker.padStart(input.markerWidth) + " ", "markup.list")])
+    marker.width = input.markerWidth + 1
+
+    const children = content.getChildren()
+    let childIndex = 0
+    let pendingMarginTop = 0
+
+    for (let index = 0; index < input.item.tokens.length; index += 1) {
+      const child = input.item.tokens[index] as MarkedToken | undefined
+      if (!child) continue
+      if (child.type === "checkbox") continue
+      if (child.type === "space") {
+        pendingMarginTop = Math.max(pendingMarginTop, 1)
+        continue
+      }
+
+      const existing = children[childIndex]
+      if (existing && this.applyListChildRenderable(existing, child)) {
+        existing.marginTop = pendingMarginTop
+      } else {
+        existing?.destroyRecursively()
+        const next = this.createListChildRenderable(child, `${input.id}-child-${index}`)
+        if (!next) continue
+        next.marginTop = pendingMarginTop
+        content.add(next, childIndex)
+      }
+
+      pendingMarginTop = 0
+      childIndex += 1
+    }
+
+    for (let index = children.length - 1; index >= childIndex; index -= 1) {
+      children[index]?.destroyRecursively()
+    }
+
+    return true
+  }
+
   private createListChildRenderable(token: MarkedToken, id: string): Renderable | null {
     if (token.type === "text") return this.createMarkdownCodeRenderable(token.raw, id)
     if (token.type === "paragraph")
@@ -677,6 +784,59 @@ export class MarkdownRenderable extends Renderable {
     if (token.type === "hr") return this.createHorizontalRuleRenderable(id)
     if (token.type === "table") return this.createTableBlock(token as Tokens.Table, id).renderable
     return token.raw ? this.createMarkdownCodeRenderable(token.raw, id) : null
+  }
+
+  private applyListChildRenderable(renderable: Renderable, token: MarkedToken): boolean {
+    if (token.type === "text") {
+      if (!(renderable instanceof CodeRenderable)) return false
+      this.applyMarkdownCodeRenderable(renderable, token.raw, 0)
+      return true
+    }
+
+    if (token.type === "paragraph") {
+      if (!(renderable instanceof CodeRenderable)) return false
+      this.applyMarkdownCodeRenderable(renderable, this.normalizeScrollbackMarkdownBlockRaw(token.raw), 0)
+      return true
+    }
+
+    if (token.type === "list") return this.applyListRenderable(renderable, token as Tokens.List, renderable.id)
+
+    if (token.type === "code") {
+      if (!(renderable instanceof CodeRenderable)) return false
+      this.applyCodeBlockRenderable(renderable, token as Tokens.Code, 0)
+      return true
+    }
+
+    if (token.type === "blockquote") {
+      if (!(renderable instanceof BoxRenderable)) return false
+      this.applyBlockquoteRenderable(renderable, token, 0)
+      return true
+    }
+
+    if (token.type === "hr") {
+      if (!(renderable instanceof BoxRenderable)) return false
+      renderable.marginBottom = 0
+      return true
+    }
+
+    if (token.type === "table") {
+      const tableToken = token as Tokens.Table
+      const { cache } = this.buildTableContentCache(tableToken)
+      if (!cache) {
+        if (!(renderable instanceof CodeRenderable)) return false
+        this.applyMarkdownCodeRenderable(renderable, tableToken.raw, 0)
+        return true
+      }
+      if (!(renderable instanceof TextTableRenderable)) return false
+      renderable.content = cache.content
+      this.applyTableRenderableOptions(renderable, this.resolveTableRenderableOptions())
+      renderable.marginBottom = 0
+      return true
+    }
+
+    if (!token.raw || !(renderable instanceof CodeRenderable)) return false
+    this.applyMarkdownCodeRenderable(renderable, token.raw, 0)
+    return true
   }
 
   private createHorizontalRuleRenderable(id: string, marginBottom: number = 0): BoxRenderable {
@@ -1315,9 +1475,13 @@ export class MarkdownRenderable extends Renderable {
     }
 
     if (token.type === "list") {
-      state.renderable.destroyRecursively()
-      state.renderable = this.createListRenderable(token as Tokens.List, `${this.id}-block-${index}`, marginBottom)
-      this.add(state.renderable, index)
+      if (
+        !this.applyListRenderable(state.renderable, token as Tokens.List, `${this.id}-block-${index}`, marginBottom)
+      ) {
+        state.renderable.destroyRecursively()
+        state.renderable = this.createListRenderable(token as Tokens.List, `${this.id}-block-${index}`, marginBottom)
+        this.add(state.renderable, index)
+      }
       return
     }
 
@@ -1460,7 +1624,7 @@ export class MarkdownRenderable extends Renderable {
 
     if (token.type === "table") return renderable instanceof TextTableRenderable
     if (token.type === "blockquote") return renderable instanceof BoxRenderable
-    if (token.type === "list") return false
+    if (token.type === "list") return this.isListRenderable(renderable)
     if (token.type === "hr") return renderable instanceof BoxRenderable
     return renderable instanceof CodeRenderable
   }
@@ -1631,9 +1795,17 @@ export class MarkdownRenderable extends Renderable {
       }
 
       if (state.token.type === "list") {
-        state.renderable.destroyRecursively()
-        state.renderable = this.createListRenderable(state.token as Tokens.List, `${this.id}-block-${i}`, marginBottom)
-        this.add(state.renderable, i)
+        if (
+          !this.applyListRenderable(state.renderable, state.token as Tokens.List, `${this.id}-block-${i}`, marginBottom)
+        ) {
+          state.renderable.destroyRecursively()
+          state.renderable = this.createListRenderable(
+            state.token as Tokens.List,
+            `${this.id}-block-${i}`,
+            marginBottom,
+          )
+          this.add(state.renderable, i)
+        }
         continue
       }
 

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -177,6 +177,13 @@ interface MarkdownRenderBlock {
   marginTop: number
 }
 
+interface ListItemRenderInput {
+  item: Tokens.ListItem
+  marker: string
+  markerWidth: number
+  id: string
+}
+
 export class MarkdownRenderable extends Renderable {
   private _content: string = ""
   private _syntaxStyle: SyntaxStyle
@@ -589,9 +596,6 @@ export class MarkdownRenderable extends Renderable {
   }
 
   private createListRenderable(token: Tokens.List, id: string, marginBottom: number = 0): BoxRenderable {
-    const items = token.items ?? []
-    const start = token.start === "" || token.start === undefined || token.start === null ? 1 : Number(token.start)
-    const markerWidth = Math.max(1, ...items.map((_, index) => (token.ordered ? `${start + index}.` : "-").length))
     const list = new BoxRenderable(this.ctx, {
       id,
       width: "100%",
@@ -600,50 +604,51 @@ export class MarkdownRenderable extends Renderable {
       marginBottom,
     })
 
-    for (let index = 0; index < items.length; index += 1) {
-      const item = items[index]
-      if (!item) continue
-      list.add(
-        this.createListItemRenderable({
-          item,
-          marker: token.ordered ? `${start + index}.` : "-",
-          markerWidth,
-          id: `${id}-item-${index}`,
-        }),
-      )
+    for (const item of this.getListItemInputs(token, id)) {
+      list.add(this.createListItemRenderable(item))
     }
 
     return list
   }
 
-  private applyListRenderable(
-    renderable: Renderable,
-    token: Tokens.List,
-    id: string,
-    marginBottom: number = 0,
-  ): boolean {
-    if (!this.isListRenderable(renderable)) return false
-
-    renderable.marginBottom = marginBottom
-
+  private getListItemInputs(token: Tokens.List, id: string): ListItemRenderInput[] {
     const items = token.items ?? []
     const start = token.start === "" || token.start === undefined || token.start === null ? 1 : Number(token.start)
     const markerWidth = Math.max(1, ...items.map((_, index) => (token.ordered ? `${start + index}.` : "-").length))
+
+    return items.map((item, index) => ({
+      item,
+      marker: token.ordered ? `${start + index}.` : "-",
+      markerWidth,
+      id: `${id}-item-${index}`,
+    }))
+  }
+
+  private applyListRenderable(
+    renderable: Renderable,
+    token: Tokens.List,
+    previousToken: Tokens.List | undefined,
+    id: string,
+    marginBottom: number = 0,
+  ): boolean {
+    if (!(renderable instanceof BoxRenderable)) return false
+
+    renderable.marginBottom = marginBottom
+
+    const inputs = this.getListItemInputs(token, id)
+    const previousItems = previousToken?.items ?? []
     const rows = renderable.getChildren()
 
-    for (let index = 0; index < items.length; index += 1) {
-      const item = items[index]
-      if (!item) continue
-
-      const input = {
-        item,
-        marker: token.ordered ? `${start + index}.` : "-",
-        markerWidth,
-        id: `${id}-item-${index}`,
-      }
+    for (let index = 0; index < inputs.length; index += 1) {
+      const input = inputs[index]
       const existing = rows[index]
 
-      if (existing instanceof BoxRenderable && this.applyListItemRenderable(existing, input)) {
+      if (
+        existing instanceof BoxRenderable &&
+        previousItems[index] &&
+        this.getListItemReuseKey(previousItems[index]) === this.getListItemReuseKey(input.item)
+      ) {
+        this.applyListItemMarker(existing, input)
         continue
       }
 
@@ -651,33 +656,18 @@ export class MarkdownRenderable extends Renderable {
       renderable.add(this.createListItemRenderable(input), index)
     }
 
-    for (let index = rows.length - 1; index >= items.length; index -= 1) {
+    for (let index = rows.length - 1; index >= inputs.length; index -= 1) {
       rows[index]?.destroyRecursively()
     }
 
     return true
   }
 
-  private isListRenderable(renderable: Renderable): renderable is BoxRenderable {
-    if (!(renderable instanceof BoxRenderable)) return false
-
-    const rows = renderable.getChildren()
-    return (
-      rows.length > 0 &&
-      rows.every((row) => {
-        if (!(row instanceof BoxRenderable)) return false
-        const [marker, content] = row.getChildren()
-        return marker instanceof TextRenderable && content instanceof BoxRenderable
-      })
-    )
+  private getListItemReuseKey(item: Tokens.ListItem): string {
+    return this.normalizeScrollbackMarkdownBlockRaw(item.raw)
   }
 
-  private createListItemRenderable(input: {
-    item: Tokens.ListItem
-    marker: string
-    markerWidth: number
-    id: string
-  }): BoxRenderable {
+  private createListItemRenderable(input: ListItemRenderInput): BoxRenderable {
     const row = new BoxRenderable(this.ctx, {
       id: input.id,
       width: "100%",
@@ -723,55 +713,12 @@ export class MarkdownRenderable extends Renderable {
     return row
   }
 
-  private applyListItemRenderable(
-    row: BoxRenderable,
-    input: {
-      item: Tokens.ListItem
-      marker: string
-      markerWidth: number
-      id: string
-    },
-  ): boolean {
-    const [marker, content] = row.getChildren()
-    if (!(marker instanceof TextRenderable) || !(content instanceof BoxRenderable)) return false
-
+  private applyListItemMarker(row: BoxRenderable, input: ListItemRenderInput): void {
+    const marker = row.getChildren()[0]
+    if (!(marker instanceof TextRenderable)) return
     row.marginBottom = /\n[ \t]*\n$/.test(input.item.raw) ? 1 : 0
     marker.content = new StyledText([this.createChunk(input.marker.padStart(input.markerWidth) + " ", "markup.list")])
     marker.width = input.markerWidth + 1
-
-    const children = content.getChildren()
-    let childIndex = 0
-    let pendingMarginTop = 0
-
-    for (let index = 0; index < input.item.tokens.length; index += 1) {
-      const child = input.item.tokens[index] as MarkedToken | undefined
-      if (!child) continue
-      if (child.type === "checkbox") continue
-      if (child.type === "space") {
-        pendingMarginTop = Math.max(pendingMarginTop, 1)
-        continue
-      }
-
-      const existing = children[childIndex]
-      if (existing && this.applyListChildRenderable(existing, child)) {
-        existing.marginTop = pendingMarginTop
-      } else {
-        existing?.destroyRecursively()
-        const next = this.createListChildRenderable(child, `${input.id}-child-${index}`)
-        if (!next) continue
-        next.marginTop = pendingMarginTop
-        content.add(next, childIndex)
-      }
-
-      pendingMarginTop = 0
-      childIndex += 1
-    }
-
-    for (let index = children.length - 1; index >= childIndex; index -= 1) {
-      children[index]?.destroyRecursively()
-    }
-
-    return true
   }
 
   private createListChildRenderable(token: MarkedToken, id: string): Renderable | null {
@@ -784,59 +731,6 @@ export class MarkdownRenderable extends Renderable {
     if (token.type === "hr") return this.createHorizontalRuleRenderable(id)
     if (token.type === "table") return this.createTableBlock(token as Tokens.Table, id).renderable
     return token.raw ? this.createMarkdownCodeRenderable(token.raw, id) : null
-  }
-
-  private applyListChildRenderable(renderable: Renderable, token: MarkedToken): boolean {
-    if (token.type === "text") {
-      if (!(renderable instanceof CodeRenderable)) return false
-      this.applyMarkdownCodeRenderable(renderable, token.raw, 0)
-      return true
-    }
-
-    if (token.type === "paragraph") {
-      if (!(renderable instanceof CodeRenderable)) return false
-      this.applyMarkdownCodeRenderable(renderable, this.normalizeScrollbackMarkdownBlockRaw(token.raw), 0)
-      return true
-    }
-
-    if (token.type === "list") return this.applyListRenderable(renderable, token as Tokens.List, renderable.id)
-
-    if (token.type === "code") {
-      if (!(renderable instanceof CodeRenderable)) return false
-      this.applyCodeBlockRenderable(renderable, token as Tokens.Code, 0)
-      return true
-    }
-
-    if (token.type === "blockquote") {
-      if (!(renderable instanceof BoxRenderable)) return false
-      this.applyBlockquoteRenderable(renderable, token, 0)
-      return true
-    }
-
-    if (token.type === "hr") {
-      if (!(renderable instanceof BoxRenderable)) return false
-      renderable.marginBottom = 0
-      return true
-    }
-
-    if (token.type === "table") {
-      const tableToken = token as Tokens.Table
-      const { cache } = this.buildTableContentCache(tableToken)
-      if (!cache) {
-        if (!(renderable instanceof CodeRenderable)) return false
-        this.applyMarkdownCodeRenderable(renderable, tableToken.raw, 0)
-        return true
-      }
-      if (!(renderable instanceof TextTableRenderable)) return false
-      renderable.content = cache.content
-      this.applyTableRenderableOptions(renderable, this.resolveTableRenderableOptions())
-      renderable.marginBottom = 0
-      return true
-    }
-
-    if (!token.raw || !(renderable instanceof CodeRenderable)) return false
-    this.applyMarkdownCodeRenderable(renderable, token.raw, 0)
-    return true
   }
 
   private createHorizontalRuleRenderable(id: string, marginBottom: number = 0): BoxRenderable {
@@ -1476,7 +1370,13 @@ export class MarkdownRenderable extends Renderable {
 
     if (token.type === "list") {
       if (
-        !this.applyListRenderable(state.renderable, token as Tokens.List, `${this.id}-block-${index}`, marginBottom)
+        !this.applyListRenderable(
+          state.renderable,
+          token as Tokens.List,
+          state.token as Tokens.List,
+          `${this.id}-block-${index}`,
+          marginBottom,
+        )
       ) {
         state.renderable.destroyRecursively()
         state.renderable = this.createListRenderable(token as Tokens.List, `${this.id}-block-${index}`, marginBottom)
@@ -1624,7 +1524,7 @@ export class MarkdownRenderable extends Renderable {
 
     if (token.type === "table") return renderable instanceof TextTableRenderable
     if (token.type === "blockquote") return renderable instanceof BoxRenderable
-    if (token.type === "list") return this.isListRenderable(renderable)
+    if (token.type === "list") return renderable instanceof BoxRenderable
     if (token.type === "hr") return renderable instanceof BoxRenderable
     return renderable instanceof CodeRenderable
   }
@@ -1795,17 +1695,7 @@ export class MarkdownRenderable extends Renderable {
       }
 
       if (state.token.type === "list") {
-        if (
-          !this.applyListRenderable(state.renderable, state.token as Tokens.List, `${this.id}-block-${i}`, marginBottom)
-        ) {
-          state.renderable.destroyRecursively()
-          state.renderable = this.createListRenderable(
-            state.token as Tokens.List,
-            `${this.id}-block-${i}`,
-            marginBottom,
-          )
-          this.add(state.renderable, i)
-        }
+        this.updateBlockRenderable(state, state.token, i, hasNextToken)
         continue
       }
 

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -646,7 +646,7 @@ export class MarkdownRenderable extends Renderable {
       if (
         existing instanceof BoxRenderable &&
         previousItems[index] &&
-        this.getListItemReuseKey(previousItems[index]) === this.getListItemReuseKey(input.item)
+        this.canReuseListItem(previousItems[index], input.item)
       ) {
         this.applyListItemMarker(existing, input)
         continue
@@ -661,6 +661,10 @@ export class MarkdownRenderable extends Renderable {
     }
 
     return true
+  }
+
+  private canReuseListItem(previous: Tokens.ListItem, next: Tokens.ListItem): boolean {
+    return previous.raw === next.raw || this.getListItemReuseKey(previous) === this.getListItemReuseKey(next)
   }
 
   private getListItemReuseKey(item: Tokens.ListItem): string {
@@ -716,9 +720,15 @@ export class MarkdownRenderable extends Renderable {
   private applyListItemMarker(row: BoxRenderable, input: ListItemRenderInput): void {
     const marker = row.getChildren()[0]
     if (!(marker instanceof TextRenderable)) return
-    row.marginBottom = /\n[ \t]*\n$/.test(input.item.raw) ? 1 : 0
-    marker.content = new StyledText([this.createChunk(input.marker.padStart(input.markerWidth) + " ", "markup.list")])
-    marker.width = input.markerWidth + 1
+    const marginBottom = /\n[ \t]*\n$/.test(input.item.raw) ? 1 : 0
+    const markerWidth = input.markerWidth + 1
+    const markerText = input.marker.padStart(input.markerWidth) + " "
+
+    if (row.marginBottom !== marginBottom) row.marginBottom = marginBottom
+    if (marker.width !== markerWidth) marker.width = markerWidth
+    if (marker.chunks[0]?.text !== markerText) {
+      marker.content = new StyledText([this.createChunk(markerText, "markup.list")])
+    }
   }
 
   private createListChildRenderable(token: MarkedToken, id: string): Renderable | null {
@@ -1355,7 +1365,13 @@ export class MarkdownRenderable extends Renderable {
     return this.createMarkdownCodeRenderable(token.raw, id, marginBottom)
   }
 
-  private updateBlockRenderable(state: BlockState, token: MarkedToken, index: number, hasNextToken: boolean): void {
+  private updateBlockRenderable(
+    state: BlockState,
+    token: MarkedToken,
+    index: number,
+    hasNextToken: boolean,
+    forceListRefresh: boolean = false,
+  ): void {
     const marginBottom = this.getInterBlockMargin(token, hasNextToken)
 
     if (token.type === "code") {
@@ -1373,7 +1389,7 @@ export class MarkdownRenderable extends Renderable {
         !this.applyListRenderable(
           state.renderable,
           token as Tokens.List,
-          state.token as Tokens.List,
+          forceListRefresh ? undefined : (state.token as Tokens.List),
           `${this.id}-block-${index}`,
           marginBottom,
         )
@@ -1695,7 +1711,7 @@ export class MarkdownRenderable extends Renderable {
       }
 
       if (state.token.type === "list") {
-        this.updateBlockRenderable(state, state.token, i, hasNextToken)
+        this.updateBlockRenderable(state, state.token, i, hasNextToken, true)
         continue
       }
 

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -2,6 +2,7 @@ import { test, expect, beforeAll, beforeEach, afterEach, afterAll } from "bun:te
 import { Lexer } from "marked"
 import { MarkdownRenderable, type MarkdownOptions } from "../Markdown.js"
 import { CodeRenderable } from "../Code.js"
+import { BoxRenderable } from "../Box.js"
 import { TextRenderable } from "../Text.js"
 import { TextTableRenderable } from "../TextTable.js"
 import { SyntaxStyle } from "../../syntax-style.js"
@@ -1153,6 +1154,10 @@ test("streaming structured lists reuse existing renderables while appending", as
   const listBefore = md._blockStates[0]?.renderable
   const firstRowBefore = listBefore?.getChildren()[0]
   const firstTextBefore = firstRowBefore?.getChildren()[1]?.getChildren()[0]
+
+  expect(listBefore).toBeInstanceOf(BoxRenderable)
+  expect(firstRowBefore).toBeInstanceOf(BoxRenderable)
+  expect(firstTextBefore).toBeInstanceOf(CodeRenderable)
 
   md.content = "- first\n- second"
   await renderMarkdownRenderable(md)

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -18,6 +18,7 @@ import {
   MockTreeSitterClient,
   TestRecorder,
 } from "../../testing.js"
+import { ManualClock } from "../../testing/manual-clock.js"
 import { TextAttributes, type CapturedFrame } from "../../types.js"
 
 let renderer: TestRenderer
@@ -1169,6 +1170,58 @@ test("streaming structured lists reuse existing renderables while appending", as
   expect(listAfter).toBe(listBefore)
   expect(firstRowAfter).toBe(firstRowBefore)
   expect(firstTextAfter).toBe(firstTextBefore)
+})
+
+test("streaming structured list updates keep previous item text visible while highlighting", async () => {
+  const mockTreeSitterClient = new MockTreeSitterClient()
+  const md = createMarkdownRenderable({
+    id: "markdown-streaming-structured-list-no-flicker",
+    content: "- alp\n- bet\n- gam",
+    syntaxStyle,
+    streaming: true,
+    internalBlockMode: "top-level",
+    treeSitterClient: mockTreeSitterClient,
+  })
+
+  renderer.root.add(md)
+  await renderOnce()
+  expect(mockTreeSitterClient.isHighlighting()).toBe(true)
+  mockTreeSitterClient.resolveAllHighlightOnce()
+  await Bun.sleep(0)
+  await renderOnce()
+
+  const settledFrame = captureFrame()
+  expect(settledFrame).toContain("- alp")
+  expect(settledFrame).toContain("- bet")
+  expect(settledFrame).toContain("- gam")
+
+  const clock = new ManualClock()
+  const recorder = new TestRecorder(renderer, { now: () => clock.now() })
+  recorder.rec()
+
+  md.content = "- alpha\n- beta\n- gamma"
+  await renderOnce()
+  clock.advance(16)
+  await renderOnce()
+
+  const framesBeforeHighlight = recorder.recordedFrames.map((recorded) => recorded.frame)
+  expect(framesBeforeHighlight.length).toBeGreaterThan(0)
+  for (const frame of framesBeforeHighlight) {
+    expect(frame).toContain("- alp")
+    expect(frame).toContain("- bet")
+    expect(frame).toContain("- gam")
+  }
+
+  expect(mockTreeSitterClient.isHighlighting()).toBe(true)
+  mockTreeSitterClient.resolveAllHighlightOnce()
+  await Bun.sleep(0)
+  await renderOnce()
+  recorder.stop()
+
+  const finalFrame = captureFrame()
+  expect(finalFrame).toContain("- alpha")
+  expect(finalFrame).toContain("- beta")
+  expect(finalFrame).toContain("- gamma")
 })
 
 test("assistant-style top-level markdown layout", async () => {

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1138,6 +1138,34 @@ test("top-level structured ordered lists align multi-digit markers", async () =>
   `)
 })
 
+test("streaming structured lists reuse existing renderables while appending", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-streaming-structured-list-reuse",
+    content: "- first",
+    syntaxStyle,
+    streaming: true,
+    internalBlockMode: "top-level",
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const listBefore = md._blockStates[0]?.renderable
+  const firstRowBefore = listBefore?.getChildren()[0]
+  const firstTextBefore = firstRowBefore?.getChildren()[1]?.getChildren()[0]
+
+  md.content = "- first\n- second"
+  await renderMarkdownRenderable(md)
+
+  const listAfter = md._blockStates[0]?.renderable
+  const firstRowAfter = listAfter?.getChildren()[0]
+  const firstTextAfter = firstRowAfter?.getChildren()[1]?.getChildren()[0]
+
+  expect(listAfter).toBe(listBefore)
+  expect(firstRowAfter).toBe(firstRowBefore)
+  expect(firstTextAfter).toBe(firstTextBefore)
+})
+
 test("assistant-style top-level markdown layout", async () => {
   const md = createMarkdownRenderable({
     id: "assistant-style-layout",


### PR DESCRIPTION
## Summary
- Reuse the structured markdown list container when streaming content updates.
- Preserve unchanged list rows by comparing normalized item source, while replacing only changed/new/removed rows.
- Add regression coverage that appending to a streaming list preserves existing renderable identities.

## Tests
- `PATH="/opt/homebrew/opt/zig@0.15/bin:$PATH" bun run build:native:dev`
- `bunx oxlint packages/core/src/renderables/Markdown.ts packages/core/src/renderables/__tests__/Markdown.test.ts`
- `bunx oxfmt --check packages/core/src/renderables/Markdown.ts packages/core/src/renderables/__tests__/Markdown.test.ts`
- `bun test src/renderables/__tests__/Markdown.test.ts -t "streaming structured lists reuse existing renderables while appending"`
- `bun test src/renderables/__tests__/Markdown.test.ts -t "structured|list"`

## Note
- Full `bun test src/renderables/__tests__/Markdown.test.ts` hit a native panic in `CliRenderer.prepareRenderFrame` (`integer does not fit in destination type`) and timed out locally.