### PR TITLE
solid: add JSX runtime and Node test lanes

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NODE_VERSION: 26.3.0
   ZIG_VERSION: 0.15.2
 
 jobs:
@@ -68,6 +69,12 @@ jobs:
         with:
           bun-version: 1.3.13
 
+      - name: Setup Node
+        if: runner.os == 'Linux'
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
@@ -107,6 +114,11 @@ jobs:
           cd packages/core
           export OTUI_TREE_SITTER_WORKER_PATH="$(bun -e 'import { resolve } from "node:path"; console.log(resolve("dist/parser.worker.js"))')"
           bun run test:js
+
+      - name: Run Node TypeScript tests
+        if: runner.os == 'Linux'
+        working-directory: packages/core
+        run: bun run test:js:node
 
   # Gate job for branch protection
   build-complete:

--- a/.github/workflows/build-keymap.yml
+++ b/.github/workflows/build-keymap.yml
@@ -54,9 +54,47 @@ jobs:
           cd packages/keymap
           bun run test
 
+  packed-consumer:
+    name: Packed Consumer Smoke
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build core
+        run: |
+          cd packages/core
+          bun run build
+
+      - name: Build keymap
+        run: |
+          cd packages/keymap
+          bun run build --ci
+
+      - name: Run packed consumer smoke test
+        run: |
+          cd packages/keymap
+          bun run test:dist --skip-build
+
   build-complete:
     name: Keymap - Build and Test
-    needs: [test]
+    needs: [test, packed-consumer]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -64,6 +102,10 @@ jobs:
         run: |
           if [ "${{ needs.test.result }}" != "success" ]; then
             echo "Tests failed"
+            exit 1
+          fi
+          if [ "${{ needs.packed-consumer.result }}" != "success" ]; then
+            echo "Packed consumer smoke test failed"
             exit 1
           fi
           echo "All tests passed"

--- a/.github/workflows/build-keymap.yml
+++ b/.github/workflows/build-keymap.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NODE_VERSION: 26.3.0
 
 jobs:
   test:
@@ -63,6 +64,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/build-keymap.yml
+++ b/.github/workflows/build-keymap.yml
@@ -47,9 +47,47 @@ jobs:
           cd packages/keymap
           bun run test
 
+  packed-consumer:
+    name: Packed Consumer Smoke
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build core
+        run: |
+          cd packages/core
+          bun run build
+
+      - name: Build keymap
+        run: |
+          cd packages/keymap
+          bun run build --ci
+
+      - name: Run packed consumer smoke test
+        run: |
+          cd packages/keymap
+          bun run test:dist --skip-build
+
   build-complete:
     name: Keymap - Build and Test
-    needs: [test]
+    needs: [test, packed-consumer]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -57,6 +95,10 @@ jobs:
         run: |
           if [ "${{ needs.test.result }}" != "success" ]; then
             echo "Tests failed"
+            exit 1
+          fi
+          if [ "${{ needs.packed-consumer.result }}" != "success" ]; then
+            echo "Packed consumer smoke test failed"
             exit 1
           fi
           echo "All tests passed"

--- a/.github/workflows/build-solid.yml
+++ b/.github/workflows/build-solid.yml
@@ -6,8 +6,8 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    name: Test (${{ matrix.os }})
+  bun-test:
+    name: Bun Test (${{ matrix.os }})
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -33,31 +33,106 @@ jobs:
         run: bun install
 
       - name: Build core
-        run: |
-          cd packages/core
-          bun run build
+        working-directory: packages/core
+        run: bun run build
 
       - name: Build
-        run: |
-          cd packages/solid
-          bun run build --ci
+        working-directory: packages/solid
+        run: bun run build --ci
 
       - name: Run tests
-        run: |
-          cd packages/solid
-          bun run test
+        working-directory: packages/solid
+        run: bun run test
+
+  node-source:
+    name: Node Source Lane
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build core
+        working-directory: packages/core
+        run: bun run build
+
+      - name: Build solid
+        working-directory: packages/solid
+        run: bun run build --ci
+
+      - name: Run Node source lane
+        working-directory: packages/solid
+        run: bun run test:js:node
+
+  packed-consumer:
+    name: Packed Consumer Smoke
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build core
+        working-directory: packages/core
+        run: bun run build
+
+      - name: Build solid
+        working-directory: packages/solid
+        run: bun run build --ci
+
+      - name: Run packed consumer smoke test
+        working-directory: packages/solid
+        run: bun run test:dist --skip-build
 
   # Gate job for branch protection
   build-complete:
     name: Solid - Build and Test
-    needs: [test]
+    needs: [bun-test, node-source, packed-consumer]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check test results
         run: |
-          if [ "${{ needs.test.result }}" != "success" ]; then
-            echo "Tests failed"
+          if [ "${{ needs.bun-test.result }}" != "success" ]; then
+            echo "Bun tests failed"
+            exit 1
+          fi
+          if [ "${{ needs.node-source.result }}" != "success" ]; then
+            echo "Node source lane failed"
+            exit 1
+          fi
+          if [ "${{ needs.packed-consumer.result }}" != "success" ]; then
+            echo "Packed consumer smoke test failed"
             exit 1
           fi
           echo "All tests passed"

--- a/.github/workflows/build-solid.yml
+++ b/.github/workflows/build-solid.yml
@@ -9,8 +9,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  test:
-    name: Test (${{ matrix.os }})
+  bun-test:
+    name: Bun Test (${{ matrix.os }})
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -40,31 +40,106 @@ jobs:
         run: bun install
 
       - name: Build core
-        run: |
-          cd packages/core
-          bun run build
+        working-directory: packages/core
+        run: bun run build
 
       - name: Build
-        run: |
-          cd packages/solid
-          bun run build --ci
+        working-directory: packages/solid
+        run: bun run build --ci
 
       - name: Run tests
-        run: |
-          cd packages/solid
-          bun run test
+        working-directory: packages/solid
+        run: bun run test
+
+  node-source:
+    name: Node Source Lane
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build core
+        working-directory: packages/core
+        run: bun run build
+
+      - name: Build solid
+        working-directory: packages/solid
+        run: bun run build --ci
+
+      - name: Run Node source lane
+        working-directory: packages/solid
+        run: bun run test:js:node
+
+  packed-consumer:
+    name: Packed Consumer Smoke
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build core
+        working-directory: packages/core
+        run: bun run build
+
+      - name: Build solid
+        working-directory: packages/solid
+        run: bun run build --ci
+
+      - name: Run packed consumer smoke test
+        working-directory: packages/solid
+        run: bun run test:dist --skip-build
 
   # Gate job for branch protection
   build-complete:
     name: Solid - Build and Test
-    needs: [test]
+    needs: [bun-test, node-source, packed-consumer]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check test results
         run: |
-          if [ "${{ needs.test.result }}" != "success" ]; then
-            echo "Tests failed"
+          if [ "${{ needs.bun-test.result }}" != "success" ]; then
+            echo "Bun tests failed"
+            exit 1
+          fi
+          if [ "${{ needs.node-source.result }}" != "success" ]; then
+            echo "Node source lane failed"
+            exit 1
+          fi
+          if [ "${{ needs.packed-consumer.result }}" != "success" ]; then
+            echo "Packed consumer smoke test failed"
             exit 1
           fi
           echo "All tests passed"

--- a/.github/workflows/build-solid.yml
+++ b/.github/workflows/build-solid.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NODE_VERSION: 26.3.0
 
 jobs:
   bun-test:
@@ -61,6 +62,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -95,6 +101,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/npm-latest-release.yml
+++ b/.github/workflows/npm-latest-release.yml
@@ -100,6 +100,15 @@ jobs:
 
           echo "Package extraction complete"
 
+      - name: Run packed Node smoke tests
+        run: |
+          cd packages/core
+          bun run test:dist --skip-build
+          cd ../solid
+          bun run test:dist --skip-build
+          cd ../keymap
+          bun run test:dist --skip-build
+
       - name: Publish packages (dry-run)
         if: ${{ inputs.isDryRun }}
         run: |

--- a/.github/workflows/npm-latest-release.yml
+++ b/.github/workflows/npm-latest-release.yml
@@ -20,6 +20,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  NODE_VERSION: 26.3.0
+
 jobs:
   publish:
     runs-on: macos-latest
@@ -29,6 +32,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/npm-latest-release.yml
+++ b/.github/workflows/npm-latest-release.yml
@@ -93,6 +93,15 @@ jobs:
 
           echo "Package extraction complete"
 
+      - name: Run packed Node smoke tests
+        run: |
+          cd packages/core
+          bun run test:dist --skip-build
+          cd ../solid
+          bun run test:dist --skip-build
+          cd ../keymap
+          bun run test:dist --skip-build
+
       - name: Publish packages (dry-run)
         if: ${{ inputs.isDryRun }}
         run: |

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -67,6 +67,15 @@ jobs:
           cd ../react && bun run build
           cd ../keymap && bun run build
 
+      - name: Run packed Node smoke tests
+        run: |
+          cd packages/core
+          bun run test:dist --skip-build
+          cd ../solid
+          bun run test:dist --skip-build
+          cd ../keymap
+          bun run test:dist --skip-build
+
       - name: Publish packages
         run: bun run publish
         env:

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -62,6 +62,15 @@ jobs:
           cd ../react && bun run build
           cd ../keymap && bun run build
 
+      - name: Run packed Node smoke tests
+        run: |
+          cd packages/core
+          bun run test:dist --skip-build
+          cd ../solid
+          bun run test:dist --skip-build
+          cd ../keymap
+          bun run test:dist --skip-build
+
       - name: Publish packages
         run: bun run publish
         env:

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NODE_VERSION: 26.3.0
 
 jobs:
   release:
@@ -20,6 +21,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  NODE_VERSION: 26.3.0
+
 jobs:
   # Extract version and check if it's a dry run
   prepare:
@@ -60,6 +63,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Check version matches package.json files
         run: |

--- a/packages/core/scripts/dist-test.ts
+++ b/packages/core/scripts/dist-test.ts
@@ -5,6 +5,8 @@ import { dirname, join, relative, resolve } from "node:path"
 import process from "node:process"
 import { fileURLToPath } from "node:url"
 
+import { requireNode26 } from "../../../scripts/node26.mjs"
+
 interface PackageJson {
   name: string
   version: string
@@ -17,6 +19,7 @@ const distDir = join(rootDir, "dist")
 const args = new Set(process.argv.slice(2))
 const keepTemp = args.has("--keep-temp")
 const skipBuild = args.has("--skip-build")
+const nodePath = requireNode26()
 
 const packageJson = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8")) as PackageJson
 const nativePackageName = `${packageJson.name}-${process.platform}-${process.arch}`
@@ -204,7 +207,7 @@ function assertNodeStaticImportFailure(
   expectedMessage: string,
 ): void {
   const result = runCommandExpectFailure(
-    "node",
+    nodePath,
     ["--input-type=module", "-e", `import { ${importedName} } from ${JSON.stringify(specifier)}`],
     nodeDir,
     `Expected static Node import of ${specifier} to fail`,
@@ -223,8 +226,8 @@ function assertNodeStaticImportFailure(
 
 function installAndTest(nodeDir: string, bunDir: string): void {
   runCommand("npm", ["install", "--ignore-scripts", "--no-package-lock"], nodeDir, "Node dist test install failed")
-  runCommand("node", ["-e", `import(${JSON.stringify(packageJson.name)})`], nodeDir, "Node import smoke check failed")
-  runCommand("node", ["index.mjs"], nodeDir, "Node dist smoke tests failed")
+  runCommand(nodePath, ["-e", `import(${JSON.stringify(packageJson.name)})`], nodeDir, "Node import smoke check failed")
+  runCommand(nodePath, ["index.mjs"], nodeDir, "Node dist smoke tests failed")
 
   assertNodeStaticImportFailure(
     nodeDir,

--- a/packages/core/scripts/test-node.ts
+++ b/packages/core/scripts/test-node.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
-import { ensureNode26 } from "../../../scripts/node26.mjs"
+import { requireNode26 } from "../../../scripts/node26.mjs"
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const packageRoot = resolve(scriptDir, "..")
@@ -34,6 +34,7 @@ const treeSitterCacheTestAddress = "127.0.0.1:55231"
 const treeSitterAssetsDir = "src/lib/tree-sitter/assets"
 const nodeTestTimeoutMs = 30_000
 const nodeProcessTimeoutMs = 10 * 60_000
+const nodePath = requireNode26()
 const emittedAllowlist = [
   ".node-test/src/platform/ffi.test.js",
   ".node-test/src/platform/runtime.test.js",
@@ -165,8 +166,6 @@ try {
     for (const dataPath of treeSitterTestDataPaths) {
       mkdirSync(dataPath, { recursive: true })
     }
-
-    const nodePath = ensureNode26()
 
     exitCode = run(
       nodePath,

--- a/packages/core/src/platform/ffi.test.ts
+++ b/packages/core/src/platform/ffi.test.ts
@@ -100,7 +100,7 @@ function createMockNodeBackend(options: MockNodeBackendOptions = {}) {
   const backend = createNodeBackend({
     dlopen(
       path: string | null,
-      symbols: Record<string, { readonly parameters: readonly string[]; readonly result: string }>,
+      symbols: Record<string, { readonly arguments: readonly string[]; readonly return: string }>,
     ) {
       paths.push(path)
       symbolDefinitions.push(symbols)
@@ -114,7 +114,7 @@ function createMockNodeBackend(options: MockNodeBackendOptions = {}) {
             }
           },
           registerCallback(
-            signature: { readonly parameters: readonly string[]; readonly result: string },
+            signature: { readonly arguments: readonly string[]; readonly return: string },
             _callback: (...args: any[]) => any,
           ) {
             const pointer = nextCallbackPtr++
@@ -294,7 +294,7 @@ describe("platform/ffi", () => {
     expect(symbolDefinitions).toEqual([
       {
         primitives: {
-          parameters: [
+          arguments: [
             "char",
             "i8",
             "i8",
@@ -315,7 +315,7 @@ describe("platform/ffi", () => {
             "u64",
             "bool",
           ],
-          result: "void",
+          return: "void",
         },
       },
     ])
@@ -334,8 +334,8 @@ describe("platform/ffi", () => {
     expect(symbolDefinitions).toEqual([
       {
         floats: {
-          parameters: ["f32", "f32", "f64", "f64"],
-          result: "void",
+          arguments: ["f32", "f32", "f64", "f64"],
+          return: "void",
         },
       },
     ])
@@ -354,8 +354,8 @@ describe("platform/ffi", () => {
     expect(symbolDefinitions).toEqual([
       {
         pointers: {
-          parameters: ["pointer", "pointer", "pointer", "pointer", "buffer", "string"],
-          result: "void",
+          arguments: ["pointer", "pointer", "pointer", "pointer", "buffer", "string"],
+          return: "void",
         },
       },
     ])
@@ -447,7 +447,7 @@ describe("platform/ffi", () => {
 
     expect(callback.ptr).toBe(9000n as Pointer)
     expect(callback.threadsafe).toBe(false)
-    expect(callbackDefinitions).toEqual([{ parameters: ["i32"], result: "i32" }])
+    expect(callbackDefinitions).toEqual([{ arguments: ["i32"], return: "i32" }])
 
     callback.close()
     callback.close()

--- a/packages/core/src/platform/ffi.ts
+++ b/packages/core/src/platform/ffi.ts
@@ -124,8 +124,8 @@ interface BunFfiBackend {
 }
 
 interface NodeFFIFunction {
-  readonly parameters: readonly string[]
-  readonly result: string
+  readonly arguments: readonly string[]
+  readonly return: string
 }
 
 interface NodeDynamicLibrary {
@@ -547,8 +547,8 @@ function normalizeNodeDefinition(definition: FFIFunction): NodeFFIFunction {
   }
 
   return {
-    parameters: (definition.args ?? []).map((type) => toNodeFFIType(type, "parameter")),
-    result: toNodeFFIType(definition.returns ?? FFIType.void, "result"),
+    arguments: (definition.args ?? []).map((type) => toNodeFFIType(type, "parameter")),
+    return: toNodeFFIType(definition.returns ?? FFIType.void, "result"),
   }
 }
 

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -16,7 +16,6 @@
     "dev": "bun src/index.ts",
     "build": "bun scripts/build.ts",
     "build:host": "bun scripts/build.ts --host",
-    "download:node26": "node scripts/download-node26.mjs",
     "dev:node": "node scripts/run-node26.mjs"
   },
   "dependencies": {

--- a/packages/examples/scripts/build.ts
+++ b/packages/examples/scripts/build.ts
@@ -54,6 +54,14 @@ if (!bunWebgpuVersion) {
 const workspaceAliasPlugin: BunPlugin = {
   name: "workspace-alias",
   setup(build) {
+    build.onResolve({ filter: /^@opentui\/core-(?:darwin|linux|win32)-/ }, (args) => {
+      if (existsSync(join(coreRoot, "node_modules", args.path))) return
+
+      // Bun resolves unreachable dynamic imports while compiling. Keep absent
+      // optional native variants external so host-only builds need only the host package.
+      return { path: args.path, external: true }
+    })
+
     build.onResolve({ filter: /^@opentui\/core$/ }, () => ({
       path: join(coreRoot, "src", "index.ts"),
     }))

--- a/packages/examples/scripts/download-node26.mjs
+++ b/packages/examples/scripts/download-node26.mjs
@@ -1,3 +1,0 @@
-import { ensureNode26 } from "../../../scripts/node26.mjs"
-
-console.log(ensureNode26())

--- a/packages/examples/scripts/run-node26.mjs
+++ b/packages/examples/scripts/run-node26.mjs
@@ -9,13 +9,15 @@ const scriptDir = dirname(fileURLToPath(import.meta.url))
 const packageRoot = resolve(scriptDir, "..")
 const repoRoot = resolve(packageRoot, "../..")
 const coreRoot = resolve(repoRoot, "packages/core")
+const coreDistDir = resolve(coreRoot, "dist")
 const nodePath = ensureNode26()
 const bundleDir = resolve(packageRoot, ".node")
 const bundleEntry = resolve(bundleDir, "index.js")
 const workerEntry = resolve(bundleDir, "parser.worker.js")
 
-ensureNativePackage()
+prepareCorePackage()
 buildNodeExamples()
+copyCoreDistPackage()
 
 const result = spawnSync(nodePath, ["--experimental-ffi", "--no-warnings", bundleEntry], {
   cwd: packageRoot,
@@ -50,21 +52,30 @@ function buildNodeExamples() {
       "[name].[ext]",
       "--define",
       "OPENTUI_BUN_ONLY_EXAMPLES=false",
+      "--external",
+      "@opentui/core",
     ],
     packageRoot,
   )
 }
 
-function ensureNativePackage() {
+function prepareCorePackage() {
   const nativePackageName = `core-${process.platform === "win32" ? "win32" : process.platform}-${process.arch}`
   const sourceNativeDir = resolve(coreRoot, "node_modules", "@opentui", nativePackageName)
   const targetNativeDir = resolve(packageRoot, "node_modules", "@opentui", nativePackageName)
 
-  run("bun", ["run", "build:native"], coreRoot)
+  run("bun", ["run", "build"], coreRoot)
 
   mkdirSync(resolve(packageRoot, "node_modules", "@opentui"), { recursive: true })
   rmSync(targetNativeDir, { recursive: true, force: true })
   cpSync(sourceNativeDir, targetNativeDir, { recursive: true, dereference: true })
+}
+
+function copyCoreDistPackage() {
+  const targetCoreDir = resolve(bundleDir, "node_modules", "@opentui", "core")
+
+  mkdirSync(resolve(targetCoreDir, ".."), { recursive: true })
+  cpSync(coreDistDir, targetCoreDir, { recursive: true })
 }
 
 function run(command, args, cwd) {

--- a/packages/examples/scripts/run-node26.mjs
+++ b/packages/examples/scripts/run-node26.mjs
@@ -3,14 +3,14 @@ import { cpSync, mkdirSync, rmSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
-import { ensureNode26 } from "../../../scripts/node26.mjs"
+import { requireNode26 } from "../../../scripts/node26.mjs"
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const packageRoot = resolve(scriptDir, "..")
 const repoRoot = resolve(packageRoot, "../..")
 const coreRoot = resolve(repoRoot, "packages/core")
 const coreDistDir = resolve(coreRoot, "dist")
-const nodePath = ensureNode26()
+const nodePath = requireNode26()
 const bundleDir = resolve(packageRoot, ".node")
 const bundleEntry = resolve(bundleDir, "index.js")
 const workerEntry = resolve(bundleDir, "parser.worker.js")

--- a/packages/keymap/package.json
+++ b/packages/keymap/package.json
@@ -61,6 +61,7 @@
   "scripts": {
     "build": "bun run scripts/build.ts",
     "publish": "bun run scripts/publish.ts",
+    "test:dist": "bun run scripts/test-packed-consumer.ts",
     "test": "bun run scripts/test.ts"
   },
   "dependencies": {

--- a/packages/keymap/scripts/test-packed-consumer.ts
+++ b/packages/keymap/scripts/test-packed-consumer.ts
@@ -1,0 +1,233 @@
+/**
+ * Smoke-tests the packed npm consumer contract for `@opentui/keymap`.
+ *
+ * This verifies the built tarballs install in a fresh Node project and that the
+ * Node-safe keymap entrypoints import and run without Bun or FFI flags.
+ */
+
+import { spawnSync, type SpawnSyncReturns } from "node:child_process"
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, relative, resolve } from "node:path"
+import process from "node:process"
+import { fileURLToPath } from "node:url"
+
+interface PackageJson {
+  name: string
+  version: string
+}
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const rootDir = resolve(__dirname, "..")
+const coreRootDir = resolve(rootDir, "..", "core")
+const distDir = join(rootDir, "dist")
+const coreDistDir = join(coreRootDir, "dist")
+const args = new Set(process.argv.slice(2))
+const keepTemp = args.has("--keep-temp")
+const skipBuild = args.has("--skip-build")
+
+const packageJson = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8")) as PackageJson
+const corePackageJson = JSON.parse(readFileSync(join(coreRootDir, "package.json"), "utf8")) as PackageJson
+const nativePackageName = `${corePackageJson.name}-${process.platform}-${process.arch}`
+const nativePackageDir = join(coreRootDir, "node_modules", nativePackageName)
+
+function runCommand(
+  command: string,
+  commandArgs: string[],
+  cwd: string,
+  errorMessage: string,
+  options: { stdio?: "inherit" | "pipe" } = {},
+): SpawnSyncReturns<Buffer> {
+  const result = spawnSync(command, commandArgs, {
+    cwd,
+    stdio: options.stdio ?? "inherit",
+  })
+
+  if (result.error) {
+    throw new Error(`${errorMessage}: ${result.error.message}`)
+  }
+
+  if (result.status !== 0) {
+    throw new Error(errorMessage)
+  }
+
+  return result
+}
+
+function ensureBuildArtifacts(): void {
+  if (!skipBuild) {
+    runCommand("bun", ["run", "build"], coreRootDir, "Core build failed")
+    runCommand("bun", ["run", "build"], rootDir, "Keymap build failed")
+  }
+
+  if (!existsSync(coreDistDir)) {
+    throw new Error(`Missing core dist directory at ${coreDistDir}. Run bun run build in packages/core first.`)
+  }
+
+  if (!existsSync(distDir)) {
+    throw new Error(`Missing keymap dist directory at ${distDir}. Run bun run build first.`)
+  }
+
+  if (!existsSync(nativePackageDir)) {
+    throw new Error(
+      `Missing native package directory at ${nativePackageDir}. Run bun run build in packages/core first.`,
+    )
+  }
+}
+
+function packArtifact(packageDir: string, packDir: string): string {
+  const result = runCommand(
+    "npm",
+    ["pack", "--pack-destination", packDir],
+    packageDir,
+    `Failed to pack ${packageDir}`,
+    {
+      stdio: "pipe",
+    },
+  )
+
+  const tarballName = result.stdout.toString("utf8").trim().split(/\r?\n/).at(-1)
+  if (!tarballName) {
+    throw new Error(`Failed to determine tarball name for ${packageDir}`)
+  }
+
+  return join(packDir, tarballName)
+}
+
+function writeConsumerPackage(
+  consumerDir: string,
+  keymapTarball: string,
+  coreTarball: string,
+  nativeTarball: string,
+): void {
+  const keymapDependency = `file:${relative(consumerDir, keymapTarball).replaceAll("\\", "/")}`
+  const coreDependency = `file:${relative(consumerDir, coreTarball).replaceAll("\\", "/")}`
+  const nativeDependency = `file:${relative(consumerDir, nativeTarball).replaceAll("\\", "/")}`
+
+  writeFileSync(
+    join(consumerDir, "package.json"),
+    JSON.stringify(
+      {
+        name: "opentui-keymap-dist-test-node",
+        private: true,
+        type: "module",
+        dependencies: {
+          [packageJson.name]: keymapDependency,
+          [corePackageJson.name]: coreDependency,
+          [nativePackageName]: nativeDependency,
+        },
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+function writeNodeTest(nodeDir: string): void {
+  writeFileSync(
+    join(nodeDir, "index.mjs"),
+    `import assert from "node:assert/strict"
+
+const nativePackageName = ${JSON.stringify(nativePackageName)}
+
+const keymap = await import(${JSON.stringify(packageJson.name)})
+const addons = await import(${JSON.stringify(`${packageJson.name}/addons`)})
+const opentuiAddons = await import(${JSON.stringify(`${packageJson.name}/addons/opentui`)})
+const extras = await import(${JSON.stringify(`${packageJson.name}/extras`)})
+const graph = await import(${JSON.stringify(`${packageJson.name}/extras/graph`)})
+const html = await import(${JSON.stringify(`${packageJson.name}/html`)})
+const opentui = await import(${JSON.stringify(`${packageJson.name}/opentui`)})
+const runtimeModules = await import(${JSON.stringify(`${packageJson.name}/runtime-modules`)})
+const testing = await import(${JSON.stringify(`${packageJson.name}/testing`)})
+const nativePackage = await import(nativePackageName)
+
+assert.equal(typeof keymap.Keymap, "function")
+assert.equal(typeof keymap.stringifyKeyStroke, "function")
+assert.equal(typeof addons.registerDefaultKeys, "function")
+assert.equal(typeof opentuiAddons.registerBaseLayoutFallback, "function")
+assert.equal(typeof opentuiAddons.createTextareaBindings, "function")
+assert.equal(typeof extras.formatKeySequence, "function")
+assert.equal(typeof graph.getGraphSnapshot, "function")
+assert.equal(typeof html.createHtmlKeymapEvent, "function")
+assert.equal(typeof opentui.createOpenTuiKeymap, "function")
+assert.equal(typeof runtimeModules.runtimeModules[${JSON.stringify(packageJson.name)}], "object")
+assert.equal(typeof runtimeModules.runtimeModules[${JSON.stringify(`${packageJson.name}/react`)}], "function")
+assert.equal(typeof runtimeModules.runtimeModules[${JSON.stringify(`${packageJson.name}/solid`)}], "function")
+assert.equal(typeof testing.createTestKeymap, "function")
+assert.equal(typeof nativePackage.default, "string")
+
+const htmlEvent = html.createHtmlKeymapEvent({
+  key: "Enter",
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+  metaKey: false,
+  preventDefault() {},
+  stopPropagation() {},
+})
+assert.equal(htmlEvent.name, "return")
+
+const setup = testing.createTestKeymap({ defaultKeys: true })
+let commandCalls = 0
+setup.keymap.registerLayer({
+  commands: [
+    {
+      name: "save-file",
+      run() {
+        commandCalls += 1
+      },
+    },
+  ],
+  bindings: [{ key: "ctrl+s", cmd: "save-file" }],
+})
+
+setup.host.press("s", { ctrl: true })
+assert.equal(commandCalls, 1)
+setup.cleanup()
+
+console.log("Node keymap dist smoke test passed")
+`,
+  )
+}
+
+function installAndTest(nodeDir: string): void {
+  runCommand("npm", ["install", "--ignore-scripts", "--no-package-lock"], nodeDir, "Node dist test install failed")
+  runCommand("node", ["-e", `import(${JSON.stringify(packageJson.name)})`], nodeDir, "Node import smoke check failed")
+  runCommand("node", ["index.mjs"], nodeDir, "Node keymap dist smoke tests failed")
+}
+
+let tempRoot: string | undefined
+
+try {
+  ensureBuildArtifacts()
+
+  tempRoot = mkdtempSync(join(tmpdir(), "opentui-keymap-dist-test-"))
+  const packDir = join(tempRoot, "packs")
+  const nodeDir = join(tempRoot, "node")
+
+  mkdirSync(packDir, { recursive: true })
+  mkdirSync(nodeDir, { recursive: true })
+
+  const coreTarball = packArtifact(coreDistDir, packDir)
+  const nativeTarball = packArtifact(nativePackageDir, packDir)
+  const keymapTarball = packArtifact(distDir, packDir)
+
+  writeConsumerPackage(nodeDir, keymapTarball, coreTarball, nativeTarball)
+  writeNodeTest(nodeDir)
+
+  installAndTest(nodeDir)
+
+  if (!keepTemp) {
+    rmSync(tempRoot, { recursive: true, force: true })
+    tempRoot = undefined
+  }
+
+  console.log("Packed keymap dist smoke tests passed")
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error)
+  if (tempRoot) {
+    console.error(`Dist test workspace kept at ${tempRoot}`)
+  }
+  process.exit(1)
+}

--- a/packages/keymap/scripts/test-packed-consumer.ts
+++ b/packages/keymap/scripts/test-packed-consumer.ts
@@ -12,6 +12,8 @@ import { dirname, join, relative, resolve } from "node:path"
 import process from "node:process"
 import { fileURLToPath } from "node:url"
 
+import { requireNode26 } from "../../../scripts/node26.mjs"
+
 interface PackageJson {
   name: string
   version: string
@@ -26,6 +28,7 @@ const coreDistDir = join(coreRootDir, "dist")
 const args = new Set(process.argv.slice(2))
 const keepTemp = args.has("--keep-temp")
 const skipBuild = args.has("--skip-build")
+const nodePath = requireNode26()
 
 const packageJson = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8")) as PackageJson
 const corePackageJson = JSON.parse(readFileSync(join(coreRootDir, "package.json"), "utf8")) as PackageJson
@@ -193,8 +196,8 @@ console.log("Node keymap dist smoke test passed")
 
 function installAndTest(nodeDir: string): void {
   runCommand("npm", ["install", "--ignore-scripts", "--no-package-lock"], nodeDir, "Node dist test install failed")
-  runCommand("node", ["-e", `import(${JSON.stringify(packageJson.name)})`], nodeDir, "Node import smoke check failed")
-  runCommand("node", ["index.mjs"], nodeDir, "Node keymap dist smoke tests failed")
+  runCommand(nodePath, ["-e", `import(${JSON.stringify(packageJson.name)})`], nodeDir, "Node import smoke check failed")
+  runCommand(nodePath, ["index.mjs"], nodeDir, "Node keymap dist smoke tests failed")
 }
 
 let tempRoot: string | undefined

--- a/packages/keymap/src/runtime-modules.ts
+++ b/packages/keymap/src/runtime-modules.ts
@@ -1,4 +1,4 @@
-import type { RuntimeModuleEntry } from "@opentui/core/runtime-plugin"
+import type { RuntimeModuleEntry, RuntimeModuleExports } from "@opentui/core/runtime-plugin"
 import * as keymap from "@opentui/keymap"
 import * as keymapExtras from "@opentui/keymap/extras"
 import * as keymapGraphExtra from "@opentui/keymap/extras/graph"
@@ -6,8 +6,14 @@ import * as keymapAddons from "@opentui/keymap/addons"
 import * as keymapOpenTuiAddons from "@opentui/keymap/addons/opentui"
 import * as keymapHtml from "@opentui/keymap/html"
 import * as keymapOpenTui from "@opentui/keymap/opentui"
-import * as keymapReact from "@opentui/keymap/react"
-import * as keymapSolid from "@opentui/keymap/solid"
+
+const loadKeymapReact = async (): Promise<RuntimeModuleExports> => {
+  return (await import("@opentui/keymap/react")) as RuntimeModuleExports
+}
+
+const loadKeymapSolid = async (): Promise<RuntimeModuleExports> => {
+  return (await import("@opentui/keymap/solid")) as RuntimeModuleExports
+}
 
 export const runtimeModules = {
   "@opentui/keymap": keymap,
@@ -17,6 +23,6 @@ export const runtimeModules = {
   "@opentui/keymap/addons/opentui": keymapOpenTuiAddons,
   "@opentui/keymap/html": keymapHtml,
   "@opentui/keymap/opentui": keymapOpenTui,
-  "@opentui/keymap/react": keymapReact,
-  "@opentui/keymap/solid": keymapSolid,
+  "@opentui/keymap/react": loadKeymapReact,
+  "@opentui/keymap/solid": loadKeymapSolid,
 } satisfies Record<string, RuntimeModuleEntry>

--- a/packages/solid/index.ts
+++ b/packages/solid/index.ts
@@ -1,6 +1,6 @@
 import { CliRenderer, createCliRenderer, engine, type CliRendererConfig } from "@opentui/core"
 import { createTestRenderer, type TestRendererOptions } from "@opentui/core/testing"
-import type { JSX } from "./jsx-runtime"
+import type { JSX } from "./jsx-runtime.js"
 import { RendererContext } from "./src/elements/index.js"
 import { _render as renderInternal, createComponent } from "./src/reconciler.js"
 
@@ -48,7 +48,7 @@ const mountSolidRoot = (renderer: CliRenderer, node: () => JSX.Element) => {
             return renderer
           },
           get children() {
-            return createComponent(node, {})
+            return (createComponent as any)(node, {})
           },
         }),
       renderer.root,

--- a/packages/solid/jsx-dev-runtime.d.ts
+++ b/packages/solid/jsx-dev-runtime.d.ts
@@ -1,0 +1,1 @@
+export { Fragment, jsxDEV, type JSX } from "./jsx-runtime.js"

--- a/packages/solid/jsx-dev-runtime.ts
+++ b/packages/solid/jsx-dev-runtime.ts
@@ -1,0 +1,2 @@
+export { Fragment, jsxDEV } from "./jsx-runtime.js"
+export type { JSX } from "./jsx-runtime.js"

--- a/packages/solid/jsx-runtime.d.ts
+++ b/packages/solid/jsx-runtime.d.ts
@@ -1,4 +1,3 @@
-import { Renderable } from "@opentui/core"
 import type {
   AsciiFontProps,
   BoxProps,
@@ -15,13 +14,17 @@ import type {
   TextareaProps,
   TextProps,
 } from "./src/types/elements.js"
-import type { DomNode } from "./dist"
+import type { JSX as SolidJSX } from "solid-js"
 
-declare namespace JSX {
-  // Replace Node with Renderable
-  type Element = DomNode | ArrayElement | string | number | boolean | null | undefined
+type JsxComponent = (props: Record<string, unknown>) => unknown
 
-  type ArrayElement = Array<Element>
+export declare function jsx(type: string | JsxComponent, props?: Record<string, unknown> | null): JSX.Element
+export declare const jsxs: typeof jsx
+export declare function jsxDEV(type: string | JsxComponent, props?: Record<string, unknown> | null): JSX.Element
+export declare function Fragment(props: { children?: JSX.Element }): JSX.Element
+
+export declare namespace JSX {
+  type Element = SolidJSX.Element
 
   interface IntrinsicElements extends ExtendedIntrinsicElements<OpenTUIComponents> {
     box: BoxProps

--- a/packages/solid/jsx-runtime.d.ts
+++ b/packages/solid/jsx-runtime.d.ts
@@ -1,4 +1,3 @@
-import { Renderable } from "@opentui/core"
 import type {
   AsciiFontProps,
   BoxProps,
@@ -15,9 +14,16 @@ import type {
   TextareaProps,
   TextProps,
 } from "./src/types/elements.js"
-import type { DomNode } from "./dist"
+import type { DomNode } from "./src/reconciler.js"
 
-declare namespace JSX {
+type JsxComponent = (props: Record<string, unknown>) => unknown
+
+export declare function jsx(type: string | JsxComponent, props?: Record<string, unknown> | null): JSX.Element
+export declare const jsxs: typeof jsx
+export declare function jsxDEV(type: string | JsxComponent, props?: Record<string, unknown> | null): JSX.Element
+export declare function Fragment(props: { children?: JSX.Element }): JSX.Element
+
+export declare namespace JSX {
   // Replace Node with Renderable
   type Element = DomNode | ArrayElement | string | number | boolean | null | undefined
 

--- a/packages/solid/jsx-runtime.ts
+++ b/packages/solid/jsx-runtime.ts
@@ -1,0 +1,95 @@
+import { createComponent, createElement, spread } from "@opentui/solid"
+import type {
+  AsciiFontProps,
+  BoxProps,
+  CodeProps,
+  ExtendedIntrinsicElements,
+  InputProps,
+  LinkProps,
+  MarkdownProps,
+  OpenTUIComponents,
+  ScrollBoxProps,
+  SelectProps,
+  SpanProps,
+  TabSelectProps,
+  TextareaProps,
+  TextProps,
+} from "./src/types/elements.js"
+import type { JSX as SolidJSX } from "solid-js"
+
+type SolidComponent = (props: Record<string, unknown>) => unknown
+
+interface JsxProps {
+  children?: unknown
+  key?: unknown
+  [key: string]: unknown
+}
+
+function normalizeProps(props: JsxProps | null | undefined): Record<string, unknown> {
+  if (!props) {
+    return {}
+  }
+
+  if (!("key" in props)) {
+    return props
+  }
+
+  const { key: _key, ...rest } = props
+  return rest
+}
+
+function createIntrinsicElement(type: string, props: Record<string, unknown>): unknown {
+  const element = createElement(type)
+  spread(element, props)
+  return element
+}
+
+export function jsx(type: string | SolidComponent, props: JsxProps | null = {}): unknown {
+  const normalizedProps = normalizeProps(props)
+
+  if (typeof type === "function") {
+    return (createComponent as any)(type, normalizedProps)
+  }
+
+  return createIntrinsicElement(type, normalizedProps)
+}
+
+export const jsxs = jsx
+
+export function jsxDEV(type: string | SolidComponent, props: JsxProps | null = {}): unknown {
+  return jsx(type, props)
+}
+
+export function Fragment(props: { children?: unknown }): unknown {
+  return props.children ?? null
+}
+
+export namespace JSX {
+  export type Element = SolidJSX.Element
+
+  export interface IntrinsicElements extends ExtendedIntrinsicElements<OpenTUIComponents> {
+    box: BoxProps
+    text: TextProps
+    span: SpanProps
+    input: InputProps
+    select: SelectProps
+    ascii_font: AsciiFontProps
+    tab_select: TabSelectProps
+    scrollbox: ScrollBoxProps
+    code: CodeProps
+    textarea: TextareaProps
+    markdown: MarkdownProps
+
+    b: SpanProps
+    strong: SpanProps
+    i: SpanProps
+    em: SpanProps
+    u: SpanProps
+    br: {}
+    a: LinkProps
+  }
+
+  export interface ElementChildrenAttribute {
+    children: {}
+  }
+}

--- a/packages/solid/jsx-runtime.ts
+++ b/packages/solid/jsx-runtime.ts
@@ -1,0 +1,96 @@
+import { createComponent, createElement, spread } from "./index.js"
+import type {
+  AsciiFontProps,
+  BoxProps,
+  CodeProps,
+  ExtendedIntrinsicElements,
+  InputProps,
+  LinkProps,
+  MarkdownProps,
+  OpenTUIComponents,
+  ScrollBoxProps,
+  SelectProps,
+  SpanProps,
+  TabSelectProps,
+  TextareaProps,
+  TextProps,
+} from "./src/types/elements.js"
+import type { DomNode } from "./src/reconciler.js"
+
+type SolidComponent = (props: Record<string, unknown>) => unknown
+
+interface JsxProps {
+  children?: unknown
+  key?: unknown
+  [key: string]: unknown
+}
+
+function normalizeProps(props: JsxProps | null | undefined): Record<string, unknown> {
+  if (!props) {
+    return {}
+  }
+
+  if (!("key" in props)) {
+    return props
+  }
+
+  const { key: _key, ...rest } = props
+  return rest
+}
+
+function createIntrinsicElement(type: string, props: Record<string, unknown>): unknown {
+  const element = createElement(type)
+  spread(element, props)
+  return element
+}
+
+export function jsx(type: string | SolidComponent, props: JsxProps | null = {}): unknown {
+  const normalizedProps = normalizeProps(props)
+
+  if (typeof type === "function") {
+    return (createComponent as any)(type, normalizedProps)
+  }
+
+  return createIntrinsicElement(type, normalizedProps)
+}
+
+export const jsxs = jsx
+
+export function jsxDEV(type: string | SolidComponent, props: JsxProps | null = {}): unknown {
+  return jsx(type, props)
+}
+
+export function Fragment(props: { children?: unknown }): unknown {
+  return props.children ?? null
+}
+
+export namespace JSX {
+  export type Element = DomNode | ArrayElement | string | number | boolean | null | undefined
+  export type ArrayElement = Array<Element>
+
+  export interface IntrinsicElements extends ExtendedIntrinsicElements<OpenTUIComponents> {
+    box: BoxProps
+    text: TextProps
+    span: SpanProps
+    input: InputProps
+    select: SelectProps
+    ascii_font: AsciiFontProps
+    tab_select: TabSelectProps
+    scrollbox: ScrollBoxProps
+    code: CodeProps
+    textarea: TextareaProps
+    markdown: MarkdownProps
+
+    b: SpanProps
+    strong: SpanProps
+    i: SpanProps
+    em: SpanProps
+    u: SpanProps
+    br: {}
+    a: LinkProps
+  }
+
+  export interface ElementChildrenAttribute {
+    children: {}
+  }
+}

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -16,6 +16,8 @@
     "build": "bun scripts/build.ts",
     "build:examples": "bun examples/build.ts",
     "publish": "bun scripts/publish.ts",
+    "test:dist": "bun scripts/test-packed-consumer.ts",
+    "test:js:node": "bun scripts/test-node.ts",
     "test": "bun test"
   },
   "exports": {
@@ -41,8 +43,14 @@
       "types": "./components.ts",
       "import": "./components.ts"
     },
-    "./jsx-runtime": "./jsx-runtime.d.ts",
-    "./jsx-dev-runtime": "./jsx-runtime.d.ts"
+    "./jsx-runtime": {
+      "types": "./jsx-runtime.d.ts",
+      "import": "./jsx-runtime.ts"
+    },
+    "./jsx-dev-runtime": {
+      "types": "./jsx-dev-runtime.d.ts",
+      "import": "./jsx-dev-runtime.ts"
+    }
   },
   "devDependencies": {
     "@opentui/keymap": "workspace:*",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -16,6 +16,8 @@
     "build": "bun scripts/build.ts",
     "build:examples": "bun examples/build.ts",
     "publish": "bun scripts/publish.ts",
+    "test:dist": "bun scripts/test-packed-consumer.ts",
+    "test:js:node": "bun scripts/test-node.ts",
     "test": "bun test"
   },
   "exports": {
@@ -37,8 +39,14 @@
       "types": "./scripts/runtime-plugin-support-configure.ts",
       "import": "./scripts/runtime-plugin-support-configure.ts"
     },
-    "./jsx-runtime": "./jsx-runtime.d.ts",
-    "./jsx-dev-runtime": "./jsx-runtime.d.ts"
+    "./jsx-runtime": {
+      "types": "./jsx-runtime.d.ts",
+      "import": "./jsx-runtime.ts"
+    },
+    "./jsx-dev-runtime": {
+      "types": "./jsx-dev-runtime.d.ts",
+      "import": "./jsx-dev-runtime.ts"
+    }
   },
   "devDependencies": {
     "@opentui/keymap": "workspace:*",

--- a/packages/solid/scripts/build.ts
+++ b/packages/solid/scripts/build.ts
@@ -5,6 +5,10 @@ import { ModuleKind, ScriptTarget, transpileModule } from "typescript"
 import { fileURLToPath } from "url"
 import process from "process"
 import { createSolidTransformPlugin } from "./solid-plugin.js"
+import { resolveNodeSolidRuntimeImport } from "./solid-transform.js"
+
+// `packages/solid/package.json` is the workspace manifest used for repo development.
+// This build writes `packages/solid/dist/package.json`, which is the actual published npm manifest.
 
 interface PackageJson {
   name: string
@@ -50,6 +54,14 @@ interface BunOnlyStubOptions {
   defaultExport?: boolean
 }
 
+interface MainBuildOptions {
+  entryPoint?: string
+  label: string
+  outputFile: string
+  resolvePath?: (specifier: string) => string | null
+  target: "bun" | "node"
+}
+
 const transpileEntryPoint = (entryPoint: string, outputFile: string): void => {
   const sourcePath = join(rootDir, entryPoint)
   const outputPath = join(rootDir, "dist", outputFile)
@@ -67,6 +79,45 @@ const transpileEntryPoint = (entryPoint: string, outputFile: string): void => {
   writeFileSync(outputPath, result.outputText)
   if (result.sourceMapText) {
     writeFileSync(`${outputPath}.map`, result.sourceMapText)
+  }
+}
+
+const buildMainEntryPoint = async (options: MainBuildOptions): Promise<void> => {
+  console.log(`Building ${options.label} entry point...`)
+
+  const external = new Set(externalDeps)
+
+  for (const specifier of ["solid-js", "solid-js/store"]) {
+    const rewritten = options.resolvePath?.(specifier)
+    if (rewritten) {
+      external.add(rewritten)
+    }
+  }
+
+  const buildResult = await Bun.build({
+    entrypoints: [join(rootDir, options.entryPoint ?? packageJson.module!)],
+    external: [...external],
+    outfile: join(rootDir, "dist", options.outputFile),
+    plugins: [createSolidTransformPlugin({ resolvePath: options.resolvePath })],
+    sourcemap: "external",
+    target: options.target,
+  })
+
+  if (!buildResult.success) {
+    console.error(`Build failed for ${options.label} entry point:`, buildResult.logs)
+    process.exit(1)
+  }
+
+  const outputPath = join(rootDir, "dist", options.outputFile)
+  for (const output of buildResult.outputs) {
+    if (output.kind === "entry-point") {
+      await Bun.write(outputPath, output)
+      continue
+    }
+
+    if (output.kind === "sourcemap") {
+      await Bun.write(`${outputPath}.map`, output)
+    }
   }
 }
 
@@ -111,20 +162,25 @@ if (!packageJson.module) {
   process.exit(1)
 }
 
-console.log("Building main entry point...")
-const mainBuildResult = await Bun.build({
-  entrypoints: [join(rootDir, packageJson.module), join(rootDir, "components.ts")],
-  target: "bun",
-  outdir: join(rootDir, "dist"),
-  external: externalDeps,
-  plugins: [createSolidTransformPlugin()],
-  splitting: true,
+await buildMainEntryPoint({
+  label: "Node",
+  outputFile: "index.js",
+  resolvePath: resolveNodeSolidRuntimeImport,
+  target: "node",
 })
 
-if (!mainBuildResult.success) {
-  console.error("Build failed for main entry point:", mainBuildResult.logs)
-  process.exit(1)
-}
+await buildMainEntryPoint({
+  label: "Bun",
+  outputFile: "index.bun.js",
+  target: "bun",
+})
+
+await buildMainEntryPoint({
+  entryPoint: "components.ts",
+  label: "components",
+  outputFile: "components.js",
+  target: "node",
+})
 
 console.log("Generating TypeScript declarations...")
 
@@ -166,9 +222,17 @@ if (existsSync(join(rootDir, "jsx-runtime.d.ts"))) {
   copyFileSync(join(rootDir, "jsx-runtime.d.ts"), join(distDir, "jsx-runtime.d.ts"))
 }
 
+if (existsSync(join(rootDir, "jsx-dev-runtime.d.ts"))) {
+  copyFileSync(join(rootDir, "jsx-dev-runtime.d.ts"), join(distDir, "jsx-dev-runtime.d.ts"))
+}
+
+transpileEntryPoint("jsx-runtime.ts", "jsx-runtime.js")
+transpileEntryPoint("jsx-dev-runtime.ts", "jsx-dev-runtime.js")
+
 mkdirSync(join(distDir, "scripts"), { recursive: true })
 
 transpileEntryPoint("scripts/solid-plugin.ts", "scripts/solid-plugin.js")
+transpileEntryPoint("scripts/solid-transform.ts", "scripts/solid-transform.js")
 transpileEntryPoint("scripts/preload.ts", "scripts/preload.js")
 transpileEntryPoint("scripts/runtime-plugin-support.ts", "scripts/runtime-plugin-support.js")
 transpileEntryPoint("scripts/runtime-plugin-support-configure.ts", "scripts/runtime-plugin-support-configure.js")
@@ -191,8 +255,10 @@ writeBunOnlyStub(
 const exports = {
   ".": {
     types: "./index.d.ts",
+    bun: "./index.bun.js",
+    node: "./index.js",
     import: "./index.js",
-    require: "./index.js",
+    default: "./index.js",
   },
   "./preload": {
     bun: "./scripts/preload.js",
@@ -222,8 +288,16 @@ const exports = {
     import: "./components.js",
     require: "./components.js",
   },
-  "./jsx-runtime": "./jsx-runtime.d.ts",
-  "./jsx-dev-runtime": "./jsx-runtime.d.ts",
+  "./jsx-runtime": {
+    types: "./jsx-runtime.d.ts",
+    import: "./jsx-runtime.js",
+    default: "./jsx-runtime.js",
+  },
+  "./jsx-dev-runtime": {
+    types: "./jsx-dev-runtime.d.ts",
+    import: "./jsx-dev-runtime.js",
+    default: "./jsx-dev-runtime.js",
+  },
 }
 
 // Process dependencies to replace workspace references with actual versions

--- a/packages/solid/scripts/build.ts
+++ b/packages/solid/scripts/build.ts
@@ -5,6 +5,10 @@ import { ModuleKind, ScriptTarget, transpileModule } from "typescript"
 import { fileURLToPath } from "url"
 import process from "process"
 import { createSolidTransformPlugin } from "./solid-plugin.js"
+import { resolveNodeSolidRuntimeImport } from "./solid-transform.js"
+
+// `packages/solid/package.json` is the workspace manifest used for repo development.
+// This build writes `packages/solid/dist/package.json`, which is the actual published npm manifest.
 
 interface PackageJson {
   name: string
@@ -50,6 +54,13 @@ interface BunOnlyStubOptions {
   defaultExport?: boolean
 }
 
+interface MainBuildOptions {
+  label: string
+  outputFile: string
+  resolvePath?: (specifier: string) => string | null
+  target: "bun" | "node"
+}
+
 const transpileEntryPoint = (entryPoint: string, outputFile: string): void => {
   const sourcePath = join(rootDir, entryPoint)
   const outputPath = join(rootDir, "dist", outputFile)
@@ -67,6 +78,45 @@ const transpileEntryPoint = (entryPoint: string, outputFile: string): void => {
   writeFileSync(outputPath, result.outputText)
   if (result.sourceMapText) {
     writeFileSync(`${outputPath}.map`, result.sourceMapText)
+  }
+}
+
+const buildMainEntryPoint = async (options: MainBuildOptions): Promise<void> => {
+  console.log(`Building ${options.label} entry point...`)
+
+  const external = new Set(externalDeps)
+
+  for (const specifier of ["solid-js", "solid-js/store"]) {
+    const rewritten = options.resolvePath?.(specifier)
+    if (rewritten) {
+      external.add(rewritten)
+    }
+  }
+
+  const buildResult = await Bun.build({
+    entrypoints: [join(rootDir, packageJson.module!)],
+    external: [...external],
+    outfile: join(rootDir, "dist", options.outputFile),
+    plugins: [createSolidTransformPlugin({ resolvePath: options.resolvePath })],
+    sourcemap: "external",
+    target: options.target,
+  })
+
+  if (!buildResult.success) {
+    console.error(`Build failed for ${options.label} entry point:`, buildResult.logs)
+    process.exit(1)
+  }
+
+  const outputPath = join(rootDir, "dist", options.outputFile)
+  for (const output of buildResult.outputs) {
+    if (output.kind === "entry-point") {
+      await Bun.write(outputPath, output)
+      continue
+    }
+
+    if (output.kind === "sourcemap") {
+      await Bun.write(`${outputPath}.map`, output)
+    }
   }
 }
 
@@ -111,20 +161,18 @@ if (!packageJson.module) {
   process.exit(1)
 }
 
-console.log("Building main entry point...")
-const mainBuildResult = await Bun.build({
-  entrypoints: [join(rootDir, packageJson.module)],
-  target: "bun",
-  outdir: join(rootDir, "dist"),
-  external: externalDeps,
-  plugins: [createSolidTransformPlugin()],
-  splitting: true,
+await buildMainEntryPoint({
+  label: "Node",
+  outputFile: "index.js",
+  resolvePath: resolveNodeSolidRuntimeImport,
+  target: "node",
 })
 
-if (!mainBuildResult.success) {
-  console.error("Build failed for main entry point:", mainBuildResult.logs)
-  process.exit(1)
-}
+await buildMainEntryPoint({
+  label: "Bun",
+  outputFile: "index.bun.js",
+  target: "bun",
+})
 
 console.log("Generating TypeScript declarations...")
 
@@ -166,9 +214,17 @@ if (existsSync(join(rootDir, "jsx-runtime.d.ts"))) {
   copyFileSync(join(rootDir, "jsx-runtime.d.ts"), join(distDir, "jsx-runtime.d.ts"))
 }
 
+if (existsSync(join(rootDir, "jsx-dev-runtime.d.ts"))) {
+  copyFileSync(join(rootDir, "jsx-dev-runtime.d.ts"), join(distDir, "jsx-dev-runtime.d.ts"))
+}
+
+transpileEntryPoint("jsx-runtime.ts", "jsx-runtime.js")
+transpileEntryPoint("jsx-dev-runtime.ts", "jsx-dev-runtime.js")
+
 mkdirSync(join(distDir, "scripts"), { recursive: true })
 
 transpileEntryPoint("scripts/solid-plugin.ts", "scripts/solid-plugin.js")
+transpileEntryPoint("scripts/solid-transform.ts", "scripts/solid-transform.js")
 transpileEntryPoint("scripts/preload.ts", "scripts/preload.js")
 transpileEntryPoint("scripts/runtime-plugin-support.ts", "scripts/runtime-plugin-support.js")
 transpileEntryPoint("scripts/runtime-plugin-support-configure.ts", "scripts/runtime-plugin-support-configure.js")
@@ -191,8 +247,10 @@ writeBunOnlyStub(
 const exports = {
   ".": {
     types: "./index.d.ts",
+    bun: "./index.bun.js",
+    node: "./index.js",
     import: "./index.js",
-    require: "./index.js",
+    default: "./index.js",
   },
   "./preload": {
     bun: "./scripts/preload.js",
@@ -217,8 +275,16 @@ const exports = {
     node: "./scripts/runtime-plugin-support-configure.node.js",
     default: "./scripts/runtime-plugin-support-configure.node.js",
   },
-  "./jsx-runtime": "./jsx-runtime.d.ts",
-  "./jsx-dev-runtime": "./jsx-runtime.d.ts",
+  "./jsx-runtime": {
+    types: "./jsx-runtime.d.ts",
+    import: "./jsx-runtime.js",
+    default: "./jsx-runtime.js",
+  },
+  "./jsx-dev-runtime": {
+    types: "./jsx-dev-runtime.d.ts",
+    import: "./jsx-dev-runtime.js",
+    default: "./jsx-dev-runtime.js",
+  },
 }
 
 // Process dependencies to replace workspace references with actual versions

--- a/packages/solid/scripts/runtime-plugin-support-configure.ts
+++ b/packages/solid/scripts/runtime-plugin-support-configure.ts
@@ -9,7 +9,7 @@ import {
 } from "@opentui/core/runtime-plugin"
 import * as solidJsRuntime from "solid-js"
 import * as solidJsStoreRuntime from "solid-js/store"
-import * as solidRuntime from "../index.js"
+import * as solidRuntime from "@opentui/solid"
 import { ensureSolidTransformPlugin } from "./solid-plugin.js"
 
 const runtimePluginSupportInstalledKey = Symbol.for("opentui.solid.runtime-plugin-support")

--- a/packages/solid/scripts/solid-plugin.ts
+++ b/packages/solid/scripts/solid-plugin.ts
@@ -1,13 +1,5 @@
-import { transformAsync } from "@babel/core"
-// @ts-expect-error - Types not important.
-import ts from "@babel/preset-typescript"
-// @ts-expect-error - Types not important.
-import moduleResolver from "babel-plugin-module-resolver"
-// @ts-expect-error - Types not important.
-import solid from "babel-preset-solid"
 import { plugin as registerBunPlugin, type BunPlugin } from "bun"
-
-export type ResolveImportPath = (specifier: string) => string | null
+import { stripQueryAndHash, transformSolidSource, type ResolveImportPath } from "./solid-transform.js"
 
 const solidTransformStateKey = Symbol.for("opentui.solid.transform")
 
@@ -40,13 +32,6 @@ const getSolidTransformRuntime = (): SolidTransformRuntime => {
   return getSolidTransformState().runtime ?? {}
 }
 
-const sourcePath = (path: string): string => {
-  const searchIndex = path.indexOf("?")
-  const hashIndex = path.indexOf("#")
-  const end = [searchIndex, hashIndex].filter((index) => index >= 0).sort((a, b) => a - b)[0]
-  return end === undefined ? path : path.slice(0, end)
-}
-
 const hasSolidTransformRuntime = (input: CreateSolidTransformPluginOptions): boolean => {
   return input.moduleName !== undefined || input.resolvePath !== undefined
 }
@@ -77,11 +62,15 @@ export function resetSolidTransformPluginState(): void {
 }
 
 export function createSolidTransformPlugin(input: CreateSolidTransformPluginOptions = {}): BunPlugin {
+  const sourceFilter = input.resolvePath
+    ? /^(?!.*[/\\]node_modules[/\\]).*\.[cm]?[jt]sx?(?:[?#].*)?$/
+    : /^(?!.*[/\\]node_modules[/\\]).*\.[cm]?[jt]sx(?:[?#].*)?$/
+
   return {
     name: "bun-plugin-solid",
     setup: (build) => {
       build.onLoad({ filter: /[/\\]node_modules[/\\]solid-js[/\\]dist[/\\]server\.js(?:[?#].*)?$/ }, async (args) => {
-        const path = sourcePath(args.path).replace("server.js", "solid.js")
+        const path = stripQueryAndHash(args.path).replace("server.js", "solid.js")
         const file = Bun.file(path)
         const code = await file.text()
         return { contents: code, loader: "js" }
@@ -90,52 +79,29 @@ export function createSolidTransformPlugin(input: CreateSolidTransformPluginOpti
       build.onLoad(
         { filter: /[/\\]node_modules[/\\]solid-js[/\\]store[/\\]dist[/\\]server\.js(?:[?#].*)?$/ },
         async (args) => {
-          const path = sourcePath(args.path).replace("server.js", "store.js")
+          const path = stripQueryAndHash(args.path).replace("server.js", "store.js")
           const file = Bun.file(path)
           const code = await file.text()
           return { contents: code, loader: "js" }
         },
       )
 
-      build.onLoad({ filter: /\.(js|ts)x(?:[?#].*)?$/ }, async (args) => {
-        const path = sourcePath(args.path)
+      build.onLoad({ filter: sourceFilter }, async (args) => {
+        const path = stripQueryAndHash(args.path)
+
         const file = Bun.file(path)
         const code = await file.text()
         const runtime = getSolidTransformRuntime()
         const moduleName = input.moduleName ?? runtime.moduleName ?? "@opentui/solid"
         const resolvePath = input.resolvePath ?? runtime.resolvePath
-        const plugins = resolvePath
-          ? [
-              [
-                moduleResolver,
-                {
-                  resolvePath(specifier: string) {
-                    return resolvePath(specifier) ?? specifier
-                  },
-                },
-              ],
-            ]
-          : []
-
-        const transforms = await transformAsync(code, {
+        const contents = await transformSolidSource(code, {
           filename: path,
-          configFile: false,
-          babelrc: false,
-          plugins,
-          presets: [
-            [
-              solid,
-              {
-                moduleName,
-                generate: "universal",
-              },
-            ],
-            [ts],
-          ],
+          moduleName,
+          resolvePath,
         })
 
         return {
-          contents: transforms?.code ?? "",
+          contents,
           loader: "js",
         }
       })

--- a/packages/solid/scripts/solid-transform.ts
+++ b/packages/solid/scripts/solid-transform.ts
@@ -1,0 +1,83 @@
+import { transformAsync } from "@babel/core"
+// @ts-expect-error - Types not important.
+import ts from "@babel/preset-typescript"
+// @ts-expect-error - Types not important.
+import moduleResolver from "babel-plugin-module-resolver"
+// @ts-expect-error - Types not important.
+import solid from "babel-preset-solid"
+
+export type ResolveImportPath = (specifier: string) => string | null
+
+export interface TransformSolidSourceOptions {
+  filename: string
+  moduleName?: string
+  resolvePath?: ResolveImportPath
+}
+
+const nodeModulesPattern = /[/\\]node_modules[/\\]/
+const tsPattern = /\.[cm]?tsx?$/
+const jsxPattern = /\.[cm]?[jt]sx$/
+
+export function stripQueryAndHash(path: string): string {
+  const searchIndex = path.indexOf("?")
+  const hashIndex = path.indexOf("#")
+  const end = [searchIndex, hashIndex].filter((index) => index >= 0).sort((a, b) => a - b)[0]
+  return end === undefined ? path : path.slice(0, end)
+}
+
+export function isNodeModulesPath(path: string): boolean {
+  return nodeModulesPattern.test(path)
+}
+
+export function resolveNodeSolidRuntimeImport(specifier: string): string | null {
+  switch (specifier) {
+    case "solid-js":
+      return "solid-js/dist/solid.js"
+    case "solid-js/store":
+      return "solid-js/store/dist/store.js"
+    default:
+      return null
+  }
+}
+
+export async function transformSolidSource(code: string, options: TransformSolidSourceOptions): Promise<string> {
+  const filename = stripQueryAndHash(options.filename)
+  const plugins = options.resolvePath
+    ? [
+        [
+          moduleResolver,
+          {
+            resolvePath(specifier: string) {
+              return options.resolvePath?.(specifier) ?? specifier
+            },
+          },
+        ],
+      ]
+    : []
+
+  const presets = []
+
+  if (jsxPattern.test(filename)) {
+    presets.push([
+      solid,
+      {
+        moduleName: options.moduleName ?? "@opentui/solid",
+        generate: "universal",
+      },
+    ])
+  }
+
+  if (tsPattern.test(filename)) {
+    presets.push([ts])
+  }
+
+  const transformed = await transformAsync(code, {
+    filename,
+    configFile: false,
+    babelrc: false,
+    plugins,
+    presets,
+  })
+
+  return transformed?.code ?? code
+}

--- a/packages/solid/scripts/test-node-hook.mjs
+++ b/packages/solid/scripts/test-node-hook.mjs
@@ -1,0 +1,16 @@
+import { registerHooks } from "node:module"
+
+const bunTestUrl = new URL("../.node-test/src/testing/bun-test-node.js", import.meta.url).href
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === "bun:test") {
+      return {
+        shortCircuit: true,
+        url: bunTestUrl,
+      }
+    }
+
+    return nextResolve(specifier, context)
+  },
+})

--- a/packages/solid/scripts/test-node.ts
+++ b/packages/solid/scripts/test-node.ts
@@ -1,0 +1,168 @@
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, join, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { ensureNode26 } from "../../../scripts/node26.mjs"
+import { createSolidTransformPlugin } from "./solid-plugin.js"
+import { resolveNodeSolidRuntimeImport } from "./solid-transform.js"
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, "..")
+const workspaceRoot = resolve(packageRoot, "..", "..")
+const corePackageRoot = resolve(packageRoot, "..", "core")
+const coreDistRoot = resolve(corePackageRoot, "dist")
+const outDir = resolve(packageRoot, ".node-test")
+const nodeTestTimeoutMs = 30_000
+const nodeProcessTimeoutMs = 5 * 60_000
+const emittedAllowlist = [".node-test/tests/box.test.js", ".node-test/tests/control-flow-updates.test.js"]
+const testEntries = [
+  { source: "tests/box.test.tsx", output: "tests/box.test.js" },
+  { source: "tests/control-flow-updates.test.tsx", output: "tests/control-flow-updates.test.js" },
+  { source: "src/testing/bun-test-node.ts", output: "src/testing/bun-test-node.js" },
+]
+
+let exitCode = 0
+
+try {
+  rmSync(outDir, { recursive: true, force: true })
+  mkdirSync(outDir, { recursive: true })
+
+  ensureCoreBuildArtifacts()
+  writeCoreDistProxyPackage()
+
+  for (const entry of testEntries) {
+    await buildEntryPoint(entry.source, entry.output)
+  }
+
+  const nodePath = ensureNode26()
+  exitCode = run(
+    nodePath,
+    [
+      "--disable-warning=SecurityWarning",
+      "--disable-warning=ExperimentalWarning",
+      "--permission",
+      `--allow-fs-read=${workspaceRoot}`,
+      `--allow-fs-write=${outDir}`,
+      "--allow-child-process",
+      "--allow-ffi",
+      "--experimental-ffi",
+      "--import",
+      "./scripts/test-node-hook.mjs",
+      "--test-concurrency=1",
+      `--test-timeout=${nodeTestTimeoutMs}`,
+      "--test",
+      ...emittedAllowlist,
+    ],
+    { cwd: packageRoot, timeout: nodeProcessTimeoutMs },
+  )
+} finally {
+  rmSync(outDir, { recursive: true, force: true })
+}
+
+process.exit(exitCode)
+
+async function buildEntryPoint(source: string, output: string): Promise<void> {
+  const result = await Bun.build({
+    entrypoints: [join(packageRoot, source)],
+    outfile: join(outDir, output),
+    target: "node",
+    format: "esm",
+    sourcemap: "external",
+    external: [
+      "bun:test",
+      "@opentui/core",
+      "@opentui/core/testing",
+      "solid-js/dist/solid.js",
+      "solid-js/store/dist/store.js",
+    ],
+    plugins: [
+      createSolidTransformPlugin({
+        resolvePath(specifier) {
+          return resolveNodeSolidRuntimeImport(specifier)
+        },
+      }),
+    ],
+  })
+
+  if (!result.success) {
+    console.error(`Failed to build ${source}`)
+    for (const log of result.logs) {
+      console.error(log)
+    }
+    process.exit(1)
+  }
+
+  const outputPath = join(outDir, output)
+  for (const buildOutput of result.outputs) {
+    if (buildOutput.kind === "entry-point") {
+      await Bun.write(outputPath, buildOutput)
+      continue
+    }
+
+    if (buildOutput.kind === "sourcemap") {
+      await Bun.write(`${outputPath}.map`, buildOutput)
+    }
+  }
+}
+
+function ensureCoreBuildArtifacts(): void {
+  const nativePackageName = `@opentui/core-${process.platform}-${process.arch}`
+  const nativePackageDir = join(corePackageRoot, "node_modules", nativePackageName)
+  const hasCoreDist = existsSync(join(coreDistRoot, "index.js")) && existsSync(join(coreDistRoot, "testing.js"))
+
+  if (hasCoreDist && existsSync(nativePackageDir)) {
+    return
+  }
+
+  const buildExitCode = run("bun", ["run", "build"], { cwd: corePackageRoot })
+  if (buildExitCode !== 0) {
+    process.exit(buildExitCode)
+  }
+}
+
+function writeCoreDistProxyPackage(): void {
+  const proxyDir = join(outDir, "node_modules", "@opentui", "core")
+  mkdirSync(proxyDir, { recursive: true })
+
+  const relativeCoreDistIndex = relative(proxyDir, join(coreDistRoot, "index.js")).replaceAll("\\", "/")
+  const relativeCoreDistTesting = relative(proxyDir, join(coreDistRoot, "testing.js")).replaceAll("\\", "/")
+
+  writeFileSync(join(proxyDir, "index.js"), `export * from ${JSON.stringify(relativeCoreDistIndex)}\n`)
+  writeFileSync(join(proxyDir, "testing.js"), `export * from ${JSON.stringify(relativeCoreDistTesting)}\n`)
+
+  writeFileSync(
+    join(proxyDir, "package.json"),
+    JSON.stringify(
+      {
+        name: "@opentui/core",
+        private: true,
+        type: "module",
+        exports: {
+          ".": "./index.js",
+          "./testing": "./testing.js",
+        },
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+function run(command: string, args: string[], options: { cwd?: string; timeout?: number } = {}): number {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? packageRoot,
+    stdio: "inherit",
+    timeout: options.timeout,
+  })
+
+  if (result.error) {
+    if (result.error.name === "TimeoutError") {
+      console.error(`Command timed out after ${options.timeout}ms: ${command} ${args.join(" ")}`)
+    }
+
+    throw result.error
+  }
+
+  return result.status ?? 1
+}

--- a/packages/solid/scripts/test-node.ts
+++ b/packages/solid/scripts/test-node.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
-import { ensureNode26 } from "../../../scripts/node26.mjs"
+import { requireNode26 } from "../../../scripts/node26.mjs"
 import { createSolidTransformPlugin } from "./solid-plugin.js"
 import { resolveNodeSolidRuntimeImport } from "./solid-transform.js"
 
@@ -15,6 +15,7 @@ const coreDistRoot = resolve(corePackageRoot, "dist")
 const outDir = resolve(packageRoot, ".node-test")
 const nodeTestTimeoutMs = 30_000
 const nodeProcessTimeoutMs = 5 * 60_000
+const nodePath = requireNode26()
 const emittedAllowlist = [".node-test/tests/box.test.js", ".node-test/tests/control-flow-updates.test.js"]
 const testEntries = [
   { source: "tests/box.test.tsx", output: "tests/box.test.js" },
@@ -35,7 +36,6 @@ try {
     await buildEntryPoint(entry.source, entry.output)
   }
 
-  const nodePath = ensureNode26()
   exitCode = run(
     nodePath,
     [

--- a/packages/solid/scripts/test-packed-consumer.ts
+++ b/packages/solid/scripts/test-packed-consumer.ts
@@ -1,0 +1,455 @@
+/**
+ * Smoke-tests the packed npm consumer contract for `@opentui/solid`.
+ *
+ * This verifies the built tarballs install in a fresh project, the published
+ * `exports` map resolves correctly in Node, a consumer TSX file typechecks, the
+ * real JSX runtime files load, and Bun-only subpaths fail with the intended error
+ * instead of ESM export errors.
+ */
+
+import { spawnSync, type SpawnSyncReturns } from "node:child_process"
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, relative, resolve } from "node:path"
+import process from "node:process"
+import { fileURLToPath } from "node:url"
+
+import { ensureNode26 } from "../../../scripts/node26.mjs"
+
+interface PackageJson {
+  name: string
+  peerDependencies?: Record<string, string>
+  version: string
+}
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const rootDir = resolve(__dirname, "..")
+const coreRootDir = resolve(rootDir, "..", "core")
+const distDir = join(rootDir, "dist")
+const coreDistDir = join(coreRootDir, "dist")
+const args = new Set(process.argv.slice(2))
+const keepTemp = args.has("--keep-temp")
+const skipBuild = args.has("--skip-build")
+
+const packageJson = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8")) as PackageJson
+const corePackageJson = JSON.parse(readFileSync(join(coreRootDir, "package.json"), "utf8")) as PackageJson
+const nativePackageName = `${corePackageJson.name}-${process.platform}-${process.arch}`
+const nativePackageDir = join(coreRootDir, "node_modules", nativePackageName)
+const solidJsVersion = packageJson.peerDependencies?.["solid-js"] ?? "1.9.12"
+
+function runCommand(
+  command: string,
+  commandArgs: string[],
+  cwd: string,
+  errorMessage: string,
+  options: { stdio?: "inherit" | "pipe" } = {},
+): SpawnSyncReturns<Buffer> {
+  const result = spawnSync(command, commandArgs, {
+    cwd,
+    stdio: options.stdio ?? "inherit",
+  })
+
+  if (result.error) {
+    throw new Error(`${errorMessage}: ${result.error.message}`)
+  }
+
+  if (result.status !== 0) {
+    throw new Error(errorMessage)
+  }
+
+  return result
+}
+
+function runCommandExpectFailure(
+  command: string,
+  commandArgs: string[],
+  cwd: string,
+  errorMessage: string,
+): SpawnSyncReturns<Buffer> {
+  const result = spawnSync(command, commandArgs, {
+    cwd,
+    stdio: "pipe",
+  })
+
+  if (result.error) {
+    throw new Error(`${errorMessage}: ${result.error.message}`)
+  }
+
+  if (result.status === 0) {
+    throw new Error(errorMessage)
+  }
+
+  return result
+}
+
+function ensureBuildArtifacts(): void {
+  if (!skipBuild) {
+    runCommand("bun", ["run", "build"], coreRootDir, "Core build failed")
+    runCommand("bun", ["run", "build"], rootDir, "Solid build failed")
+  }
+
+  if (!existsSync(coreDistDir)) {
+    throw new Error(`Missing core dist directory at ${coreDistDir}. Run bun run build in packages/core first.`)
+  }
+
+  if (!existsSync(distDir)) {
+    throw new Error(`Missing solid dist directory at ${distDir}. Run bun run build first.`)
+  }
+
+  if (!existsSync(nativePackageDir)) {
+    throw new Error(
+      `Missing native package directory at ${nativePackageDir}. Run bun run build in packages/core first.`,
+    )
+  }
+}
+
+function packArtifact(packageDir: string, packDir: string): string {
+  const result = runCommand(
+    "npm",
+    ["pack", "--pack-destination", packDir],
+    packageDir,
+    `Failed to pack ${packageDir}`,
+    {
+      stdio: "pipe",
+    },
+  )
+
+  const tarballName = result.stdout.toString("utf8").trim().split(/\r?\n/).at(-1)
+  if (!tarballName) {
+    throw new Error(`Failed to determine tarball name for ${packageDir}`)
+  }
+
+  return join(packDir, tarballName)
+}
+
+function writeConsumerPackage(
+  consumerDir: string,
+  solidTarball: string,
+  coreTarball: string,
+  nativeTarball: string,
+): void {
+  const solidDependency = `file:${relative(consumerDir, solidTarball).replaceAll("\\", "/")}`
+  const coreDependency = `file:${relative(consumerDir, coreTarball).replaceAll("\\", "/")}`
+  const nativeDependency = `file:${relative(consumerDir, nativeTarball).replaceAll("\\", "/")}`
+
+  writeFileSync(
+    join(consumerDir, "package.json"),
+    JSON.stringify(
+      {
+        name: "opentui-solid-dist-test-node",
+        private: true,
+        type: "module",
+        dependencies: {
+          [packageJson.name]: solidDependency,
+          [corePackageJson.name]: coreDependency,
+          [nativePackageName]: nativeDependency,
+          "solid-js": solidJsVersion,
+          typescript: "^5",
+        },
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+function writeTypecheckFixture(consumerDir: string): void {
+  writeFileSync(
+    join(consumerDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          jsx: "preserve",
+          jsxImportSource: packageJson.name,
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          noEmit: true,
+          skipLibCheck: true,
+          strict: true,
+        },
+      },
+      null,
+      2,
+    ),
+  )
+  writeFileSync(
+    join(consumerDir, "fixture.tsx"),
+    `import { For, Match, Show, Switch } from "solid-js"
+import { Portal, testRender } from ${JSON.stringify(packageJson.name)}
+
+export function render() {
+  return testRender(() => (
+    <box>
+      <For each={["one"]}>{(item) => <text>{item}</text>}</For>
+      <Show when={true}>
+        <text>Shown</text>
+      </Show>
+      <Switch fallback={<text>Fallback</text>}>
+        <Match when={true}>
+          <Portal>
+            <text>Portal</text>
+          </Portal>
+        </Match>
+      </Switch>
+    </box>
+  ))
+}
+`,
+  )
+}
+
+function writeNodeTest(nodeDir: string): void {
+  writeFileSync(
+    join(nodeDir, "index.mjs"),
+    `import assert from "node:assert/strict"
+import { rmSync, writeFileSync } from "node:fs"
+import { mkdirSync } from "node:fs"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { transformAsync } from "@babel/core"
+import ts from "@babel/preset-typescript"
+import moduleResolver from "babel-plugin-module-resolver"
+import solid from "babel-preset-solid"
+
+const solidRuntime = await import(${JSON.stringify(packageJson.name)})
+const jsxRuntime = await import(${JSON.stringify(`${packageJson.name}/jsx-runtime`)})
+const jsxDevRuntime = await import(${JSON.stringify(`${packageJson.name}/jsx-dev-runtime`)})
+
+assert.equal(typeof solidRuntime.testRender, "function")
+assert.equal(typeof jsxRuntime.jsx, "function")
+assert.equal(typeof jsxRuntime.jsxs, "function")
+assert.equal(typeof jsxRuntime.Fragment, "function")
+assert.equal(typeof jsxDevRuntime.jsxDEV, "function")
+
+const fixtureSource = [
+  'import { createSignal, For, Match, Show, Switch } from "solid-js"',
+  'import { testRender } from ${JSON.stringify(packageJson.name)}',
+  '',
+  'export async function run() {',
+  '  const [items, setItems] = createSignal(["Hello"])',
+  '  const [showTail, setShowTail] = createSignal(false)',
+  '  const [mode, setMode] = createSignal(1)',
+  '  const setup = await testRender(() => (',
+  '    <box>',
+  '      <For each={items()}>{(item) => <text>{item}</text>}</For>',
+  '      <Show when={showTail()}>',
+  '        <text>World</text>',
+  '      </Show>',
+  '      <Switch fallback={<text>Fallback</text>}>',
+  '        <Match when={mode() === 1}><text>ModeOne</text></Match>',
+  '        <Match when={mode() === 2}><text>ModeTwo</text></Match>',
+  '      </Switch>',
+  '    </box>',
+  '  ), { width: 24, height: 8 })',
+  '  await setup.renderOnce()',
+  '  const first = setup.captureCharFrame()',
+  '  setItems(["Hello", "Node"])',
+  '  setShowTail(true)',
+  '  setMode(2)',
+  '  await setup.renderOnce()',
+  '  const second = setup.captureCharFrame()',
+  '  setup.renderer.destroy()',
+  '  return { first, second }',
+  '}',
+].join("\\n")
+
+const transformed = await transformAsync(fixtureSource, {
+  filename: join(process.cwd(), "fixture.tsx"),
+  configFile: false,
+  babelrc: false,
+  plugins: [
+    [
+      moduleResolver,
+      {
+        resolvePath(specifier) {
+          if (specifier === "solid-js") return "solid-js/dist/solid.js"
+          if (specifier === "solid-js/store") return "solid-js/store/dist/store.js"
+          return specifier
+        },
+      },
+    ],
+  ],
+  presets: [
+    [solid, { moduleName: ${JSON.stringify(packageJson.name)}, generate: "universal" }],
+    [ts],
+  ],
+})
+
+if (!transformed?.code) {
+  throw new Error("Failed to transform Solid fixture")
+}
+
+const runtimeDir = join(process.cwd(), ".dist-node-runtime")
+const runtimePath = join(runtimeDir, "fixture.mjs")
+mkdirSync(runtimeDir, { recursive: true })
+writeFileSync(runtimePath, transformed.code)
+
+try {
+  const { run } = await import(pathToFileURL(runtimePath).href)
+  const result = await run()
+  assert.match(result.first, /Hello/)
+  assert.match(result.first, /ModeOne/)
+  assert.doesNotMatch(result.first, /World/)
+  assert.match(result.second, /Hello/)
+  assert.match(result.second, /Node/)
+  assert.match(result.second, /World/)
+  assert.match(result.second, /ModeTwo/)
+} finally {
+  rmSync(runtimeDir, { recursive: true, force: true })
+}
+
+const expectBunOnlyFailure = async (specifier, expectedMessage) => {
+  await assert.rejects(import(specifier), (error) => {
+    return error instanceof Error && error.message.includes(expectedMessage)
+  })
+}
+
+await expectBunOnlyFailure(${JSON.stringify(`${packageJson.name}/preload`)}, ${JSON.stringify(`${packageJson.name}/preload is Bun-only`)})
+await expectBunOnlyFailure(${JSON.stringify(`${packageJson.name}/bun-plugin`)}, ${JSON.stringify(`${packageJson.name}/bun-plugin is Bun-only`)})
+await expectBunOnlyFailure(
+  ${JSON.stringify(`${packageJson.name}/runtime-plugin-support`)},
+  ${JSON.stringify(`${packageJson.name}/runtime-plugin-support is Bun-only`)},
+)
+await expectBunOnlyFailure(
+  ${JSON.stringify(`${packageJson.name}/runtime-plugin-support/configure`)},
+  ${JSON.stringify(`${packageJson.name}/runtime-plugin-support/configure is Bun-only`)},
+)
+
+console.log("Node solid dist smoke test passed")
+`,
+  )
+}
+
+function writeBunTest(bunDir: string): void {
+  writeFileSync(
+    join(bunDir, "fixture.bun.tsx"),
+    `import { testRender } from ${JSON.stringify(packageJson.name)}
+
+export async function run() {
+  const setup = await testRender(() => <box />)
+  setup.renderer.destroy()
+}
+`,
+  )
+  writeFileSync(
+    join(bunDir, "index.bun.mjs"),
+    `import { ensureRuntimePluginSupport } from ${JSON.stringify(`${packageJson.name}/runtime-plugin-support/configure`)}
+import { testRender } from ${JSON.stringify(packageJson.name)}
+import { jsx } from ${JSON.stringify(`${packageJson.name}/jsx-runtime`)}
+
+const setup = await testRender(() => jsx("box", {}))
+setup.renderer.destroy()
+
+ensureRuntimePluginSupport()
+await import("./fixture.bun.tsx").then((fixture) => fixture.run())
+
+console.log("Bun solid dist smoke test passed")
+`,
+  )
+}
+
+function assertNodeStaticImportFailure(
+  nodeDir: string,
+  importedName: string,
+  specifier: string,
+  expectedMessage: string,
+): void {
+  const result = runCommandExpectFailure(
+    ensureNode26(),
+    ["--input-type=module", "-e", `import { ${importedName} } from ${JSON.stringify(specifier)}`],
+    nodeDir,
+    `Expected static Node import of ${specifier} to fail`,
+  )
+
+  const output = `${result.stdout.toString("utf8")}\n${result.stderr.toString("utf8")}`
+
+  if (output.includes("does not provide an export named")) {
+    throw new Error(`Static Node import of ${specifier} failed before the Bun-only stub could run`)
+  }
+
+  if (!output.includes(expectedMessage)) {
+    throw new Error(`Static Node import of ${specifier} did not report the expected Bun-only error`)
+  }
+}
+
+function installAndTest(nodeDir: string): void {
+  runCommand("npm", ["install", "--ignore-scripts", "--no-package-lock"], nodeDir, "Node dist test install failed")
+  runCommand("npm", ["exec", "--", "tsc", "--noEmit"], nodeDir, "Node dist consumer typecheck failed")
+  runCommand("bun", ["index.bun.mjs"], nodeDir, "Bun solid dist smoke tests failed")
+
+  const nodePath = ensureNode26()
+  runCommand(nodePath, ["-e", `import(${JSON.stringify(packageJson.name)})`], nodeDir, "Node import smoke check failed")
+  runCommand(
+    nodePath,
+    [
+      "--disable-warning=SecurityWarning",
+      "--disable-warning=ExperimentalWarning",
+      "--permission",
+      `--allow-fs-read=${nodeDir}`,
+      `--allow-fs-write=${nodeDir}`,
+      "--allow-ffi",
+      "--experimental-ffi",
+      "index.mjs",
+    ],
+    nodeDir,
+    "Node solid dist smoke tests failed",
+  )
+
+  assertNodeStaticImportFailure(
+    nodeDir,
+    "createSolidTransformPlugin",
+    `${packageJson.name}/bun-plugin`,
+    `${packageJson.name}/bun-plugin is Bun-only`,
+  )
+  assertNodeStaticImportFailure(
+    nodeDir,
+    "ensureRuntimePluginSupport",
+    `${packageJson.name}/runtime-plugin-support`,
+    `${packageJson.name}/runtime-plugin-support is Bun-only`,
+  )
+  assertNodeStaticImportFailure(
+    nodeDir,
+    "ensureRuntimePluginSupport",
+    `${packageJson.name}/runtime-plugin-support/configure`,
+    `${packageJson.name}/runtime-plugin-support/configure is Bun-only`,
+  )
+}
+
+let tempRoot: string | undefined
+
+try {
+  ensureBuildArtifacts()
+
+  tempRoot = mkdtempSync(join(tmpdir(), "opentui-solid-dist-test-"))
+  const packDir = join(tempRoot, "packs")
+  const nodeDir = join(tempRoot, "node")
+
+  mkdirSync(packDir, { recursive: true })
+  mkdirSync(nodeDir, { recursive: true })
+
+  const coreTarball = packArtifact(coreDistDir, packDir)
+  const nativeTarball = packArtifact(nativePackageDir, packDir)
+  const solidTarball = packArtifact(distDir, packDir)
+
+  writeConsumerPackage(nodeDir, solidTarball, coreTarball, nativeTarball)
+  writeTypecheckFixture(nodeDir)
+  writeNodeTest(nodeDir)
+  writeBunTest(nodeDir)
+
+  installAndTest(nodeDir)
+
+  if (!keepTemp) {
+    rmSync(tempRoot, { recursive: true, force: true })
+    tempRoot = undefined
+  }
+
+  console.log("Packed solid dist smoke tests passed")
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error)
+  if (tempRoot) {
+    console.error(`Dist test workspace kept at ${tempRoot}`)
+  }
+  process.exit(1)
+}

--- a/packages/solid/scripts/test-packed-consumer.ts
+++ b/packages/solid/scripts/test-packed-consumer.ts
@@ -7,7 +7,7 @@
  */
 
 import { spawnSync, type SpawnSyncReturns } from "node:child_process"
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join, relative, resolve } from "node:path"
 import process from "node:process"
@@ -303,6 +303,8 @@ function installAndTest(nodeDir: string): void {
   runCommand("npm", ["install", "--ignore-scripts", "--no-package-lock"], nodeDir, "Node dist test install failed")
 
   const nodePath = ensureNode26()
+  const nodeRealDir = realpathSync(nodeDir)
+  const nodePermissionDirs = [...new Set([nodeDir, nodeRealDir])]
   runCommand(nodePath, ["-e", `import(${JSON.stringify(packageJson.name)})`], nodeDir, "Node import smoke check failed")
   runCommand(
     nodePath,
@@ -310,8 +312,8 @@ function installAndTest(nodeDir: string): void {
       "--disable-warning=SecurityWarning",
       "--disable-warning=ExperimentalWarning",
       "--permission",
-      `--allow-fs-read=${nodeDir}`,
-      `--allow-fs-write=${nodeDir}`,
+      ...nodePermissionDirs.map((path) => `--allow-fs-read=${path}`),
+      ...nodePermissionDirs.map((path) => `--allow-fs-write=${path}`),
       "--allow-ffi",
       "--experimental-ffi",
       "index.mjs",

--- a/packages/solid/scripts/test-packed-consumer.ts
+++ b/packages/solid/scripts/test-packed-consumer.ts
@@ -1,0 +1,376 @@
+/**
+ * Smoke-tests the packed npm consumer contract for `@opentui/solid`.
+ *
+ * This verifies the built tarballs install in a fresh project, the published
+ * `exports` map resolves correctly in Node, the real JSX runtime files load,
+ * and Bun-only subpaths fail with the intended error instead of ESM export errors.
+ */
+
+import { spawnSync, type SpawnSyncReturns } from "node:child_process"
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, relative, resolve } from "node:path"
+import process from "node:process"
+import { fileURLToPath } from "node:url"
+
+import { ensureNode26 } from "../../../scripts/node26.mjs"
+
+interface PackageJson {
+  name: string
+  peerDependencies?: Record<string, string>
+  version: string
+}
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const rootDir = resolve(__dirname, "..")
+const coreRootDir = resolve(rootDir, "..", "core")
+const distDir = join(rootDir, "dist")
+const coreDistDir = join(coreRootDir, "dist")
+const args = new Set(process.argv.slice(2))
+const keepTemp = args.has("--keep-temp")
+const skipBuild = args.has("--skip-build")
+
+const packageJson = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8")) as PackageJson
+const corePackageJson = JSON.parse(readFileSync(join(coreRootDir, "package.json"), "utf8")) as PackageJson
+const nativePackageName = `${corePackageJson.name}-${process.platform}-${process.arch}`
+const nativePackageDir = join(coreRootDir, "node_modules", nativePackageName)
+const solidJsVersion = packageJson.peerDependencies?.["solid-js"] ?? "1.9.12"
+
+function runCommand(
+  command: string,
+  commandArgs: string[],
+  cwd: string,
+  errorMessage: string,
+  options: { stdio?: "inherit" | "pipe" } = {},
+): SpawnSyncReturns<Buffer> {
+  const result = spawnSync(command, commandArgs, {
+    cwd,
+    stdio: options.stdio ?? "inherit",
+  })
+
+  if (result.error) {
+    throw new Error(`${errorMessage}: ${result.error.message}`)
+  }
+
+  if (result.status !== 0) {
+    throw new Error(errorMessage)
+  }
+
+  return result
+}
+
+function runCommandExpectFailure(
+  command: string,
+  commandArgs: string[],
+  cwd: string,
+  errorMessage: string,
+): SpawnSyncReturns<Buffer> {
+  const result = spawnSync(command, commandArgs, {
+    cwd,
+    stdio: "pipe",
+  })
+
+  if (result.error) {
+    throw new Error(`${errorMessage}: ${result.error.message}`)
+  }
+
+  if (result.status === 0) {
+    throw new Error(errorMessage)
+  }
+
+  return result
+}
+
+function ensureBuildArtifacts(): void {
+  if (!skipBuild) {
+    runCommand("bun", ["run", "build"], coreRootDir, "Core build failed")
+    runCommand("bun", ["run", "build"], rootDir, "Solid build failed")
+  }
+
+  if (!existsSync(coreDistDir)) {
+    throw new Error(`Missing core dist directory at ${coreDistDir}. Run bun run build in packages/core first.`)
+  }
+
+  if (!existsSync(distDir)) {
+    throw new Error(`Missing solid dist directory at ${distDir}. Run bun run build first.`)
+  }
+
+  if (!existsSync(nativePackageDir)) {
+    throw new Error(
+      `Missing native package directory at ${nativePackageDir}. Run bun run build in packages/core first.`,
+    )
+  }
+}
+
+function packArtifact(packageDir: string, packDir: string): string {
+  const result = runCommand(
+    "npm",
+    ["pack", "--pack-destination", packDir],
+    packageDir,
+    `Failed to pack ${packageDir}`,
+    {
+      stdio: "pipe",
+    },
+  )
+
+  const tarballName = result.stdout.toString("utf8").trim().split(/\r?\n/).at(-1)
+  if (!tarballName) {
+    throw new Error(`Failed to determine tarball name for ${packageDir}`)
+  }
+
+  return join(packDir, tarballName)
+}
+
+function writeConsumerPackage(
+  consumerDir: string,
+  solidTarball: string,
+  coreTarball: string,
+  nativeTarball: string,
+): void {
+  const solidDependency = `file:${relative(consumerDir, solidTarball).replaceAll("\\", "/")}`
+  const coreDependency = `file:${relative(consumerDir, coreTarball).replaceAll("\\", "/")}`
+  const nativeDependency = `file:${relative(consumerDir, nativeTarball).replaceAll("\\", "/")}`
+
+  writeFileSync(
+    join(consumerDir, "package.json"),
+    JSON.stringify(
+      {
+        name: "opentui-solid-dist-test-node",
+        private: true,
+        type: "module",
+        dependencies: {
+          [packageJson.name]: solidDependency,
+          [corePackageJson.name]: coreDependency,
+          [nativePackageName]: nativeDependency,
+          "solid-js": solidJsVersion,
+        },
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+function writeNodeTest(nodeDir: string): void {
+  writeFileSync(
+    join(nodeDir, "index.mjs"),
+    `import assert from "node:assert/strict"
+import { rmSync, writeFileSync } from "node:fs"
+import { mkdirSync } from "node:fs"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { transformAsync } from "@babel/core"
+import ts from "@babel/preset-typescript"
+import moduleResolver from "babel-plugin-module-resolver"
+import solid from "babel-preset-solid"
+
+const solidRuntime = await import(${JSON.stringify(packageJson.name)})
+const jsxRuntime = await import(${JSON.stringify(`${packageJson.name}/jsx-runtime`)})
+const jsxDevRuntime = await import(${JSON.stringify(`${packageJson.name}/jsx-dev-runtime`)})
+
+assert.equal(typeof solidRuntime.testRender, "function")
+assert.equal(typeof jsxRuntime.jsx, "function")
+assert.equal(typeof jsxRuntime.jsxs, "function")
+assert.equal(typeof jsxRuntime.Fragment, "function")
+assert.equal(typeof jsxDevRuntime.jsxDEV, "function")
+
+const fixtureSource = [
+  'import { createSignal, For, Match, Show, Switch } from "solid-js"',
+  'import { testRender } from ${JSON.stringify(packageJson.name)}',
+  '',
+  'export async function run() {',
+  '  const [items, setItems] = createSignal(["Hello"])',
+  '  const [showTail, setShowTail] = createSignal(false)',
+  '  const [mode, setMode] = createSignal(1)',
+  '  const setup = await testRender(() => (',
+  '    <box>',
+  '      <For each={items()}>{(item) => <text>{item}</text>}</For>',
+  '      <Show when={showTail()}>',
+  '        <text>World</text>',
+  '      </Show>',
+  '      <Switch fallback={<text>Fallback</text>}>',
+  '        <Match when={mode() === 1}><text>ModeOne</text></Match>',
+  '        <Match when={mode() === 2}><text>ModeTwo</text></Match>',
+  '      </Switch>',
+  '    </box>',
+  '  ), { width: 24, height: 8 })',
+  '  await setup.renderOnce()',
+  '  const first = setup.captureCharFrame()',
+  '  setItems(["Hello", "Node"])',
+  '  setShowTail(true)',
+  '  setMode(2)',
+  '  await setup.renderOnce()',
+  '  const second = setup.captureCharFrame()',
+  '  setup.renderer.destroy()',
+  '  return { first, second }',
+  '}',
+].join("\\n")
+
+const transformed = await transformAsync(fixtureSource, {
+  filename: join(process.cwd(), "fixture.tsx"),
+  configFile: false,
+  babelrc: false,
+  plugins: [
+    [
+      moduleResolver,
+      {
+        resolvePath(specifier) {
+          if (specifier === "solid-js") return "solid-js/dist/solid.js"
+          if (specifier === "solid-js/store") return "solid-js/store/dist/store.js"
+          return specifier
+        },
+      },
+    ],
+  ],
+  presets: [
+    [solid, { moduleName: ${JSON.stringify(packageJson.name)}, generate: "universal" }],
+    [ts],
+  ],
+})
+
+if (!transformed?.code) {
+  throw new Error("Failed to transform Solid fixture")
+}
+
+const runtimeDir = join(process.cwd(), ".dist-node-runtime")
+const runtimePath = join(runtimeDir, "fixture.mjs")
+mkdirSync(runtimeDir, { recursive: true })
+writeFileSync(runtimePath, transformed.code)
+
+try {
+  const { run } = await import(pathToFileURL(runtimePath).href)
+  const result = await run()
+  assert.match(result.first, /Hello/)
+  assert.match(result.first, /ModeOne/)
+  assert.doesNotMatch(result.first, /World/)
+  assert.match(result.second, /Hello/)
+  assert.match(result.second, /Node/)
+  assert.match(result.second, /World/)
+  assert.match(result.second, /ModeTwo/)
+} finally {
+  rmSync(runtimeDir, { recursive: true, force: true })
+}
+
+const expectBunOnlyFailure = async (specifier, expectedMessage) => {
+  await assert.rejects(import(specifier), (error) => {
+    return error instanceof Error && error.message.includes(expectedMessage)
+  })
+}
+
+await expectBunOnlyFailure(${JSON.stringify(`${packageJson.name}/preload`)}, ${JSON.stringify(`${packageJson.name}/preload is Bun-only`)})
+await expectBunOnlyFailure(${JSON.stringify(`${packageJson.name}/bun-plugin`)}, ${JSON.stringify(`${packageJson.name}/bun-plugin is Bun-only`)})
+await expectBunOnlyFailure(
+  ${JSON.stringify(`${packageJson.name}/runtime-plugin-support`)},
+  ${JSON.stringify(`${packageJson.name}/runtime-plugin-support is Bun-only`)},
+)
+await expectBunOnlyFailure(
+  ${JSON.stringify(`${packageJson.name}/runtime-plugin-support/configure`)},
+  ${JSON.stringify(`${packageJson.name}/runtime-plugin-support/configure is Bun-only`)},
+)
+
+console.log("Node solid dist smoke test passed")
+`,
+  )
+}
+
+function assertNodeStaticImportFailure(
+  nodeDir: string,
+  importedName: string,
+  specifier: string,
+  expectedMessage: string,
+): void {
+  const result = runCommandExpectFailure(
+    ensureNode26(),
+    ["--input-type=module", "-e", `import { ${importedName} } from ${JSON.stringify(specifier)}`],
+    nodeDir,
+    `Expected static Node import of ${specifier} to fail`,
+  )
+
+  const output = `${result.stdout.toString("utf8")}\n${result.stderr.toString("utf8")}`
+
+  if (output.includes("does not provide an export named")) {
+    throw new Error(`Static Node import of ${specifier} failed before the Bun-only stub could run`)
+  }
+
+  if (!output.includes(expectedMessage)) {
+    throw new Error(`Static Node import of ${specifier} did not report the expected Bun-only error`)
+  }
+}
+
+function installAndTest(nodeDir: string): void {
+  runCommand("npm", ["install", "--ignore-scripts", "--no-package-lock"], nodeDir, "Node dist test install failed")
+
+  const nodePath = ensureNode26()
+  runCommand(nodePath, ["-e", `import(${JSON.stringify(packageJson.name)})`], nodeDir, "Node import smoke check failed")
+  runCommand(
+    nodePath,
+    [
+      "--disable-warning=SecurityWarning",
+      "--disable-warning=ExperimentalWarning",
+      "--permission",
+      `--allow-fs-read=${nodeDir}`,
+      `--allow-fs-write=${nodeDir}`,
+      "--allow-ffi",
+      "--experimental-ffi",
+      "index.mjs",
+    ],
+    nodeDir,
+    "Node solid dist smoke tests failed",
+  )
+
+  assertNodeStaticImportFailure(
+    nodeDir,
+    "createSolidTransformPlugin",
+    `${packageJson.name}/bun-plugin`,
+    `${packageJson.name}/bun-plugin is Bun-only`,
+  )
+  assertNodeStaticImportFailure(
+    nodeDir,
+    "ensureRuntimePluginSupport",
+    `${packageJson.name}/runtime-plugin-support`,
+    `${packageJson.name}/runtime-plugin-support is Bun-only`,
+  )
+  assertNodeStaticImportFailure(
+    nodeDir,
+    "ensureRuntimePluginSupport",
+    `${packageJson.name}/runtime-plugin-support/configure`,
+    `${packageJson.name}/runtime-plugin-support/configure is Bun-only`,
+  )
+}
+
+let tempRoot: string | undefined
+
+try {
+  ensureBuildArtifacts()
+
+  tempRoot = mkdtempSync(join(tmpdir(), "opentui-solid-dist-test-"))
+  const packDir = join(tempRoot, "packs")
+  const nodeDir = join(tempRoot, "node")
+
+  mkdirSync(packDir, { recursive: true })
+  mkdirSync(nodeDir, { recursive: true })
+
+  const coreTarball = packArtifact(coreDistDir, packDir)
+  const nativeTarball = packArtifact(nativePackageDir, packDir)
+  const solidTarball = packArtifact(distDir, packDir)
+
+  writeConsumerPackage(nodeDir, solidTarball, coreTarball, nativeTarball)
+  writeNodeTest(nodeDir)
+
+  installAndTest(nodeDir)
+
+  if (!keepTemp) {
+    rmSync(tempRoot, { recursive: true, force: true })
+    tempRoot = undefined
+  }
+
+  console.log("Packed solid dist smoke tests passed")
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error)
+  if (tempRoot) {
+    console.error(`Dist test workspace kept at ${tempRoot}`)
+  }
+  process.exit(1)
+}

--- a/packages/solid/scripts/test-packed-consumer.ts
+++ b/packages/solid/scripts/test-packed-consumer.ts
@@ -14,7 +14,7 @@ import { dirname, join, relative, resolve } from "node:path"
 import process from "node:process"
 import { fileURLToPath } from "node:url"
 
-import { ensureNode26 } from "../../../scripts/node26.mjs"
+import { requireNode26 } from "../../../scripts/node26.mjs"
 
 interface PackageJson {
   name: string
@@ -31,6 +31,7 @@ const coreDistDir = join(coreRootDir, "dist")
 const args = new Set(process.argv.slice(2))
 const keepTemp = args.has("--keep-temp")
 const skipBuild = args.has("--skip-build")
+const nodePath = requireNode26()
 
 const packageJson = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8")) as PackageJson
 const corePackageJson = JSON.parse(readFileSync(join(coreRootDir, "package.json"), "utf8")) as PackageJson
@@ -357,7 +358,7 @@ function assertNodeStaticImportFailure(
   expectedMessage: string,
 ): void {
   const result = runCommandExpectFailure(
-    ensureNode26(),
+    nodePath,
     ["--input-type=module", "-e", `import { ${importedName} } from ${JSON.stringify(specifier)}`],
     nodeDir,
     `Expected static Node import of ${specifier} to fail`,
@@ -379,7 +380,6 @@ function installAndTest(nodeDir: string): void {
   runCommand("npm", ["exec", "--", "tsc", "--noEmit"], nodeDir, "Node dist consumer typecheck failed")
   runCommand("bun", ["index.bun.mjs"], nodeDir, "Bun solid dist smoke tests failed")
 
-  const nodePath = ensureNode26()
   const nodeRealDir = realpathSync(nodeDir)
   const nodePermissionDirs = [...new Set([nodeDir, nodeRealDir])]
   runCommand(nodePath, ["-e", `import(${JSON.stringify(packageJson.name)})`], nodeDir, "Node import smoke check failed")

--- a/packages/solid/scripts/test-packed-consumer.ts
+++ b/packages/solid/scripts/test-packed-consumer.ts
@@ -8,7 +8,7 @@
  */
 
 import { spawnSync, type SpawnSyncReturns } from "node:child_process"
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join, relative, resolve } from "node:path"
 import process from "node:process"
@@ -380,6 +380,8 @@ function installAndTest(nodeDir: string): void {
   runCommand("bun", ["index.bun.mjs"], nodeDir, "Bun solid dist smoke tests failed")
 
   const nodePath = ensureNode26()
+  const nodeRealDir = realpathSync(nodeDir)
+  const nodePermissionDirs = [...new Set([nodeDir, nodeRealDir])]
   runCommand(nodePath, ["-e", `import(${JSON.stringify(packageJson.name)})`], nodeDir, "Node import smoke check failed")
   runCommand(
     nodePath,
@@ -387,8 +389,8 @@ function installAndTest(nodeDir: string): void {
       "--disable-warning=SecurityWarning",
       "--disable-warning=ExperimentalWarning",
       "--permission",
-      `--allow-fs-read=${nodeDir}`,
-      `--allow-fs-write=${nodeDir}`,
+      ...nodePermissionDirs.map((path) => `--allow-fs-read=${path}`),
+      ...nodePermissionDirs.map((path) => `--allow-fs-write=${path}`),
       "--allow-ffi",
       "--experimental-ffi",
       "index.mjs",

--- a/packages/solid/src/elements/extras.ts
+++ b/packages/solid/src/elements/extras.ts
@@ -1,6 +1,6 @@
 import { createEffect, createMemo, getOwner, onCleanup, runWithOwner, splitProps, untrack } from "solid-js"
 import { createSlotNode, createElement, insert, spread, type DomNode } from "../reconciler.js"
-import type { JSX } from "../../jsx-runtime"
+import type { JSX } from "../../jsx-runtime.js"
 import type { ValidComponent, ComponentProps } from "solid-js"
 import { useRenderer } from "./hooks.js"
 
@@ -11,7 +11,7 @@ import { useRenderer } from "./hooks.js"
  *
  * @description https://docs.solidjs.com/reference/components/portal
  */
-export function Portal(props: { mount?: DomNode; ref?: (el: {}) => void; children: JSX.Element }): DomNode {
+export function Portal(props: { mount?: DomNode; ref?: (el: {}) => void; children: JSX.Element }): JSX.Element {
   const renderer = useRenderer()
 
   const marker = createSlotNode(),
@@ -41,7 +41,8 @@ export function Portal(props: { mount?: DomNode; ref?: (el: {}) => void; childre
     undefined,
     { render: true },
   )
-  return marker
+  // The reconciler consumes this marker as the runtime representation of the portal JSX node.
+  return marker as unknown as JSX.Element
 }
 
 export type DynamicProps<T extends ValidComponent, P = ComponentProps<T>> = {

--- a/packages/solid/src/elements/extras.ts
+++ b/packages/solid/src/elements/extras.ts
@@ -1,6 +1,6 @@
 import { createEffect, createMemo, getOwner, onCleanup, runWithOwner, splitProps, untrack } from "solid-js"
 import { createSlotNode, createElement, insert, spread, type DomNode } from "../reconciler.js"
-import type { JSX } from "../../jsx-runtime"
+import type { JSX } from "../../jsx-runtime.js"
 import type { ValidComponent, ComponentProps } from "solid-js"
 import { useRenderer } from "./hooks.js"
 

--- a/packages/solid/src/testing/bun-test-node.ts
+++ b/packages/solid/src/testing/bun-test-node.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict"
+import { after, afterEach, before, beforeEach, describe, test } from "node:test"
+import { inspect, isDeepStrictEqual } from "node:util"
+
+function fail(message: string): never {
+  throw new assert.AssertionError({ message })
+}
+
+function formatValue(value: unknown): string {
+  return inspect(value, { depth: 5 })
+}
+
+function createMatchers(received: unknown, inverted = false) {
+  const assertMatch = (pass: boolean, message: string): void => {
+    if (inverted ? pass : !pass) {
+      fail(message)
+    }
+  }
+
+  return {
+    get not() {
+      return createMatchers(received, !inverted)
+    },
+    toBe(expected: unknown) {
+      assertMatch(
+        Object.is(received, expected),
+        `Expected ${formatValue(received)} ${inverted ? "not " : ""}to be ${formatValue(expected)}`,
+      )
+    },
+    toBeDefined() {
+      assertMatch(received !== undefined, `Expected value ${inverted ? "not " : ""}to be defined`)
+    },
+    toBeFalsy() {
+      assertMatch(!received, `Expected ${formatValue(received)} ${inverted ? "not " : ""}to be falsy`)
+    },
+    toBeTruthy() {
+      assertMatch(Boolean(received), `Expected ${formatValue(received)} ${inverted ? "not " : ""}to be truthy`)
+    },
+    toContain(expected: unknown) {
+      const pass =
+        typeof received === "string"
+          ? received.includes(String(expected))
+          : Array.isArray(received)
+            ? received.includes(expected)
+            : false
+
+      assertMatch(
+        pass,
+        `Expected ${formatValue(received)} ${inverted ? "not " : ""}to contain ${formatValue(expected)}`,
+      )
+    },
+    toEqual(expected: unknown) {
+      assertMatch(
+        isDeepStrictEqual(received, expected),
+        `Expected ${formatValue(received)} ${inverted ? "not " : ""}to equal ${formatValue(expected)}`,
+      )
+    },
+  }
+}
+
+export { after as afterAll, afterEach, before as beforeAll, beforeEach, describe, test }
+export const it = test
+
+export function expect(received: unknown) {
+  return createMatchers(received)
+}

--- a/packages/solid/src/types/elements.ts
+++ b/packages/solid/src/types/elements.ts
@@ -28,7 +28,7 @@ import type {
   TextRenderable,
 } from "@opentui/core"
 import type { Ref } from "solid-js"
-import type { JSX } from "../../jsx-runtime"
+import type { JSX } from "../../jsx-runtime.js"
 
 // ============================================================================
 // Core Type System

--- a/packages/solid/tests/control-flow-updates.test.tsx
+++ b/packages/solid/tests/control-flow-updates.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { createSignal, For, Match, Show, Switch } from "solid-js"
+import { testRender } from "../index.js"
+
+let testSetup: Awaited<ReturnType<typeof testRender>>
+
+describe("SolidJS Renderer - Control Flow Updates", () => {
+  beforeEach(() => {
+    if (testSetup) {
+      testSetup.renderer.destroy()
+    }
+  })
+
+  afterEach(() => {
+    if (testSetup) {
+      testSetup.renderer.destroy()
+    }
+  })
+
+  it("updates <For> collections reactively", async () => {
+    const [items, setItems] = createSignal(["A", "B"])
+
+    testSetup = await testRender(
+      () => (
+        <box>
+          <For each={items()}>{(item) => <text>Item: {item}</text>}</For>
+        </box>
+      ),
+      { width: 20, height: 10 },
+    )
+
+    await testSetup.renderOnce()
+    expect(testSetup.captureCharFrame()).toContain("Item: B")
+
+    setItems(["A", "B", "C"])
+    await testSetup.renderOnce()
+
+    const frame = testSetup.captureCharFrame()
+    expect(frame).toContain("Item: A")
+    expect(frame).toContain("Item: C")
+    expect(testSetup.renderer.root.getChildren()[0]!.getChildren().length).toBe(3)
+  })
+
+  it("switches between <Show> content and fallback reactively", async () => {
+    const [visible, setVisible] = createSignal(true)
+
+    testSetup = await testRender(
+      () => (
+        <box>
+          <Show when={visible()} fallback={<text>Fallback</text>}>
+            <text>Main</text>
+          </Show>
+        </box>
+      ),
+      { width: 20, height: 5 },
+    )
+
+    await testSetup.renderOnce()
+    expect(testSetup.captureCharFrame()).toContain("Main")
+
+    setVisible(false)
+    await testSetup.renderOnce()
+
+    const frame = testSetup.captureCharFrame()
+    expect(frame).toContain("Fallback")
+    expect(frame).not.toContain("Main")
+  })
+
+  it("re-evaluates <Switch> matches reactively", async () => {
+    const [selected, setSelected] = createSignal(1)
+
+    testSetup = await testRender(
+      () => (
+        <box>
+          <Switch fallback={<text>Other</text>}>
+            <Match when={selected() === 1}>
+              <text>One</text>
+            </Match>
+            <Match when={selected() === 2}>
+              <text>Two</text>
+            </Match>
+          </Switch>
+        </box>
+      ),
+      { width: 20, height: 5 },
+    )
+
+    await testSetup.renderOnce()
+    expect(testSetup.captureCharFrame()).toContain("One")
+
+    setSelected(2)
+    await testSetup.renderOnce()
+
+    let frame = testSetup.captureCharFrame()
+    expect(frame).toContain("Two")
+    expect(frame).not.toContain("One")
+
+    setSelected(3)
+    await testSetup.renderOnce()
+
+    frame = testSetup.captureCharFrame()
+    expect(frame).toContain("Other")
+    expect(frame).not.toContain("Two")
+  })
+})

--- a/packages/solid/tsconfig.build.json
+++ b/packages/solid/tsconfig.build.json
@@ -24,8 +24,10 @@
     "components.ts",
     "src/**/*",
     "jsx-runtime.d.ts",
+    "jsx-dev-runtime.d.ts",
     // See the comment below
     "scripts/solid-plugin.ts",
+    "scripts/solid-transform.ts",
     "scripts/runtime-plugin-support.ts",
     "scripts/runtime-plugin-support-configure.ts"
   ],

--- a/packages/solid/tsconfig.build.json
+++ b/packages/solid/tsconfig.build.json
@@ -23,8 +23,10 @@
     "index.ts",
     "src/**/*",
     "jsx-runtime.d.ts",
+    "jsx-dev-runtime.d.ts",
     // See the comment below
     "scripts/solid-plugin.ts",
+    "scripts/solid-transform.ts",
     "scripts/runtime-plugin-support.ts",
     "scripts/runtime-plugin-support-configure.ts"
   ],

--- a/packages/web/src/content/docs/bindings/solid.mdx
+++ b/packages/web/src/content/docs/bindings/solid.mdx
@@ -17,6 +17,20 @@ Build terminal user interfaces with Solid.js's fine-grained reactivity and OpenT
 bun install solid-js @opentui/solid
 ```
 
+## Runtime support
+
+`@opentui/solid` publishes one npm package with runtime-specific entrypoints behind the package `exports` map. The root package and JSX runtime subpaths work in both Bun and Node. Bun-specific helpers stay Bun-only and throw a clear runtime error if imported from Node.
+
+| Entrypoint                                        | Bun | Node | Notes                                           |
+| ------------------------------------------------- | --- | ---- | ----------------------------------------------- |
+| `@opentui/solid`                                  | yes | yes  | Main renderer and test helpers                  |
+| `@opentui/solid/jsx-runtime`                      | yes | yes  | Real runtime module for compiled JSX            |
+| `@opentui/solid/jsx-dev-runtime`                  | yes | yes  | Real dev runtime module for compiled JSX        |
+| `@opentui/solid/preload`                          | yes | no   | Bun preload hook                                |
+| `@opentui/solid/bun-plugin`                       | yes | no   | Bun bundler/plugin entry                        |
+| `@opentui/solid/runtime-plugin-support`           | yes | no   | Bun runtime-loader support                      |
+| `@opentui/solid/runtime-plugin-support/configure` | yes | no   | Bun runtime-loader support without side effects |
+
 ## Setup
 
 ### 1. Configure TypeScript
@@ -40,7 +54,35 @@ Add preload script to `bunfig.toml`:
 preload = ["@opentui/solid/preload"]
 ```
 
-### 3. Enable runtime-loaded plugin support (if needed)
+### 3. Configure Node compilation
+
+Node support currently targets compiled Solid TSX. Use Solid's universal transform semantics and point the generated runtime imports at the published `solid-js` JS files:
+
+```js
+import ts from "@babel/preset-typescript"
+import moduleResolver from "babel-plugin-module-resolver"
+import solid from "babel-preset-solid"
+
+export default {
+  plugins: [
+    [
+      moduleResolver,
+      {
+        resolvePath(specifier) {
+          if (specifier === "solid-js") return "solid-js/dist/solid.js"
+          if (specifier === "solid-js/store") return "solid-js/store/dist/store.js"
+          return specifier
+        },
+      },
+    ],
+  ],
+  presets: [[solid, { moduleName: "@opentui/solid", generate: "universal" }], [ts]],
+}
+```
+
+The current Node runtime path is still lower-level than Bun. OpenTUI's native renderer currently relies on Node's experimental FFI support, so expect a recent Node 26.x build plus `--experimental-ffi`, `--permission`, and the filesystem or FFI permissions your app needs.
+
+### 4. Enable runtime-loaded plugin support (if needed)
 
 If your app loads external TS/TSX modules at runtime (for example a file-based plugin system), import this once in your entry file before dynamic imports:
 
@@ -48,7 +90,9 @@ If your app loads external TS/TSX modules at runtime (for example a file-based p
 import "@opentui/solid/runtime-plugin-support"
 ```
 
-### 4. Create your app
+This entrypoint is Bun-only.
+
+### 5. Create your app
 
 ```tsx
 import { render } from "@opentui/solid"

--- a/packages/web/src/content/docs/bindings/solid.mdx
+++ b/packages/web/src/content/docs/bindings/solid.mdx
@@ -80,7 +80,7 @@ export default {
 }
 ```
 
-The current Node runtime path is still lower-level than Bun. OpenTUI's native renderer currently relies on Node's experimental FFI support, so expect a recent Node 26.x build plus `--experimental-ffi`, `--permission`, and the filesystem or FFI permissions your app needs.
+The current Node runtime path is still lower-level than Bun. OpenTUI's native renderer currently relies on Node's experimental FFI support, so select Node 26.3.0 before running it and pass `--experimental-ffi`, `--permission`, and the filesystem or FFI permissions your app needs. OpenTUI does not install Node automatically.
 
 ### 4. Enable runtime-loaded plugin support (if needed)
 

--- a/packages/web/src/content/docs/getting-started.mdx
+++ b/packages/web/src/content/docs/getting-started.mdx
@@ -14,13 +14,19 @@ OpenTUI is a native terminal UI core written in Zig with TypeScript bindings. Th
 
 ## Installation
 
-OpenTUI is currently [Bun](https://bun.sh) exclusive but Deno and Node support in-progress.
+OpenTUI's renderer examples currently use [Bun](https://bun.sh). Published portable entrypoints can be imported from Node.js without Bun or FFI flags, including `@opentui/keymap` and import-only `@opentui/core` usage. Creating a native renderer from Node is a separate runtime path and currently targets Node 26.x with experimental FFI enabled.
 
 ```bash
 mkdir my-tui && cd my-tui
 bun init -y
 bun add @opentui/core
 ```
+
+## Runtime support
+
+Import-only package use does not require native FFI. For example, `await import("@opentui/keymap")` and `await import("@opentui/core")` can load in Node without `--experimental-ffi`.
+
+Renderer support is different. Calling `createCliRenderer()` or APIs that load and call OpenTUI's native Zig renderer needs native FFI. Under Node, that path currently requires Node 26.x with `--experimental-ffi` and, when using Node permissions, `--allow-ffi` plus the filesystem permissions your app needs.
 
 ## Hello world
 

--- a/packages/web/src/content/docs/getting-started.mdx
+++ b/packages/web/src/content/docs/getting-started.mdx
@@ -26,7 +26,7 @@ bun add @opentui/core
 
 Import-only package use does not require native FFI. For example, `await import("@opentui/keymap")` and `await import("@opentui/core")` can load in Node without `--experimental-ffi`.
 
-Renderer support is different. Calling `createCliRenderer()` or APIs that load and call OpenTUI's native Zig renderer needs native FFI. Under Node, that path currently requires Node 26.x with `--experimental-ffi` and, when using Node permissions, `--allow-ffi` plus the filesystem permissions your app needs.
+Renderer support is different. Calling `createCliRenderer()` or APIs that load and call OpenTUI's native Zig renderer needs native FFI. Under Node, that path currently requires Node 26.3.0 with `--experimental-ffi` and, when using Node permissions, `--allow-ffi` plus the filesystem permissions your app needs. OpenTUI does not install Node; select the required version before running Node-specific examples or scripts.
 
 ## Hello world
 

--- a/packages/web/src/content/docs/keymap/overview.mdx
+++ b/packages/web/src/content/docs/keymap/overview.mdx
@@ -15,8 +15,12 @@ OpenTUI Keymap is a host-agnostic binding engine for terminals and the browser. 
 ## Installation
 
 ```bash
-bun install @opentui/keymap
+bun add @opentui/keymap
+# or
+npm install @opentui/keymap
 ```
+
+The bare keymap package is JavaScript-only and can be imported from Node without Bun or native FFI flags. OpenTUI renderer integration is separate: importing the OpenTUI host helpers is supported, but actually creating a native renderer on Node follows the Node 26 experimental FFI requirements in [Getting started](/docs/getting-started#runtime-support).
 
 Live demo: [HTML keymap demo](/demos/keymap-html/)
 

--- a/scripts/node26.mjs
+++ b/scripts/node26.mjs
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
-export const NODE26_VERSION = "v26.1.0"
+export const NODE26_VERSION = "v26.3.0"
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(scriptDir, "..")

--- a/scripts/node26.mjs
+++ b/scripts/node26.mjs
@@ -10,34 +10,40 @@ const repoRoot = resolve(scriptDir, "..")
 const cacheDir = resolve(repoRoot, ".cache/node26")
 
 function getTarget() {
-  if (process.arch !== "x64") {
-    throw new Error(
-      `This repo Node 26 runner downloads the x64 Node 26 builds, not ${process.platform}-${process.arch}.`,
-    )
-  }
+  const arch = getNodeDownloadArch()
 
   switch (process.platform) {
     case "linux":
       return {
-        archiveName: `node-${NODE26_VERSION}-linux-x64.tar.xz`,
-        directoryName: `node-${NODE26_VERSION}-linux-x64`,
+        archiveName: `node-${NODE26_VERSION}-linux-${arch}.tar.xz`,
+        directoryName: `node-${NODE26_VERSION}-linux-${arch}`,
         nodeRelativePath: "bin/node",
-        url: `https://nodejs.org/dist/${NODE26_VERSION}/node-${NODE26_VERSION}-linux-x64.tar.xz`,
+        url: `https://nodejs.org/dist/${NODE26_VERSION}/node-${NODE26_VERSION}-linux-${arch}.tar.xz`,
       }
     case "darwin":
       return {
-        archiveName: `node-${NODE26_VERSION}-darwin-x64.tar.gz`,
-        directoryName: `node-${NODE26_VERSION}-darwin-x64`,
+        archiveName: `node-${NODE26_VERSION}-darwin-${arch}.tar.gz`,
+        directoryName: `node-${NODE26_VERSION}-darwin-${arch}`,
         nodeRelativePath: "bin/node",
-        url: `https://nodejs.org/dist/${NODE26_VERSION}/node-${NODE26_VERSION}-darwin-x64.tar.gz`,
+        url: `https://nodejs.org/dist/${NODE26_VERSION}/node-${NODE26_VERSION}-darwin-${arch}.tar.gz`,
       }
     case "win32":
       return {
-        archiveName: `node-${NODE26_VERSION}-win-x64.zip`,
-        directoryName: `node-${NODE26_VERSION}-win-x64`,
+        archiveName: `node-${NODE26_VERSION}-win-${arch}.zip`,
+        directoryName: `node-${NODE26_VERSION}-win-${arch}`,
         nodeRelativePath: "node.exe",
-        url: `https://nodejs.org/dist/${NODE26_VERSION}/node-${NODE26_VERSION}-win-x64.zip`,
+        url: `https://nodejs.org/dist/${NODE26_VERSION}/node-${NODE26_VERSION}-win-${arch}.zip`,
       }
+    default:
+      throw new Error(`This repo Node 26 runner does not have a download for ${process.platform}-${process.arch}.`)
+  }
+}
+
+function getNodeDownloadArch() {
+  switch (process.arch) {
+    case "x64":
+    case "arm64":
+      return process.arch
     default:
       throw new Error(`This repo Node 26 runner does not have a download for ${process.platform}-${process.arch}.`)
   }

--- a/scripts/node26.mjs
+++ b/scripts/node26.mjs
@@ -1,110 +1,47 @@
 import { spawnSync } from "node:child_process"
-import { existsSync, mkdirSync } from "node:fs"
-import { dirname, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
+import { delimiter, dirname } from "node:path"
 
 export const NODE26_VERSION = "v26.3.0"
 
-const scriptDir = dirname(fileURLToPath(import.meta.url))
-const repoRoot = resolve(scriptDir, "..")
-const cacheDir = resolve(repoRoot, ".cache/node26")
-
-function getTarget() {
-  const arch = getNodeDownloadArch()
-
-  switch (process.platform) {
-    case "linux":
-      return {
-        archiveName: `node-${NODE26_VERSION}-linux-${arch}.tar.xz`,
-        directoryName: `node-${NODE26_VERSION}-linux-${arch}`,
-        nodeRelativePath: "bin/node",
-        url: `https://nodejs.org/dist/${NODE26_VERSION}/node-${NODE26_VERSION}-linux-${arch}.tar.xz`,
-      }
-    case "darwin":
-      return {
-        archiveName: `node-${NODE26_VERSION}-darwin-${arch}.tar.gz`,
-        directoryName: `node-${NODE26_VERSION}-darwin-${arch}`,
-        nodeRelativePath: "bin/node",
-        url: `https://nodejs.org/dist/${NODE26_VERSION}/node-${NODE26_VERSION}-darwin-${arch}.tar.gz`,
-      }
-    case "win32":
-      return {
-        archiveName: `node-${NODE26_VERSION}-win-${arch}.zip`,
-        directoryName: `node-${NODE26_VERSION}-win-${arch}`,
-        nodeRelativePath: "node.exe",
-        url: `https://nodejs.org/dist/${NODE26_VERSION}/node-${NODE26_VERSION}-win-${arch}.zip`,
-      }
-    default:
-      throw new Error(`This repo Node 26 runner does not have a download for ${process.platform}-${process.arch}.`)
-  }
-}
-
-function getNodeDownloadArch() {
-  switch (process.arch) {
-    case "x64":
-    case "arm64":
-      return process.arch
-    default:
-      throw new Error(`This repo Node 26 runner does not have a download for ${process.platform}-${process.arch}.`)
-  }
-}
-
-export function getNode26Path() {
-  const target = getTarget()
-  return resolve(cacheDir, target.directoryName, target.nodeRelativePath)
-}
-
-export function ensureNode26() {
-  const target = getTarget()
-  const archivePath = resolve(cacheDir, target.archiveName)
-  const nodeDir = resolve(cacheDir, target.directoryName)
-  const nodePath = resolve(nodeDir, target.nodeRelativePath)
-
-  if (existsSync(nodePath)) {
-    return nodePath
-  }
-
-  mkdirSync(cacheDir, { recursive: true })
-
-  if (!existsSync(archivePath)) {
-    run("curl", ["-L", target.url, "-o", archivePath])
-  }
-
-  extractArchive(archivePath, cacheDir)
-
-  if (!existsSync(nodePath)) {
-    throw new Error(`Downloaded Node 26 archive did not produce ${nodePath}`)
-  }
-
-  return nodePath
-}
-
-function extractArchive(archivePath, outputDir) {
-  if (archivePath.endsWith(".zip")) {
-    if (process.platform === "win32") {
-      run("powershell", [
-        "-NoProfile",
-        "-Command",
-        `Expand-Archive -Path '${archivePath}' -DestinationPath '${outputDir}' -Force`,
-      ])
-      return
-    }
-
-    run("unzip", ["-q", archivePath, "-d", outputDir])
-    return
-  }
-
-  run("tar", ["-xf", archivePath, "-C", outputDir])
-}
-
-function run(command, args) {
-  const result = spawnSync(command, args, { stdio: "inherit" })
+export function requireNode26() {
+  const nodeCommand = typeof process.versions?.bun === "string" ? "node" : process.execPath
+  const result = spawnSync(
+    nodeCommand,
+    ["--eval", "process.stdout.write(JSON.stringify({ version: process.version, execPath: process.execPath }))"],
+    { encoding: "utf8" },
+  )
 
   if (result.error) {
-    throw result.error
+    throw new Error(nodeVersionError(`${nodeCommand} is not available`), { cause: result.error })
   }
 
   if (result.status !== 0) {
-    process.exit(result.status ?? 1)
+    throw new Error(nodeVersionError(`${nodeCommand} exited with status ${result.status ?? "unknown"}`))
   }
+
+  const runtime = parseNodeRuntime(nodeCommand, result.stdout)
+  if (runtime.version !== NODE26_VERSION) {
+    throw new Error(nodeVersionError(`${runtime.execPath} reports ${runtime.version}`))
+  }
+
+  // Keep npm and env-based child launches on the same runtime that was validated.
+  process.env.PATH = [dirname(runtime.execPath), process.env.PATH].filter(Boolean).join(delimiter)
+  return runtime.execPath
+}
+
+function parseNodeRuntime(nodeCommand, output) {
+  try {
+    const runtime = JSON.parse(output)
+    if (typeof runtime.version === "string" && typeof runtime.execPath === "string" && runtime.execPath.length > 0) {
+      return runtime
+    }
+  } catch (error) {
+    throw new Error(nodeVersionError(`${nodeCommand} reported an invalid runtime`), { cause: error })
+  }
+
+  throw new Error(nodeVersionError(`${nodeCommand} reported an invalid runtime`))
+}
+
+function nodeVersionError(actualVersion) {
+  return `Node.js ${NODE26_VERSION} is required, but ${actualVersion}. Select the required Node.js version before running this command; OpenTUI will not install it automatically.`
 }


### PR DESCRIPTION
Add jsx/jsxs/jsxDEV/Fragment runtime implementations, split the build into Node and Bun entry points, and gate CI on Bun tests, Node source tests, and a packed-consumer smoke test that verifies the tarball installs and runs under Node.