### PR TITLE
fix(core): preserve markdown block spacing

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -927,9 +927,9 @@ export class MarkdownRenderable extends Renderable {
     return token.type === "code" || token.type === "table" || token.type === "blockquote" || token.type === "hr"
   }
 
-  private getInterBlockMargin(token: MarkedToken, hasNextToken: boolean): number {
-    if (!hasNextToken) return 0
-    return this.shouldRenderSeparately(token) ? 1 : 0
+  private getInterBlockMargin(token: MarkedToken, nextToken: MarkedToken | undefined): number {
+    if (!nextToken) return 0
+    return this.shouldRenderSeparately(token) || this.shouldRenderSeparately(nextToken) ? 1 : 0
   }
 
   private createMarkdownBlockToken(raw: string): MarkedToken {
@@ -1425,9 +1425,9 @@ export class MarkdownRenderable extends Renderable {
     return next ?? this.createTopLevelDefaultRenderable(block, index)
   }
 
-  private createDefaultRenderable(token: MarkedToken, index: number, hasNextToken: boolean = false): Renderable | null {
+  private createDefaultRenderable(token: MarkedToken, index: number, nextToken?: MarkedToken): Renderable | null {
     const id = `${this.id}-block-${index}`
-    const marginBottom = this.getInterBlockMargin(token, hasNextToken)
+    const marginBottom = this.getInterBlockMargin(token, nextToken)
 
     if (token.type === "code") {
       return this.createCodeRenderable(token, id, marginBottom)
@@ -1464,10 +1464,10 @@ export class MarkdownRenderable extends Renderable {
     state: BlockState,
     token: MarkedToken,
     index: number,
-    hasNextToken: boolean,
+    nextToken: MarkedToken | undefined,
     forceListRefresh: boolean = false,
   ): void {
-    const marginBottom = this.getInterBlockMargin(token, hasNextToken)
+    const marginBottom = this.getInterBlockMargin(token, nextToken)
 
     if (token.type === "code") {
       this.applyCodeBlockRenderable(state.renderable, token as Tokens.Code, marginBottom)
@@ -1596,7 +1596,7 @@ export class MarkdownRenderable extends Renderable {
         existing.token.type === block.token.type &&
         this.canUpdateBlockRenderable(existing.renderable, block.token)
       ) {
-        this.updateBlockRenderable(existing, block.token, blockIndex, blockIndex < blocks.length - 1)
+        this.updateBlockRenderable(existing, block.token, blockIndex, blocks[i + 1]?.token)
         existing.renderable.marginBottom = 0
         if (existing.marginTop !== block.marginTop) {
           this.applyMargins(existing.renderable, block.marginTop, 0)
@@ -1677,19 +1677,16 @@ export class MarkdownRenderable extends Renderable {
 
     this._stableBlockCount = 0
     const blockTokens = this.buildRenderableTokens(tokens)
-    const lastBlockIndex = blockTokens.length - 1
-
     let blockIndex = 0
     for (let i = 0; i < blockTokens.length; i++) {
       const token = blockTokens[i]
-      const hasNextToken = i < lastBlockIndex
       const existing = this._blockStates[blockIndex]
 
       const shouldForceRefresh = forceTableRefresh
 
       if (existing && existing.token === token) {
         if (shouldForceRefresh) {
-          this.updateBlockRenderable(existing, token, blockIndex, hasNextToken)
+          this.updateBlockRenderable(existing, token, blockIndex, blockTokens[i + 1])
           existing.tokenRaw = token.raw
         }
         blockIndex++
@@ -1699,7 +1696,7 @@ export class MarkdownRenderable extends Renderable {
       if (existing && existing.tokenRaw === token.raw && existing.token.type === token.type) {
         existing.token = token
         if (shouldForceRefresh) {
-          this.updateBlockRenderable(existing, token, blockIndex, hasNextToken)
+          this.updateBlockRenderable(existing, token, blockIndex, blockTokens[i + 1])
           existing.tokenRaw = token.raw
         }
         blockIndex++
@@ -1707,7 +1704,7 @@ export class MarkdownRenderable extends Renderable {
       }
 
       if (existing && existing.token.type === token.type) {
-        this.updateBlockRenderable(existing, token, blockIndex, hasNextToken)
+        this.updateBlockRenderable(existing, token, blockIndex, blockTokens[i + 1])
         existing.token = token
         existing.tokenRaw = token.raw
         blockIndex++
@@ -1727,7 +1724,7 @@ export class MarkdownRenderable extends Renderable {
           conceal: this._conceal,
           concealCode: this._concealCode,
           treeSitterClient: this._treeSitterClient,
-          defaultRender: () => this.createDefaultRenderable(token, blockIndex, hasNextToken),
+          defaultRender: () => this.createDefaultRenderable(token, blockIndex, blockTokens[i + 1]),
         }
         const custom = this._renderNode(token, context)
         if (custom) {
@@ -1740,12 +1737,12 @@ export class MarkdownRenderable extends Renderable {
           const tableBlock = this.createTableBlock(
             token,
             `${this.id}-block-${blockIndex}`,
-            this.getInterBlockMargin(token, hasNextToken),
+            this.getInterBlockMargin(token, blockTokens[i + 1]),
           )
           renderable = tableBlock.renderable
           tableContentCache = tableBlock.tableContentCache
         } else {
-          renderable = this.createDefaultRenderable(token, blockIndex, hasNextToken) ?? undefined
+          renderable = this.createDefaultRenderable(token, blockIndex, blockTokens[i + 1]) ?? undefined
         }
       }
 
@@ -1792,8 +1789,7 @@ export class MarkdownRenderable extends Renderable {
 
     for (let i = 0; i < this._blockStates.length; i++) {
       const state = this._blockStates[i]
-      const hasNextToken = i < this._blockStates.length - 1
-      const marginBottom = this.getInterBlockMargin(state.token, hasNextToken)
+      const marginBottom = this.getInterBlockMargin(state.token, this._blockStates[i + 1]?.token)
 
       if (state.token.type === "code") {
         this.applyCodeBlockRenderable(state.renderable, state.token as Tokens.Code, marginBottom)
@@ -1806,7 +1802,7 @@ export class MarkdownRenderable extends Renderable {
       }
 
       if (state.token.type === "list") {
-        this.updateBlockRenderable(state, state.token, i, hasNextToken, true)
+        this.updateBlockRenderable(state, state.token, i, this._blockStates[i + 1]?.token, true)
         continue
       }
 

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -167,6 +167,7 @@ export interface BlockState {
   marginTop?: number
   renderable: Renderable
   tableContentCache?: TableContentCache
+  tracksInterBlockMargin?: boolean
 }
 
 export type { ParseState }
@@ -929,7 +930,14 @@ export class MarkdownRenderable extends Renderable {
 
   private getInterBlockMargin(token: MarkedToken, nextToken: MarkedToken | undefined): number {
     if (!nextToken) return 0
-    return this.shouldRenderSeparately(token) || this.shouldRenderSeparately(nextToken) ? 1 : 0
+    if (this.shouldRenderSeparately(token)) return 1
+    if (!this.shouldRenderSeparately(nextToken)) return 0
+    return TRAILING_MARKDOWN_BLOCK_NEWLINES_RE.test(token.raw) ? 0 : 1
+  }
+
+  private applyInterBlockMargin(state: BlockState, token: MarkedToken, nextToken: MarkedToken | undefined): void {
+    if (state.tracksInterBlockMargin === false) return
+    state.renderable.marginBottom = this.getInterBlockMargin(token, nextToken)
   }
 
   private createMarkdownBlockToken(raw: string): MarkedToken {
@@ -1665,6 +1673,7 @@ export class MarkdownRenderable extends Renderable {
           tokenRaw: this._content,
           marginTop: 0,
           renderable: fallback,
+          tracksInterBlockMargin: true,
         },
       ]
       return
@@ -1680,14 +1689,17 @@ export class MarkdownRenderable extends Renderable {
     let blockIndex = 0
     for (let i = 0; i < blockTokens.length; i++) {
       const token = blockTokens[i]
+      const nextToken = blockTokens[i + 1]
       const existing = this._blockStates[blockIndex]
 
       const shouldForceRefresh = forceTableRefresh
 
       if (existing && existing.token === token) {
         if (shouldForceRefresh) {
-          this.updateBlockRenderable(existing, token, blockIndex, blockTokens[i + 1])
+          this.updateBlockRenderable(existing, token, blockIndex, nextToken)
           existing.tokenRaw = token.raw
+        } else {
+          this.applyInterBlockMargin(existing, token, nextToken)
         }
         blockIndex++
         continue
@@ -1696,17 +1708,20 @@ export class MarkdownRenderable extends Renderable {
       if (existing && existing.tokenRaw === token.raw && existing.token.type === token.type) {
         existing.token = token
         if (shouldForceRefresh) {
-          this.updateBlockRenderable(existing, token, blockIndex, blockTokens[i + 1])
+          this.updateBlockRenderable(existing, token, blockIndex, nextToken)
           existing.tokenRaw = token.raw
+        } else {
+          this.applyInterBlockMargin(existing, token, nextToken)
         }
         blockIndex++
         continue
       }
 
       if (existing && existing.token.type === token.type) {
-        this.updateBlockRenderable(existing, token, blockIndex, blockTokens[i + 1])
+        this.updateBlockRenderable(existing, token, blockIndex, nextToken)
         existing.token = token
         existing.tokenRaw = token.raw
+        existing.tracksInterBlockMargin = true
         blockIndex++
         continue
       }
@@ -1717,18 +1732,24 @@ export class MarkdownRenderable extends Renderable {
 
       let renderable: Renderable | undefined
       let tableContentCache: TableContentCache | undefined
+      let tracksInterBlockMargin = true
 
       if (this._renderNode) {
+        let defaultRenderable: Renderable | null | undefined
         const context: RenderNodeContext = {
           syntaxStyle: this._syntaxStyle,
           conceal: this._conceal,
           concealCode: this._concealCode,
           treeSitterClient: this._treeSitterClient,
-          defaultRender: () => this.createDefaultRenderable(token, blockIndex, blockTokens[i + 1]),
+          defaultRender: () => {
+            defaultRenderable = this.createDefaultRenderable(token, blockIndex, nextToken)
+            return defaultRenderable
+          },
         }
         const custom = this._renderNode(token, context)
         if (custom) {
           renderable = custom
+          tracksInterBlockMargin = custom === defaultRenderable
         }
       }
 
@@ -1737,12 +1758,12 @@ export class MarkdownRenderable extends Renderable {
           const tableBlock = this.createTableBlock(
             token,
             `${this.id}-block-${blockIndex}`,
-            this.getInterBlockMargin(token, blockTokens[i + 1]),
+            this.getInterBlockMargin(token, nextToken),
           )
           renderable = tableBlock.renderable
           tableContentCache = tableBlock.tableContentCache
         } else {
-          renderable = this.createDefaultRenderable(token, blockIndex, blockTokens[i + 1]) ?? undefined
+          renderable = this.createDefaultRenderable(token, blockIndex, nextToken) ?? undefined
         }
       }
 
@@ -1758,6 +1779,7 @@ export class MarkdownRenderable extends Renderable {
           tokenRaw: token.raw,
           renderable,
           tableContentCache,
+          tracksInterBlockMargin,
         }
       }
       blockIndex++

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -484,6 +484,25 @@ test("table inside code block should NOT be formatted", async () => {
   `)
 })
 
+test("paragraphs and fenced code blocks keep markdown block spacing", async () => {
+  const markdown = `Before
+
+\`\`\`ts
+const value = 1
+\`\`\`
+
+After`
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    Before
+
+    const value = 1
+
+    After"
+  `)
+})
+
 test("multiple tables in same document", async () => {
   const markdown = `| Table1 | A |
 |---|---|
@@ -504,6 +523,7 @@ Some text between.
     └──────┴─┘
 
     Some text between.
+
     ┌────────────┬──┐
     │Table2      │BB│
     ├────────────┼──┤
@@ -755,6 +775,7 @@ This is a paragraph after the table.`
   expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
     "
     This is a paragraph before the table.
+
     ┌─────┬───┐
     │Name │Age│
     ├─────┼───┤
@@ -850,6 +871,7 @@ And here is more text after.`
   expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
     "
     Here is some code:
+
     function hello() {
       return "world";
     }
@@ -874,9 +896,11 @@ fn main() {}
   expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
     "
     First block:
+
     print("hello")
 
     Second block:
+
     fn main() {}"
   `)
 })
@@ -1683,8 +1707,9 @@ After`
   expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
     "
     Before
+
     ────────────────────────────────────────────────────────────
-    
+
     After"
   `)
 })
@@ -1756,6 +1781,7 @@ Visit [GitHub](https://github.com) for more.
 
     Code Example
 
+
     const md = new MarkdownRenderable(ctx, {
       content: "# Hello",
     })
@@ -1763,6 +1789,7 @@ Visit [GitHub](https://github.com) for more.
     Links
 
     Visit GitHub (https://github.com) for more.
+
     ────────────────────────────────────────────────────────────
 
     Press ? for help"
@@ -2025,6 +2052,7 @@ console.log(x);`
   expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
     "
     Here is some code:
+
     const x = 1;
     console.log(x);"
   `)
@@ -2169,6 +2197,7 @@ const x = 1;
   expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
     "
     Text before
+
     const x = 1;"
   `)
 })

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1,4 +1,5 @@
 import { test, expect, beforeAll, beforeEach, afterEach, afterAll } from "bun:test"
+import { Edge } from "yoga-layout"
 import { Lexer } from "marked"
 import { MarkdownRenderable, type MarkdownOptions } from "../Markdown.js"
 import { CodeRenderable } from "../Code.js"
@@ -122,6 +123,15 @@ function findSpanContaining(frame: CapturedFrame, text: string) {
   }
 
   return undefined
+}
+
+function getMarginBottom(renderable: { getLayoutNode(): { getMargin(edge: Edge): unknown } }): number {
+  const margin = renderable.getLayoutNode().getMargin(Edge.Bottom) as unknown
+  if (typeof margin === "number") return margin
+  if (typeof margin === "object" && margin && "value" in margin && typeof margin.value === "number") {
+    return margin.value
+  }
+  return 0
 }
 
 test("basic table alignment", async () => {
@@ -500,6 +510,160 @@ After`
     const value = 1
 
     After"
+  `)
+})
+
+test("paragraphs keep spacing when a fenced code block is appended", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-append-code-spacing",
+    content: "Before",
+    syntaxStyle,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  md.content = `Before
+
+\`\`\`ts
+const value = 1
+\`\`\``
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates.map((state) => state.token.type)).toEqual(["paragraph", "code"])
+  expect(getMarginBottom(md._blockStates[0]!.renderable)).toBe(1)
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    Before
+
+    const value = 1"
+  `)
+})
+
+test("paragraph margins update when a following fenced code block is removed", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-remove-code-spacing",
+    content: `Before
+
+\`\`\`ts
+const value = 1
+\`\`\``,
+    syntaxStyle,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  expect(getMarginBottom(md._blockStates[0]!.renderable)).toBe(1)
+
+  md.content = "Before"
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates.map((state) => state.token.type)).toEqual(["paragraph"])
+  expect(getMarginBottom(md._blockStates[0]!.renderable)).toBe(0)
+})
+
+test("code block margins update when a following paragraph is removed", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-remove-paragraph-after-code-spacing",
+    content: `\`\`\`ts
+const value = 1
+\`\`\`
+
+After`,
+    syntaxStyle,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates.map((state) => state.token.type)).toEqual(["code", "paragraph"])
+  expect(getMarginBottom(md._blockStates[0]!.renderable)).toBe(1)
+
+  md.content = `\`\`\`ts
+const value = 1
+\`\`\``
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates.map((state) => state.token.type)).toEqual(["code"])
+  expect(getMarginBottom(md._blockStates[0]!.renderable)).toBe(0)
+})
+
+test("tight paragraphs and fenced code blocks keep exactly one separator row", async () => {
+  const markdown = `Before
+\`\`\`ts
+const value = 1
+\`\`\``
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    Before
+
+    const value = 1"
+  `)
+})
+
+test("headings and fenced code blocks keep exactly one separator row", async () => {
+  const markdown = `## Before
+
+\`\`\`ts
+const value = 1
+\`\`\``
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    Before
+
+    const value = 1"
+  `)
+})
+
+test("headings and tables keep exactly one separator row", async () => {
+  const markdown = `## Before
+
+| A | B |
+|---|---|
+| 1 | 2 |`
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    Before
+
+    ┌─┬─┐
+    │A│B│
+    ├─┼─┤
+    │1│2│
+    └─┴─┘"
+  `)
+})
+
+test("headings and blockquotes keep exactly one separator row", async () => {
+  const markdown = `## Before
+
+> quoted text`
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    Before
+
+    │ quoted text"
+  `)
+})
+
+test("headings and horizontal rules keep exactly one separator row", async () => {
+  const markdown = `## Before
+
+---`
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    Before
+
+    ────────────────────────────────────────────────────────────"
   `)
 })
 
@@ -1780,7 +1944,6 @@ Visit [GitHub](https://github.com) for more.
     - Italic and bold text
 
     Code Example
-
 
     const md = new MarkdownRenderable(ctx, {
       content: "# Hello",


### PR DESCRIPTION
**What changed**

Markdown block margins now consider both sides of a render-block edge. Separately rendered blocks like fenced code, tables, blockquotes, and horizontal rules keep a blank line when either the current block or the next block needs separation.

**Why**

Paragraphs before fenced code blocks rendered without the markdown paragraph gap, so the code block visually touched the paragraph. The old logic only looked at the current token, which handled spacing after separately rendered blocks but not before them.

**Validation**

- `bun test src/renderables/__tests__/Markdown.test.ts -u`
- `bun run test`