### PR TITLE
fix(core): make TextNodeRenderable reject message actionable for nested <text>

### DIFF
--- a/packages/core/src/renderables/TextNode.test.ts
+++ b/packages/core/src/renderables/TextNode.test.ts
@@ -154,7 +154,29 @@ describe("TextNodeRenderable", () => {
 
       expect(() => {
         node.add(invalidChild as any, 0)
-      }).toThrow("TextNodeRenderable only accepts strings, TextNodeRenderable instances, or StyledText instances")
+      }).toThrow(/TextNodeRenderable only accepts strings, TextNodeRenderable instances/)
+    })
+
+    it("should hint at <span> when a nested <text> (rootTextNode-bearing object) is added (#438)", () => {
+      const node = new TextNodeRenderable({})
+      // Duck-typed stand-in for a TextRenderable, which carries an inline
+      // content tree on `.rootTextNode`.
+      const fakeBlockText = { rootTextNode: new TextNodeRenderable({}) }
+
+      expect(() => {
+        node.add(fakeBlockText as any)
+      }).toThrow(/<text> \(block\) — use <span>/)
+    })
+
+    it("should hint at <span> when a nested <text> is passed to insertBefore (#438)", () => {
+      const parent = new TextNodeRenderable({})
+      const anchor = new TextNodeRenderable({})
+      parent.add(anchor)
+      const fakeBlockText = { rootTextNode: new TextNodeRenderable({}) }
+
+      expect(() => {
+        parent.insertBefore(fakeBlockText as any, anchor)
+      }).toThrow(/<text> \(block\) — use <span>/)
     })
 
     it("should add StyledText child using add method", () => {

--- a/packages/core/src/renderables/TextNode.ts
+++ b/packages/core/src/renderables/TextNode.ts
@@ -18,6 +18,30 @@ export function isTextNodeRenderable(obj: any): obj is TextNodeRenderable {
   return !!obj?.[BrandedTextNodeRenderable]
 }
 
+function describeRejectedChild(obj: unknown): string {
+  if (obj === null) return "null"
+  if (obj === undefined) return "undefined"
+  if (typeof obj !== "object") return typeof obj
+
+  // Block-text renderable (e.g. <text>) keeps its inline content under .rootTextNode.
+  // Nesting <text> inside <text> is the most common mistake and deserves a hint
+  // pointing at the inline-styling tags that actually work here.
+  if ("rootTextNode" in obj && isTextNodeRenderable((obj as { rootTextNode: unknown }).rootTextNode)) {
+    return "<text> (block) — use <span>/<b>/<i>/<u>/<a> for inline styling inside <text>"
+  }
+
+  const ctorName = (obj as { constructor?: { name?: string } }).constructor?.name
+  return ctorName ?? "unknown object"
+}
+
+function rejectChildMessage(obj: unknown): string {
+  return (
+    "TextNodeRenderable only accepts strings, TextNodeRenderable instances " +
+    "(e.g. <span>, <b>, <i>, <u>, <a>), or StyledText instances. " +
+    `Received: ${describeRejectedChild(obj)}`
+  )
+}
+
 function styledTextToTextNodes(styledText: StyledText): TextNodeRenderable[] {
   return styledText.chunks.map((chunk) => {
     const node = new TextNodeRenderable({
@@ -109,7 +133,7 @@ export class TextNodeRenderable extends BaseRenderable {
       return insertIndex
     }
 
-    throw new Error("TextNodeRenderable only accepts strings, TextNodeRenderable instances, or StyledText instances")
+    throw new Error(rejectChildMessage(obj))
   }
 
   public replace(obj: TextNodeRenderable | string, index: number) {
@@ -143,7 +167,7 @@ export class TextNodeRenderable extends BaseRenderable {
       this._children.splice(anchorIndex, 0, ...textNodes)
       textNodes.forEach((node) => (node.parent = this))
     } else {
-      throw new Error("Child must be a string, TextNodeRenderable, or StyledText instance")
+      throw new Error(rejectChildMessage(child))
     }
 
     this.requestRender()


### PR DESCRIPTION
Closes #438.

## What changed

`<text>` maps to `TextRenderable`, which is a **block** renderable. Its inline content lives on `this.rootTextNode` (a `TextNodeRenderable`). When users nest `<text>` inside `<text>` — the natural reflex for inline styling — the React/Solid host calls `outer.rootTextNode.add(innerTextRenderable)` and hits the catch-all throw in `TextNodeRenderable.add()`:

```
TextNodeRenderable only accepts strings, TextNodeRenderable instances, or StyledText instances
```

That message tells the user *nothing* about how to get the layout they actually wanted. The right tools already exist — `<span>`, `<b>`, `<i>`, `<u>`, `<a>` are all `TextNodeRenderable` subclasses and *do* nest inside `<text>`.

This PR replaces both rejection throws (`add` and `insertBefore`) with a small helper that names what was actually passed and, when the value looks like a block-text renderable (has a `.rootTextNode`), hints at the inline-styling tags the user almost certainly meant:

```
TextNodeRenderable only accepts strings, TextNodeRenderable instances
(e.g. <span>, <b>, <i>, <u>, <a>), or StyledText instances.
Received: <text> (block) — use <span>/<b>/<i>/<u>/<a> for inline styling inside <text>
```

## Why not allow nested `<text>`?

`<text>` participates in block layout (yoga node, frame buffer). Re-parenting one inside another's inline tree would require either inlining its content (breaking React/Solid identity for the inner node, so reactive updates would break) or carrying it through as an embedded sub-tree (a significant new code path with sub-layout semantics). The smallest fix that resolves the reporter's confusion is to make the error point at the inline-styling tags they should use today.

## How I verified

`cd packages/core && bun test src/renderables/TextNode.test.ts` — 54 pass, 0 fail. The existing rejection test now matches a regex; two new tests assert the `<text>` hint fires on both `add()` and `insertBefore()`.

Live repro confirmed: instantiating `TextRenderable` directly and adding another `TextRenderable` produces the new helpful message.

`bunx oxfmt` applied.
