### PR TITLE
blend fg into flattened bg

### DIFF
--- a/packages/core/src/buffer.test.ts
+++ b/packages/core/src/buffer.test.ts
@@ -236,9 +236,9 @@ describe("OptimizedBuffer", () => {
       buffer.drawChar(65, 0, 0, fg, bg) // 'A'
 
       const fgBuffer = buffer.buffers.fg
-      // Source-over into a transparent destination keeps the source channel and alpha.
-      expect(fgBuffer[0] & 0xff).toBe(255)
-      expect(fgBuffer[3] & 0xff).toBe(128)
+      // Foreground alpha is flattened against the final opaque cell background.
+      expect(fgBuffer[0] & 0xff).toBe(128)
+      expect(fgBuffer[3] & 0xff).toBe(255)
     })
 
     it("should blend semi-transparent background", () => {

--- a/packages/core/src/renderables/Box.test.ts
+++ b/packages/core/src/renderables/Box.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test"
 import { BoxRenderable, type BoxOptions } from "./Box.js"
 import { createTestRenderer, type TestRenderer } from "../testing/test-renderer.js"
 import type { BorderStyle } from "../lib/border.js"
+import { RGBA } from "../lib/RGBA.js"
 
 let testRenderer: TestRenderer
 let renderOnce: () => Promise<void>
@@ -201,6 +202,34 @@ describe("BoxRenderable - border titles (top and bottom)", () => {
 
     const lines = captureFrame().split("\n")
     expect(lines[4].slice(0, 18)).toBe(expectedBorder)
+  })
+})
+
+describe("BoxRenderable - transparent border blending", () => {
+  test("blends transparent border foreground against the box background", async () => {
+    const panel = RGBA.fromHex("#123456")
+    const box = new BoxRenderable(testRenderer, {
+      id: "transparent-border-box",
+      width: 6,
+      height: 3,
+      border: ["left"],
+      borderStyle: "heavy",
+      borderColor: RGBA.fromInts(0, 0, 0, 0),
+      backgroundColor: panel,
+    })
+
+    testRenderer.root.add(box)
+    await renderOnce()
+
+    const buffer = testRenderer.currentRenderBuffer
+    expect(buffer.buffers.char[0]).toBe("┃".codePointAt(0))
+    expect({
+      fg: RGBA.fromArray(buffer.buffers.fg.slice(0, 4)).toInts(),
+      bg: RGBA.fromArray(buffer.buffers.bg.slice(0, 4)).toInts(),
+    }).toEqual({
+      fg: panel.toInts(),
+      bg: panel.toInts(),
+    })
   })
 })
 

--- a/packages/core/src/zig/buffer.zig
+++ b/packages/core/src/zig/buffer.zig
@@ -765,7 +765,7 @@ pub const OptimizedBuffer = struct {
                 finalFg = blendColors(overlayCell.bg, destCell.fg, self.blendBackdropColor);
             } else {
                 finalFg = if (hasFgAlpha)
-                    blendColors(overlayCell.fg, destCell.bg, self.blendBackdropColor)
+                    blendColors(overlayCell.fg, blendedBg, self.blendBackdropColor)
                 else
                     overlayCell.fg;
             }

--- a/packages/core/src/zig/tests/buffer_test.zig
+++ b/packages/core/src/zig/tests/buffer_test.zig
@@ -1976,6 +1976,37 @@ test "OptimizedBuffer - drawBox transparent border preserves destination backgro
     try std.testing.expectEqual(@as(u32, 0), cell.attributes);
 }
 
+test "OptimizedBuffer - drawBox transparent border foreground blends against box background" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+
+    var buf = try OptimizedBuffer.init(
+        std.testing.allocator,
+        4,
+        4,
+        .{ .pool = pool, .id = "test-buffer" },
+    );
+    defer buf.deinit();
+
+    const transparent = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0);
+    const panel = ansi.rgbColor(0x12, 0x34, 0x56, 255);
+    buf.clear(transparent, null);
+
+    const border_chars = [_]u32{ 0x250c, 0x2510, 0x2514, 0x2518, 0x2500, 0x2502, 0, 0, 0, 0, 0 };
+    try buf.drawBox(0, 0, 4, 4, &border_chars, .{ .left = true }, transparent, panel, true, null, 0, null, 0);
+
+    const cell = buf.get(0, 1).?;
+    try std.testing.expectEqual(@as(u32, 0x2502), cell.char);
+    try std.testing.expectEqual(ansi.red(panel), ansi.red(cell.fg));
+    try std.testing.expectEqual(ansi.green(panel), ansi.green(cell.fg));
+    try std.testing.expectEqual(ansi.blue(panel), ansi.blue(cell.fg));
+    try std.testing.expectEqual(ansi.alpha(panel), ansi.alpha(cell.fg));
+    try std.testing.expectEqual(ansi.red(panel), ansi.red(cell.bg));
+    try std.testing.expectEqual(ansi.green(panel), ansi.green(cell.bg));
+    try std.testing.expectEqual(ansi.blue(panel), ansi.blue(cell.bg));
+    try std.testing.expectEqual(ansi.alpha(panel), ansi.alpha(cell.bg));
+}
+
 test "OptimizedBuffer - link reuse after free" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/solid/tests/box.test.tsx
+++ b/packages/solid/tests/box.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "bun:test"
+import { RGBA } from "@opentui/core"
 import { testRender } from "../index.js"
 import { createSignal } from "solid-js"
 
@@ -40,5 +41,35 @@ describe("Box Component", () => {
     await testSetup.renderOnce()
 
     expect(boxRef.focused).toBe(false)
+  })
+
+  it("should blend transparent border foreground against the box background", async () => {
+    const panel = RGBA.fromHex("#123456")
+
+    testSetup = await testRender(
+      () => (
+        <box
+          width={6}
+          height={3}
+          border={["left"]}
+          borderStyle="heavy"
+          borderColor={RGBA.fromInts(0, 0, 0, 0)}
+          backgroundColor={panel}
+        />
+      ),
+      { width: 8, height: 5 },
+    )
+
+    await testSetup.renderOnce()
+
+    const buffer = testSetup.renderer.currentRenderBuffer
+    expect(buffer.buffers.char[0]).toBe("┃".codePointAt(0))
+    expect({
+      fg: RGBA.fromArray(buffer.buffers.fg.slice(0, 4)).toInts(),
+      bg: RGBA.fromArray(buffer.buffers.bg.slice(0, 4)).toInts(),
+    }).toEqual({
+      fg: panel.toInts(),
+      bg: panel.toInts(),
+    })
   })
 })


### PR DESCRIPTION
- Fixes anomalyco/opencode#27590
- Blends replacement glyph foreground alpha against the cell’s final background instead of the previous destination background
- Prevents transparent border glyphs from rendering as black over opaque box backgrounds
- Adds native, core, and Solid regression coverage for transparent box borders
- Updates foreground-alpha test expectation to match final-background compositing behavior