### PR TITLE
fix(solid): remove unwired onKeyPress prop from TextareaProps

### DIFF
--- a/packages/solid/src/types/elements.ts
+++ b/packages/solid/src/types/elements.ts
@@ -134,7 +134,6 @@ export type TextareaProps = ComponentProps<TextareaOptions, TextareaRenderable> 
   onContentChange?: (value: string) => void
   onCursorChange?: (value: { line: number; visualColumn: number }) => void
   onKeyDown?: (event: KeyEvent) => void
-  onKeyPress?: (event: KeyEvent) => void
 }
 
 export type SelectProps = ComponentProps<SelectRenderableOptions, SelectRenderable> & {


### PR DESCRIPTION
Closes #481.

## What changed

`TextareaProps` in `packages/solid/src/types/elements.ts` declared `onKeyPress?: (event: KeyEvent) => void`, but it was never wired anywhere:

- The Solid reconciler (`packages/solid/src/reconciler.ts`) has explicit cases for `onChange`, `onInput`, `onSubmit`, `onSelect`, then a default that does `node[name] = value`. There is no setter for `onKeyPress` on `Renderable` (only `onKeyDown` at `Renderable.ts:1640`), so the assignment is silent dead storage.
- Core's `Renderable.focus()` only dispatches `_keyListeners["down"]?.(key)` — the `_keyListeners` map is typed `Partial<Record<"down", …>>`, so there is no "press" slot to fire.

Users had a TypeScript-happy handler that never ran. The React adapter (`packages/react/src/types/components.ts`) already only declares `onKeyDown`, so this brings Solid in line.

Reporter's option 1 ("Remove the type definition — breaking change, but honest").

## Alternative considered

Implementing it as a synonym for `onKeyDown` in the Solid reconciler would create a footgun: if a user has both `onKeyDown` and `onKeyPress`, whichever wins the reconciler's prop iteration overwrites the other. Worse than current state for that case.

True `onKeyPress` semantics (distinct from `onKeyDown` — e.g. fire only on printable keys, or fire only after `keydown` but before `keyrelease`) would require:

1. Widening `_keyListeners` in core to include `"press"` and dispatching from the focus-time keypress handler
2. Adding `onKeyPress` setter/getter on `Renderable`
3. Updating both Solid and React adapter types in sync
4. Documenting the difference vs `onKeyDown`

That is a feature, not a fix for the silently-dead type, so it belongs in a separate PR.

## How I verified

- `cd packages/solid && bun test tests/` — 256 pass, 0 fail
- Type check on the touched file: no diagnostics introduced
- Grep confirms no remaining `onKeyPress` references inside `packages/solid/src/`

`bunx oxfmt` applied.
