### PR TITLE
fix(core): reschedule when requestRender races the loop scheduling

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -4009,6 +4009,18 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.rendering = false
       if (this._destroyPending) {
         this.finalizeDestroy()
+      } else if (this.immediateRerenderRequested) {
+        // A requestRender() that fired during the in-flight frame, after the
+        // scheduling decision above, was demoted to just setting this flag
+        // (because `this.rendering` was still true at the time). Without
+        // this re-issue the loop can silently stall. Defer via setImmediate
+        // so the eventual requestRender() runs after activateFrame's own
+        // finally has cleared `updateScheduled` — otherwise the request
+        // would be dropped at the `!updateScheduled` guard. See #789.
+        this.immediateRerenderRequested = false
+        setImmediate(() => {
+          if (!this._isDestroyed) this.requestRender()
+        })
       }
       this.resolveIdleIfNeeded()
     }

--- a/packages/core/src/tests/renderer.control.test.ts
+++ b/packages/core/src/tests/renderer.control.test.ts
@@ -197,6 +197,56 @@ test("requestRender() does trigger when renderer is paused", async () => {
   renderer.renderNative = originalRender
 })
 
+test("loop() finally reschedules when requestRender races the schedule decision (#789)", async () => {
+  // Drive the renderer in paused mode so it does NOT auto-loop. Each requestRender()
+  // schedules a one-off frame, and at the end of that frame the scheduler hits the
+  // else-branch (clearTimeout + renderTimeout = null) because _isRunning is false
+  // and immediateRerenderRequested is false. That is the exact path where a sync
+  // requestRender() between line 4005 (renderTimeout = null) and line 4009
+  // (this.rendering = false) is lost.
+  renderer.start()
+  await Bun.sleep(20)
+  renderer.pause()
+
+  let renderCount = 0
+  // @ts-expect-error - renderNative is private
+  const originalRender = renderer.renderNative.bind(renderer)
+  // @ts-expect-error - renderNative is private
+  renderer.renderNative = () => {
+    renderCount++
+    return originalRender()
+  }
+
+  // Inject a sync requestRender() right when the loop is clearing the
+  // (already-elapsed) renderTimeout in the else branch. At that point
+  // `this.rendering` is still true, so requestRender() only sets the flag.
+  // Without the fix, finally then sets rendering=false and the request is
+  // dropped. With the fix, finally re-issues it.
+  const clock = (renderer as any).clock
+  const originalClearTimeout = clock.clearTimeout.bind(clock)
+  let injected = false
+  clock.clearTimeout = (id: unknown) => {
+    if (!injected && (renderer as any).rendering) {
+      injected = true
+      renderer.requestRender()
+    }
+    return originalClearTimeout(id)
+  }
+
+  renderer.requestRender()
+  await Bun.sleep(60)
+
+  clock.clearTimeout = originalClearTimeout
+  // @ts-expect-error - renderNative is private
+  renderer.renderNative = originalRender
+
+  expect(injected).toBe(true)
+  // Without the finally fix: only the initial requested frame renders (count=1)
+  // because the injected requestRender's flag is dropped when rendering=false.
+  // With the fix: finally re-issues, producing at least a second frame.
+  expect(renderCount).toBeGreaterThanOrEqual(2)
+})
+
 test("auto() transitions running renderer to AUTO_STARTED state", () => {
   renderer.start()
   expect(renderer.controlState).toBe(RendererControlState.EXPLICIT_STARTED)


### PR DESCRIPTION
Closes #789.

## What changed

If `requestRender()` fires while a frame is in flight (`this.rendering` is true), it is demoted to setting `immediateRerenderRequested` and returns. The loop's end-of-frame schedule decision at `renderer.ts:3995` reads that flag and reschedules, but a request that arrives between that read and `this.rendering = false` in the finally block is dropped: the read already happened, and after the finally the renderer goes idle with no pending timer.

The reporter's RCA in #789 describes the symptom: blank screen with `rendering=false scheduled=false running=false`, the process otherwise healthy, modals still rendering on top — the next paint never fires.

The fix re-checks `immediateRerenderRequested` inside the loop's finally, clears it, and re-issues the request via `setImmediate`.

```diff
   } finally {
     this.rendering = false
     if (this._destroyPending) {
       this.finalizeDestroy()
+    } else if (this.immediateRerenderRequested) {
+      this.immediateRerenderRequested = false
+      setImmediate(() => {
+        if (!this._isDestroyed) this.requestRender()
+      })
     }
     this.resolveIdleIfNeeded()
   }
```

### Why `setImmediate` (not `nextTick`)

On the one-off (paused / idle) scheduling path, `activateFrame` keeps `updateScheduled = true` until its own finally runs, and that finally runs **after** `loop()`'s finally. `process.nextTick` fires before microtasks resume, which means it runs before `activateFrame`'s finally — at which point `requestRender()` is blocked by the `!updateScheduled` guard at line 1247 and silently no-ops. `setImmediate` runs after the microtask queue drains, by which point `updateScheduled` is back to false and the request schedules normally.

## How I verified

`cd packages/core && bun test src/tests/renderer.control.test.ts` — 29 pass, 0 fail. New test "loop() finally reschedules when requestRender races the schedule decision (#789)" exercises the one-off path:

1. Start + pause renderer
2. Monkey-patch `clock.clearTimeout` (called in the loop's else branch at line 4004) to fire a sync `requestRender()` while `rendering` is still true
3. Assert `renderCount >= 2`

Confirmed the test **fails without the fix** (`Received: 1`) and **passes with it** by reverting `renderer.ts` and re-running.

Also ran the broader `bun test src/tests/renderer*` sweep — 408 pass, 0 fail. `bunx oxfmt` applied.
