### PR TITLE
Fix Kitty ctrl+space

### DIFF
--- a/packages/core/src/lib/parse.keypress-kitty.protocol.test.ts
+++ b/packages/core/src/lib/parse.keypress-kitty.protocol.test.ts
@@ -285,6 +285,10 @@ const modifierCases: KeyCase[] = [
 ]
 
 const eventAndPayloadCases = [
+  ["\x1b[32u", { name: "space", sequence: " " }],
+  ["\x1b[32;2u", { name: "space", sequence: " ", shift: true }],
+  ["\x1b[32;5u", { name: "space", sequence: " ", ctrl: true }],
+  ["\x1b[32:32:32;5u", { name: "space", sequence: " ", ctrl: true, baseCode: 32 }],
   ["\x1b[97;1:1u", { name: "a", eventType: "press" }],
   ["\x1b[97;1:2u", { name: "a", eventType: "press", repeated: true }],
   ["\x1b[97;1:3u", { name: "a", eventType: "release" }],

--- a/packages/core/src/lib/parse.keypress-kitty.test.ts
+++ b/packages/core/src/lib/parse.keypress-kitty.test.ts
@@ -65,9 +65,17 @@ test("parseKeypress - Kitty keyboard arrow key", () => {
 test("parseKeypress - Kitty keyboard shift+space", () => {
   const options: ParseKeypressOptions = { useKittyKeyboard: true }
   const result = parseKeypress("\x1b[32;2u", options)!
-  expect(result.name).toBe(" ")
+  expect(result.name).toBe("space")
   expect(result.sequence).toBe(" ")
   expect(result.shift).toBe(true)
+})
+
+test("parseKeypress - Kitty keyboard ctrl+space", () => {
+  const options: ParseKeypressOptions = { useKittyKeyboard: true }
+  const result = parseKeypress("\x1b[32;5u", options)!
+  expect(result.name).toBe("space")
+  expect(result.sequence).toBe(" ")
+  expect(result.ctrl).toBe(true)
 })
 
 test("parseKeypress - Kitty keyboard event types", () => {

--- a/packages/core/src/lib/parse.keypress-kitty.ts
+++ b/packages/core/src/lib/parse.keypress-kitty.ts
@@ -350,7 +350,7 @@ export function parseKittyKeyboard(sequence: string): ParsedKey | null {
     // It's a Unicode character
     if (codepoint > 0 && codepoint <= 0x10ffff) {
       const char = String.fromCodePoint(codepoint)
-      key.name = char
+      key.name = char === " " ? "space" : char
 
       // Keep the raw Unicode codepoint from Kitty so higher-level matching can
       // later turn `99` into `c` and use that as a layout-stable fallback.
@@ -413,7 +413,9 @@ export function parseKittyKeyboard(sequence: string): ParsedKey | null {
     const isPrintable = key.name.length > 0 && !kittyKeyMap[codepoint]
     if (isPrintable) {
       // Use shifted codepoint if shift is active and we have one
-      if (key.shift && shiftedCodepoint) {
+      if (codepoint === 32) {
+        text = " "
+      } else if (key.shift && shiftedCodepoint) {
         text = String.fromCodePoint(shiftedCodepoint)
       } else if (key.shift && key.name.length === 1) {
         // When shift is pressed but terminal didn't provide shifted codepoint,
@@ -423,11 +425,6 @@ export function parseKittyKeyboard(sequence: string): ParsedKey | null {
         text = key.name
       }
     }
-  }
-
-  // Special case: shift + space should produce a space
-  if (key.name === " " && key.shift && !key.ctrl && !key.meta) {
-    text = " "
   }
 
   if (text) {

--- a/packages/core/src/lib/stdin-parser.test.ts
+++ b/packages/core/src/lib/stdin-parser.test.ts
@@ -544,8 +544,11 @@ describe("StdinParser", () => {
     // CSI codepoint u format
     table([
       ["a key", "\x1b[97u", [k("a", { raw: "\x1b[97u" })]],
+      ["space", "\x1b[32u", [k("space", { raw: "\x1b[32u" })]],
       ["shift+a", "\x1b[97;2u", [k("a", { raw: "\x1b[97;2u", shift: true })]],
+      ["shift+space", "\x1b[32;2u", [k("space", { raw: "\x1b[32;2u", shift: true })]],
       ["ctrl+a", "\x1b[97;5u", [k("a", { raw: "\x1b[97;5u", ctrl: true })]],
+      ["ctrl+space", "\x1b[32;5u", [k("space", { raw: "\x1b[32;5u", ctrl: true })]],
       ["alt+a", "\x1b[97;3u", [k("a", { raw: "\x1b[97;3u", meta: true })]],
       ["ctrl+shift+a", "\x1b[97;6u", [k("a", { raw: "\x1b[97;6u", ctrl: true, shift: true })]],
       ["a release", "\x1b[97;1:3u", [k("a", { raw: "\x1b[97;1:3u", eventType: "release" })]],

--- a/packages/core/src/renderables/__tests__/Textarea.keybinding.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.keybinding.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, afterAll, beforeEach, afterEach } from "bun:test"
 import { createTestRenderer, type TestRenderer, type MockMouse, type MockInput } from "../../testing/test-renderer.js"
 import { createTextareaRenderable } from "./renderable-test-utils.js"
 import { KeyEvent } from "../../lib/KeyHandler.js"
+import { parseKeypress } from "../../lib/parse.keypress.js"
 
 // Helper function to create a KeyEvent from a string
 function createKeyEvent(
@@ -624,6 +625,25 @@ describe("Textarea - Keybinding Tests", () => {
       currentMockInput.pressKey("g", { ctrl: true })
       expect(editor.logicalCursor.row).toBe(0)
       expect(editor.logicalCursor.col).toBe(0)
+    })
+
+    it("should match ctrl+space from Kitty keyboard protocol", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "Hello",
+        width: 40,
+        height: 10,
+        keyBindings: [{ name: "space", ctrl: true, action: "newline" }],
+      })
+
+      editor.gotoLine(9999)
+
+      const key = parseKeypress("\x1b[32;5u", { useKittyKeyboard: true })
+      expect(key).toMatchObject({ name: "space", ctrl: true, sequence: " " })
+
+      const handled = editor.handleKeyPress(new KeyEvent(key!))
+
+      expect(handled).toBe(true)
+      expect(editor.plainText).toBe("Hello\n")
     })
 
     it("should use baseCode when matching ctrl shortcuts from alternate layouts", async () => {

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -791,7 +791,7 @@ test("Kitty keyboard shift+space via keyInput events", async () => {
   const result = await triggerKittyInput("\x1b[32;2u")
   expect(result).toMatchObject({
     eventType: "press",
-    name: " ",
+    name: "space",
     ctrl: false,
     meta: false,
     shift: true,
@@ -799,6 +799,25 @@ test("Kitty keyboard shift+space via keyInput events", async () => {
     number: false,
     sequence: " ",
     raw: "\x1b[32;2u",
+    super: false,
+    hyper: false,
+    capsLock: false,
+    numLock: false,
+  })
+})
+
+test("Kitty keyboard ctrl+space via keyInput events", async () => {
+  const result = await triggerKittyInput("\x1b[32;5u")
+  expect(result).toMatchObject({
+    eventType: "press",
+    name: "space",
+    ctrl: true,
+    meta: false,
+    shift: false,
+    option: false,
+    number: false,
+    sequence: " ",
+    raw: "\x1b[32;5u",
     super: false,
     hyper: false,
     capsLock: false,

--- a/packages/keymap/src/tests/keymap.parsing-and-binding-pipeline.test.ts
+++ b/packages/keymap/src/tests/keymap.parsing-and-binding-pipeline.test.ts
@@ -90,6 +90,27 @@ describe("keymap: parsing and binding pipeline", () => {
     expect(calls).toEqual(["direct"])
   })
 
+  test("matches ctrl+space from Kitty keyboard protocol", () => {
+    const keymap = getKeymap(renderer)
+    const calls: string[] = []
+
+    keymap.registerLayer({
+      commands: [
+        {
+          name: "leader",
+          run() {
+            calls.push("leader")
+          },
+        },
+      ],
+    })
+    keymap.registerLayer({ bindings: [{ key: "ctrl+space", cmd: "leader" }] })
+
+    renderer.stdin.emit("data", Buffer.from("\x1b[32;5u"))
+
+    expect(calls).toEqual(["leader"])
+  })
+
   test("prefers lower-layer direct strokes over higher-layer fallback strokes", () => {
     const keymap = getKeymap(renderer)
     const calls: string[] = []

--- a/packages/web/src/content/docs/components/tab-select.mdx
+++ b/packages/web/src/content/docs/components/tab-select.mdx
@@ -112,8 +112,8 @@ tabs.on(TabSelectRenderableEvents.SELECTION_CHANGED, (index: number, option: Tab
 | `showDescription`          | `boolean`               | `true`        | Show tab descriptions          |
 | `showUnderline`            | `boolean`               | `true`        | Show underline on selected tab |
 | `wrapSelection`            | `boolean`               | `false`       | Wrap around when navigating    |
-| `keyBindings`              | `TabSelectKeyBinding[]` | -             | Custom key bindings            |
-| `keyAliasMap`              | `KeyAliasMap`           | -             | Key alias mappings             |
+| `keyBindings`              | `TabSelectKeyBinding[]`  | -             | Custom key bindings            |
+| `keyAliasMap`              | `Record<string, string>` | -             | Key alias mappings             |
 
 ## Example: Tabbed Interface
 

--- a/packages/web/src/content/docs/components/tab-select.mdx
+++ b/packages/web/src/content/docs/components/tab-select.mdx
@@ -96,22 +96,22 @@ tabs.on(TabSelectRenderableEvents.SELECTION_CHANGED, (index: number, option: Tab
 
 ## Properties
 
-| Property                   | Type                    | Default       | Description                    |
-| -------------------------- | ----------------------- | ------------- | ------------------------------ |
-| `width`                    | `number`                | -             | Total component width          |
-| `options`                  | `TabSelectOption[]`     | `[]`          | Available tabs                 |
-| `tabWidth`                 | `number`                | `20`          | Width of each tab              |
-| `backgroundColor`          | `string \| RGBA`        | `transparent` | Background color               |
-| `textColor`                | `string \| RGBA`        | `#FFFFFF`     | Normal tab text                |
-| `focusedBackgroundColor`   | `string \| RGBA`        | `#1a1a1a`     | Background color when focused  |
-| `focusedTextColor`         | `string \| RGBA`        | `#FFFFFF`     | Text color when focused        |
-| `selectedBackgroundColor`  | `string \| RGBA`        | `#334455`     | Selected tab background        |
-| `selectedTextColor`        | `string \| RGBA`        | `#FFFF00`     | Selected tab text              |
-| `selectedDescriptionColor` | `string \| RGBA`        | `#CCCCCC`     | Description text color         |
-| `showScrollArrows`         | `boolean`               | `true`        | Show scroll indicators         |
-| `showDescription`          | `boolean`               | `true`        | Show tab descriptions          |
-| `showUnderline`            | `boolean`               | `true`        | Show underline on selected tab |
-| `wrapSelection`            | `boolean`               | `false`       | Wrap around when navigating    |
+| Property                   | Type                     | Default       | Description                    |
+| -------------------------- | ------------------------ | ------------- | ------------------------------ |
+| `width`                    | `number`                 | -             | Total component width          |
+| `options`                  | `TabSelectOption[]`      | `[]`          | Available tabs                 |
+| `tabWidth`                 | `number`                 | `20`          | Width of each tab              |
+| `backgroundColor`          | `string \| RGBA`         | `transparent` | Background color               |
+| `textColor`                | `string \| RGBA`         | `#FFFFFF`     | Normal tab text                |
+| `focusedBackgroundColor`   | `string \| RGBA`         | `#1a1a1a`     | Background color when focused  |
+| `focusedTextColor`         | `string \| RGBA`         | `#FFFFFF`     | Text color when focused        |
+| `selectedBackgroundColor`  | `string \| RGBA`         | `#334455`     | Selected tab background        |
+| `selectedTextColor`        | `string \| RGBA`         | `#FFFF00`     | Selected tab text              |
+| `selectedDescriptionColor` | `string \| RGBA`         | `#CCCCCC`     | Description text color         |
+| `showScrollArrows`         | `boolean`                | `true`        | Show scroll indicators         |
+| `showDescription`          | `boolean`                | `true`        | Show tab descriptions          |
+| `showUnderline`            | `boolean`                | `true`        | Show underline on selected tab |
+| `wrapSelection`            | `boolean`                | `false`       | Wrap around when navigating    |
 | `keyBindings`              | `TabSelectKeyBinding[]`  | -             | Custom key bindings            |
 | `keyAliasMap`              | `Record<string, string>` | -             | Key alias mappings             |
 

--- a/packages/web/src/content/docs/components/textarea.mdx
+++ b/packages/web/src/content/docs/components/textarea.mdx
@@ -83,7 +83,7 @@ const textarea = new TextareaRenderable(renderer, {
 | `cursorColor`            | `string` or `RGBA`                    | `#FFFFFF`   | Cursor color                      |
 | `cursorStyle`            | `CursorStyleOptions`                  | -           | Cursor style and blinking         |
 | `keyBindings`            | `KeyBinding[]`                        | -           | Custom keybindings                |
-| `keyAliasMap`            | `KeyAliasMap`                         | -           | Key alias mapping                 |
+| `keyAliasMap`            | `Record<string, string>`              | -           | Key alias mapping                 |
 | `onSubmit`               | `(event: SubmitEvent) => void`        | -           | Submit handler                    |
 | `onContentChange`        | `(event: ContentChangeEvent) => void` | -           | Fired on content changes          |
 | `onCursorChange`         | `(event: CursorChangeEvent) => void`  | -           | Fired on cursor movement          |

--- a/packages/web/src/content/docs/core-concepts/keyboard.mdx
+++ b/packages/web/src/content/docs/core-concepts/keyboard.mdx
@@ -34,25 +34,25 @@ keyHandler.on("keypress", (key: KeyEvent) => {
 
 Each `KeyEvent` contains the parsed key identity, the generated input sequence, and the original terminal input:
 
-| Property    | Type                | Description                                                                                 |
-| ----------- | ------------------- | ------------------------------------------------------------------------------------------- |
-| `name`      | `string`            | Canonical key identity, such as `"a"`, `"space"`, `"return"`, `"escape"`, or `"f1"`        |
-| `sequence`  | `string`            | Decoded input sequence/text for the key. For printable keys this is the text, such as `"a"` or `" "` |
-| `raw`       | `string`            | Exact terminal input sequence for this key event, decoded as a string                       |
-| `source`    | `"raw" \| "kitty"` | Parser path that produced the event                                                         |
-| `ctrl`      | `boolean`           | Whether Ctrl was held                                                                       |
-| `shift`     | `boolean`           | Whether Shift was held                                                                      |
-| `meta`      | `boolean`           | Whether Alt/Meta was held                                                                   |
-| `option`    | `boolean`           | Whether Option was held (macOS Alt/Option path)                                             |
-| `super`     | `boolean?`          | Whether Super/Cmd/Windows was held, when reported                                           |
-| `hyper`     | `boolean?`          | Whether Hyper was held, when reported                                                       |
-| `eventType` | `"press" \| "repeat" \| "release"` | Key event type. Kitty repeat events are emitted as `"press"` with `repeated: true` |
-| `repeated`  | `boolean?`          | `true` for Kitty repeat events                                                              |
-| `number`    | `boolean`           | `true` when the parsed key is a digit from legacy input                                     |
-| `code`      | `string?`           | Terminal key code for recognized function-style escape sequences                            |
-| `capsLock`  | `boolean?`          | Kitty Caps Lock modifier state, when reported                                               |
-| `numLock`   | `boolean?`          | Kitty Num Lock modifier state, when reported                                                |
-| `baseCode`  | `number?`           | Kitty base-layout codepoint used by layout-stable shortcut matching                         |
+| Property    | Type                               | Description                                                                                          |
+| ----------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `name`      | `string`                           | Canonical key identity, such as `"a"`, `"space"`, `"return"`, `"escape"`, or `"f1"`                  |
+| `sequence`  | `string`                           | Decoded input sequence/text for the key. For printable keys this is the text, such as `"a"` or `" "` |
+| `raw`       | `string`                           | Exact terminal input sequence for this key event, decoded as a string                                |
+| `source`    | `"raw" \| "kitty"`                 | Parser path that produced the event                                                                  |
+| `ctrl`      | `boolean`                          | Whether Ctrl was held                                                                                |
+| `shift`     | `boolean`                          | Whether Shift was held                                                                               |
+| `meta`      | `boolean`                          | Whether Alt/Meta was held                                                                            |
+| `option`    | `boolean`                          | Whether Option was held (macOS Alt/Option path)                                                      |
+| `super`     | `boolean?`                         | Whether Super/Cmd/Windows was held, when reported                                                    |
+| `hyper`     | `boolean?`                         | Whether Hyper was held, when reported                                                                |
+| `eventType` | `"press" \| "repeat" \| "release"` | Key event type. Kitty repeat events are emitted as `"press"` with `repeated: true`                   |
+| `repeated`  | `boolean?`                         | `true` for Kitty repeat events                                                                       |
+| `number`    | `boolean`                          | `true` when the parsed key is a digit from legacy input                                              |
+| `code`      | `string?`                          | Terminal key code for recognized function-style escape sequences                                     |
+| `capsLock`  | `boolean?`                         | Kitty Caps Lock modifier state, when reported                                                        |
+| `numLock`   | `boolean?`                         | Kitty Num Lock modifier state, when reported                                                         |
+| `baseCode`  | `number?`                          | Kitty base-layout codepoint used by layout-stable shortcut matching                                  |
 
 `sequence` is not always the raw terminal bytes. For example, Kitty `Ctrl+Space` arrives as raw `"\x1b[32;5u"`, but emits `name: "space"`, `ctrl: true`, and `sequence: " "`. Use `raw` when you need the exact terminal sequence.
 

--- a/packages/web/src/content/docs/core-concepts/keyboard.mdx
+++ b/packages/web/src/content/docs/core-concepts/keyboard.mdx
@@ -21,7 +21,8 @@ const keyHandler = renderer.keyInput
 
 keyHandler.on("keypress", (key: KeyEvent) => {
   console.log("Key name:", key.name)
-  console.log("Sequence:", key.sequence)
+  console.log("Input sequence:", key.sequence)
+  console.log("Raw input:", key.raw)
   console.log("Ctrl pressed:", key.ctrl)
   console.log("Shift pressed:", key.shift)
   console.log("Alt pressed:", key.meta)
@@ -31,22 +32,35 @@ keyHandler.on("keypress", (key: KeyEvent) => {
 
 ## KeyEvent properties
 
-Each `KeyEvent` contains:
+Each `KeyEvent` contains the parsed key identity, the generated input sequence, and the original terminal input:
 
-| Property   | Type      | Description                              |
-| ---------- | --------- | ---------------------------------------- |
-| `name`     | `string`  | The key name (e.g., "a", "escape", "f1") |
-| `sequence` | `string`  | The raw escape sequence                  |
-| `ctrl`     | `boolean` | Whether Ctrl was held                    |
-| `shift`    | `boolean` | Whether Shift was held                   |
-| `meta`     | `boolean` | Whether Alt/Meta was held                |
-| `option`   | `boolean` | Whether Option was held (macOS)          |
+| Property    | Type                | Description                                                                                 |
+| ----------- | ------------------- | ------------------------------------------------------------------------------------------- |
+| `name`      | `string`            | Canonical key identity, such as `"a"`, `"space"`, `"return"`, `"escape"`, or `"f1"`        |
+| `sequence`  | `string`            | Decoded input sequence/text for the key. For printable keys this is the text, such as `"a"` or `" "` |
+| `raw`       | `string`            | Exact terminal input sequence for this key event, decoded as a string                       |
+| `source`    | `"raw" \| "kitty"` | Parser path that produced the event                                                         |
+| `ctrl`      | `boolean`           | Whether Ctrl was held                                                                       |
+| `shift`     | `boolean`           | Whether Shift was held                                                                      |
+| `meta`      | `boolean`           | Whether Alt/Meta was held                                                                   |
+| `option`    | `boolean`           | Whether Option was held (macOS Alt/Option path)                                             |
+| `super`     | `boolean?`          | Whether Super/Cmd/Windows was held, when reported                                           |
+| `hyper`     | `boolean?`          | Whether Hyper was held, when reported                                                       |
+| `eventType` | `"press" \| "repeat" \| "release"` | Key event type. Kitty repeat events are emitted as `"press"` with `repeated: true` |
+| `repeated`  | `boolean?`          | `true` for Kitty repeat events                                                              |
+| `number`    | `boolean`           | `true` when the parsed key is a digit from legacy input                                     |
+| `code`      | `string?`           | Terminal key code for recognized function-style escape sequences                            |
+| `capsLock`  | `boolean?`          | Kitty Caps Lock modifier state, when reported                                               |
+| `numLock`   | `boolean?`          | Kitty Num Lock modifier state, when reported                                                |
+| `baseCode`  | `number?`           | Kitty base-layout codepoint used by layout-stable shortcut matching                         |
 
-## Key aliases
+`sequence` is not always the raw terminal bytes. For example, Kitty `Ctrl+Space` arrives as raw `"\x1b[32;5u"`, but emits `name: "space"`, `ctrl: true`, and `sequence: " "`. Use `raw` when you need the exact terminal sequence.
 
-OpenTUI normalizes several key names so your keybindings work the same across layouts and input paths. OpenTUI applies aliases after the parser reports a key, before emitting `keypress`.
+## Keybinding aliases
 
-The default aliases are:
+Some core renderables and the built-in console support aliases for configured keybindings. These aliases are applied when building a component's keybinding lookup map; they do not rewrite emitted `KeyEvent.name` values.
+
+The default keybinding aliases are:
 
 ```ts
 // enter -> return
@@ -54,13 +68,15 @@ The default aliases are:
 //
 // Numpad keys are aliased to their main-keyboard equivalents:
 // kp0..kp9   -> "0".."9"
-// kpenter    -> enter  (then via enter -> return)
+// kpenter    -> enter
 // kpleft/kpright/kpup/kpdown -> arrow keys
 // kphome/kpend/kppageup/kppagedown/kpinsert/kpdelete -> navigation
 // kpdecimal/kpdivide/kpmultiply/kpminus/kpplus/kpequal/kpseparator -> symbols
 ```
 
-Both `key.name === "enter"` and `key.name === "kpenter"` resolve to `"return"` when you match them with `matchesKeyBinding`. Editable components that accept a `keyAliasMap` option (`InputRenderable`, `TextareaRenderable`, `SelectRenderable`, etc.) merge these defaults with your own map:
+Aliases are one-step mappings from configured binding names to additional lookup names. For example, a component binding configured as `{ name: "enter", action: "submit" }` also matches an emitted `KeyEvent` whose `name` is `"return"`. Low-level helpers such as `matchesKeyBinding` do not apply aliases; pass canonical names such as `"return"`, `"escape"`, and `"space"` there.
+
+Editable components that accept a `keyAliasMap` option (`InputRenderable`, `TextareaRenderable`, `SelectRenderable`, etc.) merge these defaults with your own map:
 
 ```typescript
 import { InputRenderable } from "@opentui/core"
@@ -225,6 +241,8 @@ await createCliRenderer({ useKittyKeyboard: null })
 `events: true` enables the `keyrelease` event on `renderer.keyInput` as well as `eventType` on `KeyEvent`.
 
 `useKittyKeyboard: {}` applies the defaults (`disambiguate` + `alternateKeys`). Passing `null` disables the protocol entirely.
+
+Kitty escape sequences still emit the same canonical key names as legacy input where possible. For example, Kitty `Ctrl+Space` emits `name: "space"` with `ctrl: true`; the literal typed text remains available as `sequence: " "`, and the original escape sequence remains available as `raw`.
 
 ## Focus and key routing
 

--- a/packages/web/src/content/docs/core-concepts/keyboard.mdx
+++ b/packages/web/src/content/docs/core-concepts/keyboard.mdx
@@ -74,7 +74,7 @@ The default keybinding aliases are:
 // kpdecimal/kpdivide/kpmultiply/kpminus/kpplus/kpequal/kpseparator -> symbols
 ```
 
-Aliases are one-step mappings from configured binding names to additional lookup names. For example, a component binding configured as `{ name: "enter", action: "submit" }` also matches an emitted `KeyEvent` whose `name` is `"return"`. Low-level helpers such as `matchesKeyBinding` do not apply aliases; pass canonical names such as `"return"`, `"escape"`, and `"space"` there.
+Aliases are one-step mappings from configured binding names to additional lookup names. For example, a component binding configured as `{ name: "enter", action: "submit" }` also matches an emitted `KeyEvent` whose `name` is `"return"`. This aliasing is component-specific; direct `renderer.keyInput` handlers receive the parser's canonical names and should compare against names such as `"return"`, `"escape"`, and `"space"`.
 
 Editable components that accept a `keyAliasMap` option (`InputRenderable`, `TextareaRenderable`, `SelectRenderable`, etc.) merge these defaults with your own map:
 

--- a/packages/web/src/content/docs/keymap/core.mdx
+++ b/packages/web/src/content/docs/keymap/core.mdx
@@ -90,7 +90,7 @@ keymap.registerLayer({
 
 | Form            | Example                              | Notes                                         |
 | --------------- | ------------------------------------ | --------------------------------------------- |
-| String stroke   | `"x"`, `"ctrl+x"`, `"enter"`         | Requires a registered binding parser          |
+| String stroke   | `"x"`, `"ctrl+x"`, `"return"`        | Requires a registered binding parser          |
 | String sequence | `"dd"`, `"<leader>s"`, `"{count}j"`  | Concatenated multi-stroke sequence            |
 | Object stroke   | `{ name: "return", ctrl: true }`     | Skips string parsing and normalizes directly  |
 | Release binding | `{ key: "a", event: "release", ...}` | Release bindings support a single stroke only |


### PR DESCRIPTION
- Fixes anomalyco/opencode#27096
- Normalize Kitty keyboard protocol space events to name: "space"
- Preserve text insertion behavior with sequence: " "
- Update keyboard docs to distinguish name, sequence, and raw accurately
- Remove docs references to internal-only core keybinding helpers