### PR TITLE
fix(console): handle kpplus and kpminus for resize keybindings

### DIFF
--- a/packages/core/src/console.test.ts
+++ b/packages/core/src/console.test.ts
@@ -119,6 +119,54 @@ describe("TerminalConsole", () => {
     })
   })
 
+  describe("Resize keypad bindings (#412)", () => {
+    test("kpplus increases sizePercent like +", () => {
+      terminalConsole = new TerminalConsole(mockRenderer as any, {
+        position: ConsolePosition.BOTTOM,
+        sizePercent: 30,
+      })
+
+      terminalConsole["handleKeyPress"]({ name: "kpplus", ctrl: false, shift: false, meta: false } as any)
+
+      expect(terminalConsole["options"].sizePercent).toBe(35)
+    })
+
+    test("kpminus decreases sizePercent like -", () => {
+      terminalConsole = new TerminalConsole(mockRenderer as any, {
+        position: ConsolePosition.BOTTOM,
+        sizePercent: 30,
+      })
+
+      terminalConsole["handleKeyPress"]({ name: "kpminus", ctrl: false, shift: false, meta: false } as any)
+
+      expect(terminalConsole["options"].sizePercent).toBe(25)
+    })
+
+    test("repeated kpplus presses cap at 100", () => {
+      terminalConsole = new TerminalConsole(mockRenderer as any, {
+        position: ConsolePosition.BOTTOM,
+        sizePercent: 95,
+      })
+
+      terminalConsole["handleKeyPress"]({ name: "kpplus", ctrl: false, shift: false, meta: false } as any)
+      terminalConsole["handleKeyPress"]({ name: "kpplus", ctrl: false, shift: false, meta: false } as any)
+
+      expect(terminalConsole["options"].sizePercent).toBe(100)
+    })
+
+    test("repeated kpminus presses floor at 10", () => {
+      terminalConsole = new TerminalConsole(mockRenderer as any, {
+        position: ConsolePosition.BOTTOM,
+        sizePercent: 15,
+      })
+
+      terminalConsole["handleKeyPress"]({ name: "kpminus", ctrl: false, shift: false, meta: false } as any)
+      terminalConsole["handleKeyPress"]({ name: "kpminus", ctrl: false, shift: false, meta: false } as any)
+
+      expect(terminalConsole["options"].sizePercent).toBe(10)
+    })
+  })
+
   describe("Console Selection", () => {
     test("should have no selection initially", () => {
       terminalConsole = new TerminalConsole(mockRenderer as any, {

--- a/packages/core/src/console.ts
+++ b/packages/core/src/console.ts
@@ -249,7 +249,9 @@ const defaultConsoleKeybindings: ConsoleKeyBinding[] = [
   { name: "o", ctrl: true, action: "position-next" },
   { name: "+", action: "size-increase" },
   { name: "=", shift: true, action: "size-increase" },
+  { name: "kpplus", action: "size-increase" },
   { name: "-", action: "size-decrease" },
+  { name: "kpminus", action: "size-decrease" },
   { name: "s", ctrl: true, action: "save-logs" },
   { name: "c", ctrl: true, shift: true, action: "copy-selection" },
 ]


### PR DESCRIPTION
Closes #412.

## What changed

`defaultConsoleKeybindings` in `packages/core/src/console.ts` listed `+` / Shift+`=` for `size-increase` and `-` for `size-decrease`, but ignored the numeric keypad equivalents. With kitty keyboard enabled, the parser produces `key.name = "kpplus"` / `"kpminus"` for those keys (not `"+"` / `"-"`), and the keybinding alias map (`defaultKeyAliases`) only normalizes _binding_ names in the forward direction (a binding declared as `kpplus` is also stored under `+`) — it doesn't reverse-alias _event_ names, so the existing `{name: "+"}` binding never matched a `kpplus` event.

Added explicit `kpplus` / `kpminus` entries, mirroring how `Textarea` registers its own keypad equivalent (`{name: "kpenter", action: "newline"}`):

```diff
   { name: "+", action: "size-increase" },
   { name: "=", shift: true, action: "size-increase" },
+  { name: "kpplus", action: "size-increase" },
   { name: "-", action: "size-decrease" },
+  { name: "kpminus", action: "size-decrease" },
```

Scope intentionally limited to what #412 calls out (resize keys). The same pattern exists for other console keypad equivalents (kpup/kpdown for scrolling), but those can land separately if desired.

## How I verified

Before the fix, dispatching `{name: "kpplus"}` to `TerminalConsole.handleKeyPress` left `sizePercent` unchanged. After the fix it tracks `+` exactly.

`cd packages/core && bun test src/console.test.ts` — 33 pass, 0 fail. Four new assertions cover kpplus increase, kpminus decrease, the 100% cap on repeated kpplus, and the 10% floor on repeated kpminus.

`bunx oxfmt` applied to both files.
