### PR TITLE
fix(core): avoid GLIBC_2.29 requirement in linux prebuilds

### DIFF
--- a/packages/core/src/zig/build.zig
+++ b/packages/core/src/zig/build.zig
@@ -17,9 +17,10 @@ const SupportedTarget = struct {
     description: []const u8,
 };
 
+// Unpinned linux-gnu targets can bind host libm symbols such as GLIBC_2.29.
 const SUPPORTED_TARGETS = [_]SupportedTarget{
-    .{ .zig_target = "x86_64-linux-gnu", .output_name = "x86_64-linux", .description = "Linux x86_64" },
-    .{ .zig_target = "aarch64-linux-gnu", .output_name = "aarch64-linux", .description = "Linux aarch64" },
+    .{ .zig_target = "x86_64-linux-gnu.2.28", .output_name = "x86_64-linux", .description = "Linux x86_64" },
+    .{ .zig_target = "aarch64-linux-gnu.2.28", .output_name = "aarch64-linux", .description = "Linux aarch64" },
     .{ .zig_target = "x86_64-macos", .output_name = "x86_64-macos", .description = "macOS x86_64 (Intel)" },
     .{ .zig_target = "aarch64-macos", .output_name = "aarch64-macos", .description = "macOS aarch64 (Apple Silicon)" },
     .{ .zig_target = "x86_64-windows-gnu", .output_name = "x86_64-windows", .description = "Windows x86_64" },
@@ -118,7 +119,7 @@ fn addMiniaudioShim(
             flags[3] = macos_sdk_path.?;
             break :blk flags;
         },
-        else => &.{ "-std=c99" },
+        else => &.{"-std=c99"},
     };
 
     artifact.addIncludePath(b.path("."));
@@ -212,7 +213,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const bench_optimize = b.option(std.builtin.OptimizeMode, "bench-optimize", "Optimize mode for benchmarks") orelse .ReleaseFast;
     const debug_use_llvm = b.option(bool, "debug-llvm", "Use LLVM backend for debug/test artifacts");
-    const target_option = b.option([]const u8, "target", "Build for specific target (e.g., 'x86_64-linux-gnu').");
+    const target_option = b.option([]const u8, "target", "Build for specific target (e.g., 'x86_64-linux-gnu.2.28').");
     const build_all = b.option(bool, "all", "Build for all supported targets") orelse false;
     const gpa_safe_stats = b.option(bool, "gpa-safe-stats", "Enable GPA safety checks for trustworthy allocator stats") orelse false;
     const macos_sdk_path = resolveMacOSSDKPath(b);


### PR DESCRIPTION
Pin Linux native prebuild targets to glibc 2.28.

After the native audio change, miniaudio pulls in libm symbols. With
unpinned linux-gnu targets, builds on newer hosts bound against
GLIBC_2.29, preventing the prebuilt library from loading on systems
with older glibc (e.g. RHEL/AlmaLinux 8).

Pinning x86_64-linux-gnu.2.28 and aarch64-linux-gnu.2.28 caps the
maximum referenced symbol version at GLIBC_2.28 while preserving
GNU/glibc dynamic linking. Verified via dlopen(RTLD_NOW) on
AlmaLinux 8 (glibc 2.28) and Ubuntu 18.04 (glibc 2.27)
