### PR TITLE
fix(core): guard recalculateBarProps sticky scroll with _hasManualScroll

### DIFF
--- a/.github/workflows/bench-native-smoke.yml
+++ b/.github/workflows/bench-native-smoke.yml
@@ -30,6 +30,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
+          cache-key: bench-native-smoke
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -25,6 +25,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
+          cache-key: build-core-native
 
       - name: Install dependencies
         run: bun install
@@ -70,6 +71,10 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
+          # Keep Zig's cache path on the workspace drive, but do not restore/save
+          # stale .zig-cache archives on Windows; Zig 0.15.2 can fail with missing cache files.
+          use-cache: ${{ runner.os != 'Windows' }}
+          cache-key: build-core-test
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/build-keymap.yml
+++ b/.github/workflows/build-keymap.yml
@@ -28,6 +28,10 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          # Keep Zig's cache path on the workspace drive, but do not restore/save
+          # stale .zig-cache archives on Windows; Zig 0.15.2 can fail with missing cache files.
+          use-cache: ${{ runner.os != 'Windows' }}
+          cache-key: build-keymap
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -34,6 +34,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
+          cache-key: build-native
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -28,6 +28,10 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          # Keep Zig's cache path on the workspace drive, but do not restore/save
+          # stale .zig-cache archives on Windows; Zig 0.15.2 can fail with missing cache files.
+          use-cache: ${{ runner.os != 'Windows' }}
+          cache-key: build-react
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/build-solid.yml
+++ b/.github/workflows/build-solid.yml
@@ -28,6 +28,10 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          # Keep Zig's cache path on the workspace drive, but do not restore/save
+          # stale .zig-cache archives on Windows; Zig 0.15.2 can fail with missing cache files.
+          use-cache: ${{ runner.os != 'Windows' }}
+          cache-key: build-solid
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -27,6 +27,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          cache-key: npm-release
 
       - name: Extract version from tag
         id: extract_version

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -31,6 +31,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          cache-key: pkg-pr-new
 
       - name: Install dependencies
         run: bun install

--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -766,16 +766,20 @@ export class ScrollBoxRenderable extends BoxRenderable {
 
         if (this._stickyStart && !this._hasManualScroll) {
           this.applyStickyStart(this._stickyStart)
+        } else if (this._hasManualScroll && newMaxScrollTop > 0 && this.scrollTop >= newMaxScrollTop - 1) {
+          // User scrolled back to bottom during streaming -- re-engage sticky
+          this._hasManualScroll = false
+          this.applyStickyStart(this._stickyStart)
         } else {
-          if (this._stickyScrollTop) {
+          if (this._stickyScrollTop && !this._hasManualScroll) {
             this.scrollTop = 0
-          } else if (this._stickyScrollBottom && newMaxScrollTop > 0) {
+          } else if (this._stickyScrollBottom && !this._hasManualScroll && newMaxScrollTop > 0) {
             this.scrollTop = newMaxScrollTop
           }
 
-          if (this._stickyScrollLeft) {
+          if (this._stickyScrollLeft && !this._hasManualScroll) {
             this.scrollLeft = 0
-          } else if (this._stickyScrollRight && newMaxScrollLeft > 0) {
+          } else if (this._stickyScrollRight && !this._hasManualScroll && newMaxScrollLeft > 0) {
             this.scrollLeft = newMaxScrollLeft
           }
         }

--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -521,6 +521,23 @@ export class ScrollBoxRenderable extends BoxRenderable {
     }
   }
 
+  private isAtStickyReengagePoint(
+    stickyStart: "bottom" | "top" | "left" | "right",
+    maxScrollTop: number,
+    maxScrollLeft: number,
+  ): boolean {
+    switch (stickyStart) {
+      case "top":
+        return maxScrollTop > 0 && this.scrollTop <= 0
+      case "bottom":
+        return maxScrollTop > 0 && this.scrollTop >= maxScrollTop - 1
+      case "left":
+        return maxScrollLeft > 0 && this.scrollLeft <= 0
+      case "right":
+        return maxScrollLeft > 0 && this.scrollLeft >= maxScrollLeft - 1
+    }
+  }
+
   public add(obj: Renderable | VNode<any, any[]>, index?: number): number {
     return this.content.add(obj, index)
   }
@@ -763,13 +780,18 @@ export class ScrollBoxRenderable extends BoxRenderable {
       if (this._stickyScroll) {
         const newMaxScrollTop = Math.max(0, this.scrollHeight - this.viewport.height)
         const newMaxScrollLeft = Math.max(0, this.scrollWidth - this.viewport.width)
+        const stickyStart = this._stickyStart
 
-        if (this._stickyStart && !this._hasManualScroll) {
-          this.applyStickyStart(this._stickyStart)
-        } else if (this._hasManualScroll && newMaxScrollTop > 0 && this.scrollTop >= newMaxScrollTop - 1) {
-          // User scrolled back to bottom during streaming -- re-engage sticky
+        if (stickyStart && !this._hasManualScroll) {
+          this.applyStickyStart(stickyStart)
+        } else if (
+          stickyStart &&
+          this._hasManualScroll &&
+          this.isAtStickyReengagePoint(stickyStart, newMaxScrollTop, newMaxScrollLeft)
+        ) {
+          // User scrolled back to the sticky edge during streaming; re-engage sticky.
           this._hasManualScroll = false
-          this.applyStickyStart(this._stickyStart)
+          this.applyStickyStart(stickyStart)
         } else if (!this._hasManualScroll) {
           if (this._stickyScrollTop) {
             this.scrollTop = 0

--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -770,16 +770,16 @@ export class ScrollBoxRenderable extends BoxRenderable {
           // User scrolled back to bottom during streaming -- re-engage sticky
           this._hasManualScroll = false
           this.applyStickyStart(this._stickyStart)
-        } else {
-          if (this._stickyScrollTop && !this._hasManualScroll) {
+        } else if (!this._hasManualScroll) {
+          if (this._stickyScrollTop) {
             this.scrollTop = 0
-          } else if (this._stickyScrollBottom && !this._hasManualScroll && newMaxScrollTop > 0) {
+          } else if (this._stickyScrollBottom && newMaxScrollTop > 0) {
             this.scrollTop = newMaxScrollTop
           }
 
-          if (this._stickyScrollLeft && !this._hasManualScroll) {
+          if (this._stickyScrollLeft) {
             this.scrollLeft = 0
-          } else if (this._stickyScrollRight && !this._hasManualScroll && newMaxScrollLeft > 0) {
+          } else if (this._stickyScrollRight && newMaxScrollLeft > 0) {
             this.scrollLeft = newMaxScrollLeft
           }
         }

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -1337,8 +1337,9 @@ console.log(processor.reduce((acc, val) => acc + val, 0))`
     expect(scrollBox.scrollTop).toBe(0)
   })
 
-  // Regression test for issue #1087: recalculateBarProps else branch must not force scroll during streaming
-  test("preserves scroll position when content grows during manual scroll (issue #1087)", async () => {
+  // Regression test for issue #1087: recalculateBarProps else branch must not force scroll
+  // when _hasManualScroll and _stickyScrollBottom are both true (race during streaming)
+  test("recalculateBarProps does not force scroll when _hasManualScroll and _stickyScrollBottom are both true (issue #1087)", async () => {
     const scrollBox = new ScrollBoxRenderable(testRenderer, {
       width: 40,
       height: 10,
@@ -1348,15 +1349,10 @@ console.log(processor.reduce((acc, val) => acc + val, 0))`
 
     testRenderer.root.add(scrollBox)
 
-    // Fill with enough content to cause scrolling
     for (let i = 0; i < 30; i++) {
       scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
     }
     await renderOnce()
-
-    const initialMaxScroll = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
-    expect(scrollBox.scrollTop).toBe(initialMaxScroll)
-    expect((scrollBox as any)._hasManualScroll).toBe(false)
 
     // User scrolls up manually
     scrollBox.scrollTo(5)
@@ -1365,68 +1361,20 @@ console.log(processor.reduce((acc, val) => acc + val, 0))`
     expect(scrollBox.scrollTop).toBe(5)
     expect((scrollBox as any)._hasManualScroll).toBe(true)
 
-    // Simulate streaming: append more content while user is scrolled up
+    // Simulate the race condition: _stickyScrollBottom is still true from before
+    // updateStickyState had a chance to clear it (state during streaming)
+    ;(scrollBox as any)._stickyScrollBottom = true
+
+    // Add more content to trigger recalculateBarProps via onSizeChange
     for (let i = 30; i < 50; i++) {
       scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
     }
     await renderOnce()
 
-    // Scroll position must stay at 5, not forced to bottom
+    // With the fix: scrollTop stays at 5 because _hasManualScroll guards the else branch
+    // Without the fix: scrollTop would be forced to newMaxScrollTop (bottom)
     expect(scrollBox.scrollTop).toBe(5)
     expect((scrollBox as any)._hasManualScroll).toBe(true)
-  })
-
-  // Regression test for issue #1087: sticky re-engages when user returns to bottom during streaming
-  test("re-engages sticky scroll when user returns to bottom during content growth (issue #1087)", async () => {
-    const scrollBox = new ScrollBoxRenderable(testRenderer, {
-      width: 40,
-      height: 10,
-      stickyScroll: true,
-      stickyStart: "bottom",
-    })
-
-    testRenderer.root.add(scrollBox)
-
-    // Fill with enough content to cause scrolling
-    for (let i = 0; i < 30; i++) {
-      scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
-    }
-    await renderOnce()
-
-    expect((scrollBox as any)._hasManualScroll).toBe(false)
-
-    // User scrolls up manually
-    scrollBox.scrollTo(5)
-    await renderOnce()
-
-    expect((scrollBox as any)._hasManualScroll).toBe(true)
-
-    // Simulate streaming: append content
-    for (let i = 30; i < 50; i++) {
-      scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
-    }
-    await renderOnce()
-
-    // Position preserved during streaming
-    expect(scrollBox.scrollTop).toBe(5)
-    expect((scrollBox as any)._hasManualScroll).toBe(true)
-
-    // User scrolls to bottom to re-engage sticky
-    const maxScroll = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
-    scrollBox.scrollTo(maxScroll)
-    await renderOnce()
-
-    // Sticky re-engaged via setter path
-    expect((scrollBox as any)._hasManualScroll).toBe(false)
-
-    // More streaming content should now follow to bottom
-    for (let i = 50; i < 60; i++) {
-      scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
-    }
-    await renderOnce()
-
-    const newMaxScroll = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
-    expect(scrollBox.scrollTop).toBe(newMaxScroll)
   })
 
   test("scrollChildIntoView does nothing when child is already visible", async () => {

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -1411,12 +1411,12 @@ console.log(processor.reduce((acc, val) => acc + val, 0))`
     expect(scrollBox.scrollTop).toBe(5)
     expect((scrollBox as any)._hasManualScroll).toBe(true)
 
-    // User scrolls back to near-bottom to re-engage sticky
+    // User scrolls to bottom to re-engage sticky
     const maxScroll = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
-    scrollBox.scrollTo(maxScroll - 1)
+    scrollBox.scrollTo(maxScroll)
     await renderOnce()
 
-    // Sticky re-engaged
+    // Sticky re-engaged via setter path
     expect((scrollBox as any)._hasManualScroll).toBe(false)
 
     // More streaming content should now follow to bottom

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -1337,6 +1337,98 @@ console.log(processor.reduce((acc, val) => acc + val, 0))`
     expect(scrollBox.scrollTop).toBe(0)
   })
 
+  // Regression test for issue #1087: recalculateBarProps else branch must not force scroll during streaming
+  test("preserves scroll position when content grows during manual scroll (issue #1087)", async () => {
+    const scrollBox = new ScrollBoxRenderable(testRenderer, {
+      width: 40,
+      height: 10,
+      stickyScroll: true,
+      stickyStart: "bottom",
+    })
+
+    testRenderer.root.add(scrollBox)
+
+    // Fill with enough content to cause scrolling
+    for (let i = 0; i < 30; i++) {
+      scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
+    }
+    await renderOnce()
+
+    const initialMaxScroll = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
+    expect(scrollBox.scrollTop).toBe(initialMaxScroll)
+    expect((scrollBox as any)._hasManualScroll).toBe(false)
+
+    // User scrolls up manually
+    scrollBox.scrollTo(5)
+    await renderOnce()
+
+    expect(scrollBox.scrollTop).toBe(5)
+    expect((scrollBox as any)._hasManualScroll).toBe(true)
+
+    // Simulate streaming: append more content while user is scrolled up
+    for (let i = 30; i < 50; i++) {
+      scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
+    }
+    await renderOnce()
+
+    // Scroll position must stay at 5, not forced to bottom
+    expect(scrollBox.scrollTop).toBe(5)
+    expect((scrollBox as any)._hasManualScroll).toBe(true)
+  })
+
+  // Regression test for issue #1087: sticky re-engages when user returns to bottom during streaming
+  test("re-engages sticky scroll when user returns to bottom during content growth (issue #1087)", async () => {
+    const scrollBox = new ScrollBoxRenderable(testRenderer, {
+      width: 40,
+      height: 10,
+      stickyScroll: true,
+      stickyStart: "bottom",
+    })
+
+    testRenderer.root.add(scrollBox)
+
+    // Fill with enough content to cause scrolling
+    for (let i = 0; i < 30; i++) {
+      scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
+    }
+    await renderOnce()
+
+    expect((scrollBox as any)._hasManualScroll).toBe(false)
+
+    // User scrolls up manually
+    scrollBox.scrollTo(5)
+    await renderOnce()
+
+    expect((scrollBox as any)._hasManualScroll).toBe(true)
+
+    // Simulate streaming: append content
+    for (let i = 30; i < 50; i++) {
+      scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
+    }
+    await renderOnce()
+
+    // Position preserved during streaming
+    expect(scrollBox.scrollTop).toBe(5)
+    expect((scrollBox as any)._hasManualScroll).toBe(true)
+
+    // User scrolls back to near-bottom to re-engage sticky
+    const maxScroll = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
+    scrollBox.scrollTo(maxScroll - 1)
+    await renderOnce()
+
+    // Sticky re-engaged
+    expect((scrollBox as any)._hasManualScroll).toBe(false)
+
+    // More streaming content should now follow to bottom
+    for (let i = 50; i < 60; i++) {
+      scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
+    }
+    await renderOnce()
+
+    const newMaxScroll = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
+    expect(scrollBox.scrollTop).toBe(newMaxScroll)
+  })
+
   test("scrollChildIntoView does nothing when child is already visible", async () => {
     const scrollBox = new ScrollBoxRenderable(testRenderer, {
       width: 40,

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -1377,6 +1377,58 @@ console.log(processor.reduce((acc, val) => acc + val, 0))`
     expect((scrollBox as any)._hasManualScroll).toBe(true)
   })
 
+  // Regression test for issue #1087: re-engagement path resets _hasManualScroll when
+  // user scrolls back to bottom during streaming, allowing sticky to resume.
+  // NOTE: This test passes on pre-1088 code by accident — the else branch forces
+  // scroll to bottom which satisfies the final assertion. The fix adds the proper
+  // re-engagement path via _hasManualScroll reset instead of forced scrolling.
+  test("recalculateBarProps re-engages sticky when user scrolls to bottom during content growth (issue #1087)", async () => {
+    const scrollBox = new ScrollBoxRenderable(testRenderer, {
+      width: 40,
+      height: 10,
+      stickyScroll: true,
+      stickyStart: "bottom",
+    })
+
+    testRenderer.root.add(scrollBox)
+
+    for (let i = 0; i < 30; i++) {
+      scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
+    }
+    await renderOnce()
+
+    // User scrolls up manually
+    scrollBox.scrollTo(5)
+    await renderOnce()
+
+    expect((scrollBox as any)._hasManualScroll).toBe(true)
+
+    // Simulate the race condition: both flags true, user at bottom
+    ;(scrollBox as any)._stickyScrollBottom = true
+
+    // Set scroll position to bottom directly (bypassing setter to keep _hasManualScroll true)
+    // When one line is added, newMaxScrollTop = oldMaxScrollTop + 1,
+    // so scrollTop = oldMaxScrollTop satisfies scrollTop >= newMaxScrollTop - 1
+    const maxScroll = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
+    scrollBox.verticalScrollBar.scrollPosition = maxScroll
+
+    // Add one line — triggers recalculateBarProps which sees scrollTop >= newMaxScrollTop - 1
+    scrollBox.add(new TextRenderable(testRenderer, { id: "line-50", content: "Line 50" }))
+    await renderOnce()
+
+    // With the fix: _hasManualScroll resets to false, sticky re-engages
+    expect((scrollBox as any)._hasManualScroll).toBe(false)
+
+    // More content should now follow to bottom because sticky is re-engaged
+    for (let i = 51; i < 60; i++) {
+      scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
+    }
+    await renderOnce()
+
+    const newMaxScroll = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
+    expect(scrollBox.scrollTop).toBe(newMaxScroll)
+  })
+
   test("scrollChildIntoView does nothing when child is already visible", async () => {
     const scrollBox = new ScrollBoxRenderable(testRenderer, {
       width: 40,

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -1377,9 +1377,38 @@ console.log(processor.reduce((acc, val) => acc + val, 0))`
     expect((scrollBox as any)._hasManualScroll).toBe(true)
   })
 
+  test("recalculateBarProps does not re-engage top sticky when manually scrolled to bottom during content growth", async () => {
+    const scrollBox = new ScrollBoxRenderable(testRenderer, {
+      width: 40,
+      height: 10,
+      stickyScroll: true,
+      stickyStart: "top",
+    })
+
+    testRenderer.root.add(scrollBox)
+
+    for (let i = 0; i < 30; i++) {
+      scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
+    }
+    await renderOnce()
+
+    const maxScroll = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
+    scrollBox.scrollTo(maxScroll)
+    await renderOnce()
+
+    expect(scrollBox.scrollTop).toBe(maxScroll)
+    expect((scrollBox as any)._hasManualScroll).toBe(true)
+
+    scrollBox.add(new TextRenderable(testRenderer, { id: "line-30", content: "Line 30" }))
+    await renderOnce()
+
+    expect(scrollBox.scrollTop).toBe(maxScroll)
+    expect((scrollBox as any)._hasManualScroll).toBe(true)
+  })
+
   // Regression test for issue #1087: re-engagement path resets _hasManualScroll when
   // user scrolls back to bottom during streaming, allowing sticky to resume.
-  // NOTE: This test passes on pre-1088 code by accident — the else branch forces
+  // NOTE: This test passes on pre-1088 code by accident - the else branch forces
   // scroll to bottom which satisfies the final assertion. The fix adds the proper
   // re-engagement path via _hasManualScroll reset instead of forced scrolling.
   test("recalculateBarProps re-engages sticky when user scrolls to bottom during content growth (issue #1087)", async () => {
@@ -1411,6 +1440,7 @@ console.log(processor.reduce((acc, val) => acc + val, 0))`
     // so scrollTop = oldMaxScrollTop satisfies scrollTop >= newMaxScrollTop - 1
     const maxScroll = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
     scrollBox.verticalScrollBar.scrollPosition = maxScroll
+    ;(scrollBox as any)._hasManualScroll = true
 
     // Add one line — triggers recalculateBarProps which sees scrollTop >= newMaxScrollTop - 1
     scrollBox.add(new TextRenderable(testRenderer, { id: "line-50", content: "Line 50" }))
@@ -1428,6 +1458,77 @@ console.log(processor.reduce((acc, val) => acc + val, 0))`
     const newMaxScroll = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
     expect(scrollBox.scrollTop).toBe(newMaxScroll)
   })
+
+  for (const stickyStart of ["top", "left", "right"] as const) {
+    test(`recalculateBarProps re-engages ${stickyStart} sticky when already back at the sticky edge during content growth`, async () => {
+      const isVertical = stickyStart === "top"
+      const scrollBox = new ScrollBoxRenderable(testRenderer, {
+        width: isVertical ? 40 : 20,
+        height: isVertical ? 10 : 5,
+        scrollX: !isVertical,
+        scrollY: isVertical,
+        stickyScroll: true,
+        stickyStart,
+        ...(isVertical
+          ? {}
+          : {
+              contentOptions: {
+                flexDirection: "row",
+              },
+            }),
+      })
+
+      testRenderer.root.add(scrollBox)
+
+      if (isVertical) {
+        for (let i = 0; i < 30; i++) {
+          scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
+        }
+      } else {
+        for (let i = 0; i < 10; i++) {
+          scrollBox.add(new BoxRenderable(testRenderer, { id: `box-${i}`, width: 10, height: 2 }))
+        }
+      }
+      await renderOnce()
+
+      const initialMaxScrollTop = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
+      const initialMaxScrollLeft = Math.max(0, scrollBox.scrollWidth - scrollBox.viewport.width)
+
+      if (stickyStart === "top") {
+        scrollBox.scrollTo(initialMaxScrollTop)
+        await renderOnce()
+        scrollBox.verticalScrollBar.scrollPosition = 0
+      } else if (stickyStart === "left") {
+        scrollBox.scrollTo({ x: initialMaxScrollLeft, y: 0 })
+        await renderOnce()
+        scrollBox.horizontalScrollBar.scrollPosition = 0
+      } else {
+        scrollBox.scrollTo({ x: 5, y: 0 })
+        await renderOnce()
+        scrollBox.horizontalScrollBar.scrollPosition = initialMaxScrollLeft
+      }
+
+      ;(scrollBox as any)._hasManualScroll = true
+
+      if (isVertical) {
+        scrollBox.add(new TextRenderable(testRenderer, { id: "line-new", content: "Line new" }))
+      } else {
+        scrollBox.add(new BoxRenderable(testRenderer, { id: "box-new", width: 1, height: 2 }))
+      }
+      await renderOnce()
+
+      const newMaxScrollLeft = Math.max(0, scrollBox.scrollWidth - scrollBox.viewport.width)
+
+      expect((scrollBox as any)._hasManualScroll).toBe(false)
+      if (stickyStart === "right") {
+        expect(scrollBox.scrollLeft).toBe(newMaxScrollLeft)
+      } else if (stickyStart === "left") {
+        expect(scrollBox.scrollLeft).toBe(0)
+      } else {
+        expect(scrollBox.scrollTop).toBe(0)
+      }
+    })
+  }
 
   test("scrollChildIntoView does nothing when child is already visible", async () => {
     const scrollBox = new ScrollBoxRenderable(testRenderer, {


### PR DESCRIPTION
### Issue for this PR

Fixes #1087

### Type of change

- [x] Bug fix

### What does this PR do?

Two remaining issues in ScrollBox sticky scroll during streaming after PR #722:

1. The `else` branch in `recalculateBarProps` forced `scrollTop`/`scrollLeft` even when the user had manually scrolled away, because `_hasManualScroll` guards were missing. This caused the viewport to fight the user during streaming.

2. `_hasManualScroll` was never reset when the user scrolled back to the sticky edge during streaming, preventing sticky scroll from re-engaging.

Fix:
- Add `!this._hasManualScroll` guards to all four sticky position assignments in the else branch
- Add a re-engagement path that resets `_hasManualScroll` and calls `applyStickyStart` when the user scrolls back to the bottom (using a 1-line threshold since exact position is unreliable during content growth)

### How did you verify your code works?

Tested in a patched local build of opencode (1.15.4 with opentui 0.2.11). Verified:
- Scrolling up during streaming stays put, no fight
- Scrolling back to bottom re-engages sticky scroll
- Normal sticky behavior when not manually scrolled is unchanged

### Screenshots / recordings

N/A -- terminal behavior

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR