### PR TITLE
fix(core): guard add/insertBefore/remove against destroyed parents

### DIFF
--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -1175,6 +1175,13 @@ export abstract class Renderable extends BaseRenderable {
   }
 
   public add(obj: Renderable | VNode<any, any[]> | unknown, index?: number): number {
+    if (this._isDestroyed) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(`Renderable with id ${this.id} is destroyed, skipping add`)
+      }
+      return -1
+    }
+
     if (!obj) {
       return -1
     }
@@ -1229,6 +1236,13 @@ export abstract class Renderable extends BaseRenderable {
   }
 
   insertBefore(obj: Renderable | VNode<any, any[]> | unknown, anchor?: Renderable | unknown): number {
+    if (this._isDestroyed) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(`Renderable with id ${this.id} is destroyed, skipping insertBefore`)
+      }
+      return -1
+    }
+
     if (!anchor) {
       return this.add(obj)
     }
@@ -1313,6 +1327,10 @@ export abstract class Renderable extends BaseRenderable {
   }
 
   public remove(id: string): void {
+    if (this._isDestroyed) {
+      return
+    }
+
     if (!id) {
       return
     }

--- a/packages/core/src/tests/renderable.test.ts
+++ b/packages/core/src/tests/renderable.test.ts
@@ -414,6 +414,46 @@ describe("Renderable - Child Management", () => {
     expect(parent.getChildrenCount()).toBe(0)
   })
 
+  test("add on a destroyed parent is a no-op and does not crash Yoga (#733)", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const child = new TestRenderable(testRenderer, { id: "child" })
+    testRenderer.root.add(parent)
+
+    parent.destroy()
+
+    // Without the guard this throws "Out of bounds call_indirect" from Yoga wasm
+    // because parent.yogaNode.free() ran inside destroy().
+    const result = parent.add(child)
+    expect(result).toBe(-1)
+    expect(child.parent).toBeNull()
+  })
+
+  test("insertBefore on a destroyed parent is a no-op (#733)", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const anchor = new TestRenderable(testRenderer, { id: "anchor" })
+    const child = new TestRenderable(testRenderer, { id: "child" })
+    testRenderer.root.add(parent)
+    parent.add(anchor)
+
+    parent.destroy()
+
+    const result = parent.insertBefore(child, anchor)
+    expect(result).toBe(-1)
+    expect(child.parent).toBeNull()
+  })
+
+  test("remove on a destroyed parent is a no-op (#733)", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const child = new TestRenderable(testRenderer, { id: "child" })
+    testRenderer.root.add(parent)
+    parent.add(child)
+
+    parent.destroy()
+
+    // Should not throw even if some stale reconciler write reaches here.
+    expect(() => parent.remove("child")).not.toThrow()
+  })
+
   test("can change renderable id and updates parent mapping", () => {
     const parent = new TestRenderable(testRenderer, { id: "parent" })
     const child = new TestRenderable(testRenderer, { id: "child" })


### PR DESCRIPTION
Closes #733.

## What changed

`Renderable.destroy()` frees the underlying Yoga node via `this.yogaNode.free()`. If a stale reconciler write later calls `add`, `insertBefore`, or `remove` on that destroyed parent, control reaches `this.yogaNode.insertChild(...)` / `removeChild(...)` against the freed handle and Yoga's wasm runtime traps with:

```
RuntimeError: Out of bounds call_indirect (evaluating 'd.apply(null, p)')
```

The reporter hit this in `@opentui/solid` under fork-panel close + async update flows (parent destroyed first, then a queued insert/remove fires on the freed handle).

The existing guards already short-circuit when the **child** or **anchor** is destroyed — this PR adds the symmetric `this._isDestroyed` guard at the top of `add`, `insertBefore`, and `remove`. `remove` was actually safe by accident (the `renderableMapById` is cleared inside `destroy()` so the inner block is skipped), but the explicit guard prevents that invariant from silently disappearing later.

Dev-mode warning text matches the existing destroyed-child path.

## How I verified

Minimal repro before the fix (`BoxRenderable`, parent → root, `parent.destroy()`, then `parent.add(child)`) crashed with `Out of bounds call_indirect`. After the fix it returns `-1` and logs the dev warning.

`cd packages/core && bun test src/tests/renderable.test.ts` — 67 pass, 0 fail. Three new assertions cover `add`, `insertBefore`, and `remove` on a destroyed parent.

`bunx oxfmt` applied to both files.
