### PR TITLE
Fix(solid/reconciler): incorrect insert order in Show with fragments

### DIFF
--- a/packages/solid/src/reconciler.ts
+++ b/packages/solid/src/reconciler.ts
@@ -376,8 +376,15 @@ export const {
       log("No parent found for node:", logId(node))
       return undefined
     }
-    const siblings = getNodeChildren(parent)
 
+    if (node instanceof SlotRenderable) {
+      const layoutSlotNode = node.getSlotChildForRemoval(parent)
+      if (layoutSlotNode) {
+        node = layoutSlotNode
+      }
+    }
+
+    const siblings = getNodeChildren(parent)
     const index = siblings.indexOf(node)
 
     if (index === -1 || index === siblings.length - 1) {

--- a/packages/solid/tests/control-flow.test.tsx
+++ b/packages/solid/tests/control-flow.test.tsx
@@ -306,6 +306,57 @@ describe("SolidJS Renderer - Control Flow Components", () => {
       expect(children[1]!.id).toBe("second")
       expect(children[2]!.id).toBe("third")
     })
+
+    it("should reinsert multiple fragment children with <Show> before the following static sibling", async () => {
+      const [showContent, setShowContent] = createSignal(true)
+      const expectedVisibleIds = [
+        "top",
+        "fragment-title",
+        "fragment-alpha",
+        "fragment-bravo",
+        "fragment-charlie",
+        "bottom",
+      ]
+      const expectedHiddenIds = ["top", "bottom"]
+
+      testSetup = await testRender(
+        () => (
+          <box id="container">
+            <box id="top" />
+            <Show when={showContent()}>
+              <>
+                <box id="fragment-title" />
+                <box id="fragment-alpha" />
+                <box id="fragment-bravo" />
+                <box id="fragment-charlie" />
+              </>
+            </Show>
+            <box id="bottom" />
+          </box>
+        ),
+        { width: 40, height: 20 },
+      )
+
+      const getOrderedIds = () => {
+        const ids = new Set(expectedVisibleIds)
+        const container = testSetup.renderer.root.findDescendantById("container")!
+        return container
+          .getChildren()
+          .map((child) => child.id)
+          .filter((id) => ids.has(id))
+      }
+
+      await testSetup.renderOnce()
+      expect(getOrderedIds()).toEqual(expectedVisibleIds)
+
+      setShowContent(false)
+      await testSetup.renderOnce()
+      expect(getOrderedIds()).toEqual(expectedHiddenIds)
+
+      setShowContent(true)
+      await testSetup.renderOnce()
+      expect(getOrderedIds()).toEqual(expectedVisibleIds)
+    })
   })
 
   describe("<Switch> and <Match> Components", () => {


### PR DESCRIPTION
### Bug: incorrect insert order in \<Show\/\> with fragments
```tsx
<box id="top" />
<Show when={visible()}>
  <>
    <box id="a" />
    <box id="b" />
    <box id="c" />
  </>
</Show>
<box id="bottom" />
```
Toggling the Show content off and back on could lead to the wrong child order:
["top", "bottom", "a", "b", "c"]
instead of:
["top", "a", "b", "c", "bottom"]

### Cause
getNextChild in the reconciler was resolving the abstract SlotNode instead of the concrete layout slot node.
That missed the sibling order check, so reinserted children were appended in the wrong place.
### Fix
Resolve slot nodes to their concrete layout slot node before checking sibling order.