### PR TITLE
fix(core): Preserve empty lines when copying selected text

### DIFF
--- a/packages/core/src/renderables/Text.test.ts
+++ b/packages/core/src/renderables/Text.test.ts
@@ -144,10 +144,11 @@ describe("TextRenderable Selection", () => {
       const selection = text.getSelection()
       expect(selection).not.toBe(null)
       // With newline-aware offsets: Line 0 (0-5) + newline (6) + Line 1 (7-12) + newline (13) + Line 2 empty (14)
-      // Selecting to (col=2, row=2) on empty line clamps to col=0, so end=14
+      // Selecting to (col=2, row=2) on empty line clamps to col=0, so end=14.
+      // The range includes the line break before the empty logical line.
       expect(selection!.start).toBe(0)
       expect(selection!.end).toBe(14)
-      expect(text.getSelectedText()).toBe("Line 1\nLine 2")
+      expect(text.getSelectedText()).toBe("Line 1\nLine 2\n")
     })
 
     it("should handle selection ending in empty line", async () => {
@@ -163,10 +164,11 @@ describe("TextRenderable Selection", () => {
       const selection = text.getSelection()
       expect(selection).not.toBe(null)
       // With newline-aware offsets: Line 0 (0-5) + newline (6) + Line 1 empty (7)
-      // Selecting to (col=3, row=1) on empty line clamps to col=0, so end=7
+      // Selecting to (col=3, row=1) on empty line clamps to col=0, so end=7.
+      // The range includes the line break before the empty logical line.
       expect(selection!.start).toBe(0)
       expect(selection!.end).toBe(7)
-      expect(text.getSelectedText()).toBe("Line 1")
+      expect(text.getSelectedText()).toBe("Line 1\n")
     })
 
     it("should handle selection spanning multiple lines completely", async () => {

--- a/packages/core/src/renderables/__tests__/Textarea.keybinding.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.keybinding.test.ts
@@ -3026,9 +3026,9 @@ describe("Textarea - Keybinding Tests", () => {
       // At end of line 1
       editor.editBuffer.setCursor(0, 6)
 
-      // First ctrl+shift+a from EOL should select entire line
+      // First ctrl+shift+a from EOL selects through the line break at EOL
       kittyMockInput.pressKey("a", { ctrl: true, shift: true })
-      expect(editor.getSelectedText()).toBe("Line 1")
+      expect(editor.getSelectedText()).toBe("Line 1\n")
 
       // Reset
       editor.editBuffer.setCursor(0, 0)

--- a/packages/core/src/renderables/__tests__/Textarea.selection.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.selection.test.ts
@@ -578,7 +578,7 @@ describe("Textarea - Selection Tests", () => {
 
       expect(editor.hasSelection()).toBe(true)
       const selectedText = editor.getSelectedText()
-      expect(selectedText).toBe("Line 1")
+      expect(selectedText).toBe("Line 1\n")
     })
 
     it("should select with shift+up", async () => {
@@ -744,7 +744,7 @@ describe("Textarea - Selection Tests", () => {
       currentMockInput.pressArrow("down", { shift: true })
 
       const selectedText = editor.getSelectedText()
-      expect(selectedText).toBe("Line 2")
+      expect(selectedText).toBe("Line 2\n")
 
       currentMockInput.pressKey("DELETE")
 

--- a/packages/core/src/zig/tests/text-buffer-selection_test.zig
+++ b/packages/core/src/zig/tests/text-buffer-selection_test.zig
@@ -512,6 +512,28 @@ test "Selection - getSelectedText with newlines" {
     try std.testing.expectEqualStrings("Line 1\nLi", text);
 }
 
+test "Selection - getSelectedText preserves empty lines" {
+  const pool = gp.initGlobalPool(std.testing.allocator);
+  defer gp.deinitGlobalPool();
+  const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+  defer link.deinitGlobalLinkPool();
+
+  var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+  defer tb.deinit();
+
+  var view = try TextBufferView.init(std.testing.allocator, tb);
+  defer view.deinit();
+
+  try tb.setText("const a = 1\n\nconst b = 2");
+
+  view.setSelection(0, 24, null, null);
+
+  var out_buffer: [100]u8 = undefined;
+  const len = view.getSelectedTextIntoBuffer(&out_buffer);
+
+  try std.testing.expectEqualStrings("const a = 1\n\nconst b = 2", out_buffer[0..len]);
+}
+
 test "Selection - spanning multiple lines with getSelectedText" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/core/src/zig/tests/text-buffer-selection_test.zig
+++ b/packages/core/src/zig/tests/text-buffer-selection_test.zig
@@ -513,25 +513,25 @@ test "Selection - getSelectedText with newlines" {
 }
 
 test "Selection - getSelectedText preserves empty lines" {
-  const pool = gp.initGlobalPool(std.testing.allocator);
-  defer gp.deinitGlobalPool();
-  const link_pool = link.initGlobalLinkPool(std.testing.allocator);
-  defer link.deinitGlobalLinkPool();
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
 
-  var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
-  defer tb.deinit();
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
 
-  var view = try TextBufferView.init(std.testing.allocator, tb);
-  defer view.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
 
-  try tb.setText("const a = 1\n\nconst b = 2");
+    try tb.setText("const a = 1\n\nconst b = 2");
 
-  view.setSelection(0, 24, null, null);
+    view.setSelection(0, 24, null, null);
 
-  var out_buffer: [100]u8 = undefined;
-  const len = view.getSelectedTextIntoBuffer(&out_buffer);
+    var out_buffer: [100]u8 = undefined;
+    const len = view.getSelectedTextIntoBuffer(&out_buffer);
 
-  try std.testing.expectEqualStrings("const a = 1\n\nconst b = 2", out_buffer[0..len]);
+    try std.testing.expectEqualStrings("const a = 1\n\nconst b = 2", out_buffer[0..len]);
 }
 
 test "Selection - spanning multiple lines with getSelectedText" {

--- a/packages/core/src/zig/text-buffer-iterators.zig
+++ b/packages/core/src/zig/text-buffer-iterators.zig
@@ -414,7 +414,6 @@ pub fn extractTextBetweenOffsets(
         start: u32,
         end: u32,
         line_count: u32,
-        line_had_content: bool = false,
 
         fn segment_callback(ctx_ptr: *anyopaque, line_idx: u32, chunk: *const TextChunk, chunk_idx_in_line: u32) void {
             _ = line_idx;
@@ -429,8 +428,6 @@ pub fn extractTextBetweenOffsets(
                 ctx.col_offset.* = chunk_end_offset;
                 return;
             }
-
-            ctx.line_had_content = true;
 
             const chunk_bytes = chunk.getBytes(ctx.mem_registry);
             const is_ascii_only = (chunk.flags & TextChunk.Flags.ASCII_ONLY) != 0;
@@ -469,15 +466,14 @@ pub fn extractTextBetweenOffsets(
             const ctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
 
             // Add newline if we had content and range extends beyond this line's newline
-            if (ctx.line_had_content and line_info.line_idx < ctx.line_count - 1 and ctx.col_offset.* + 1 < ctx.end and ctx.out_index.* < ctx.out_buffer.len) {
+            const newline_offset = ctx.col_offset.*;
+            if (line_info.line_idx < ctx.line_count - 1 and newline_offset >= ctx.start and newline_offset < ctx.end and ctx.out_index.* < ctx.out_buffer.len) {
                 ctx.out_buffer[ctx.out_index.*] = '\n';
                 ctx.out_index.* += 1;
             }
 
             // Account for newline in display offset
             ctx.col_offset.* += 1;
-
-            ctx.line_had_content = false;
         }
     };
 

--- a/packages/core/src/zig/text-buffer-iterators.zig
+++ b/packages/core/src/zig/text-buffer-iterators.zig
@@ -465,7 +465,8 @@ pub fn extractTextBetweenOffsets(
         fn line_end_callback(ctx_ptr: *anyopaque, line_info: LineInfo) void {
             const ctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
 
-            // Add newline if we had content and range extends beyond this line's newline
+            // Add newline when the newline offset is inside the selected range,
+            // even for empty logical lines.
             const newline_offset = ctx.col_offset.*;
             if (line_info.line_idx < ctx.line_count - 1 and newline_offset >= ctx.start and newline_offset < ctx.end and ctx.out_index.* < ctx.out_buffer.len) {
                 ctx.out_buffer[ctx.out_index.*] = '\n';


### PR DESCRIPTION
OpenTUI currently completely drops empty logical lines from selected text. This means highlight-copying code can remove intentional blank lines, which often breaks formatting.

This affects Opencode heavily, making copying/pasting code excessively annoying because all blank lines are completely erased.

The behavior was caused by `extractTextBetweenOffsets`. Newline output was gated on whether the line had content, therefore empty selected lines never emitted their newline. This PR changes newline emission to be based on whether the newline offset is inside the selected range, regardless of line content.

 Includes a regression test for:

 ```txt
const a = 1

const b = 2
 ```

copying back exactly as selected.