### PR TITLE
core(renderer): add resize-reset for split-footer

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -204,6 +204,26 @@ export type ScreenMode = "alternate-screen" | "main-screen" | "split-footer"
 // - "passthrough": Leave stdout alone.
 export type ExternalOutputMode = "capture-stdout" | "passthrough"
 
+export interface SplitFooterResizeResetEvent {
+  phase: "burst-start" | "burst-update" | "settle" | "cancel"
+  previousTerminalWidth: number
+  previousTerminalHeight: number
+  targetTerminalWidth: number
+  targetTerminalHeight: number
+  debounceDelay: number
+  verticalDelta?: number
+  scrollLines?: number
+  footerTopLine?: number
+  upperHeight?: number
+  terminalCleared?: boolean
+  renderWidth?: number
+  renderHeight?: number
+  renderOffset?: number
+  forcedFullRepaint?: boolean
+  pendingOutputCommits?: number
+  reason?: string
+}
+
 // Controls the built-in console overlay:
 //
 // - "console-overlay": Capture `console.*` output and show the overlay.
@@ -325,6 +345,22 @@ type PendingSplitFooterTransition = {
   targetTopLine: number
   targetHeight: number
   scrollLines?: number
+}
+
+type SplitFooterResizeResetState = "idle" | "resize_reset_active" | "resize_reset_settle"
+
+type SplitFooterResizeResetSurfaceState = {
+  footerTopLine: number
+  upperHeight: number
+  verticalDelta: number
+  terminalCleared: boolean
+}
+
+type ApplyTerminalResizeGeometryOptions = {
+  resetSplitScrollback?: boolean
+  forceFullRepaint?: boolean
+  emitResize?: boolean
+  requestRender?: boolean
 }
 
 class ExternalOutputQueue {
@@ -655,6 +691,7 @@ export async function createCliRenderer(config: CliRendererConfig = {}): Promise
 
 export enum CliRenderEvents {
   RESIZE = "resize",
+  SPLIT_FOOTER_RESIZE_RESET = "splitFooter:resizeReset",
   FOCUS = "focus",
   BLUR = "blur",
   FOCUSED_RENDERABLE = "focused_renderable",
@@ -775,6 +812,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private _screenMode: ScreenMode = "alternate-screen"
   private _footerHeight: number = DEFAULT_FOOTER_HEIGHT
   private _externalOutputMode: ExternalOutputMode = "passthrough"
+  private splitFooterResizeResetState: SplitFooterResizeResetState = "idle"
+  private pendingSplitFooterResizeResetDimensions: { width: number; height: number } | null = null
+  private splitFooterResizeResetViewportHeight: number | null = null
   private clearOnShutdown: boolean = true
   private _suspendedMouseEnabled: boolean = false
   private _previousControlState: RendererControlState = RendererControlState.IDLE
@@ -963,7 +1003,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     ]
 
     this.clipboard = new Clipboard(this.lib, this.rendererPtr)
-    this.resizeDebounceDelay = config.debounceDelay || 100
+    this.debounceDelay = config.debounceDelay ?? 100
     this.targetFps = config.targetFps || 30
     this.maxFps = config.maxFps || 60
     this.clock = config.clock ?? new SystemClock()
@@ -1419,6 +1459,18 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     return this._externalOutputMode
   }
 
+  public get debounceDelay(): number {
+    return this.resizeDebounceDelay
+  }
+
+  public set debounceDelay(debounceDelay: number) {
+    if (!Number.isFinite(debounceDelay)) {
+      throw new Error("debounceDelay must be a finite number")
+    }
+
+    this.resizeDebounceDelay = Math.max(0, Math.trunc(debounceDelay))
+  }
+
   public set externalOutputMode(mode: ExternalOutputMode) {
     if (mode === "capture-stdout" && this.screenMode !== "split-footer") {
       throw new Error('externalOutputMode "capture-stdout" requires screenMode "split-footer"')
@@ -1430,6 +1482,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
         this.pendingExternalOutputMode = null
       }
       return
+    }
+
+    if (previousMode === "capture-stdout" && mode === "passthrough" && this.isSplitFooterResizeResetPending()) {
+      this.cancelSplitFooterResizeReset("output-mode-change")
     }
 
     const canFlushSplitOutputBeforeTransition = this.canFlushSplitOutputBeforeTransition()
@@ -1454,6 +1510,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   private applyExternalOutputMode(mode: ExternalOutputMode): void {
+    if (mode !== "capture-stdout") {
+      this.cancelSplitFooterResizeReset("output-mode-change")
+    }
+
     this._externalOutputMode = mode
     this.stdout.write = mode === "capture-stdout" ? this.interceptStdoutWrite : this.realStdoutWrite
   }
@@ -2406,6 +2466,270 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.lib.clearPendingSplitFooterTransition(this.rendererPtr)
   }
 
+  private shouldUseSplitFooterResizeReset(): boolean {
+    return this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout" && this._splitHeight > 0
+  }
+
+  private isSplitFooterResizeResetPending(): boolean {
+    return this.splitFooterResizeResetState !== "idle"
+  }
+
+  private emitSplitFooterResizeResetEvent(event: SplitFooterResizeResetEvent): void {
+    this.emit(CliRenderEvents.SPLIT_FOOTER_RESIZE_RESET, event)
+  }
+
+  private applyTerminalResizeGeometry(
+    width: number,
+    height: number,
+    options: ApplyTerminalResizeGeometryOptions = {},
+  ): void {
+    this._terminalWidth = width
+    this._terminalHeight = height
+    this.queryPixelResolution()
+
+    this.setCapturedRenderable(undefined)
+    this.stdinParser?.resetMouseState()
+
+    const nextGeometry = calculateRenderGeometry(
+      this._screenMode,
+      this._terminalWidth,
+      this._terminalHeight,
+      this._footerHeight,
+    )
+
+    this.clearPendingSplitFooterTransition()
+
+    this._splitHeight = nextGeometry.effectiveFooterHeight
+    this.width = nextGeometry.renderWidth
+    this.height = nextGeometry.renderHeight
+
+    this.lib.resizeRenderer(this.rendererPtr, this.width, this.height)
+
+    if (this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout") {
+      if (options.resetSplitScrollback ?? false) {
+        this.resetSplitScrollback(0)
+      } else {
+        this.syncSplitScrollback()
+      }
+    } else {
+      this.syncSplitFooterState()
+    }
+
+    this.nextRenderBuffer = this.lib.getNextBuffer(this.rendererPtr)
+    this.currentRenderBuffer = this.lib.getCurrentBuffer(this.rendererPtr)
+    this.currentRenderBuffer.clear(this.backgroundColor)
+    this.nextRenderBuffer.clear(this.backgroundColor)
+    this._console.resize(this.width, this.height)
+    this.root.resize(this.width, this.height)
+
+    if (options.forceFullRepaint ?? false) {
+      this.forceFullRepaintRequested = true
+    }
+
+    if (options.emitResize ?? true) {
+      this.emit(CliRenderEvents.RESIZE, this.width, this.height)
+    }
+
+    if (options.requestRender ?? true) {
+      this.requestRender()
+    }
+  }
+
+  private cancelSplitFooterResizeReset(
+    reason: string = "cancelled",
+    options: { emitResize?: boolean; requestRender?: boolean } = {},
+  ): void {
+    if (!this.isSplitFooterResizeResetPending() && this.pendingSplitFooterResizeResetDimensions === null) {
+      return
+    }
+
+    const pendingDimensions = this.pendingSplitFooterResizeResetDimensions ?? {
+      width: this._terminalWidth,
+      height: this._terminalHeight,
+    }
+
+    if (this.resizeTimeoutId !== null) {
+      this.clock.clearTimeout(this.resizeTimeoutId)
+      this.resizeTimeoutId = null
+    }
+
+    this.emitSplitFooterResizeResetEvent({
+      phase: "cancel",
+      previousTerminalWidth: this._terminalWidth,
+      previousTerminalHeight: this._terminalHeight,
+      targetTerminalWidth: pendingDimensions.width,
+      targetTerminalHeight: pendingDimensions.height,
+      debounceDelay: this.resizeDebounceDelay,
+      pendingOutputCommits: this.externalOutputQueue.size,
+      reason,
+    })
+
+    this.splitFooterResizeResetState = "idle"
+    this.pendingSplitFooterResizeResetDimensions = null
+    this.splitFooterResizeResetViewportHeight = null
+
+    if (
+      (pendingDimensions.width !== this._terminalWidth || pendingDimensions.height !== this._terminalHeight) &&
+      !this._isDestroyed
+    ) {
+      this.applyTerminalResizeGeometry(pendingDimensions.width, pendingDimensions.height, {
+        forceFullRepaint: true,
+        emitResize: options.emitResize,
+        requestRender: options.requestRender,
+      })
+    }
+  }
+
+  private clearSplitFooterSurfaceForResizeReset(targetTerminalHeight: number): SplitFooterResizeResetSurfaceState {
+    const previousFooterTopLine = Math.max(this.pendingSplitFooterTransition?.sourceTopLine ?? this.renderOffset + 1, 1)
+    const verticalDelta = targetTerminalHeight - this._terminalHeight
+    const footerTopLine = Math.max(
+      Math.min(previousFooterTopLine + verticalDelta, Math.max(targetTerminalHeight, 1)),
+      1,
+    )
+    const upperHeight = Math.max(footerTopLine - 1, 0)
+
+    if (
+      !this._terminalIsSetup ||
+      this._controlState === RendererControlState.EXPLICIT_SUSPENDED ||
+      targetTerminalHeight <= 0
+    ) {
+      return {
+        footerTopLine,
+        upperHeight,
+        verticalDelta,
+        terminalCleared: false,
+      }
+    }
+
+    let resetOutput = ANSI.moveCursorAndClear(footerTopLine, 1)
+
+    if (upperHeight > 0) {
+      resetOutput += `${ANSI.moveCursor(1, 1)}${ANSI.scrollUp(upperHeight)}`
+    }
+
+    this.writeOut(resetOutput)
+
+    return {
+      footerTopLine,
+      upperHeight,
+      verticalDelta,
+      terminalCleared: true,
+    }
+  }
+
+  private maintainBlankSplitFooterResizeResetSurface(targetTerminalHeight: number): number {
+    const previousViewportHeight = this.splitFooterResizeResetViewportHeight
+    this.splitFooterResizeResetViewportHeight = targetTerminalHeight
+
+    if (
+      previousViewportHeight === null ||
+      targetTerminalHeight <= previousViewportHeight ||
+      !this._terminalIsSetup ||
+      this._controlState === RendererControlState.EXPLICIT_SUSPENDED
+    ) {
+      return 0
+    }
+
+    const scrollLines = targetTerminalHeight - previousViewportHeight
+    this.writeOut(`${ANSI.moveCursor(1, 1)}${ANSI.scrollUp(scrollLines)}`)
+    return scrollLines
+  }
+
+  private beginSplitFooterResizeResetBurst(width: number, height: number): boolean {
+    if (this.isSplitFooterResizeResetPending()) {
+      return true
+    }
+
+    const previousTerminalWidth = this._terminalWidth
+    const previousTerminalHeight = this._terminalHeight
+
+    // Resize-reset intentionally abandons the startup cursor seed because settle
+    // always restarts split scrollback from origin instead of preserving viewport state.
+    this.abortSplitStartupCursorSeed()
+
+    if (
+      this._terminalIsSetup &&
+      this._controlState !== RendererControlState.EXPLICIT_SUSPENDED &&
+      this._externalOutputMode === "capture-stdout"
+    ) {
+      this.flushPendingSplitOutputBeforeTransition()
+    }
+
+    if (!this.shouldUseSplitFooterResizeReset()) {
+      return false
+    }
+
+    const surfaceState = this.clearSplitFooterSurfaceForResizeReset(height)
+    this.clearPendingSplitFooterTransition()
+    this.currentRenderBuffer.clear(this.backgroundColor)
+    this.nextRenderBuffer.clear(this.backgroundColor)
+    this.splitFooterResizeResetState = "resize_reset_active"
+    this.splitFooterResizeResetViewportHeight = height
+
+    this.emitSplitFooterResizeResetEvent({
+      phase: "burst-start",
+      previousTerminalWidth,
+      previousTerminalHeight,
+      targetTerminalWidth: width,
+      targetTerminalHeight: height,
+      debounceDelay: this.resizeDebounceDelay,
+      verticalDelta: surfaceState.verticalDelta,
+      scrollLines: surfaceState.upperHeight,
+      footerTopLine: surfaceState.footerTopLine,
+      upperHeight: surfaceState.upperHeight,
+      terminalCleared: surfaceState.terminalCleared,
+      pendingOutputCommits: this.externalOutputQueue.size,
+    })
+
+    return true
+  }
+
+  private scheduleSplitFooterResizeResetSettle(): void {
+    if (this.resizeTimeoutId !== null) {
+      this.clock.clearTimeout(this.resizeTimeoutId)
+      this.resizeTimeoutId = null
+    }
+
+    this.splitFooterResizeResetState = "resize_reset_settle"
+    this.resizeTimeoutId = this.clock.setTimeout(() => {
+      this.resizeTimeoutId = null
+      this.finishSplitFooterResizeResetBurst()
+    }, this.resizeDebounceDelay)
+  }
+
+  private finishSplitFooterResizeResetBurst(): void {
+    const dimensions = this.pendingSplitFooterResizeResetDimensions
+    const previousTerminalWidth = this._terminalWidth
+    const previousTerminalHeight = this._terminalHeight
+    this.splitFooterResizeResetState = "idle"
+    this.pendingSplitFooterResizeResetDimensions = null
+    this.splitFooterResizeResetViewportHeight = null
+
+    if (dimensions === null || this._isDestroyed) {
+      return
+    }
+
+    this.applyTerminalResizeGeometry(dimensions.width, dimensions.height, {
+      resetSplitScrollback: true,
+      forceFullRepaint: true,
+    })
+
+    this.emitSplitFooterResizeResetEvent({
+      phase: "settle",
+      previousTerminalWidth,
+      previousTerminalHeight,
+      targetTerminalWidth: dimensions.width,
+      targetTerminalHeight: dimensions.height,
+      debounceDelay: this.resizeDebounceDelay,
+      renderWidth: this.width,
+      renderHeight: this.height,
+      renderOffset: this.renderOffset,
+      forcedFullRepaint: true,
+      pendingOutputCommits: this.externalOutputQueue.size,
+    })
+  }
+
   private setPendingSplitFooterTransition(transition: PendingSplitFooterTransition): void {
     this.pendingSplitFooterTransition = transition
     this.lib.setPendingSplitFooterTransition(
@@ -2487,6 +2811,12 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this._footerHeight,
     )
     const nextSplitHeight = nextGeometry.effectiveFooterHeight
+
+    if (screenMode !== "split-footer") {
+      this.cancelSplitFooterResizeReset("screen-mode-change", { emitResize: false, requestRender: false })
+    } else if (this.isSplitFooterResizeResetPending() && prevScreenMode === "split-footer") {
+      return
+    }
 
     if (prevScreenMode === screenMode && prevSplitHeight === nextSplitHeight) {
       return
@@ -3328,6 +3658,43 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private handleResize(width: number, height: number): void {
     if (this._isDestroyed) return
+    if (this.shouldUseSplitFooterResizeReset()) {
+      const hadPendingResizeReset = this.isSplitFooterResizeResetPending()
+      const previousResizeResetDimensions = this.pendingSplitFooterResizeResetDimensions ?? {
+        width: this._terminalWidth,
+        height: this._terminalHeight,
+      }
+
+      if (!this.isSplitFooterResizeResetPending() && width === this._terminalWidth && height === this._terminalHeight) {
+        return
+      }
+
+      if (!this.isSplitFooterResizeResetPending() && !this.beginSplitFooterResizeResetBurst(width, height)) {
+        this.processResize(width, height)
+        return
+      }
+
+      this.pendingSplitFooterResizeResetDimensions = { width, height }
+
+      if (hadPendingResizeReset) {
+        const scrollLines = this.maintainBlankSplitFooterResizeResetSurface(height)
+        this.emitSplitFooterResizeResetEvent({
+          phase: "burst-update",
+          previousTerminalWidth: previousResizeResetDimensions.width,
+          previousTerminalHeight: previousResizeResetDimensions.height,
+          targetTerminalWidth: width,
+          targetTerminalHeight: height,
+          debounceDelay: this.resizeDebounceDelay,
+          verticalDelta: height - previousResizeResetDimensions.height,
+          scrollLines,
+          pendingOutputCommits: this.externalOutputQueue.size,
+        })
+      }
+
+      this.scheduleSplitFooterResizeResetSettle()
+      return
+    }
+
     if (this._splitHeight > 0) {
       this.processResize(width, height)
       return
@@ -4028,6 +4395,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.renderingNative = true
 
     if (this.isSplitCursorSeedFrameBlocked()) {
+      this.renderingNative = false
+      return
+    }
+
+    if (this.isSplitFooterResizeResetPending()) {
       this.renderingNative = false
       return
     }

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1424,6 +1424,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   public set screenMode(mode: ScreenMode) {
     if (this.externalOutputMode === "capture-stdout" && mode !== "split-footer") {
+      if (this.isSplitFooterResizeResetPending()) {
+        this.pendingExternalOutputMode = "passthrough"
+        this.cancelSplitFooterResizeReset("screen-mode-change", { emitResize: false, requestRender: false })
+      }
+
       if (this.pendingExternalOutputMode === "passthrough") {
         this.flushPendingSplitOutputBeforeLeavingSplitFooter()
       }

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -5,7 +5,7 @@ import { capture } from "../console.ts"
 import { clearEnvCache } from "../lib/env.ts"
 import { createTestRenderer, type TestRenderer } from "../testing/test-renderer.js"
 import { ManualClock } from "../testing/manual-clock.js"
-import { TextRenderable, type ScrollbackRenderContext } from "../index.js"
+import { CliRenderEvents, TextRenderable, type ScrollbackRenderContext } from "../index.js"
 
 let renderer: TestRenderer | null = null
 let previousShowConsole: string | undefined
@@ -756,6 +756,244 @@ test("CliRenderer flushes pending writeToScrollback output before resize applies
 
   lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
   lib.resizeRenderer = originalResizeRenderer
+})
+
+test("CliRenderer split-footer reset resize clears once, debounces geometry, and repaints from origin", async () => {
+  const clock = new ManualClock()
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+    clock,
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  ;(renderer as any).renderOffset = 6
+
+  const writeOutSpy = spyOn(renderer as any, "writeOut")
+  const resizeSpy = spyOn((renderer as any).lib, "resizeRenderer")
+  const repaintSpy = spyOn((renderer as any).lib, "repaintSplitFooter")
+
+  ;(renderer as any).handleResize(60, 16)
+  ;(renderer as any).handleResize(70, 18)
+
+  expect(writeOutSpy).toHaveBeenCalledTimes(2)
+  expect(writeOutSpy.mock.calls[0]?.[0]).toBe(
+    `${ANSI.moveCursorAndClear(13, 1)}${ANSI.moveCursor(1, 1)}${ANSI.scrollUp(12)}`,
+  )
+  expect(writeOutSpy.mock.calls[1]?.[0]).toBe(`${ANSI.moveCursor(1, 1)}${ANSI.scrollUp(2)}`)
+  expect(resizeSpy).toHaveBeenCalledTimes(0)
+  expect(renderer.width).toBe(40)
+  expect(renderer.height).toBe(4)
+  expect((renderer as any).splitFooterResizeResetState).toBe("resize_reset_settle")
+
+  clock.advance(99)
+
+  expect(renderer.width).toBe(40)
+  expect(renderer.height).toBe(4)
+  expect(resizeSpy).toHaveBeenCalledTimes(0)
+
+  clock.advance(1)
+  await result.renderOnce()
+
+  expect(renderer.width).toBe(70)
+  expect(renderer.height).toBe(4)
+  expect(renderer.terminalWidth).toBe(70)
+  expect(renderer.terminalHeight).toBe(18)
+  expect((renderer as any).renderOffset).toBe(0)
+  expect((renderer as any).splitFooterResizeResetState).toBe("idle")
+  expect(resizeSpy).toHaveBeenCalledTimes(1)
+  expect(repaintSpy.mock.calls.at(-1)?.[2]).toBe(true)
+
+  writeOutSpy.mockRestore()
+  resizeSpy.mockRestore()
+  repaintSpy.mockRestore()
+})
+
+test("CliRenderer split-footer reset resize buffers captured output until settle", async () => {
+  const clock = new ManualClock()
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+    clock,
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const splitCommitSpy = spyOn((renderer as any).lib, "commitSplitFooterSnapshot")
+
+  ;(renderer as any).handleResize(60, 16)
+  ;(renderer as any).stdout.write("during-resize\n")
+  renderer.writeToScrollback(textScrollbackWrite("after-reset\n"))
+
+  clock.advance(20)
+  await result.renderOnce()
+
+  expect(splitCommitSpy).toHaveBeenCalledTimes(0)
+  expect((renderer as any).externalOutputQueue.size).toBe(2)
+
+  clock.advance(80)
+  await result.renderOnce()
+
+  expect(splitCommitSpy).toHaveBeenCalledTimes(2)
+  expect((renderer as any).externalOutputQueue.size).toBe(0)
+
+  splitCommitSpy.mockRestore()
+})
+
+test("CliRenderer split-footer reset cancellation applies the pending geometry before runtime mode changes", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  ;(renderer as any).handleResize(60, 16)
+
+  renderer.externalOutputMode = "passthrough"
+
+  expect(renderer.terminalWidth).toBe(60)
+  expect(renderer.terminalHeight).toBe(16)
+  expect(renderer.width).toBe(60)
+  expect(renderer.height).toBe(4)
+  expect((renderer as any).splitFooterResizeResetState).toBe("idle")
+
+  renderer.screenMode = "main-screen"
+
+  expect(renderer.width).toBe(60)
+  expect(renderer.height).toBe(16)
+
+  renderer.screenMode = "split-footer"
+  renderer.externalOutputMode = "capture-stdout"
+
+  ;(renderer as any).handleResize(72, 20)
+
+  renderer.externalOutputMode = "passthrough"
+
+  expect(renderer.terminalWidth).toBe(72)
+  expect(renderer.terminalHeight).toBe(20)
+  expect(renderer.width).toBe(72)
+  expect(renderer.height).toBe(4)
+  expect(renderer.externalOutputMode).toBe("passthrough")
+  expect((renderer as any).splitFooterResizeResetState).toBe("idle")
+})
+
+test("CliRenderer split-footer reset keeps queued output buffered when footerHeight changes during resize burst", async () => {
+  const clock = new ManualClock()
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+    clock,
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const splitCommitSpy = spyOn((renderer as any).lib, "commitSplitFooterSnapshot")
+
+  ;(renderer as any).handleResize(60, 16)
+  ;(renderer as any).stdout.write("during-resize\n")
+
+  renderer.footerHeight = 3
+
+  expect(renderer.footerHeight).toBe(3)
+  expect(renderer.height).toBe(4)
+  expect((renderer as any).splitFooterResizeResetState).toBe("resize_reset_settle")
+  expect(splitCommitSpy).toHaveBeenCalledTimes(0)
+  expect((renderer as any).externalOutputQueue.size).toBe(1)
+
+  clock.advance(100)
+  await result.renderOnce()
+
+  expect(renderer.height).toBe(3)
+  expect(splitCommitSpy).toHaveBeenCalledTimes(1)
+  expect((renderer as any).externalOutputQueue.size).toBe(0)
+
+  splitCommitSpy.mockRestore()
+})
+
+test("CliRenderer split-footer reset resize emits resize reset lifecycle events", async () => {
+  const clock = new ManualClock()
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+    clock,
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  ;(renderer as any).renderOffset = 6
+
+  const events: Array<Record<string, unknown>> = []
+  renderer.on(CliRenderEvents.SPLIT_FOOTER_RESIZE_RESET, (event: Record<string, unknown>) => {
+    events.push(event)
+  })
+
+  ;(renderer as any).handleResize(60, 16)
+  ;(renderer as any).handleResize(70, 18)
+
+  clock.advance(100)
+  await result.renderOnce()
+
+  expect(events.map((event) => event.phase)).toEqual(["burst-start", "burst-update", "settle"])
+  expect(events[0]).toMatchObject({
+    phase: "burst-start",
+    previousTerminalWidth: 40,
+    previousTerminalHeight: 10,
+    targetTerminalWidth: 60,
+    targetTerminalHeight: 16,
+    verticalDelta: 6,
+    scrollLines: 12,
+    footerTopLine: 13,
+    upperHeight: 12,
+    terminalCleared: true,
+    debounceDelay: 100,
+  })
+  expect(events[1]).toMatchObject({
+    phase: "burst-update",
+    previousTerminalWidth: 60,
+    previousTerminalHeight: 16,
+    targetTerminalWidth: 70,
+    targetTerminalHeight: 18,
+    verticalDelta: 2,
+    scrollLines: 2,
+    debounceDelay: 100,
+  })
+  expect(events[2]).toMatchObject({
+    phase: "settle",
+    previousTerminalWidth: 40,
+    previousTerminalHeight: 10,
+    targetTerminalWidth: 70,
+    targetTerminalHeight: 18,
+    renderWidth: 70,
+    renderHeight: 4,
+    renderOffset: 0,
+    forcedFullRepaint: true,
+    debounceDelay: 100,
+  })
 })
 
 test("CliRenderer reuses generic suspend/resume native helpers in split-footer mode", async () => {

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -49,6 +49,7 @@ import * as textSelectionExample from "./text-selection-demo.js"
 import * as asciiFontSelectionExample from "./ascii-font-selection-demo.js"
 import * as splitModeExample from "./split-mode-demo.js"
 import * as splitFooterStreamingDemo from "./split-footer-streaming-demo.js"
+import * as splitResizeResetDemo from "./split-resize-reset-demo.js"
 import * as consoleExample from "./console-demo.js"
 import * as notificationDemo from "./notification-demo.js"
 import * as vnodeCompositionDemo from "./vnode-composition-demo.js"
@@ -248,6 +249,12 @@ const examples: Example[] = [
     description: "Focused split-footer surface demo for progressive text, code, and markdown scrollback",
     run: splitFooterStreamingDemo.run,
     destroy: splitFooterStreamingDemo.destroy,
+  },
+  {
+    name: "Split Resize Reset Demo",
+    description: "Minimal split-footer resize-reset tracer with buffered stdout heartbeats and lifecycle logs",
+    run: splitResizeResetDemo.run,
+    destroy: splitResizeResetDemo.destroy,
   },
   {
     name: "Live State Management Demo",

--- a/packages/examples/src/split-footer-streaming-demo.ts
+++ b/packages/examples/src/split-footer-streaming-demo.ts
@@ -22,6 +22,7 @@ const DEFAULT_INTERVAL_MS = 180
 const MIN_INTERVAL_MS = 60
 const MAX_INTERVAL_MS = 1000
 const INTERVAL_STEP_MS = 40
+const SPLIT_RESIZE_CONFIRM_DELAY_MS = 250
 
 type StreamKind = "text" | "code" | "markdown"
 
@@ -190,8 +191,12 @@ class SplitFooterStreamingDemo {
   private lastStatus = "Ready. Press R to replay the current sample."
   private pendingReplayReason: string | null = null
   private wrote = false
+  private readonly previousDebounceDelay: number
 
   constructor(private renderer: CliRenderer) {
+    this.previousDebounceDelay = this.renderer.debounceDelay
+    this.renderer.debounceDelay = SPLIT_RESIZE_CONFIRM_DELAY_MS
+
     if (this.renderer.screenMode !== "split-footer") {
       this.renderer.screenMode = "split-footer"
     }
@@ -280,7 +285,7 @@ class SplitFooterStreamingDemo {
     this.footerTable.content = [
       footerRow(
         "mode",
-        `${scenario.title} · start ${this.inlinePrefix ? "inline-prefix" : "newline"} · auto ${this.autoAdvance ? `${this.intervalMs}ms` : "off"} · ${runState}`,
+        `${scenario.title} · start ${this.inlinePrefix ? "inline-prefix" : "newline"} · auto ${this.autoAdvance ? `${this.intervalMs}ms` : "off"} · resize ${this.renderer.debounceDelay}ms · ${runState}`,
         getScenarioAccent(this.currentKind),
       ),
       footerRow("status", this.lastStatus, this.lastStatus.startsWith("Error:") ? PALETTE.error : PALETTE.status),
@@ -725,6 +730,7 @@ class SplitFooterStreamingDemo {
     }
 
     if (!this.renderer.isDestroyed) {
+      this.renderer.debounceDelay = this.previousDebounceDelay
       this.renderer.externalOutputMode = "passthrough"
       this.renderer.screenMode = "main-screen"
     }
@@ -753,6 +759,7 @@ export function destroy(_renderer: CliRenderer): void {
 if (import.meta.main) {
   const renderer = await createCliRenderer({
     targetFps: 30,
+    debounceDelay: SPLIT_RESIZE_CONFIRM_DELAY_MS,
     exitOnCtrlC: true,
     useMouse: false,
     screenMode: "split-footer",

--- a/packages/examples/src/split-mode-demo.ts
+++ b/packages/examples/src/split-mode-demo.ts
@@ -8,6 +8,7 @@ import {
   type KeyEvent,
   type ScrollbackRenderContext,
   type ScrollbackSnapshot,
+  type SplitFooterResizeResetEvent,
   type ScrollbackWriter,
   type ThemeMode,
 } from "@opentui/core"
@@ -21,6 +22,7 @@ const DEFAULT_STREAM_INTERVAL = 1600
 const MIN_STREAM_INTERVAL = 180
 const MAX_STREAM_INTERVAL = 2000
 const STREAM_INTERVAL_STEP = 80
+const SPLIT_RESIZE_CONFIRM_DELAY_MS = 250
 const CTRL_R_HOLD_REPEAT_MS = 45
 const CTRL_R_HOLD_DURATION_MS = 1400
 const CTRL_R_HOLD_BOOT_DELAY_MS = 600
@@ -449,8 +451,13 @@ class SplitFooterDemo {
   private assistantTyping = false
   private statusMessage = "Ready"
   private destroyed = false
+  private readonly previousDebounceDelay: number
+  private resizeResetBurstCount = 0
 
   constructor(private renderer: CliRenderer) {
+    this.previousDebounceDelay = this.renderer.debounceDelay
+    this.renderer.debounceDelay = SPLIT_RESIZE_CONFIRM_DELAY_MS
+
     this.palette = resolveDemoPalette(this.renderer.themeMode)
     this.desiredFooterHeight = this.clampFooterHeight(this.desiredFooterHeight)
 
@@ -590,6 +597,7 @@ class SplitFooterDemo {
     this.composer.on("line-info-change", this.handleDraftChanged)
     this.renderer.keyInput.on("keypress", this.handleKeyPress)
     this.renderer.on("resize", this.handleResize)
+    this.renderer.on(CliRenderEvents.SPLIT_FOOTER_RESIZE_RESET, this.handleSplitFooterResizeReset)
     this.renderer.on(CliRenderEvents.THEME_MODE, this.handleThemeMode)
     this.renderer.on(CliRenderEvents.DESTROY, this.handleRendererDestroy)
 
@@ -656,7 +664,9 @@ class SplitFooterDemo {
 
     this.modeText.content = modeLabel
     this.statusText.content = `msg ${this.messageCount} draft ${this.draftLength} ${typingLabel} | ${this.statusMessage}`
-    this.metaText.content = `${mouseLabel} stream:${streamLabel} commits:${this.commitCount} lines:${this.streamCount}`
+    this.metaText.content =
+      `${mouseLabel} stream:${streamLabel} resize:${this.renderer.debounceDelay}ms bursts:${this.resizeResetBurstCount} ` +
+      `commits:${this.commitCount} lines:${this.streamCount}`
     this.controlsText.content =
       "Ctrl+Enter send · Enter newline · Shift+U mouse · Ctrl+S stream · Ctrl+0 mode · Ctrl+R hold-demo · /help"
   }
@@ -776,6 +786,11 @@ class SplitFooterDemo {
     )
 
     this.publishMessage("system", "Stream mode rotates through a short ordered setlist.", false)
+    this.publishMessage(
+      "system",
+      `Split resize reset policy is active. Debounce ${this.renderer.debounceDelay}ms. Drag resize and watch for reset start/update/settle messages.`,
+      false,
+    )
   }
 
   private syncStreamLoop(): void {
@@ -1211,6 +1226,49 @@ class SplitFooterDemo {
     this.refreshStatus(`theme ${mode}`)
   }
 
+  private formatResizeResetEvent(event: SplitFooterResizeResetEvent): string {
+    switch (event.phase) {
+      case "burst-start":
+        return [
+          `resize-reset start -> target ${event.targetTerminalWidth}x${event.targetTerminalHeight}`,
+          `clear row ${event.footerTopLine ?? 1}`,
+          `scroll ${event.upperHeight ?? 0}`,
+          `debounce ${event.debounceDelay}ms`,
+          event.terminalCleared === false ? "clear skipped" : "cleared",
+        ].join(" | ")
+      case "burst-update":
+        return [
+          `resize-reset update -> latest ${event.targetTerminalWidth}x${event.targetTerminalHeight}`,
+          `delta ${event.verticalDelta ?? 0}`,
+          `scroll ${event.scrollLines ?? 0}`,
+          `debounce ${event.debounceDelay}ms`,
+        ].join(" | ")
+      case "settle":
+        return [
+          `resize-reset settle -> applied ${event.targetTerminalWidth}x${event.targetTerminalHeight}`,
+          `render ${event.renderWidth}x${event.renderHeight}`,
+          `offset ${event.renderOffset}`,
+          `repaint ${event.forcedFullRepaint ? "forced" : "normal"}`,
+        ].join(" | ")
+      case "cancel":
+        return `resize-reset cancel -> target ${event.targetTerminalWidth}x${event.targetTerminalHeight} | reason ${event.reason ?? "unknown"}`
+    }
+  }
+
+  private handleSplitFooterResizeReset = (event: SplitFooterResizeResetEvent): void => {
+    if (this.destroyed) {
+      return
+    }
+
+    if (event.phase === "burst-start") {
+      this.resizeResetBurstCount += 1
+    }
+
+    const message = this.formatResizeResetEvent(event)
+    this.publishMessage("system", message, false)
+    this.refreshStatus(message)
+  }
+
   private handleResize = (): void => {
     this.desiredFooterHeight = this.clampFooterHeight(this.desiredFooterHeight)
     if (this.mode === "split-footer" && this.renderer.footerHeight !== this.desiredFooterHeight) {
@@ -1253,12 +1311,14 @@ class SplitFooterDemo {
     this.composer.onSubmit = undefined
     this.renderer.keyInput.off("keypress", this.handleKeyPress)
     this.renderer.off("resize", this.handleResize)
+    this.renderer.off(CliRenderEvents.SPLIT_FOOTER_RESIZE_RESET, this.handleSplitFooterResizeReset)
     this.renderer.off(CliRenderEvents.THEME_MODE, this.handleThemeMode)
     this.renderer.off(CliRenderEvents.DESTROY, this.handleRendererDestroy)
 
     this.renderer.root.remove(this.shell.id)
 
     if (!this.renderer.isDestroyed) {
+      this.renderer.debounceDelay = this.previousDebounceDelay
       this.renderer.externalOutputMode = "passthrough"
       this.renderer.screenMode = "main-screen"
     }
@@ -1287,6 +1347,7 @@ export function destroy(_rendererInstance: CliRenderer): void {
 if (import.meta.main) {
   const renderer = await createCliRenderer({
     targetFps: 30,
+    debounceDelay: SPLIT_RESIZE_CONFIRM_DELAY_MS,
     exitOnCtrlC: true,
     useMouse: true,
     screenMode: "split-footer",

--- a/packages/examples/src/split-resize-reset-demo.ts
+++ b/packages/examples/src/split-resize-reset-demo.ts
@@ -1,0 +1,340 @@
+import {
+  BoxRenderable,
+  CliRenderEvents,
+  TextRenderable,
+  createCliRenderer,
+  type CliRenderer,
+  type KeyEvent,
+  type SplitFooterResizeResetEvent,
+} from "@opentui/core"
+import { setupCommonDemoKeys } from "./lib/standalone-keys.js"
+
+const FOOTER_HEIGHT = 8
+const RESIZE_DEBOUNCE_MS = 250
+const HEARTBEAT_INTERVAL_MS = 400
+
+class SplitResizeResetDemo {
+  private shell: BoxRenderable
+  private titleText: TextRenderable
+  private stateText: TextRenderable
+  private counterText: TextRenderable
+  private lastEventText: TextRenderable
+  private noteText: TextRenderable
+  private helpText: TextRenderable
+
+  private readonly previousDebounceDelay: number
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  private destroyed = false
+  private heartbeatEnabled = true
+  private resizeResetLogEnabled = true
+  private heartbeatCount = 0
+  private resizeBurstCount = 0
+  private resizeEventCount = 0
+  private lastResizeSummary = "none"
+  private lastResizeEvent = "waiting for resize"
+
+  constructor(private renderer: CliRenderer) {
+    this.previousDebounceDelay = this.renderer.debounceDelay
+    this.renderer.debounceDelay = RESIZE_DEBOUNCE_MS
+
+    if (this.renderer.screenMode !== "split-footer") {
+      this.renderer.screenMode = "split-footer"
+    }
+
+    this.renderer.footerHeight = FOOTER_HEIGHT
+
+    if (this.renderer.externalOutputMode !== "capture-stdout") {
+      this.renderer.externalOutputMode = "capture-stdout"
+    }
+
+    this.renderer.setBackgroundColor("#071018")
+
+    this.shell = new BoxRenderable(this.renderer, {
+      id: "split-resize-reset-shell",
+      width: "100%",
+      height: "100%",
+      border: ["top"],
+      borderColor: "#2d5b89",
+      backgroundColor: "#0d1723",
+      paddingTop: 1,
+      paddingBottom: 0,
+      paddingLeft: 1,
+      paddingRight: 1,
+      gap: 0,
+      flexDirection: "column",
+    })
+
+    this.titleText = new TextRenderable(this.renderer, {
+      id: "split-resize-reset-title",
+      width: "100%",
+      height: 1,
+      content: "Split Resize Reset Demo",
+      fg: "#f4f8ff",
+      attributes: 1,
+    })
+
+    this.stateText = new TextRenderable(this.renderer, {
+      id: "split-resize-reset-state",
+      width: "100%",
+      height: 1,
+      content: "",
+      fg: "#9fc7f2",
+    })
+
+    this.counterText = new TextRenderable(this.renderer, {
+      id: "split-resize-reset-counters",
+      width: "100%",
+      height: 1,
+      content: "",
+      fg: "#9fc7f2",
+    })
+
+    this.lastEventText = new TextRenderable(this.renderer, {
+      id: "split-resize-reset-last-event",
+      width: "100%",
+      height: 1,
+      content: "",
+      fg: "#f8d38a",
+    })
+
+    this.noteText = new TextRenderable(this.renderer, {
+      id: "split-resize-reset-note",
+      width: "100%",
+      height: 1,
+      content: "Drag resize. Footer should blank during drag, then logs appear after 250ms settle.",
+      fg: "#dbe7f5",
+    })
+
+    this.helpText = new TextRenderable(this.renderer, {
+      id: "split-resize-reset-help",
+      width: "100%",
+      height: 1,
+      content: "space manual stdout line | s heartbeat on/off | d resize logs on/off | common demo keys still work",
+      fg: "#7da0c5",
+    })
+
+    this.shell.add(this.titleText)
+    this.shell.add(this.stateText)
+    this.shell.add(this.counterText)
+    this.shell.add(this.lastEventText)
+    this.shell.add(this.noteText)
+    this.shell.add(this.helpText)
+    this.renderer.root.add(this.shell)
+
+    this.renderer.keyInput.on("keypress", this.handleKeyPress)
+    this.renderer.on(CliRenderEvents.SPLIT_FOOTER_RESIZE_RESET, this.handleResizeReset)
+    this.renderer.on(CliRenderEvents.RESIZE, this.handleResize)
+    this.renderer.on(CliRenderEvents.DESTROY, this.handleRendererDestroy)
+
+    this.refreshFooter()
+    this.writeCapturedLine(
+      `demo ready -> reset policy active, debounce ${this.renderer.debounceDelay}ms, footer ${this.renderer.footerHeight}`,
+    )
+    this.writeCapturedLine("drag the terminal size now; heartbeat stdout lines should buffer during resize bursts")
+    this.syncHeartbeat()
+  }
+
+  private isSplitCaptureMode(): boolean {
+    return this.renderer.screenMode === "split-footer" && this.renderer.externalOutputMode === "capture-stdout"
+  }
+
+  private timestamp(): string {
+    const date = new Date()
+    const hh = String(date.getHours()).padStart(2, "0")
+    const mm = String(date.getMinutes()).padStart(2, "0")
+    const ss = String(date.getSeconds()).padStart(2, "0")
+    return `${hh}:${mm}:${ss}`
+  }
+
+  private writeCapturedLine(message: string): void {
+    if (this.destroyed || !this.isSplitCaptureMode()) {
+      return
+    }
+
+    process.stdout.write(`[${this.timestamp()}] ${message}\n`)
+  }
+
+  private refreshFooter(): void {
+    if (this.destroyed) {
+      return
+    }
+
+    this.stateText.content =
+      `tty ${this.renderer.terminalWidth}x${this.renderer.terminalHeight} | render ${this.renderer.width}x${this.renderer.height} | ` +
+      `footer ${this.renderer.footerHeight} | debounce ${this.renderer.debounceDelay}ms`
+    this.counterText.content =
+      `bursts ${this.resizeBurstCount} | reset-events ${this.resizeEventCount} | resize-logs ${this.resizeResetLogEnabled ? "on" : "off"} | ` +
+      `heartbeat ${this.heartbeatEnabled ? `on/${HEARTBEAT_INTERVAL_MS}ms` : "off"} | ticks ${this.heartbeatCount}`
+    this.lastEventText.content = `last: ${this.lastResizeSummary} | resize: ${this.lastResizeEvent}`
+  }
+
+  private formatResizeResetEvent(event: SplitFooterResizeResetEvent): string {
+    switch (event.phase) {
+      case "burst-start":
+        return [
+          `burst-start target ${event.targetTerminalWidth}x${event.targetTerminalHeight}`,
+          `clear row ${event.footerTopLine ?? 1}`,
+          `scroll ${event.upperHeight ?? 0}`,
+          `debounce ${event.debounceDelay}ms`,
+          event.terminalCleared === false ? "clear skipped" : "cleared",
+        ].join(" | ")
+      case "burst-update":
+        return [
+          `burst-update latest ${event.targetTerminalWidth}x${event.targetTerminalHeight}`,
+          `delta ${event.verticalDelta ?? 0}`,
+          `scroll ${event.scrollLines ?? 0}`,
+          `pending ${event.pendingOutputCommits ?? 0}`,
+        ].join(" | ")
+      case "settle":
+        return [
+          `settle applied ${event.targetTerminalWidth}x${event.targetTerminalHeight}`,
+          `render ${event.renderWidth}x${event.renderHeight}`,
+          `offset ${event.renderOffset}`,
+          `repaint ${event.forcedFullRepaint ? "forced" : "normal"}`,
+        ].join(" | ")
+      case "cancel":
+        return `cancel target ${event.targetTerminalWidth}x${event.targetTerminalHeight} | reason ${event.reason ?? "unknown"}`
+    }
+  }
+
+  private syncHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+
+    if (!this.heartbeatEnabled || this.destroyed) {
+      return
+    }
+
+    this.heartbeatTimer = setInterval(() => {
+      if (this.destroyed || !this.isSplitCaptureMode()) {
+        return
+      }
+
+      this.heartbeatCount += 1
+      this.writeCapturedLine(
+        `heartbeat ${this.heartbeatCount} -> stdout writes during drag should show up after settle`,
+      )
+      this.refreshFooter()
+    }, HEARTBEAT_INTERVAL_MS)
+  }
+
+  private handleResizeReset = (event: SplitFooterResizeResetEvent): void => {
+    if (this.destroyed) {
+      return
+    }
+
+    this.resizeEventCount += 1
+    if (event.phase === "burst-start") {
+      this.resizeBurstCount += 1
+    }
+
+    this.lastResizeSummary = this.formatResizeResetEvent(event)
+    if (this.resizeResetLogEnabled) {
+      this.writeCapturedLine(`resize-reset ${this.lastResizeSummary}`)
+    }
+    this.refreshFooter()
+  }
+
+  private handleResize = (width: number, height: number): void => {
+    if (this.destroyed) {
+      return
+    }
+
+    this.lastResizeEvent = `${width}x${height}`
+    this.refreshFooter()
+  }
+
+  private handleKeyPress = (key: KeyEvent): void => {
+    if (key.name === "space") {
+      key.preventDefault()
+      this.writeCapturedLine("manual stdout line -> written immediately or buffered if resize reset is active")
+      return
+    }
+
+    if (key.name?.toLowerCase() === "s") {
+      key.preventDefault()
+      this.heartbeatEnabled = !this.heartbeatEnabled
+      this.syncHeartbeat()
+      this.writeCapturedLine(`heartbeat ${this.heartbeatEnabled ? "enabled" : "disabled"}`)
+      this.refreshFooter()
+      return
+    }
+
+    if (key.name?.toLowerCase() === "d") {
+      key.preventDefault()
+      this.resizeResetLogEnabled = !this.resizeResetLogEnabled
+      this.writeCapturedLine(`resize reset logs ${this.resizeResetLogEnabled ? "enabled" : "disabled"}`)
+      this.refreshFooter()
+    }
+  }
+
+  private handleRendererDestroy = (): void => {
+    this.destroy()
+  }
+
+  public destroy(): void {
+    if (this.destroyed) {
+      return
+    }
+
+    this.destroyed = true
+
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+
+    this.renderer.keyInput.off("keypress", this.handleKeyPress)
+    this.renderer.off(CliRenderEvents.SPLIT_FOOTER_RESIZE_RESET, this.handleResizeReset)
+    this.renderer.off(CliRenderEvents.RESIZE, this.handleResize)
+    this.renderer.off(CliRenderEvents.DESTROY, this.handleRendererDestroy)
+
+    if (!this.shell.isDestroyed) {
+      this.shell.destroyRecursively()
+    }
+
+    if (!this.renderer.isDestroyed) {
+      this.renderer.debounceDelay = this.previousDebounceDelay
+      this.renderer.externalOutputMode = "passthrough"
+      this.renderer.screenMode = "main-screen"
+    }
+  }
+}
+
+let activeDemo: SplitResizeResetDemo | null = null
+
+export function run(renderer: CliRenderer): void {
+  if (activeDemo) {
+    activeDemo.destroy()
+  }
+
+  activeDemo = new SplitResizeResetDemo(renderer)
+}
+
+export function destroy(_renderer: CliRenderer): void {
+  if (!activeDemo) {
+    return
+  }
+
+  activeDemo.destroy()
+  activeDemo = null
+}
+
+if (import.meta.main) {
+  const renderer = await createCliRenderer({
+    targetFps: 30,
+    debounceDelay: RESIZE_DEBOUNCE_MS,
+    exitOnCtrlC: true,
+    useMouse: false,
+    screenMode: "split-footer",
+    footerHeight: FOOTER_HEIGHT,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  run(renderer)
+  setupCommonDemoKeys(renderer)
+  renderer.start()
+}

--- a/packages/web/src/content/docs/core-concepts/renderer.mdx
+++ b/packages/web/src/content/docs/core-concepts/renderer.mdx
@@ -36,25 +36,26 @@ This page covers the options that most apps set directly.
 `CliRendererConfig` also includes lower-level hooks for testing and tuning, such as `stdin`, `stdout`, `clock`,
 `postProcessFns`, and `prependInputHandlers`.
 
-| Option                | Type                           | Default              | Description                                                                             |
-| --------------------- | ------------------------------ | -------------------- | --------------------------------------------------------------------------------------- |
-| `screenMode`          | `ScreenMode`                   | `"alternate-screen"` | How the renderer uses terminal space ([details](#screen-modes))                         |
-| `footerHeight`        | `number`                       | `12`                 | Requested footer rows for `"split-footer"` mode                                         |
-| `externalOutputMode`  | `ExternalOutputMode`           | varies               | How writes to `stdout.write` are handled ([details](#external-output-mode))             |
-| `consoleMode`         | `ConsoleMode`                  | `"console-overlay"`  | How the built-in console overlay behaves ([details](#console-mode))                     |
-| `exitOnCtrlC`         | `boolean`                      | `true`               | Call `renderer.destroy()` when Ctrl+C is pressed                                        |
-| `exitSignals`         | `NodeJS.Signals[]`             | see below            | Signals that trigger cleanup ([details](/docs/core-concepts/lifecycle#signal-handling)) |
-| `clearOnShutdown`     | `boolean`                      | `true`               | Clear the renderer-owned region on `suspend()` and `destroy()`                          |
-| `targetFps`           | `number`                       | `30`                 | Target frames per second for the render loop                                            |
-| `maxFps`              | `number`                       | `60`                 | Maximum FPS cap for immediate re-renders                                                |
-| `useMouse`            | `boolean`                      | `true`               | Enable mouse input                                                                      |
-| `autoFocus`           | `boolean`                      | `true`               | Focus the nearest focusable renderable on left click                                    |
-| `enableMouseMovement` | `boolean`                      | `true`               | Track mouse movement, not just clicks and scrolls                                       |
-| `useKittyKeyboard`    | `KittyKeyboardOptions \| null` | `{}`                 | Kitty keyboard protocol settings, or `null` to disable                                  |
-| `backgroundColor`     | `ColorInput`                   | transparent          | Background color for the render buffer                                                  |
-| `consoleOptions`      | `ConsoleOptions`               | -                    | Options forwarded to the built-in console overlay                                       |
-| `openConsoleOnError`  | `boolean`                      | `true` (dev)         | Open the console overlay on uncaught errors                                             |
-| `onDestroy`           | `() => void`                   | -                    | Run after the renderer finishes cleanup                                                 |
+| Option                | Type                           | Default              | Description                                                                                   |
+| --------------------- | ------------------------------ | -------------------- | --------------------------------------------------------------------------------------------- |
+| `screenMode`          | `ScreenMode`                   | `"alternate-screen"` | How the renderer uses terminal space ([details](#screen-modes))                               |
+| `footerHeight`        | `number`                       | `12`                 | Requested footer rows for `"split-footer"` mode                                               |
+| `externalOutputMode`  | `ExternalOutputMode`           | varies               | How writes to `stdout.write` are handled ([details](#external-output-mode))                   |
+| `debounceDelay`       | `number`                       | `100`                | Resize debounce in ms. The split-footer repaints once this delay elapses after resize settles |
+| `consoleMode`         | `ConsoleMode`                  | `"console-overlay"`  | How the built-in console overlay behaves ([details](#console-mode))                           |
+| `exitOnCtrlC`         | `boolean`                      | `true`               | Call `renderer.destroy()` when Ctrl+C is pressed                                              |
+| `exitSignals`         | `NodeJS.Signals[]`             | see below            | Signals that trigger cleanup ([details](/docs/core-concepts/lifecycle#signal-handling))       |
+| `clearOnShutdown`     | `boolean`                      | `true`               | Clear the renderer-owned region on `suspend()` and `destroy()`                                |
+| `targetFps`           | `number`                       | `30`                 | Target frames per second for the render loop                                                  |
+| `maxFps`              | `number`                       | `60`                 | Maximum FPS cap for immediate re-renders                                                      |
+| `useMouse`            | `boolean`                      | `true`               | Enable mouse input                                                                            |
+| `autoFocus`           | `boolean`                      | `true`               | Focus the nearest focusable renderable on left click                                          |
+| `enableMouseMovement` | `boolean`                      | `true`               | Track mouse movement, not just clicks and scrolls                                             |
+| `useKittyKeyboard`    | `KittyKeyboardOptions \| null` | `{}`                 | Kitty keyboard protocol settings, or `null` to disable                                        |
+| `backgroundColor`     | `ColorInput`                   | transparent          | Background color for the render buffer                                                        |
+| `consoleOptions`      | `ConsoleOptions`               | -                    | Options forwarded to the built-in console overlay                                             |
+| `openConsoleOnError`  | `boolean`                      | `true` (dev)         | Open the console overlay on uncaught errors                                                   |
+| `onDestroy`           | `() => void`                   | -                    | Run after the renderer finishes cleanup                                                       |
 
 You can also change `screenMode`, `footerHeight`, `externalOutputMode`, and `consoleMode` at runtime through their
 matching `renderer` properties.
@@ -103,7 +104,28 @@ renderer.footerHeight = 15
 
 Split-footer bookkeeping lives in the native renderer. A shared `SplitScrollback` model tracks the rows it has already published and the current tail column, so the footer pins to the bottom of the terminal as scrollback grows. Captured stdout and [scrollback writers](#writing-to-scrollback) both produce styled `OptimizedBuffer` snapshots. The native side emits these as ANSI alongside the footer repaint in one atomic frame. The renderer flushes pending output before `resize`, `suspend`, mode transitions, and `destroy`.
 
-## External output mode
+### Split-footer resize behavior
+
+In split-footer mode with `externalOutputMode: "capture-stdout"` is destructive.
+On the first resize in a burst, OpenTUI:
+
+1. Clears the old footer surface.
+2. Scrolls the old upper pane into terminal history.
+3. Leaves the viewport blank.
+4. Buffers new captured output instead of repainting during the drag.
+
+Once resize settles, OpenTUI:
+
+1. Waits for `debounceDelay`.
+2. Applies the latest terminal size.
+3. Resets split scrollback from origin.
+4. Forces one full footer repaint.
+5. Resumes flushing buffered output.
+
+To observe this lifecycle directly, listen for
+`CliRenderEvents.SPLIT_FOOTER_RESIZE_RESET`. The payload reports the current
+phase: entering a resize burst, updating the target size, settling, or
+canceling.## External output mode
 
 The `externalOutputMode` option controls what happens to writes that go through the renderer's configured `stdout.write` while the renderer is active. It does not change `stderr`, and it is separate from the built-in console overlay.
 

--- a/packages/web/src/content/docs/core-concepts/renderer.mdx
+++ b/packages/web/src/content/docs/core-concepts/renderer.mdx
@@ -106,7 +106,7 @@ Split-footer bookkeeping lives in the native renderer. A shared `SplitScrollback
 
 ### Split-footer resize behavior
 
-In split-footer mode with `externalOutputMode: "capture-stdout"` is destructive.
+Split-footer mode with `externalOutputMode: "capture-stdout"` uses destructive resize behavior.
 On the first resize in a burst, OpenTUI:
 
 1. Clears the old footer surface.
@@ -125,7 +125,9 @@ Once resize settles, OpenTUI:
 To observe this lifecycle directly, listen for
 `CliRenderEvents.SPLIT_FOOTER_RESIZE_RESET`. The payload reports the current
 phase: entering a resize burst, updating the target size, settling, or
-canceling.## External output mode
+canceling.
+
+## External output mode
 
 The `externalOutputMode` option controls what happens to writes that go through the renderer's configured `stdout.write` while the renderer is active. It does not change `stderr`, and it is separate from the built-in console overlay.
 


### PR DESCRIPTION
When screenMode is "split-footer" and externalOutputMode is "capture-stdout", treat resize as destructive: on the first event in a burst, scroll the upper pane into history, clear the footer area, and buffer further output. Subsequent events in the same burst only update target dimensions, scrolling any newly revealed rows to keep the viewport blank. Once debounce settles, apply the final geometry once, reset split scrollback from origin, and force a full repaint.

You get a clean footer after the user stops dragging. SPLIT_FOOTER_RESIZE_RESET exposes burst-start/update/settle/cancel phases for instrumentation.