### PR TITLE
fix(utf8): treat U+26A0 as width 1 per UAX #11

### DIFF
--- a/packages/core/src/zig/tests/unicode-width-map.zon
+++ b/packages/core/src/zig/tests/unicode-width-map.zon
@@ -1830,7 +1830,7 @@
     .{ .codepoint = "U+269D", .width = 1 },
     .{ .codepoint = "U+269E", .width = 1 },
     .{ .codepoint = "U+269F", .width = 1 },
-    .{ .codepoint = "U+26A0", .width = 2 },
+    .{ .codepoint = "U+26A0", .width = 1 },
     .{ .codepoint = "U+26A1", .width = 2 },
     .{ .codepoint = "U+26A2", .width = 1 },
     .{ .codepoint = "U+26A3", .width = 1 },

--- a/packages/core/src/zig/tests/utf8_test.zig
+++ b/packages/core/src/zig/tests/utf8_test.zig
@@ -2304,9 +2304,12 @@ test "calculateTextWidth: Devanagari नमस्ते width 4" {
 // UNICODE WARNING SIGNS WIDTH TESTS
 // ============================================================================
 
-test "calculateTextWidth: U+26A0 warning sign should be width 2" {
+test "calculateTextWidth: U+26A0 warning sign should be width 1" {
+    // U+26A0 has EAW=N (Neutral) and Emoji_Presentation=No per UAX #11 /
+    // UTS #51. Without an explicit VS16 (U+FE0F) selector, its default
+    // presentation is text → 1 cell.
     const result = utf8.calculateTextWidth("⚠", 4, false, .unicode);
-    try testing.expectEqual(@as(u32, 2), result);
+    try testing.expectEqual(@as(u32, 1), result);
 }
 
 test "calculateTextWidth: U+2049 exclamation question mark should be width 2" {

--- a/packages/core/src/zig/utf8.zig
+++ b/packages/core/src/zig/utf8.zig
@@ -672,7 +672,6 @@ inline fn eawToWidth(cp: u21, eaw: uucode.types.EastAsianWidth) i16 {
     if (cp >= 0x2630 and cp <= 0x2637) return 2;
     if (cp >= 0x2648 and cp <= 0x2653) return 2;
     if (cp == 0x267F or cp == 0x2693 or cp == 0x269B) return 2;
-    if (cp == 0x26A0 or cp == 0x26A1) return 2;
     if (cp >= 0x26AA and cp <= 0x26AB) return 2;
     if (cp >= 0x26BD and cp <= 0x26BE) return 2;
     if (cp >= 0x26C4 and cp <= 0x26C5) return 2;


### PR DESCRIPTION
[DerivedEastAsianWidth](https://www.unicode.org/Public/16.0.0/ucd/extracted/DerivedEastAsianWidth.txt) classifies U+26A0 WARNING SIGN as N (Neutral). It appears in emoji-data.txt as Emoji=Yes but Emoji_Presentation=No, so by UTS #51 its default presentation is text (emoji presentation requires VS16, U+FE0F). The hardcoded override in eawToWidth contradicts both and causes a +1-cell drift in column accounting after bare ⚠, which misaligns any downstream fixed-column content on the same row (e.g.  tmux pane borders).

```
26A0          ; N # So       WARNING SIGN
```

The removed line also covered U+26A1, but that codepoint keeps width 2 via the earlier EAW=W check, so behavior there is unchanged.

Before (note misaligned right-side tmux pane border):

<img width="1075" height="702" alt="caution-before" src="https://github.com/user-attachments/assets/ba881b8f-b837-44ff-8d11-b5083fcd4544" />

After:

<img width="1084" height="709" alt="caution-after" src="https://github.com/user-attachments/assets/4b370a95-8b5c-442f-87f3-4683a5784165" />

(These are screenshots of Codex CLI running in auto-review mode.)