### PR TITLE
docs(react): clarify <input> onChange vs onInput semantics and test the controlled-component pattern

### DIFF
--- a/packages/react/src/types/components.ts
+++ b/packages/react/src/types/components.ts
@@ -140,7 +140,22 @@ export type BoxProps = ComponentProps<ContainerProps<BoxOptions>, BoxRenderable>
 
 export type InputProps = ComponentProps<InputRenderableOptions, InputRenderable> & {
   focused?: boolean
+  /**
+   * Fires on every keystroke with the current input text.
+   *
+   * **Use this — not `onChange` — for the React-style controlled-component
+   * pattern** (`<input value={state} onInput={setState} />`). `onChange`
+   * follows native-HTML semantics (only fires on blur), so a controlled
+   * `<input>` driven by `onChange` will desync the moment the user types
+   * — see issue #726.
+   */
   onInput?: (value: string) => void
+  /**
+   * Fires when the input loses focus *and* its value changed since focus,
+   * matching native HTML `<input onchange>` semantics (NOT React web's
+   * per-keystroke `onChange`). For controlled-component / two-way binding
+   * use `onInput` instead — see issue #726.
+   */
   onChange?: (value: string) => void
   onSubmit?: (value: string) => void
 }

--- a/packages/react/tests/input-controlled.test.tsx
+++ b/packages/react/tests/input-controlled.test.tsx
@@ -1,0 +1,125 @@
+import { afterEach, beforeAll, afterAll, describe, expect, it, mock } from "bun:test"
+import { useEffect, useState } from "react"
+import { act } from "react"
+import { testRender } from "../src/test-utils.js"
+
+let testSetup: Awaited<ReturnType<typeof testRender>>
+
+describe("React Renderer | <input> controlled-component patterns (#726)", () => {
+  let originalConsoleError: (...args: any[]) => void
+
+  beforeAll(() => {
+    originalConsoleError = console.error
+    console.error = mock(() => {})
+  })
+
+  afterAll(() => {
+    console.error = originalConsoleError
+  })
+
+  afterEach(() => {
+    if (testSetup) {
+      testSetup.renderer.destroy()
+    }
+  })
+
+  it("setState that changes value re-renders and syncs the input", async () => {
+    let setExternally!: (s: string) => void
+    function App() {
+      const [value, setValue] = useState("hello")
+      useEffect(() => {
+        setExternally = setValue
+      }, [])
+      return <input value={value} onChange={() => {}} />
+    }
+
+    testSetup = await testRender(<App />, { width: 40, height: 5 })
+    await testSetup.renderOnce()
+
+    await act(async () => {
+      setExternally("")
+    })
+    await testSetup.renderOnce()
+
+    const input = testSetup.renderer.root.getChildren()[0] as any
+    expect(input.value).toBe("")
+  })
+
+  it("`onChange` is HTML-style (blur), not React-web style (per-keystroke) — typing desyncs a controlled input", async () => {
+    let setExternally!: (s: string) => void
+    let changeFired = 0
+
+    function App() {
+      const [value, setValue] = useState("")
+      useEffect(() => {
+        setExternally = setValue
+      }, [])
+      return (
+        <input
+          value={value}
+          onChange={() => {
+            changeFired++
+          }}
+          focused
+        />
+      )
+    }
+
+    testSetup = await testRender(<App />, { width: 40, height: 5 })
+    await testSetup.renderOnce()
+
+    // User types — input.value visually becomes "abc", but state stays ""
+    // because onChange (= HTML's `change`, blur-only) hasn't fired yet.
+    testSetup.mockInput.pressKey("a")
+    testSetup.mockInput.pressKey("b")
+    testSetup.mockInput.pressKey("c")
+    await testSetup.renderOnce()
+
+    const input = testSetup.renderer.root.getChildren()[0] as any
+    expect(input.value).toBe("abc")
+    expect(changeFired).toBe(0) // onChange hasn't fired — no blur yet
+
+    // Programmatic clear: state stays "" → "", React skips re-render → desync.
+    await act(async () => {
+      setExternally("")
+    })
+    await testSetup.renderOnce()
+
+    // The input still shows "abc" — the documented gotcha from #726.
+    expect(input.value).toBe("abc")
+  })
+
+  it("`onInput` keeps a controlled input in sync per keystroke (the React-web pattern)", async () => {
+    let setExternally!: (s: string) => void
+
+    function App() {
+      const [value, setValue] = useState("")
+      useEffect(() => {
+        setExternally = setValue
+      }, [])
+      return <input value={value} onInput={(v: string) => setValue(v)} focused />
+    }
+
+    testSetup = await testRender(<App />, { width: 40, height: 5 })
+    await testSetup.renderOnce()
+
+    await act(async () => {
+      testSetup.mockInput.pressKey("a")
+      testSetup.mockInput.pressKey("b")
+      testSetup.mockInput.pressKey("c")
+    })
+    await testSetup.renderOnce()
+
+    const input = testSetup.renderer.root.getChildren()[0] as any
+    expect(input.value).toBe("abc")
+
+    // State is now "abc" too, so setExternally("") actually triggers a
+    // re-render and the value prop drives the input back to "".
+    await act(async () => {
+      setExternally("")
+    })
+    await testSetup.renderOnce()
+
+    expect(input.value).toBe("")
+  })
+})


### PR DESCRIPTION
Closes #726.

## What changed

The reporter wired a controlled input as `<input value={value} onChange={setValue} />` (the React-web idiom) and was surprised that programmatic `setValue('')` didn't always clear the field after the user had typed into it.

That desync **is** the documented behavior of opentui's `onChange`, but the API surface didn't make it discoverable. Both events already exist in the React adapter:

- **`onChange`** — fires on blur with the final committed value (native HTML `<input onchange>` semantics).
- **`onInput`** — fires on every keystroke with the current value (React-web's `<input onChange>` semantics, i.e. the *controlled-component* prop).

The footgun is that React devs reach for `onChange` because that's what they know from web React, but in opentui that one waits for blur, so internal state never matches what the user typed until they tab out. A later `setState('')` is then a state-equal no-op and React skips the re-render — the input visually keeps whatever was typed.

This PR is documentation-only:

1. **`packages/react/src/types/components.ts`** — Adds JSDoc on `InputProps.onChange` and `InputProps.onInput` explicitly contrasting the two with React-web semantics, and pointing controlled-component users at `onInput`.
2. **`packages/react/tests/input-controlled.test.tsx`** — New test file with three regressions:
   - State-changing `setState` re-renders and syncs the input.
   - The `onChange` desync (typing 'abc' with state at `""`, then `setExternally('')` — input still shows `"abc"`). This is the exact gotcha from #726.
   - `onInput` keeps the controlled pattern in sync per keystroke, and a later `setExternally('')` actually clears the input.

No behavior change. If you'd prefer to *also* align the React adapter's `onChange` with React-web (per-keystroke), the one-line follow-up is to swap `InputRenderableEvents.CHANGE` → `InputRenderableEvents.INPUT` in `packages/react/src/utils/index.ts:53` — but that breaks anyone relying on the current blur-only behavior, so I left the call open for the maintainers.

## How I verified

`cd packages/react && bun test tests/` — 52 pass, 0 fail (3 new assertions added in `input-controlled.test.tsx`).

Reproduction confirmed before writing the test: typing into a `<input value=... onChange=...>` and then calling `setExternally('')` left the input showing `"abc"`.

`bunx oxfmt` applied.
