### PR TITLE
fix native benchmark and smoke test 

### DIFF
--- a/.github/workflows/bench-native-smoke.yml
+++ b/.github/workflows/bench-native-smoke.yml
@@ -1,0 +1,66 @@
+name: Native Benchmark Smoke
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  BUN_VERSION: 1.3.13
+  ZIG_VERSION: 0.15.2
+
+jobs:
+  bench-native-smoke:
+    name: Native Benchmark Smoke
+    runs-on: macos-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run native benchmark smoke test
+        working-directory: packages/core
+        run: |
+          set -euo pipefail
+          output="$(bun run bench:native --mem --filter "UTF-8 Operations" --bench "isAsciiOnly: ASCII text (1KB)" --json)"
+          printf '%s\n' "$output"
+          OUTPUT="$output" bun -e '
+            const output = process.env.OUTPUT ?? ""
+            const lines = output.split(/\r?\n/)
+            let jsonLine = ""
+            for (let i = lines.length - 1; i >= 0; i--) {
+              const line = lines[i].trim()
+              if (line.startsWith("{")) {
+                jsonLine = line
+                break
+              }
+            }
+            if (!jsonLine) throw new Error("Native benchmark smoke test produced no JSON output")
+
+            const data = JSON.parse(jsonLine)
+            if (data.benchmark !== "UTF-8 Operations") {
+              throw new Error(`Unexpected benchmark category: ${data.benchmark}`)
+            }
+            if (!Array.isArray(data.results) || data.results.length !== 1) {
+              throw new Error(`Expected exactly one benchmark result, got ${data.results?.length ?? 0}`)
+            }
+            if (data.results[0].name !== "isAsciiOnly: ASCII text (1KB)") {
+              throw new Error(`Unexpected benchmark result: ${data.results[0].name}`)
+            }
+          '

--- a/packages/core/src/zig/build.zig
+++ b/packages/core/src/zig/build.zig
@@ -149,6 +149,24 @@ fn addMacOSSystemLibraries(b: *std.Build, artifact: *std.Build.Step.Compile, sdk
     addMacOSSDKSearchPaths(b, artifact, sdk_path);
 }
 
+fn addNativeAudioDependencies(
+    b: *std.Build,
+    artifact: *std.Build.Step.Compile,
+    target: std.Build.ResolvedTarget,
+    macos_sdk_path: ?[]const u8,
+) void {
+    addMiniaudioShim(b, artifact, target, macos_sdk_path);
+
+    switch (target.result.os.tag) {
+        .macos => addMacOSSystemLibraries(b, artifact, macos_sdk_path.?),
+        .linux => {
+            artifact.linkSystemLibrary("dl");
+            artifact.linkSystemLibrary("pthread");
+        },
+        else => {},
+    }
+}
+
 /// Apply dependencies to a module
 fn applyDependencies(
     b: *std.Build,
@@ -255,23 +273,11 @@ pub fn build(b: *std.Build) void {
         .use_llvm = debug_use_llvm,
     });
 
-    addMiniaudioShim(b, test_artifact, native_target, macos_sdk_path);
-
-    switch (native_target.result.os.tag) {
-        .macos => {
-            if (macos_sdk_path) |sdk_path| {
-                addMacOSSystemLibraries(b, test_artifact, sdk_path);
-            } else {
-                printMissingMacOSSDK("native macOS tests");
-                std.process.exit(1);
-            }
-        },
-        .linux => {
-            test_artifact.linkSystemLibrary("dl");
-            test_artifact.linkSystemLibrary("pthread");
-        },
-        else => {},
+    if (native_target.result.os.tag == .macos and macos_sdk_path == null) {
+        printMissingMacOSSDK("native macOS tests");
+        std.process.exit(1);
     }
+    addNativeAudioDependencies(b, test_artifact, native_target, macos_sdk_path);
 
     const run_test = b.addRunArtifact(test_artifact);
     test_step.dependOn(&run_test.step);
@@ -306,6 +312,11 @@ pub fn build(b: *std.Build) void {
         .root_module = bench_ffi_mod,
         .linkage = .dynamic,
     });
+    if (native_target.result.os.tag == .macos and macos_sdk_path == null) {
+        printMissingMacOSSDK("native macOS benchmark FFI library");
+        std.process.exit(1);
+    }
+    addNativeAudioDependencies(b, bench_ffi_lib, native_target, macos_sdk_path);
     const install_bench_ffi = b.addInstallArtifact(bench_ffi_lib, .{});
     bench_ffi_step.dependOn(&install_bench_ffi.step);
     bench_step.dependOn(bench_ffi_step);
@@ -436,18 +447,7 @@ fn buildTarget(
         .linkage = .dynamic,
     });
 
-    addMiniaudioShim(b, lib, target, macos_sdk_path);
-
-    switch (target.result.os.tag) {
-        .macos => {
-            addMacOSSystemLibraries(b, lib, macos_sdk_path.?);
-        },
-        .linux => {
-            lib.linkSystemLibrary("dl");
-            lib.linkSystemLibrary("pthread");
-        },
-        else => {},
-    }
+    addNativeAudioDependencies(b, lib, target, macos_sdk_path);
 
     const install_dir = b.addInstallArtifact(lib, .{
         .dest_dir = .{


### PR DESCRIPTION
- Link native audio dependencies into the native_span_feed_bench dylib
- Centralize miniaudio/platform library setup for native build artifacts
- Add a PR smoke workflow for bun run bench:native --mem