### PR TITLE
fix(core): skip (href) suffix for bare URLs in MarkdownRenderable conceal mode

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -456,12 +456,15 @@ export class MarkdownRenderable extends Renderable {
       case "link": {
         const linkHref = { url: token.href }
         if (this._conceal) {
+          const isBareUrl = token.text === token.href
           for (const child of token.tokens) {
             this.renderInlineTokenWithStyle(child as MarkedToken, chunks, "markup.link.label", linkHref)
           }
-          chunks.push(this.createChunk(" (", "markup.link", linkHref))
-          chunks.push(this.createChunk(token.href, "markup.link.url", linkHref))
-          chunks.push(this.createChunk(")", "markup.link", linkHref))
+          if (!isBareUrl) {
+            chunks.push(this.createChunk(" (", "markup.link", linkHref))
+            chunks.push(this.createChunk(token.href, "markup.link.url", linkHref))
+            chunks.push(this.createChunk(")", "markup.link", linkHref))
+          }
         } else {
           chunks.push(this.createChunk("[", "markup.link", linkHref))
           for (const child of token.tokens) {

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1661,6 +1661,29 @@ test("links with conceal mode", async () => {
   `)
 })
 
+test("bare URL link in conceal mode does not duplicate the href (#1050)", async () => {
+  const markdown = `Check https://github.com/anomalyco/opentui for details.`
+
+  const rendered = await renderMarkdown(markdown)
+  expect(rendered).toContain("https://github.com/anomalyco/opentui")
+  expect(rendered).not.toContain("(https://github.com/anomalyco/opentui)")
+})
+
+test("autolink <url> in conceal mode does not duplicate the href (#1050)", async () => {
+  const markdown = `Check <https://github.com/anomalyco/opentui> for details.`
+
+  const rendered = await renderMarkdown(markdown)
+  expect(rendered).toContain("https://github.com/anomalyco/opentui")
+  expect(rendered).not.toContain("(https://github.com/anomalyco/opentui)")
+})
+
+test("named link with conceal mode still shows (href) suffix (#1050)", async () => {
+  const markdown = `Check [opentui](https://github.com/anomalyco/opentui) for details.`
+
+  const rendered = await renderMarkdown(markdown)
+  expect(rendered).toContain("opentui (https://github.com/anomalyco/opentui)")
+})
+
 test("links with conceal=false", async () => {
   const markdown = `Check out [OpenTUI](https://github.com/sst/opentui) for more.`
 


### PR DESCRIPTION
Closes #1050.

## What changed

`renderInlineToken` always appended ` (href)` after the link label in conceal mode. For named links `[text](url)` that's correct, but for autolinks and gfm bare URLs the label already equals the href, so the URL was rendered twice as `url (url)`.

Guarded the suffix with `token.text === token.href` so bare URLs render once. Source change is in `packages/core/src/renderables/Markdown.ts`, +6/-3 lines.

## How I verified

`cd packages/core && bun test src/renderables/__tests__/Markdown.test.ts` — 135 pass, 0 fail, 80 snapshots. Three new assertions cover:

- bare URL (gfm autolink): `Check https://github.com/anomalyco/opentui for details.`
- explicit autolink: `<https://example.com>`
- named link `[text](url)` still shows ` (url)` suffix

`bunx oxfmt` applied to both files.
