### PR TITLE
fix(core/editor-view): visual cursor movement at wrapped line boundaries

### DIFF
--- a/packages/core/src/zig/bench.zig
+++ b/packages/core/src/zig/bench.zig
@@ -55,6 +55,7 @@ const buffer_color_blending_bench = @import("bench/buffer-color-blending_bench.z
 const buffer_draw_box_bench = @import("bench/buffer-draw-box_bench.zig");
 const utf8_bench = @import("bench/utf8_bench.zig");
 const text_chunk_graphemes_bench = @import("bench/text-chunk-graphemes_bench.zig");
+const editor_view_bench = @import("bench/editor-view_bench.zig");
 
 const BenchModule = struct {
     name: []const u8,
@@ -105,6 +106,7 @@ pub fn main() !void {
         .{ .name = buffer_draw_box_bench.benchName, .run = buffer_draw_box_bench.run },
         .{ .name = utf8_bench.benchName, .run = utf8_bench.run },
         .{ .name = text_chunk_graphemes_bench.benchName, .run = text_chunk_graphemes_bench.run },
+        .{ .name = editor_view_bench.benchName, .run = editor_view_bench.run },
     };
 
     const args = try std.process.argsAlloc(allocator);

--- a/packages/core/src/zig/bench/editor-view_bench.zig
+++ b/packages/core/src/zig/bench/editor-view_bench.zig
@@ -1,0 +1,169 @@
+const std = @import("std");
+const bench_utils = @import("../bench-utils.zig");
+const edit_buffer = @import("../edit-buffer.zig");
+const editor_view = @import("../editor-view.zig");
+const gp = @import("../grapheme.zig");
+const link = @import("../link.zig");
+
+const BenchResult = bench_utils.BenchResult;
+const BenchStats = bench_utils.BenchStats;
+const EditBuffer = edit_buffer.EditBuffer;
+const EditorView = editor_view.EditorView;
+
+pub const benchName = "EditorView Visual Navigation";
+
+const calls_per_iteration = 10_000;
+
+fn appendResult(allocator: std.mem.Allocator, results: *std.ArrayListUnmanaged(BenchResult), name: []const u8, stats: BenchStats) !void {
+    try results.append(allocator, .{
+        .name = name,
+        .min_ns = stats.min_ns,
+        .avg_ns = stats.avg(),
+        .max_ns = stats.max_ns,
+        .total_ns = stats.total_ns,
+        .iterations = stats.count,
+        .mem_stats = null,
+    });
+}
+
+fn resetPrimaryCursor(eb: *EditBuffer, row: u32, col: u32, offset: u32) void {
+    eb.cursors.items[0] = .{
+        .row = row,
+        .col = col,
+        .desired_col = col,
+        .offset = offset,
+    };
+}
+
+fn keepAlive(checksum: u64) !void {
+    if (checksum == std.math.maxInt(u64)) return error.InvalidBenchmarkChecksum;
+}
+
+fn benchMoveDownBoundary(
+    allocator: std.mem.Allocator,
+    pool: *gp.GraphemePool,
+    link_pool: *link.LinkPool,
+    iterations: usize,
+    bench_filter: ?[]const u8,
+    results: *std.ArrayListUnmanaged(BenchResult),
+) !void {
+    const name = "moveDownVisual wrapped boundary: 10k calls";
+    if (!bench_utils.matchesBenchFilter(name, bench_filter)) return;
+
+    var eb = try EditBuffer.init(allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+    var ev = try EditorView.init(allocator, eb, 10, 10);
+    defer ev.deinit();
+
+    ev.setWrapMode(.word);
+    try eb.setText("0123456789\nquick brown fox");
+    _ = ev.getCachedLineInfo();
+
+    var stats: BenchStats = .{};
+    var checksum: u64 = 0;
+    for (0..iterations) |_| {
+        var timer = try std.time.Timer.start();
+        for (0..calls_per_iteration) |_| {
+            resetPrimaryCursor(eb, 0, 10, 10);
+            ev.desired_visual_col = null;
+            ev.moveDownVisual();
+            const cursor = eb.getPrimaryCursor();
+            checksum +%= cursor.row + cursor.col;
+        }
+        stats.record(timer.read());
+    }
+    try keepAlive(checksum);
+    try appendResult(allocator, results, name, stats);
+}
+
+fn benchMoveUpBoundary(
+    allocator: std.mem.Allocator,
+    pool: *gp.GraphemePool,
+    link_pool: *link.LinkPool,
+    iterations: usize,
+    bench_filter: ?[]const u8,
+    results: *std.ArrayListUnmanaged(BenchResult),
+) !void {
+    const name = "moveUpVisual wrapped boundary: 10k calls";
+    if (!bench_utils.matchesBenchFilter(name, bench_filter)) return;
+
+    const text = "quick brown fox";
+    var eb = try EditBuffer.init(allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+    var ev = try EditorView.init(allocator, eb, 10, 10);
+    defer ev.deinit();
+
+    ev.setWrapMode(.word);
+    try eb.setText(text);
+    _ = ev.getCachedLineInfo();
+
+    var stats: BenchStats = .{};
+    var checksum: u64 = 0;
+    for (0..iterations) |_| {
+        var timer = try std.time.Timer.start();
+        for (0..calls_per_iteration) |_| {
+            resetPrimaryCursor(eb, 0, text.len, @intCast(text.len));
+            ev.desired_visual_col = null;
+            ev.moveUpVisual();
+            const cursor = eb.getPrimaryCursor();
+            checksum +%= cursor.row + cursor.col;
+        }
+        stats.record(timer.read());
+    }
+    try keepAlive(checksum);
+    try appendResult(allocator, results, name, stats);
+}
+
+fn benchVisualEOLBoundary(
+    allocator: std.mem.Allocator,
+    pool: *gp.GraphemePool,
+    link_pool: *link.LinkPool,
+    iterations: usize,
+    bench_filter: ?[]const u8,
+    results: *std.ArrayListUnmanaged(BenchResult),
+) !void {
+    const name = "getVisualEOL wrapped boundary: 10k calls";
+    if (!bench_utils.matchesBenchFilter(name, bench_filter)) return;
+
+    var eb = try EditBuffer.init(allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+    var ev = try EditorView.init(allocator, eb, 10, 10);
+    defer ev.deinit();
+
+    ev.setWrapMode(.word);
+    try eb.setText("quick brown fox");
+    try eb.setCursor(0, 3);
+    _ = ev.getCachedLineInfo();
+
+    var stats: BenchStats = .{};
+    var checksum: u64 = 0;
+    for (0..iterations) |_| {
+        var timer = try std.time.Timer.start();
+        for (0..calls_per_iteration) |_| {
+            const cursor = ev.getVisualEOL();
+            checksum +%= cursor.visual_row + cursor.visual_col + cursor.logical_col;
+        }
+        stats.record(timer.read());
+    }
+    try keepAlive(checksum);
+    try appendResult(allocator, results, name, stats);
+}
+
+pub fn run(
+    allocator: std.mem.Allocator,
+    _: bool,
+    bench_filter: ?[]const u8,
+) ![]BenchResult {
+    const pool = gp.initGlobalPool(allocator);
+    const link_pool = link.initGlobalLinkPool(allocator);
+
+    var results: std.ArrayListUnmanaged(BenchResult) = .{};
+    errdefer results.deinit(allocator);
+
+    const iterations: usize = 20;
+    try benchMoveDownBoundary(allocator, pool, link_pool, iterations, bench_filter, &results);
+    try benchMoveUpBoundary(allocator, pool, link_pool, iterations, bench_filter, &results);
+    try benchVisualEOLBoundary(allocator, pool, link_pool, iterations, bench_filter, &results);
+
+    return results.toOwnedSlice(allocator);
+}

--- a/packages/core/src/zig/editor-view.zig
+++ b/packages/core/src/zig/editor-view.zig
@@ -525,13 +525,14 @@ pub const EditorView = struct {
         };
     }
 
-    fn clampVisualColToRequestedRow(self: *EditorView, visual_row: u32, visual_col: u32) u32 {
-        self.text_buffer_view.updateVirtualLines();
-        const vlines = self.text_buffer_view.virtual_lines.items;
+    fn clampVisualColToStayOnVisualRow(vlines: []const VirtualLine, visual_row: u32, visual_col: u32) u32 {
         if (visual_row >= vlines.len) return visual_col;
 
         const vline = &vlines[visual_row];
         var target_visual_col = @min(visual_col, vline.width_cols);
+
+        // A wrap boundary is also the start of the next visual line. Step back so
+        // logicalToVisualCursor does not canonicalize this target onto that line.
         if (target_visual_col == vline.width_cols and vline.width_cols > 0 and visual_row + 1 < vlines.len) {
             const next_vline = &vlines[visual_row + 1];
             if (next_vline.source_line == vline.source_line) {
@@ -557,7 +558,10 @@ pub const EditorView = struct {
             self.desired_visual_col = vcursor.visual_col;
         }
         const desired_visual_col = self.desired_visual_col.?;
-        const target_visual_col = self.clampVisualColToRequestedRow(target_visual_row, desired_visual_col);
+
+        // logicalToVisualCursor refreshed this snapshot; keep navigation on it.
+        const vlines = self.text_buffer_view.virtual_lines.items;
+        const target_visual_col = clampVisualColToStayOnVisualRow(vlines, target_visual_row, desired_visual_col);
 
         if (self.visualToLogicalCursor(target_visual_row, target_visual_col)) |new_vcursor| {
             if (self.edit_buffer.cursors.items.len > 0) {
@@ -579,7 +583,7 @@ pub const EditorView = struct {
         const cursor = self.edit_buffer.getPrimaryCursor();
         const vcursor = self.logicalToVisualCursor(cursor.row, cursor.col);
 
-        self.text_buffer_view.updateVirtualLines();
+        // logicalToVisualCursor refreshed this snapshot; keep navigation on it.
         const vlines = self.text_buffer_view.virtual_lines.items;
 
         if (vcursor.visual_row + 1 >= vlines.len) {
@@ -593,7 +597,7 @@ pub const EditorView = struct {
             self.desired_visual_col = vcursor.visual_col;
         }
         const desired_visual_col = self.desired_visual_col.?;
-        const target_visual_col = self.clampVisualColToRequestedRow(target_visual_row, desired_visual_col);
+        const target_visual_col = clampVisualColToStayOnVisualRow(vlines, target_visual_row, desired_visual_col);
 
         if (self.visualToLogicalCursor(target_visual_row, target_visual_col)) |new_vcursor| {
             if (self.edit_buffer.cursors.items.len > 0) {
@@ -665,7 +669,7 @@ pub const EditorView = struct {
         const cursor = self.edit_buffer.getPrimaryCursor();
         const vcursor = self.logicalToVisualCursor(cursor.row, cursor.col);
 
-        self.text_buffer_view.updateVirtualLines();
+        // logicalToVisualCursor refreshed this snapshot; keep SOL on the same row.
         const vlines = self.text_buffer_view.virtual_lines.items;
 
         if (vcursor.visual_row >= vlines.len) {
@@ -702,7 +706,7 @@ pub const EditorView = struct {
         const cursor = self.edit_buffer.getPrimaryCursor();
         const vcursor = self.logicalToVisualCursor(cursor.row, cursor.col);
 
-        self.text_buffer_view.updateVirtualLines();
+        // logicalToVisualCursor refreshed this snapshot; keep EOL on the same row.
         const vlines = self.text_buffer_view.virtual_lines.items;
 
         if (vcursor.visual_row >= vlines.len) {
@@ -712,32 +716,18 @@ pub const EditorView = struct {
         }
 
         const vline = &vlines[vcursor.visual_row];
+        const target_visual_col = clampVisualColToStayOnVisualRow(vlines, vcursor.visual_row, vline.width_cols);
         const logical_row = @as(u32, @intCast(vline.source_line));
+        const logical_col = vline.source_col_offset + target_visual_col;
+        const offset = iter_mod.coordsToOffset(self.edit_buffer.tb.rope(), logical_row, logical_col) orelse 0;
 
-        // Determine the logical column at the end of this visual line
-        var logical_col: u32 = undefined;
-        if (vcursor.visual_row + 1 < vlines.len) {
-            const next_vline = &vlines[vcursor.visual_row + 1];
-            if (next_vline.source_line == vline.source_line) {
-                // Next visual line is a continuation of the same logical line
-                // The wrap boundary is at next_vline.source_col_offset
-                // To stay on the current visual line, we need to be one position BEFORE the boundary
-                // However, if width is 0, just use the start position
-                if (vline.width_cols > 0) {
-                    logical_col = vline.source_col_offset + vline.width_cols - 1;
-                } else {
-                    logical_col = vline.source_col_offset;
-                }
-            } else {
-                // Next visual line is a different logical line, so we're at the end
-                logical_col = iter_mod.lineWidthAt(self.edit_buffer.tb.rope(), logical_row);
-            }
-        } else {
-            // This is the last visual line, use end of logical line
-            logical_col = iter_mod.lineWidthAt(self.edit_buffer.tb.rope(), logical_row);
-        }
-
-        return self.logicalToVisualCursor(logical_row, logical_col);
+        return .{
+            .visual_row = vcursor.visual_row,
+            .visual_col = target_visual_col,
+            .logical_row = logical_row,
+            .logical_col = logical_col,
+            .offset = offset,
+        };
     }
 
     // ============================================================================

--- a/packages/core/src/zig/editor-view.zig
+++ b/packages/core/src/zig/editor-view.zig
@@ -525,6 +525,23 @@ pub const EditorView = struct {
         };
     }
 
+    fn clampVisualColToRequestedRow(self: *EditorView, visual_row: u32, visual_col: u32) u32 {
+        self.text_buffer_view.updateVirtualLines();
+        const vlines = self.text_buffer_view.virtual_lines.items;
+        if (visual_row >= vlines.len) return visual_col;
+
+        const vline = &vlines[visual_row];
+        var target_visual_col = @min(visual_col, vline.width_cols);
+        if (target_visual_col == vline.width_cols and vline.width_cols > 0 and visual_row + 1 < vlines.len) {
+            const next_vline = &vlines[visual_row + 1];
+            if (next_vline.source_line == vline.source_line) {
+                target_visual_col = vline.width_cols - 1;
+            }
+        }
+
+        return target_visual_col;
+    }
+
     pub fn moveUpVisual(self: *EditorView) void {
         const cursor = self.edit_buffer.getPrimaryCursor();
         const vcursor = self.logicalToVisualCursor(cursor.row, cursor.col);
@@ -540,8 +557,9 @@ pub const EditorView = struct {
             self.desired_visual_col = vcursor.visual_col;
         }
         const desired_visual_col = self.desired_visual_col.?;
+        const target_visual_col = self.clampVisualColToRequestedRow(target_visual_row, desired_visual_col);
 
-        if (self.visualToLogicalCursor(target_visual_row, desired_visual_col)) |new_vcursor| {
+        if (self.visualToLogicalCursor(target_visual_row, target_visual_col)) |new_vcursor| {
             if (self.edit_buffer.cursors.items.len > 0) {
                 self.edit_buffer.cursors.items[0] = .{
                     .row = new_vcursor.logical_row,
@@ -575,8 +593,9 @@ pub const EditorView = struct {
             self.desired_visual_col = vcursor.visual_col;
         }
         const desired_visual_col = self.desired_visual_col.?;
+        const target_visual_col = self.clampVisualColToRequestedRow(target_visual_row, desired_visual_col);
 
-        if (self.visualToLogicalCursor(target_visual_row, desired_visual_col)) |new_vcursor| {
+        if (self.visualToLogicalCursor(target_visual_row, target_visual_col)) |new_vcursor| {
             if (self.edit_buffer.cursors.items.len > 0) {
                 self.edit_buffer.cursors.items[0] = .{
                     .row = new_vcursor.logical_row,

--- a/packages/core/src/zig/tests/editor-view_test.zig
+++ b/packages/core/src/zig/tests/editor-view_test.zig
@@ -603,6 +603,45 @@ test "EditorView - visualToLogicalCursor conversion" {
     }
 }
 
+test "EditorView - moveUpVisual resolves wrapped boundary with canonical conversion" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 10, 10);
+    defer ev.deinit();
+
+    ev.setWrapMode(.word);
+
+    const text = "quick brown fox";
+    try eb.setText(text);
+
+    const line_info = ev.getCachedLineInfo();
+    try std.testing.expectEqualSlices(u32, &[_]u32{ 6, 9 }, line_info.line_width_cols);
+
+    const canonical_boundary_cursor = ev.visualToLogicalCursor(0, 6) orelse return error.MissingVisualCursor;
+    try std.testing.expectEqual(@as(u32, 0), canonical_boundary_cursor.visual_row);
+    try std.testing.expectEqual(@as(u32, 6), canonical_boundary_cursor.visual_col);
+    try std.testing.expectEqual(@as(u32, 6), canonical_boundary_cursor.logical_col);
+
+    const canonical_cursor_from_boundary = ev.logicalToVisualCursor(canonical_boundary_cursor.logical_row, canonical_boundary_cursor.logical_col);
+    try std.testing.expectEqual(@as(u32, 1), canonical_cursor_from_boundary.visual_row);
+
+    try eb.setCursor(0, text.len);
+    var cursor = ev.getVisualCursor();
+    try std.testing.expectEqual(@as(u32, 1), cursor.visual_row);
+    try std.testing.expectEqual(@as(u32, 9), cursor.visual_col);
+
+    ev.moveUpVisual();
+    cursor = ev.getVisualCursor();
+    try std.testing.expectEqual(@as(u32, 0), cursor.visual_row);
+    try std.testing.expectEqual(@as(u32, 5), cursor.visual_col);
+}
+
 test "EditorView - moveUpVisual at top boundary" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/core/src/zig/tests/editor-view_test.zig
+++ b/packages/core/src/zig/tests/editor-view_test.zig
@@ -642,6 +642,36 @@ test "EditorView - moveUpVisual resolves wrapped boundary with canonical convers
     try std.testing.expectEqual(@as(u32, 5), cursor.visual_col);
 }
 
+test "EditorView - moveDownVisual resolves wrapped boundary with canonical conversion" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 10, 10);
+    defer ev.deinit();
+
+    ev.setWrapMode(.word);
+
+    try eb.setText("0123456789\nquick brown fox");
+
+    const line_info = ev.getCachedLineInfo();
+    try std.testing.expectEqualSlices(u32, &[_]u32{ 10, 6, 9 }, line_info.line_width_cols);
+
+    try eb.setCursor(0, 10);
+    var cursor = ev.getVisualCursor();
+    try std.testing.expectEqual(@as(u32, 0), cursor.visual_row);
+    try std.testing.expectEqual(@as(u32, 10), cursor.visual_col);
+
+    ev.moveDownVisual();
+    cursor = ev.getVisualCursor();
+    try std.testing.expectEqual(@as(u32, 1), cursor.visual_row);
+    try std.testing.expectEqual(@as(u32, 5), cursor.visual_col);
+}
+
 test "EditorView - moveUpVisual at top boundary" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();


### PR DESCRIPTION
### Bug: cursor could get stuck moving up across wrapped lines
```
quick brown fox
```
At width 10, word wrap produces:
```
quick 
brown fox
```
Moving up from the end of brown fox could resolve to the wrap boundary after "quick", which canonicalized back to the next visual line. The cursor appeared stuck instead of moving to the previous visual row.
### Cause
Vertical movement preserved the desired visual column, but when the target row was shorter, the clamped column could land exactly on a shared wrap boundary.
### Fix
Clamp the target visual column for Up/Down before converting it to a logical cursor.