### PR TITLE
chore(core): gitignore src/zig/zig-pkg cache dir

### DIFF
--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -2,3 +2,4 @@
 .zig-cache
 zig-out
 src/zig/lib
+src/zig/zig-pkg


### PR DESCRIPTION
This directory is created during `zig` builds and contains downloaded zig packages