### PR TITLE
Fix copied text for row-based selections

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.13
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.13
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v2

--- a/packages/core/src/lib/selection.ts
+++ b/packages/core/src/lib/selection.ts
@@ -110,7 +110,7 @@ export class Selection {
   }
 
   getSelectedText(): string {
-    const selectedTextsByLine = new Map<number, string[]>()
+    const selectedTextsByLine = new Map<number, Array<{ x: number; text: string }>>()
     const selectedRenderables = this._selectedRenderables
       // Sort by reading order: top-to-bottom, then left-to-right
       .sort((a, b) => {
@@ -126,12 +126,24 @@ export class Selection {
     for (const renderable of selectedRenderables) {
       const text = renderable.getSelectedText()
       if (!text) continue
-      const lines = selectedTextsByLine.get(renderable.y) ?? []
-      lines.push(text)
-      selectedTextsByLine.set(renderable.y, lines)
+      const lines = text.split("\n")
+      for (let index = 0; index < lines.length; index += 1) {
+        const y = renderable.y + index
+        const line = selectedTextsByLine.get(y) ?? []
+        line.push({ x: renderable.x, text: lines[index] })
+        selectedTextsByLine.set(y, line)
+      }
     }
 
-    return [...selectedTextsByLine.values()].map((line) => line.join("")).join("\n")
+    return [...selectedTextsByLine.entries()]
+      .sort(([leftY], [rightY]) => leftY - rightY)
+      .map(([, line]) =>
+        line
+          .sort((left, right) => left.x - right.x)
+          .map((segment) => segment.text)
+          .join(""),
+      )
+      .join("\n")
   }
 }
 

--- a/packages/core/src/lib/selection.ts
+++ b/packages/core/src/lib/selection.ts
@@ -110,7 +110,8 @@ export class Selection {
   }
 
   getSelectedText(): string {
-    const selectedTexts = this._selectedRenderables
+    const selectedTextsByLine = new Map<number, string[]>()
+    const selectedRenderables = this._selectedRenderables
       // Sort by reading order: top-to-bottom, then left-to-right
       .sort((a, b) => {
         const aY = a.y
@@ -121,9 +122,16 @@ export class Selection {
         return a.x - b.x
       })
       .filter((renderable) => !renderable.isDestroyed)
-      .map((renderable) => renderable.getSelectedText())
-      .filter((text) => text)
-    return selectedTexts.join("\n")
+
+    for (const renderable of selectedRenderables) {
+      const text = renderable.getSelectedText()
+      if (!text) continue
+      const lines = selectedTextsByLine.get(renderable.y) ?? []
+      lines.push(text)
+      selectedTextsByLine.set(renderable.y, lines)
+    }
+
+    return [...selectedTextsByLine.values()].map((line) => line.join("")).join("\n")
   }
 }
 

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1082,6 +1082,48 @@ test("task lists render checkbox and text on the same line", async () => {
   `)
 })
 
+test("selection across top-level unordered list copies marker and text on same line", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-structured-list-selection",
+    content: `- First item
+- Second item`,
+    syntaxStyle,
+    internalBlockMode: "top-level",
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const list = md._blockStates[0]?.renderable
+  expect(list).toBeInstanceOf(BoxRenderable)
+
+  await mockMouse.drag(list!.x, list!.y, list!.x + 20, list!.y + 1)
+  await renderer.idle()
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe("- First item\n- Second item")
+})
+
+test("selection across top-level ordered list copies marker and text on same line", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-structured-ordered-list-selection",
+    content: `9. Nine
+10. Ten`,
+    syntaxStyle,
+    internalBlockMode: "top-level",
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const list = md._blockStates[0]?.renderable
+  expect(list).toBeInstanceOf(BoxRenderable)
+
+  await mockMouse.drag(list!.x, list!.y, list!.x + 20, list!.y + 1)
+  await renderer.idle()
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe(" 9. Nine\n10. Ten")
+})
+
 test("top-level structured lists align nested fenced code under nested content", async () => {
   const md = createMarkdownRenderable({
     id: "markdown-structured-list-code",

--- a/packages/core/src/tests/renderer.selection.test.ts
+++ b/packages/core/src/tests/renderer.selection.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, beforeEach, afterEach } from "bun:test"
 import { createTestRenderer, type TestRenderer } from "../testing/test-renderer.js"
+import { BoxRenderable } from "../renderables/Box.js"
 import { TextRenderable } from "../renderables/Text.js"
 
 let renderer: TestRenderer
@@ -46,4 +47,92 @@ test("selection on destroyed renderable should not throw", () => {
   renderer.clearSelection()
 
   expect(renderer.getSelection()).toBeNull()
+})
+
+test("selected text joins same-row renderables without newlines", () => {
+  const row = new BoxRenderable(renderer, {
+    flexDirection: "row",
+    width: 20,
+    height: 1,
+  })
+  const left = new TextRenderable(renderer, {
+    content: "Hello ",
+    width: 6,
+    height: 1,
+    selectable: true,
+  })
+  const right = new TextRenderable(renderer, {
+    content: "World",
+    width: 5,
+    height: 1,
+    selectable: true,
+  })
+
+  row.add(left)
+  row.add(right)
+  renderer.root.add(row)
+  renderOnce()
+
+  renderer.startSelection(left, left.x, left.y)
+  renderer.updateSelection(right, right.x + right.width, right.y, { finishDragging: true })
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe("Hello World")
+})
+
+test("selected text keeps newlines between different rows", () => {
+  const top = new TextRenderable(renderer, {
+    content: "First row",
+    left: 0,
+    top: 0,
+    width: 9,
+    height: 1,
+    selectable: true,
+  })
+  const bottom = new TextRenderable(renderer, {
+    content: "Second row",
+    left: 0,
+    top: 1,
+    width: 10,
+    height: 1,
+    selectable: true,
+  })
+
+  renderer.root.add(top)
+  renderer.root.add(bottom)
+  renderOnce()
+
+  renderer.startSelection(top, top.x, top.y)
+  renderer.updateSelection(bottom, bottom.x + bottom.width, bottom.y, { finishDragging: true })
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe("First row\nSecond row")
+})
+
+test("selected text merges multiline same-row renderables by visual row", () => {
+  const row = new BoxRenderable(renderer, {
+    flexDirection: "row",
+    width: 4,
+    height: 2,
+  })
+  const left = new TextRenderable(renderer, {
+    content: "A\nB",
+    width: 1,
+    height: 2,
+    selectable: true,
+  })
+  const right = new TextRenderable(renderer, {
+    content: "1\n2",
+    width: 1,
+    height: 2,
+    selectable: true,
+  })
+
+  row.add(left)
+  row.add(right)
+  renderer.root.add(row)
+  renderOnce()
+
+  renderer.startSelection(left, left.x, left.y)
+  renderer.updateSelection(right, right.x + right.width, right.y + 1, { finishDragging: true })
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe("A1\nB2")
 })


### PR DESCRIPTION
## Summary
- Preserve same-row selected renderables as a single copied line instead of joining every renderable with newlines
- Add markdown unordered and ordered list selection regressions

## Test
- bun test packages/core/src/renderables/__tests__/Markdown.test.ts --test-name-pattern \"selection across top-level.*list copies|selection across markdown table\"