### PR TITLE
fix(core/markdown): collapse loose-list gap before nested lists

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -694,10 +694,8 @@ export class MarkdownRenderable extends Renderable {
       }
       const renderable = this.createListChildRenderable(child, `${input.id}-child-${index}`)
       if (!renderable) continue
-      if (pendingMarginTop > 0) {
-        renderable.marginTop = pendingMarginTop
-        pendingMarginTop = 0
-      }
+      renderable.marginTop = child.type === "list" ? 0 : pendingMarginTop
+      pendingMarginTop = 0
       content.add(renderable)
     }
 
@@ -744,11 +742,13 @@ export class MarkdownRenderable extends Renderable {
       const existing = children[childIndex]
       const childId = `${id}-child-${tokenIndex}`
 
+      const marginTop = token.type === "list" ? 0 : pendingMarginTop
+      pendingMarginTop = 0
+
       if (!existing) {
         const renderable = this.createListChildRenderable(token, childId)
         if (!renderable) return false
-        renderable.marginTop = pendingMarginTop
-        pendingMarginTop = 0
+        renderable.marginTop = marginTop
         content.add(renderable, childIndex)
         childIndex += 1
         continue
@@ -757,8 +757,7 @@ export class MarkdownRenderable extends Renderable {
       if (!this.applyListChildRenderable(existing, token, previousTokens[childIndex], childId)) {
         return false
       }
-      existing.marginTop = pendingMarginTop
-      pendingMarginTop = 0
+      existing.marginTop = marginTop
       childIndex += 1
     }
 

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -3636,3 +3636,32 @@ test("paragraph updates do not flash raw markdown markers", async () => {
   expect(finalFrame).toContain("Second value")
   expect(finalFrame).not.toContain("**Second**")
 })
+
+test("top-level list does not insert blank line before nested list when source has blank line", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-list-blank-before-nested",
+    content: `- Added t topic edit mode in TUI:
+
+  - t focuses input with current topic
+  - enter saves via daemon /topic
+  - esc cancels
+- Topic is now shown prominently near the top of the TUI.`,
+    syntaxStyle,
+    internalBlockMode: "top-level",
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    - Added t topic edit mode in TUI:
+      - t focuses input with current topic
+      - enter saves via daemon /topic
+      - esc cancels
+    - Topic is now shown prominently near the top of the TUI."
+  `)
+})


### PR DESCRIPTION
## Summary

When a list item contains a blank line between its text and a nested list, `marked` emits a `space` token inside the parent item. The renderer was turning that into `marginTop: 1` on the next child unconditionally — producing a visible blank line above the nested list:

```md
- Added t topic edit mode in TUI:

  - t focuses input with current topic
  - enter saves via daemon /topic
  - esc cancels
- Topic is now shown prominently near the top of the TUI.
```

Before:
```
- Added t topic edit mode in TUI:

  - t focuses input with current topic
  - enter saves via daemon /topic
  - esc cancels
- Topic is now shown prominently near the top of the TUI.
```

After:
```
- Added t topic edit mode in TUI:
  - t focuses input with current topic
  - enter saves via daemon /topic
  - esc cancels
- Topic is now shown prominently near the top of the TUI.
```

This matches HTML rendering of the same source — browsers do not put a top margin on a nested `<ul>` / `<ol>`, even when the outer list is loose. LLM-generated chat output frequently leaves a blank line after parent items (especially when the parent ends with `:`), and the spurious gap looked like a renderer bug.

## Change

In `createListItemRenderable` and `applyListItemChildren`, suppress the pending `marginTop` only when the next child is itself a `list` token. Other loose-item spacing — sibling paragraphs, fenced code blocks — still gets its blank line.

## Test plan

- [x] New snapshot test: `top-level list does not insert blank line before nested list when source has blank line`
- [x] All 137 existing Markdown tests still pass, including the loose-list-with-code snapshot at `Markdown.test.ts:1127` (blank line before a code block inside a list item is preserved)