### PR TITLE
fix(core): map SS3 application-keypad sequences for numpad keys

### DIFF
--- a/packages/core/src/lib/parse.keypress.test.ts
+++ b/packages/core/src/lib/parse.keypress.test.ts
@@ -1955,3 +1955,66 @@ test("parseKeypress - preserves printable Unicode characters including non-BMP",
     expect(key.shift).toBe(false)
   }
 })
+
+test("parseKeypress - SS3 application keypad digits (ESC O p..y)", () => {
+  const cases: Array<[string, string]> = [
+    ["\x1bOp", "0"],
+    ["\x1bOq", "1"],
+    ["\x1bOr", "2"],
+    ["\x1bOs", "3"],
+    ["\x1bOt", "4"],
+    ["\x1bOu", "5"],
+    ["\x1bOv", "6"],
+    ["\x1bOw", "7"],
+    ["\x1bOx", "8"],
+    ["\x1bOy", "9"],
+  ]
+
+  for (const [seq, digit] of cases) {
+    const key = parseKeypress(seq)
+    expect(key).not.toBeNull()
+    expect(key!.name).toBe(digit)
+    // sequence must be the printable digit, not the raw ESC sequence,
+    // so that text-insertion components can insert it without filtering it
+    expect(key!.sequence).toBe(digit)
+    expect(key!.number).toBe(true)
+    expect(key!.ctrl).toBe(false)
+    expect(key!.meta).toBe(false)
+    expect(key!.shift).toBe(false)
+    expect(key!.source).toBe("raw")
+  }
+})
+
+test("parseKeypress - SS3 application keypad operators (ESC O j/k/l/m/n/o/X)", () => {
+  const cases: Array<[string, string]> = [
+    ["\x1bOj", "*"],
+    ["\x1bOk", "+"],
+    ["\x1bOl", ","],
+    ["\x1bOm", "-"],
+    ["\x1bOn", "."],
+    ["\x1bOo", "/"],
+    ["\x1bOX", "="],
+  ]
+
+  for (const [seq, char] of cases) {
+    const key = parseKeypress(seq)
+    expect(key).not.toBeNull()
+    expect(key!.name).toBe(char)
+    expect(key!.sequence).toBe(char)
+    expect(key!.number).toBe(false)
+    expect(key!.ctrl).toBe(false)
+    expect(key!.meta).toBe(false)
+    expect(key!.shift).toBe(false)
+    expect(key!.source).toBe("raw")
+  }
+})
+
+test("parseKeypress - SS3 application keypad Enter (ESC O M)", () => {
+  const key = parseKeypress("\x1bOM")
+  expect(key).not.toBeNull()
+  expect(key!.name).toBe("return")
+  expect(key!.ctrl).toBe(false)
+  expect(key!.meta).toBe(false)
+  expect(key!.shift).toBe(false)
+  expect(key!.source).toBe("raw")
+})

--- a/packages/core/src/lib/parse.keypress.ts
+++ b/packages/core/src/lib/parse.keypress.ts
@@ -53,6 +53,27 @@ const keyName: Record<string, string> = {
   OE: "clear",
   OF: "end",
   OH: "home",
+  /* VT100 application keypad (SS3) — sent when terminal enables DECKPAM (ESC =).
+   * macOS Terminal.app and other xterm-based terminals emit these when running
+   * full-screen apps with the alternate screen. */
+  OM: "return",
+  Oj: "*",
+  Ok: "+",
+  Ol: ",",
+  Om: "-",
+  On: ".",
+  Oo: "/",
+  Op: "0",
+  Oq: "1",
+  Or: "2",
+  Os: "3",
+  Ot: "4",
+  Ou: "5",
+  Ov: "6",
+  Ow: "7",
+  Ox: "8",
+  Oy: "9",
+  OX: "=",
   /* xterm/rxvt ESC [ number ~ */
   "[1~": "home",
   "[2~": "insert",
@@ -162,6 +183,30 @@ export interface ParsedKey {
 
 export type ParseKeypressOptions = {
   useKittyKeyboard?: boolean
+}
+
+// Printable characters for VT100 SS3 application-keypad sequences.
+// When the terminal is in application keypad mode (DECKPAM / ESC =), numpad keys
+// send these SS3 codes instead of raw ASCII characters. The keys map to the same
+// printable output as their regular-keyboard equivalents.
+const ss3NumpadPrintable: Record<string, string> = {
+  Op: "0",
+  Oq: "1",
+  Or: "2",
+  Os: "3",
+  Ot: "4",
+  Ou: "5",
+  Ov: "6",
+  Ow: "7",
+  Ox: "8",
+  Oy: "9",
+  Oj: "*",
+  Ok: "+",
+  Ol: ",",
+  Om: "-",
+  On: ".",
+  Oo: "/",
+  OX: "=",
 }
 
 const modifyOtherKeysRe = /^\x1b\[27;(\d+);(\d+)~$/
@@ -407,6 +452,17 @@ export const parseKeypress = (s: Buffer | string = "", options: ParseKeypressOpt
       key.name = keyNameResult
       key.shift = isShiftKey(code) || key.shift
       key.ctrl = isCtrlKey(code) || key.ctrl
+
+      // SS3 application-keypad sequences have a raw sequence starting with ESC
+      // which the text-insertion branch would filter out (charCode 27 < 32).
+      // Override sequence with the printable character so text input works.
+      const ss3Char = ss3NumpadPrintable[code]
+      if (ss3Char !== undefined) {
+        key.sequence = ss3Char
+        if (key.name >= "0" && key.name <= "9") {
+          key.number = true
+        }
+      }
     } else {
       // If we matched the regex but didn't find a valid key name,
       // reset the key to default state (unknown sequence)


### PR DESCRIPTION
VT100 application keypad mode (DECKPAM / ESC =) causes terminals to send SS3 escape sequences (ESC O p..y, ESC O M, ESC O j/k/l/m/n/o/X) instead of raw ASCII for numpad keys. These sequences were not mapped in the keyName table, so they were silently dropped — numpad produced no output.

Add the missing entries to keyName and override key.sequence with the printable character (not the raw ESC sequence) for digits and operators, so that text-insertion components receive an insertable character. Also set key.number = true for numpad digit events to match the behaviour of typing a digit from the main keyboard row.

Affected sequences:
  ESC O p..y  -> digits 0-9 (with sequence override and number:true)
  ESC O M     -> return (numpad Enter)
  ESC O j     -> * (multiply)
  ESC O k     -> + (plus)
  ESC O l     -> , (separator)
  ESC O m     -> - (minus)
  ESC O n     -> . (decimal)
  ESC O o     -> / (divide)
  ESC O X     -> = (equal)

Reproduces on macOS Terminal.app and any xterm-compatible terminal that enters application keypad mode via alternate-screen setup.

Related: anomalyco/opencode#27138, anomalyco/opentui#1097