### PR TITLE
fix: normalize numpad key names to standard equivalents

### DIFF
--- a/packages/core/src/lib/KeyHandler.test.ts
+++ b/packages/core/src/lib/KeyHandler.test.ts
@@ -636,6 +636,74 @@ test("KeyHandler - internal handler error with preventDefault still respects pre
   expect(internalCalled).toBe(false)
 })
 
+test("KeyHandler - numpad keys are normalized to standard names", () => {
+  const handler = createKeyHandler()
+
+  let receivedKey: KeyEvent | undefined
+  handler.on("keypress", (key: KeyEvent) => {
+    receivedKey = key
+  })
+
+  // Simulate a kitty protocol numpad 5 key (codepoint 57404)
+  dispatchInput(handler, "\x1b[57404u", { useKittyKeyboard: true })
+
+  expect(receivedKey).toBeDefined()
+  expect(receivedKey?.name).toBe("5")
+  expect(receivedKey?.sequence).toBe("5")
+})
+
+test("KeyHandler - numpad enter is normalized to return", () => {
+  const handler = createKeyHandler()
+
+  let receivedKey: KeyEvent | undefined
+  handler.on("keypress", (key: KeyEvent) => {
+    receivedKey = key
+  })
+
+  // Simulate a kitty protocol numpad enter (codepoint 57414)
+  dispatchInput(handler, "\x1b[57414u", { useKittyKeyboard: true })
+
+  expect(receivedKey).toBeDefined()
+  expect(receivedKey?.name).toBe("return")
+})
+
+test("KeyHandler - numpad decimal is normalized to dot", () => {
+  const handler = createKeyHandler()
+
+  let receivedKey: KeyEvent | undefined
+  handler.on("keypress", (key: KeyEvent) => {
+    receivedKey = key
+  })
+
+  // Simulate a kitty protocol numpad decimal (codepoint 57409)
+  dispatchInput(handler, "\x1b[57409u", { useKittyKeyboard: true })
+
+  expect(receivedKey).toBeDefined()
+  expect(receivedKey?.name).toBe(".")
+  expect(receivedKey?.sequence).toBe(".")
+})
+
+test("KeyHandler - numpad operators are normalized", () => {
+  const handler = createKeyHandler()
+
+  const receivedKeys: KeyEvent[] = []
+  handler.on("keypress", (key: KeyEvent) => {
+    receivedKeys.push(key)
+  })
+
+  // kpdivide=57410, kpmultiply=57411, kpminus=57412, kpplus=57413
+  dispatchInput(handler, "\x1b[57410u", { useKittyKeyboard: true })
+  dispatchInput(handler, "\x1b[57411u", { useKittyKeyboard: true })
+  dispatchInput(handler, "\x1b[57412u", { useKittyKeyboard: true })
+  dispatchInput(handler, "\x1b[57413u", { useKittyKeyboard: true })
+
+  expect(receivedKeys).toHaveLength(4)
+  expect(receivedKeys[0]?.name).toBe("/")
+  expect(receivedKeys[1]?.name).toBe("*")
+  expect(receivedKeys[2]?.name).toBe("-")
+  expect(receivedKeys[3]?.name).toBe("+")
+})
+
 test("KeyHandler - error in one event type does not prevent other event types from working", () => {
   const handler = createKeyHandler()
 

--- a/packages/core/src/lib/KeyHandler.ts
+++ b/packages/core/src/lib/KeyHandler.ts
@@ -96,8 +96,37 @@ export type KeyHandlerEventMap = {
   paste: [PasteEvent]
 }
 
+// Map numpad key names to their standard equivalents so that keybindings
+// and direct name checks (e.g. `evt.name === "return"`) work uniformly
+// regardless of whether the key was pressed on the main keyboard or numpad.
+const numpadKeyNameMap: Record<string, string> = {
+  kpenter: "return",
+  kp0: "0",
+  kp1: "1",
+  kp2: "2",
+  kp3: "3",
+  kp4: "4",
+  kp5: "5",
+  kp6: "6",
+  kp7: "7",
+  kp8: "8",
+  kp9: "9",
+  kpdecimal: ".",
+  kpdivide: "/",
+  kpmultiply: "*",
+  kpminus: "-",
+  kpplus: "+",
+  kpequal: "=",
+  kpseparator: ",",
+}
+
 export class KeyHandler extends EventEmitter<KeyHandlerEventMap> {
   public processParsedKey(parsedKey: ParsedKey): boolean {
+    const mappedName = numpadKeyNameMap[parsedKey.name]
+    if (mappedName) {
+      parsedKey.name = mappedName
+      parsedKey.sequence = mappedName
+    }
     try {
       switch (parsedKey.eventType) {
         case "press":


### PR DESCRIPTION
Numpad keys (kp0-kp9, kpenter, kpdecimal, kpdivide, kpmultiply, kpminus, kpplus, kpequal, kpseparator) are reported with distinct names by the kitty keyboard protocol. This causes them to not match keybindings or direct name checks (e.g. `evt.name === "return"` fails for numpad enter).

Normalize numpad key names in `KeyHandler.processParsedKey()` before emitting events, so all downstream handlers see standard key names regardless of whether the key was pressed on the main keyboard or numpad.

The `printableKeypadText` map already existed in the kitty parser to set `key.sequence`, but `key.name` was left as the kp-prefixed variant. This meant text insertion worked in newer versions but keybinding matching and direct name checks still failed.

Fixes anomalyco/opencode#7698
Fixes anomalyco/opencode#17457
Fixes anomalyco/opencode#27138