### PR TITLE
fix keymap fallback priority

### DIFF
--- a/packages/keymap/README.md
+++ b/packages/keymap/README.md
@@ -11,7 +11,7 @@ It models keybindings as priority-ordered, focus-scoped layers attached to targe
 - **Layered bindings** with priority ordering, newest-first ties, `fallthrough`, and `preventDefault` control.
 - **Branch-aware multi-key sequences** over flat compiled bindings, with a public pending-sequence API, synchronous `pendingSequence` events, active continuation queries, and automatic invalidation on focus changes.
 - **Programmable exact-vs-prefix disambiguation** (e.g. `g` vs `gg`) with `runExact`, `continueSequence`, `clear`, and deferred `AbortSignal` + `sleep` decisions. Ships a Neovim-style timeout resolver.
-- **Pluggable binding language**: stackable binding parsers, key expanders, layer-binding transformers, binding transformers, command resolvers, command transformers, and event-match resolvers.
+- **Pluggable binding language**: stackable binding parsers, key expanders, layer-binding transformers, binding transformers, command resolvers, command transformers, and ordered event-match resolvers.
 - **Extensible schema and activation**: register custom fields on layers, bindings, and commands. Field compilers can emit `attrs`; all field kinds can gate activation via `require(...)` and `activeWhen(matcher)`.
 - **Reactive matchers** with subscription-driven state notifications, plus React store and Solid signal helpers.
 - **Raw and key intercepts** before and after normal binding dispatch, including pre-binding `consume({ preventDefault, stopPropagation })`, post-dispatch handled/no-match outcomes, and raw input `stop()` handling.
@@ -33,7 +33,7 @@ It models keybindings as priority-ordered, focus-scoped layers attached to targe
 - `registerNeovimDisambiguation`, `registerEscapeClearsPendingSequence`, `registerBackspacePopsPendingSequence`.
 - `registerDeadBindingWarnings`, `registerUnresolvedCommandWarnings`.
 
-`@opentui/keymap/addons/opentui` adds OpenTUI-specific pieces: layout-independent matching via `event.baseCode`, and pre-wired textarea / edit-buffer commands.
+`@opentui/keymap/addons/opentui` adds OpenTUI-specific pieces: layout-independent matching via `event.baseCode`, and pre-wired textarea / edit-buffer commands. Direct event matches win before fallback matches, even across layers.
 
 ## Entry Points
 

--- a/packages/keymap/src/addons/opentui/tests/base-layout.test.ts
+++ b/packages/keymap/src/addons/opentui/tests/base-layout.test.ts
@@ -78,6 +78,39 @@ describe("base layout fallback addon", () => {
     expect(calls).toEqual(["direct"])
   })
 
+  test("keeps lower-layer direct stroke matches ahead of higher-layer base-layout fallbacks", () => {
+    const keymap = getKeymap(renderer)
+    const calls: string[] = []
+
+    registerBaseLayoutFallback(keymap)
+    keymap.registerLayer({
+      commands: [
+        {
+          name: "delete-to-end",
+          run() {
+            calls.push("delete-to-end")
+          },
+        },
+      ],
+      bindings: [{ key: "ctrl+k", cmd: "delete-to-end" }],
+    })
+    keymap.registerLayer({
+      commands: [
+        {
+          name: "paste",
+          run() {
+            calls.push("paste")
+          },
+        },
+      ],
+      bindings: [{ key: "ctrl+v", cmd: "paste" }],
+    })
+
+    renderer.stdin.emit("data", Buffer.from("\x1b[107::118;5u"))
+
+    expect(calls).toEqual(["delete-to-end"])
+  })
+
   test("can be disposed to stop base-layout fallback matching", () => {
     const keymap = getKeymap(renderer)
     const calls: string[] = []

--- a/packages/keymap/src/services/dispatch.ts
+++ b/packages/keymap/src/services/dispatch.ts
@@ -534,16 +534,16 @@ export function createDispatchService<TTarget extends object, TEvent extends Key
     const matchKeys = resolveEventMatchKeys(event)
     let outcome = noMatchOutcome()
 
-    layerLoop: for (const layer of activeLayers) {
-      if (layer.bindings.length === 0) {
-        continue
-      }
+    for (const strokeKey of matchKeys) {
+      layerLoop: for (const layer of activeLayers) {
+        if (layer.bindings.length === 0) {
+          continue
+        }
 
-      if (!conditions.matchesConditions(layer)) {
-        continue
-      }
+        if (!conditions.matchesConditions(layer)) {
+          continue
+        }
 
-      for (const strokeKey of matchKeys) {
         const result = runReleaseBindings(layer, strokeKey, event, focused)
         outcome = preferDispatchOutcome(outcome, result.outcome)
         if (!result.handled) {
@@ -571,7 +571,17 @@ export function createDispatchService<TTarget extends object, TEvent extends Key
     }
 
     const activeLayers = activation.getActiveLayers(focused)
-    return dispatchFromRoot(activeLayers, matchKeys, event, focused)
+    let outcome = noMatchOutcome()
+
+    for (const matchKey of matchKeys) {
+      const result = dispatchFromRoot(activeLayers, [matchKey], event, focused)
+      outcome = preferDispatchOutcome(outcome, result)
+      if (result.handled) {
+        return outcome
+      }
+    }
+
+    return outcome
   }
 
   function dispatchPendingSequence(

--- a/packages/keymap/src/tests/keymap.parsing-and-binding-pipeline.test.ts
+++ b/packages/keymap/src/tests/keymap.parsing-and-binding-pipeline.test.ts
@@ -90,6 +90,151 @@ describe("keymap: parsing and binding pipeline", () => {
     expect(calls).toEqual(["direct"])
   })
 
+  test("prefers lower-layer direct strokes over higher-layer fallback strokes", () => {
+    const keymap = getKeymap(renderer)
+    const calls: string[] = []
+
+    keymap.appendEventMatchResolver((event, ctx) => {
+      if (event.name !== "x") return undefined
+      return [matchEventAs(ctx, event, "y")]
+    })
+
+    keymap.registerLayer({
+      commands: [
+        {
+          name: "direct",
+          run() {
+            calls.push("direct")
+          },
+        },
+      ],
+      bindings: [{ key: "x", cmd: "direct" }],
+    })
+    keymap.registerLayer({
+      commands: [
+        {
+          name: "fallback",
+          run() {
+            calls.push("fallback")
+          },
+        },
+      ],
+      bindings: [{ key: "y", cmd: "fallback" }],
+    })
+
+    mockInput.pressKey("x")
+
+    expect(calls).toEqual(["direct"])
+  })
+
+  test("keeps higher-layer direct strokes ahead of lower-layer direct strokes", () => {
+    const keymap = getKeymap(renderer)
+    const calls: string[] = []
+
+    keymap.registerLayer({
+      commands: [
+        {
+          name: "lower",
+          run() {
+            calls.push("lower")
+          },
+        },
+      ],
+      bindings: [{ key: "x", cmd: "lower" }],
+    })
+    keymap.registerLayer({
+      commands: [
+        {
+          name: "higher",
+          run() {
+            calls.push("higher")
+          },
+        },
+      ],
+      bindings: [{ key: "x", cmd: "higher" }],
+    })
+
+    mockInput.pressKey("x")
+
+    expect(calls).toEqual(["higher"])
+  })
+
+  test("uses fallback strokes when no direct stroke is reachable", () => {
+    const keymap = getKeymap(renderer)
+    const calls: string[] = []
+
+    keymap.appendEventMatchResolver((event, ctx) => {
+      if (event.name !== "x") return undefined
+      return [matchEventAs(ctx, event, "y")]
+    })
+
+    keymap.registerLayer({
+      enabled: false,
+      commands: [
+        {
+          name: "direct",
+          run() {
+            calls.push("direct")
+          },
+        },
+      ],
+      bindings: [{ key: "x", cmd: "direct" }],
+    })
+    keymap.registerLayer({
+      commands: [
+        {
+          name: "fallback",
+          run() {
+            calls.push("fallback")
+          },
+        },
+      ],
+      bindings: [{ key: "y", cmd: "fallback" }],
+    })
+
+    mockInput.pressKey("x")
+
+    expect(calls).toEqual(["fallback"])
+  })
+
+  test("prefers direct strokes over higher-layer fallback sequence prefixes", () => {
+    const keymap = getKeymap(renderer)
+    const calls: string[] = []
+
+    keymap.appendEventMatchResolver((event, ctx) => {
+      if (event.name !== "x") return undefined
+      return [matchEventAs(ctx, event, "g")]
+    })
+
+    keymap.registerLayer({
+      commands: [
+        {
+          name: "direct",
+          run() {
+            calls.push("direct")
+          },
+        },
+      ],
+      bindings: [{ key: "x", cmd: "direct" }],
+    })
+    keymap.registerLayer({
+      commands: [
+        {
+          name: "fallback-sequence",
+          run() {
+            calls.push("fallback-sequence")
+          },
+        },
+      ],
+      bindings: [{ key: "ga", cmd: "fallback-sequence" }],
+    })
+
+    mockInput.pressKey("x")
+
+    expect(calls).toEqual(["direct"])
+    expect(keymap.getPendingSequence()).toEqual([])
+  })
+
   test("supports pending-sequence dispatch through registered fallback strokes", () => {
     const keymap = getKeymap(renderer)
     const calls: string[] = []
@@ -1099,6 +1244,57 @@ describe("keymap: parsing and binding pipeline", () => {
     )
 
     expect(calls).toEqual(["release"])
+  })
+
+  test("prefers lower-layer direct release strokes over higher-layer fallback release strokes", () => {
+    const keymap = getKeymap(renderer)
+    const calls: string[] = []
+
+    keymap.appendEventMatchResolver((event, ctx) => {
+      if (event.name !== "x") return undefined
+      return [matchEventAs(ctx, event, "y")]
+    })
+
+    keymap.registerLayer({
+      commands: [
+        {
+          name: "direct-release",
+          run() {
+            calls.push("direct")
+          },
+        },
+      ],
+      bindings: [{ key: "x", event: "release", cmd: "direct-release" }],
+    })
+    keymap.registerLayer({
+      commands: [
+        {
+          name: "fallback-release",
+          run() {
+            calls.push("fallback")
+          },
+        },
+      ],
+      bindings: [{ key: "y", event: "release", cmd: "fallback-release" }],
+    })
+
+    renderer.keyInput.emit(
+      "keyrelease",
+      new KeyEvent({
+        name: "x",
+        ctrl: false,
+        meta: false,
+        shift: false,
+        option: false,
+        sequence: "x",
+        number: false,
+        raw: "x",
+        eventType: "release",
+        source: "raw",
+      }),
+    )
+
+    expect(calls).toEqual(["direct"])
   })
 
   test("event match resolver ctx.match normalizes object keys", () => {

--- a/packages/solid/tests/runtime-plugin-support-configure-entry.fixture.tsx
+++ b/packages/solid/tests/runtime-plugin-support-configure-entry.fixture.tsx
@@ -1,0 +1,33 @@
+import { registerDefaultKeys } from "@opentui/keymap/addons"
+import { commandBindings } from "@opentui/keymap/extras"
+import { useKeymapSelector } from "@opentui/keymap/solid"
+import { stringifyKeyStroke } from "@opentui/keymap"
+import { ThreeRenderable } from "@opentui/three"
+import { createSignal } from "solid-js"
+
+type FixtureState = typeof globalThis & {
+  __solidRuntimeHost__?: {
+    keymap: Record<string, unknown>
+    keymapAddons: Record<string, unknown>
+    keymapExtras: Record<string, unknown>
+    keymapSolid: Record<string, unknown>
+    three: Record<string, unknown>
+  }
+}
+
+const state = globalThis as FixtureState
+const [value] = createSignal("ok")
+const makeNode = () => <text>{value()}</text>
+const host = state.__solidRuntimeHost__
+const checks = [
+  `keymap=${stringifyKeyStroke === host?.keymap.stringifyKeyStroke}`,
+  `keymapAddons=${registerDefaultKeys === host?.keymapAddons.registerDefaultKeys}`,
+  `keymapExtras=${commandBindings === host?.keymapExtras.commandBindings}`,
+  `keymapSolid=${useKeymapSelector === host?.keymapSolid.useKeymapSelector}`,
+  `three=${ThreeRenderable === host?.three.ThreeRenderable}`,
+  `jsx=${typeof makeNode === "function"}`,
+]
+
+console.log(checks.join(";"))
+
+export const noop = 1

--- a/packages/solid/tests/runtime-plugin-support-configure.fixture.ts
+++ b/packages/solid/tests/runtime-plugin-support-configure.fixture.ts
@@ -1,15 +1,11 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
 import { plugin as registerPlugin } from "bun"
+import type { RuntimeModuleEntry } from "@opentui/core/runtime-plugin"
 import * as keymapRuntime from "@opentui/keymap"
 import * as keymapAddonsRuntime from "@opentui/keymap/addons"
 import * as keymapExtrasRuntime from "@opentui/keymap/extras"
-import { runtimeModules as keymapRuntimeModules } from "@opentui/keymap/runtime-modules"
 import * as keymapSolidRuntime from "@opentui/keymap/solid"
 import { ensureRuntimePluginSupport } from "@opentui/solid/runtime-plugin-support/configure"
 import * as threeRuntime from "../../three/src/index.js"
-import { runtimeModules as threeRuntimeModules } from "../../three/src/runtime-modules.js"
 import { resetSolidTransformPluginState } from "../scripts/solid-plugin.js"
 
 type FixtureState = typeof globalThis & {
@@ -21,34 +17,6 @@ type FixtureState = typeof globalThis & {
     three: Record<string, unknown>
   }
 }
-
-const tempRoot = mkdtempSync(join(tmpdir(), "solid-runtime-plugin-support-configure-fixture-"))
-const entryPath = join(tempRoot, "entry.tsx")
-
-const source = [
-  'import { stringifyKeyStroke } from "@opentui/keymap"',
-  'import { registerDefaultKeys } from "@opentui/keymap/addons"',
-  'import { commandBindings } from "@opentui/keymap/extras"',
-  'import { useKeymapSelector } from "@opentui/keymap/solid"',
-  'import { ThreeRenderable } from "@opentui/three"',
-  'import { createSignal } from "solid-js"',
-  "const state = globalThis as { __solidRuntimeHost__?: { keymap: Record<string, unknown>; keymapAddons: Record<string, unknown>; keymapExtras: Record<string, unknown>; keymapSolid: Record<string, unknown>; three: Record<string, unknown> } }",
-  "const [value] = createSignal('ok')",
-  "const makeNode = () => <text>{value()}</text>",
-  "const host = state.__solidRuntimeHost__",
-  "const checks = [",
-  "  `keymap=${stringifyKeyStroke === host?.keymap.stringifyKeyStroke}`,",
-  "  `keymapAddons=${registerDefaultKeys === host?.keymapAddons.registerDefaultKeys}`,",
-  "  `keymapExtras=${commandBindings === host?.keymapExtras.commandBindings}`,",
-  "  `keymapSolid=${useKeymapSelector === host?.keymapSolid.useKeymapSelector}`,",
-  "  `three=${ThreeRenderable === host?.three.ThreeRenderable}`,",
-  "  `jsx=${typeof makeNode === 'function'}`,",
-  "]",
-  "console.log(checks.join(';'))",
-  "export const noop = 1",
-].join("\n")
-
-writeFileSync(entryPath, source)
 
 const state = globalThis as FixtureState
 state.__solidRuntimeHost__ = {
@@ -64,15 +32,17 @@ resetSolidTransformPluginState()
 
 try {
   const additional = {
-    ...keymapRuntimeModules,
-    ...threeRuntimeModules,
-  }
+    "@opentui/keymap": keymapRuntime,
+    "@opentui/keymap/addons": keymapAddonsRuntime,
+    "@opentui/keymap/extras": keymapExtrasRuntime,
+    "@opentui/keymap/solid": keymapSolidRuntime,
+    "@opentui/three": threeRuntime,
+  } satisfies Record<string, RuntimeModuleEntry>
   const first = ensureRuntimePluginSupport({ additional })
   const second = ensureRuntimePluginSupport({ additional })
   console.log(`first=${first};second=${second}`)
-  await import(entryPath)
+  await import("./runtime-plugin-support-configure-entry.fixture.tsx")
 } finally {
   registerPlugin.clearAll()
   delete state.__solidRuntimeHost__
-  rmSync(tempRoot, { recursive: true, force: true })
 }

--- a/packages/solid/tests/runtime-plugin-support.test.ts
+++ b/packages/solid/tests/runtime-plugin-support.test.ts
@@ -41,7 +41,7 @@ describe("solid runtime plugin support", () => {
     expect(stdout).toContain("keymapSolid=true")
     expect(stdout).toContain("three=true")
     expect(stdout).toContain("jsx=true")
-  })
+  }, 10_000)
 
   it("throws when modules are added after side-effect installation", () => {
     const fixturePath = join(import.meta.dir, "runtime-plugin-support-late-addition.fixture.ts")

--- a/packages/web/src/content/docs/keymap/addons.mdx
+++ b/packages/web/src/content/docs/keymap/addons.mdx
@@ -142,7 +142,7 @@ keymap.registerLayer({
 
 ### `registerBaseLayoutFallback()`
 
-Adds an event match resolver that falls back to `KeyEvent.baseCode` so bindings can ignore active keyboard layout changes when Kitty base-layout reporting is available. Direct stroke matches still win ahead of the fallback.
+Adds an event match resolver that falls back to `KeyEvent.baseCode` so bindings can ignore active keyboard layout changes when Kitty base-layout reporting is available. Direct stroke matches win before base-layout fallback matches, even across active layers.
 
 ### Edit buffer helpers
 

--- a/packages/web/src/content/docs/keymap/custom-addons.mdx
+++ b/packages/web/src/content/docs/keymap/custom-addons.mdx
@@ -80,6 +80,8 @@ Guidelines:
 | `intercept("key:after", ...)`            | Observe dispatch outcomes after binding dispatch        |
 | `intercept("raw", ...)`                  | Observe raw host input before key parsing               |
 
+Event-match resolver order is global fallback priority: earlier matches are tried across all active layers before later matches. Use binding expanders or transformers for layer-local aliases.
+
 ### Diagnostics and lifecycle
 
 | API                              | Use for                                                            |


### PR DESCRIPTION
- Prioritizes direct event matches before fallback matches across all active layers.
- Preserves layer priority within each match type.