### PR TITLE
test(core): lock in kitty numpad input handling in Textarea

### DIFF
--- a/packages/core/src/renderables/__tests__/Textarea.kitty-keypad.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.kitty-keypad.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test"
+import { createTestRenderer, type TestRenderer, type MockInput } from "../../testing/test-renderer.js"
+import { createTextareaRenderable } from "./renderable-test-utils.js"
+
+let currentRenderer: TestRenderer
+let renderOnce: () => Promise<void>
+let currentMockInput: MockInput
+
+describe("Textarea - Kitty keypad input (#1041)", () => {
+  beforeEach(async () => {
+    ;({
+      renderer: currentRenderer,
+      renderOnce,
+      mockInput: currentMockInput,
+    } = await createTestRenderer({
+      width: 80,
+      height: 24,
+      kittyKeyboard: true,
+    }))
+  })
+
+  afterEach(() => {
+    currentRenderer.destroy()
+  })
+
+  const emitKitty = async (codepoint: number): Promise<void> => {
+    currentRenderer.stdin.emit("data", Buffer.from(`\x1b[${codepoint}u`))
+    await renderOnce()
+  }
+
+  it.each([
+    [57399, "kp0", "0"],
+    [57400, "kp1", "1"],
+    [57401, "kp2", "2"],
+    [57402, "kp3", "3"],
+    [57403, "kp4", "4"],
+    [57404, "kp5", "5"],
+    [57405, "kp6", "6"],
+    [57406, "kp7", "7"],
+    [57407, "kp8", "8"],
+    [57408, "kp9", "9"],
+  ])("inserts digit when %s arrives as %s", async (codepoint, _name, expected) => {
+    const { textarea } = await createTextareaRenderable(currentRenderer, renderOnce, { width: 40, height: 4 })
+    textarea.focus()
+
+    await emitKitty(codepoint as number)
+
+    expect(textarea.plainText).toBe(expected as string)
+  })
+
+  it.each([
+    [57409, "kpdecimal", "."],
+    [57410, "kpdivide", "/"],
+    [57411, "kpmultiply", "*"],
+    [57412, "kpminus", "-"],
+    [57413, "kpplus", "+"],
+    [57415, "kpequal", "="],
+    [57416, "kpseparator", ","],
+  ])("inserts operator/symbol when %s arrives as %s", async (codepoint, _name, expected) => {
+    const { textarea } = await createTextareaRenderable(currentRenderer, renderOnce, { width: 40, height: 4 })
+    textarea.focus()
+
+    await emitKitty(codepoint as number)
+
+    expect(textarea.plainText).toBe(expected as string)
+  })
+
+  it("treats kpenter as a newline within the textarea", async () => {
+    const { textarea } = await createTextareaRenderable(currentRenderer, renderOnce, { width: 40, height: 4 })
+    textarea.focus()
+
+    currentMockInput.pressKey("a")
+    await renderOnce()
+    await emitKitty(57414) // kpenter
+    currentMockInput.pressKey("b")
+    await renderOnce()
+
+    expect(textarea.plainText).toBe("a\nb")
+  })
+
+  it("composes a multi-digit decimal across the full numpad", async () => {
+    const { textarea } = await createTextareaRenderable(currentRenderer, renderOnce, { width: 40, height: 4 })
+    textarea.focus()
+
+    // "3.14" via numpad
+    await emitKitty(57402) // kp3
+    await emitKitty(57409) // kpdecimal
+    await emitKitty(57400) // kp1
+    await emitKitty(57403) // kp4
+
+    expect(textarea.plainText).toBe("3.14")
+  })
+})


### PR DESCRIPTION
Closes #1041.

## What changed

The bug as reported (OpenTUI 0.2.5, numpad keys ignored in opencode TUI prompt) appears already resolved on current `main`. With kitty keyboard enabled, the parser at `parse.keypress-kitty.ts:434` populates `key.sequence` with the printable text for kp* keys via the `printableKeypadText` table, and `Textarea.handleKeyPress` already inserts `key.sequence` when no modifiers are held. The `kpenter` keybinding (`Textarea.ts:95`) maps to `"newline"`.

This PR is test-only — no source changes. It adds a regression test (`packages/core/src/renderables/__tests__/Textarea.kitty-keypad.test.ts`) so the working behavior doesn't quietly regress again.

Coverage:
- `kp0`–`kp9` insert the corresponding digit
- `kpdecimal`, `kpdivide`, `kpmultiply`, `kpminus`, `kpplus`, `kpequal`, `kpseparator` insert their printable character
- `kpenter` produces a newline (joins text across it as `"a\nb"`)
- Composing `"3.14"` entirely from the numpad round-trips correctly

## How I verified

`cd packages/core && bun test src/renderables/__tests__/Textarea.kitty-keypad.test.ts` — 19 pass, 0 fail. Each case writes the raw kitty CSI-u sequence (e.g. `\x1b[57404u` for kp5) onto `renderer.stdin` and asserts the resulting `textarea.plainText`.

`bunx oxfmt` applied to the new file.
