### PR TITLE
core(renderer): handle ANSI text written to stdout in split-footer mode

### DIFF
--- a/packages/core/src/lib/external-output-byte-chunk.ts
+++ b/packages/core/src/lib/external-output-byte-chunk.ts
@@ -1,0 +1,66 @@
+import { stringWidth, stripANSI } from "../platform/runtime.js"
+
+export type ExternalOutputRendering = "emulated" | "terminal-native"
+
+export interface ByteChunkExternalOutputCommit {
+  kind: "bytes"
+  snapshot?: undefined
+  text: string
+  bytes: Uint8Array
+  rowWidths: Uint32Array
+  startOnNewLine: false
+  trailingNewline: boolean
+}
+
+const encoder = new TextEncoder()
+const NEWLINE_CODE_POINT = "\n".charCodeAt(0)
+
+function getByteChunkOutputRowWidth(line: string): number {
+  const visibleLine = stripANSI(line).split("\r").at(-1) ?? ""
+  return stringWidth(visibleLine)
+}
+
+function measureByteChunkRows(text: string): { rowWidths: Uint32Array; trailingNewline: boolean } | null {
+  const rowWidths: number[] = []
+  let rowStart = 0
+
+  for (let index = 0; index < text.length; index += 1) {
+    if (text.charCodeAt(index) !== NEWLINE_CODE_POINT) {
+      continue
+    }
+
+    rowWidths.push(getByteChunkOutputRowWidth(text.slice(rowStart, index)))
+    rowStart = index + 1
+  }
+
+  const trailingNewline = rowStart === text.length
+  if (!trailingNewline) {
+    rowWidths.push(getByteChunkOutputRowWidth(text.slice(rowStart)))
+  }
+
+  if (rowWidths.length === 0) {
+    return null
+  }
+
+  return { rowWidths: Uint32Array.from(rowWidths), trailingNewline }
+}
+
+export function createByteChunkExternalOutputCommit(text: string): ByteChunkExternalOutputCommit | null {
+  if (text.length === 0) {
+    return null
+  }
+
+  const measuredRows = measureByteChunkRows(text)
+  if (measuredRows === null) {
+    return null
+  }
+
+  return {
+    kind: "bytes",
+    text,
+    bytes: encoder.encode(text),
+    rowWidths: measuredRows.rowWidths,
+    startOnNewLine: false,
+    trailingNewline: measuredRows.trailingNewline,
+  }
+}

--- a/packages/core/src/lib/external-output-byte-chunk.ts
+++ b/packages/core/src/lib/external-output-byte-chunk.ts
@@ -7,7 +7,7 @@ export interface ByteChunkExternalOutputCommit {
   snapshot?: undefined
   text: string
   bytes: Uint8Array
-  rowWidths: Uint32Array
+  rowColumnsByRow: Uint32Array
   startOnNewLine: false
   trailingNewline: boolean
 }
@@ -20,8 +20,8 @@ function getByteChunkOutputRowWidth(line: string): number {
   return stringWidth(visibleLine)
 }
 
-function measureByteChunkRows(text: string): { rowWidths: Uint32Array; trailingNewline: boolean } | null {
-  const rowWidths: number[] = []
+function measureByteChunkRows(text: string): { rowColumnsByRow: Uint32Array; trailingNewline: boolean } | null {
+  const rowColumnsByRow: number[] = []
   let rowStart = 0
 
   for (let index = 0; index < text.length; index += 1) {
@@ -29,20 +29,20 @@ function measureByteChunkRows(text: string): { rowWidths: Uint32Array; trailingN
       continue
     }
 
-    rowWidths.push(getByteChunkOutputRowWidth(text.slice(rowStart, index)))
+    rowColumnsByRow.push(getByteChunkOutputRowWidth(text.slice(rowStart, index)))
     rowStart = index + 1
   }
 
   const trailingNewline = rowStart === text.length
   if (!trailingNewline) {
-    rowWidths.push(getByteChunkOutputRowWidth(text.slice(rowStart)))
+    rowColumnsByRow.push(getByteChunkOutputRowWidth(text.slice(rowStart)))
   }
 
-  if (rowWidths.length === 0) {
+  if (rowColumnsByRow.length === 0) {
     return null
   }
 
-  return { rowWidths: Uint32Array.from(rowWidths), trailingNewline }
+  return { rowColumnsByRow: Uint32Array.from(rowColumnsByRow), trailingNewline }
 }
 
 export function createByteChunkExternalOutputCommit(text: string): ByteChunkExternalOutputCommit | null {
@@ -59,7 +59,7 @@ export function createByteChunkExternalOutputCommit(text: string): ByteChunkExte
     kind: "bytes",
     text,
     bytes: encoder.encode(text),
-    rowWidths: measuredRows.rowWidths,
+    rowColumnsByRow: measuredRows.rowColumnsByRow,
     startOnNewLine: false,
     trailingNewline: measuredRows.trailingNewline,
   }

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -2331,15 +2331,18 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     const commits = this.externalOutputQueue.claim(drainAll ? Number.POSITIVE_INFINITY : this.maxSplitCommitsPerFrame)
     let hasCommittedOutput = false
     const lastCommitIndex = commits.length - 1
+    const hasMixedCommitKinds = commits.some((commit) => commit.kind !== commits[0]?.kind)
 
     for (const [index, commit] of commits.entries()) {
       // Force repaint only on the last commit in a frame. Repainting after every
       // chunk negates batching and reintroduces duplicate clear/move traffic.
       const forceCommit = forceFooterRepaint && index === lastCommitIndex
       // beginFrame/finalizeFrame tell native code whether this commit opens or
-      // closes the shared frame envelope. Intermediate commits append payload only.
-      const beginFrame = index === 0
-      const finalizeFrame = index === lastCommitIndex
+      // closes the shared frame envelope. Keep homogeneous bursts batched, but do
+      // not mix rendered snapshots and terminal-native byte chunks in one native
+      // frame because the FFI path can drop bytes from mixed batches.
+      const beginFrame = hasMixedCommitKinds ? true : index === 0
+      const finalizeFrame = hasMixedCommitKinds ? true : index === lastCommitIndex
 
       try {
         // Keep split append policy in native code so every producer (captured stdout

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -47,6 +47,13 @@ import { type Clock, type TimerHandle, SystemClock } from "./lib/clock.js"
 import { StdinParser, type StdinEvent, type StdinParserProtocolContext } from "./lib/stdin-parser.js"
 import { matchesKeyBinding } from "./lib/keybinding.internal.js"
 import { RendererThemeMode } from "./renderer-theme-mode.js"
+import {
+  createByteChunkExternalOutputCommit,
+  type ExternalOutputRendering,
+  type ByteChunkExternalOutputCommit,
+} from "./lib/external-output-byte-chunk.js"
+
+export type { ExternalOutputRendering } from "./lib/external-output-byte-chunk.js"
 
 registerEnvVar({
   name: "OTUI_DUMP_CAPTURES",
@@ -162,6 +169,15 @@ export interface CliRendererConfig {
   // Choose what happens to writes that go through `stdout.write`.
   externalOutputMode?: ExternalOutputMode
 
+  // Choose how captured external output is rendered in split-footer mode.
+  //
+  // - "emulated": render captured output through OpenTUI snapshots.
+  // - "terminal-native": write captured output bytes directly while accounting
+  //   for their terminal row widths. This preserves ANSI escape codes.
+  //
+  // Defaults to "emulated".
+  externalOutputRendering?: ExternalOutputRendering
+
   // Choose what the built-in console overlay does.
   consoleMode?: ConsoleMode
 
@@ -204,12 +220,26 @@ export type ScreenMode = "alternate-screen" | "main-screen" | "split-footer"
 // - "passthrough": Leave stdout alone.
 export type ExternalOutputMode = "capture-stdout" | "passthrough"
 
-export interface CliRendererExternalOutputEvent {
+export interface CliRendererSnapshotExternalOutputEvent {
+  kind: "snapshot"
   snapshot: OptimizedBuffer
   rowColumns: number
   startOnNewLine: boolean
   trailingNewline: boolean
 }
+
+export interface CliRendererByteChunkExternalOutputEvent {
+  kind: "bytes"
+  snapshot?: undefined
+  text: string
+  rowWidths: Uint32Array
+  startOnNewLine: boolean
+  trailingNewline: boolean
+}
+
+export type CliRendererExternalOutputEvent =
+  | CliRendererSnapshotExternalOutputEvent
+  | CliRendererByteChunkExternalOutputEvent
 
 // Controls the built-in console overlay:
 //
@@ -312,6 +342,7 @@ function resolveModes(config: CliRendererConfig): {
   screenMode: ScreenMode
   footerHeight: number
   externalOutputMode: ExternalOutputMode
+  externalOutputRendering: ExternalOutputRendering
 } {
   let screenMode = config.screenMode ?? "alternate-screen"
   if (process.env.OTUI_USE_ALTERNATE_SCREEN !== undefined) {
@@ -335,15 +366,19 @@ function resolveModes(config: CliRendererConfig): {
     screenMode,
     footerHeight,
     externalOutputMode,
+    externalOutputRendering: config.externalOutputRendering ?? "emulated",
   }
 }
 
-type ExternalOutputCommit = {
+type ExternalOutputSnapshotCommit = {
+  kind: "snapshot"
   snapshot: OptimizedBuffer
   rowColumns: number
   startOnNewLine: boolean
   trailingNewline: boolean
 }
+
+type ExternalOutputCommit = ExternalOutputSnapshotCommit | ByteChunkExternalOutputCommit
 
 type PendingSplitFooterTransition = {
   mode: "viewport-scroll" | "clear-stale-rows"
@@ -392,7 +427,7 @@ class ExternalOutputQueue {
 
   clear(): void {
     for (const commit of this.commits) {
-      commit.snapshot.destroy()
+      commit.snapshot?.destroy()
     }
     this.commits = []
   }
@@ -804,6 +839,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private _screenMode: ScreenMode = "alternate-screen"
   private _footerHeight: number = DEFAULT_FOOTER_HEIGHT
   private _externalOutputMode: ExternalOutputMode = "passthrough"
+  private _externalOutputRendering: ExternalOutputRendering = "emulated"
+  private deferredByteChunkTrailingNewline: boolean = false
   private clearOnShutdown: boolean = true
   private _suspendedMouseEnabled: boolean = false
   private _previousControlState: RendererControlState = RendererControlState.IDLE
@@ -893,8 +930,12 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     let capturedExternalOutput = ""
     for (const commit of capturedExternalOutputCommits) {
-      capturedExternalOutput += `[snapshot ${commit.snapshot.width}x${commit.snapshot.height}]\n`
-      commit.snapshot.destroy()
+      if (commit.kind === "snapshot") {
+        capturedExternalOutput += `[snapshot ${commit.snapshot.width}x${commit.snapshot.height}]\n`
+      } else {
+        capturedExternalOutput += commit.text
+      }
+      commit.snapshot?.destroy()
     }
 
     if (capturedConsoleOutput.length > 0 || capturedExternalOutput.length > 0 || cachedLogs.length > 0) {
@@ -956,8 +997,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this._terminalWidth = stdout.columns ?? width
     this._terminalHeight = stdout.rows ?? height
     this._useThread = config.useThread === undefined ? false : config.useThread
-    const { screenMode, footerHeight, externalOutputMode } = resolveModes(config)
+    const { screenMode, footerHeight, externalOutputMode, externalOutputRendering } = resolveModes(config)
     this._externalOutputMode = externalOutputMode
+    this._externalOutputRendering = externalOutputRendering
 
     const initialGeometry = calculateRenderGeometry(screenMode, this._terminalWidth, this._terminalHeight, footerHeight)
 
@@ -1454,6 +1496,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   public get externalOutputMode(): ExternalOutputMode {
     return this._externalOutputMode
+  }
+
+  public get externalOutputRendering(): ExternalOutputRendering {
+    return this._externalOutputRendering
   }
 
   public set externalOutputMode(mode: ExternalOutputMode) {
@@ -2108,8 +2154,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       tailColumn = 0
     }
 
-    const rowWidths = this.getSnapshotRowWidths(commit.snapshot, commit.rowColumns)
-    for (const [index, rowWidth] of rowWidths.entries()) {
+    const rowWidths =
+      commit.kind === "snapshot" ? this.getSnapshotRowWidths(commit.snapshot, commit.rowColumns) : commit.rowWidths
+    for (let index = 0; index < rowWidths.length; index += 1) {
+      const rowWidth = rowWidths[index] ?? 0
       tailColumn = this.advanceSplitTailColumn(tailColumn, rowWidth, width)
       if (index < rowWidths.length - 1 || commit.trailingNewline) {
         tailColumn = 0
@@ -2150,6 +2198,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     )
 
     this.enqueueSplitCommit({
+      kind: "snapshot",
       snapshot: options.snapshot,
       rowColumns,
       startOnNewLine: options.startOnNewLine ?? true,
@@ -2192,6 +2241,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       snapshotRoot.add(snapshotRenderable)
       snapshotRoot.render(snapshotBuffer, 0)
       return {
+        kind: "snapshot",
         snapshot: snapshotBuffer,
         rowColumns,
         startOnNewLine: false,
@@ -2293,21 +2343,35 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       try {
         // Keep split append policy in native code so every producer (captured stdout
         // and writeToScrollback) shares the same cursor/scrollback invariants.
-        this.renderOffset = this.lib.commitSplitFooterSnapshot(
-          this.rendererPtr,
-          commit.snapshot,
-          commit.rowColumns,
-          commit.startOnNewLine,
-          commit.trailingNewline,
-          this.getSplitPinnedRenderOffset(),
-          forceCommit,
-          beginFrame,
-          finalizeFrame,
-        )
+        if (commit.kind === "snapshot") {
+          this.renderOffset = this.lib.commitSplitFooterSnapshot(
+            this.rendererPtr,
+            commit.snapshot,
+            commit.rowColumns,
+            commit.startOnNewLine,
+            commit.trailingNewline,
+            this.getSplitPinnedRenderOffset(),
+            forceCommit,
+            beginFrame,
+            finalizeFrame,
+          )
+        } else {
+          this.renderOffset = this.lib.commitSplitFooterByteChunk(
+            this.rendererPtr,
+            commit.bytes,
+            commit.rowWidths,
+            commit.startOnNewLine,
+            commit.trailingNewline,
+            this.getSplitPinnedRenderOffset(),
+            forceCommit,
+            beginFrame,
+            finalizeFrame,
+          )
+        }
         this.recordSplitCommit(commit)
         hasCommittedOutput = true
       } finally {
-        commit.snapshot.destroy()
+        commit.snapshot?.destroy()
       }
     }
 
@@ -2330,6 +2394,25 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
   }
 
+  private createByteChunkStdoutCommit(text: string): ByteChunkExternalOutputCommit | null {
+    if (text.length === 0) {
+      return null
+    }
+
+    let deferredText = text
+    if (this.deferredByteChunkTrailingNewline) {
+      deferredText = `\r\n${deferredText}`
+      this.deferredByteChunkTrailingNewline = false
+    }
+
+    if (deferredText.endsWith("\n")) {
+      deferredText = deferredText.slice(0, -1)
+      this.deferredByteChunkTrailingNewline = true
+    }
+
+    return createByteChunkExternalOutputCommit(deferredText)
+  }
+
   private interceptStdoutWrite = (chunk: any, encoding?: any, callback?: any): boolean => {
     const resolvedCallback = typeof encoding === "function" ? encoding : callback
     const resolvedEncoding = typeof encoding === "string" ? encoding : undefined
@@ -2339,12 +2422,22 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       // Capture mode intentionally diverts stdout into split commit snapshots
       // instead of writing directly to process stdout. Native flushing will append
       // and repaint in one controlled frame, which is what avoids footer flicker.
-      const commits = this.createStdoutSnapshotCommits(text)
-      for (const commit of commits) {
-        this.enqueueSplitCommit(commit)
+      let enqueuedCommit = false
+      if (this._externalOutputRendering === "terminal-native") {
+        const commit = this.createByteChunkStdoutCommit(text)
+        if (commit !== null) {
+          this.enqueueSplitCommit(commit)
+          enqueuedCommit = true
+        }
+      } else {
+        const commits = this.createStdoutSnapshotCommits(text)
+        for (const commit of commits) {
+          this.enqueueSplitCommit(commit)
+        }
+        enqueuedCommit = commits.length > 0
       }
 
-      if (commits.length > 0) {
+      if (enqueuedCommit) {
         // Defer actual terminal writes to the render loop so commits can be batched.
         this.requestRender()
       }
@@ -2716,8 +2809,12 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     const outputCommits = this.externalOutputQueue.claim()
     let output = ""
     for (const commit of outputCommits) {
-      output += `[snapshot ${commit.snapshot.width}x${commit.snapshot.height}]\n`
-      commit.snapshot.destroy()
+      if (commit.kind === "snapshot") {
+        output += `[snapshot ${commit.snapshot.width}x${commit.snapshot.height}]\n`
+      } else {
+        output += commit.text
+      }
+      commit.snapshot?.destroy()
     }
 
     const rendererStartLine = this.renderOffset + 1

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -934,7 +934,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       if (commit.kind === "snapshot") {
         capturedExternalOutput += `[snapshot ${commit.snapshot.width}x${commit.snapshot.height}]\n`
       } else {
-        capturedExternalOutput += commit.text
+        capturedExternalOutput += `[bytes ${commit.bytes.length} bytes, ${commit.rowColumnsByRow.length} rows]\n`
       }
       commit.snapshot?.destroy()
     }
@@ -2816,7 +2816,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       if (commit.kind === "snapshot") {
         output += `[snapshot ${commit.snapshot.width}x${commit.snapshot.height}]\n`
       } else {
-        output += commit.text
+        output += `[bytes ${commit.bytes.length} bytes, ${commit.rowColumnsByRow.length} rows]\n`
       }
       commit.snapshot?.destroy()
     }

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -232,7 +232,8 @@ export interface CliRendererByteChunkExternalOutputEvent {
   kind: "bytes"
   snapshot?: undefined
   text: string
-  rowWidths: Uint32Array
+  bytes: Uint8Array
+  rowColumnsByRow: Uint32Array
   startOnNewLine: boolean
   trailingNewline: boolean
 }
@@ -2154,12 +2155,12 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       tailColumn = 0
     }
 
-    const rowWidths =
-      commit.kind === "snapshot" ? this.getSnapshotRowWidths(commit.snapshot, commit.rowColumns) : commit.rowWidths
-    for (let index = 0; index < rowWidths.length; index += 1) {
-      const rowWidth = rowWidths[index] ?? 0
-      tailColumn = this.advanceSplitTailColumn(tailColumn, rowWidth, width)
-      if (index < rowWidths.length - 1 || commit.trailingNewline) {
+    const rowColumnsByRow =
+      commit.kind === "snapshot" ? this.getSnapshotRowWidths(commit.snapshot, commit.rowColumns) : commit.rowColumnsByRow
+    for (let index = 0; index < rowColumnsByRow.length; index += 1) {
+      const rowColumns = rowColumnsByRow[index] ?? 0
+      tailColumn = this.advanceSplitTailColumn(tailColumn, rowColumns, width)
+      if (index < rowColumnsByRow.length - 1 || commit.trailingNewline) {
         tailColumn = 0
       }
     }
@@ -2359,7 +2360,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
           this.renderOffset = this.lib.commitSplitFooterByteChunk(
             this.rendererPtr,
             commit.bytes,
-            commit.rowWidths,
+            commit.rowColumnsByRow,
             commit.startOnNewLine,
             commit.trailingNewline,
             this.getSplitPinnedRenderOffset(),

--- a/packages/core/src/testing/test-renderer.ts
+++ b/packages/core/src/testing/test-renderer.ts
@@ -120,6 +120,19 @@ class TestExternalOutputRecorder implements TestExternalOutput {
   }
 
   private record = (event: CliRendererExternalOutputEvent): void => {
+    if (event.kind === "bytes") {
+      this.commits.push({
+        text: event.text,
+        rows: event.text.split("\n"),
+        width: Math.max(1, ...event.rowWidths),
+        height: event.rowWidths.length,
+        rowColumns: event.rowWidths[0] ?? 0,
+        startOnNewLine: event.startOnNewLine,
+        trailingNewline: event.trailingNewline,
+      })
+      return
+    }
+
     const raw = decoder.decode(event.snapshot.getRealCharBytes(false))
     const rows = Array.from({ length: event.snapshot.height }, (_, index) =>
       raw.slice(index * event.snapshot.width, (index + 1) * event.snapshot.width).trimEnd(),

--- a/packages/core/src/testing/test-renderer.ts
+++ b/packages/core/src/testing/test-renderer.ts
@@ -124,9 +124,9 @@ class TestExternalOutputRecorder implements TestExternalOutput {
       this.commits.push({
         text: event.text,
         rows: event.text.split("\n"),
-        width: Math.max(1, ...event.rowWidths),
-        height: event.rowWidths.length,
-        rowColumns: event.rowWidths[0] ?? 0,
+        width: Math.max(1, ...event.rowColumnsByRow),
+        height: event.rowColumnsByRow.length,
+        rowColumns: event.rowColumnsByRow[0] ?? 0,
         startOnNewLine: event.startOnNewLine,
         trailingNewline: event.trailingNewline,
       })

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -2027,6 +2027,65 @@ test("CliRenderer split-footer terminal-native captured stdout preserves logical
   byteChunkCommitSpy.mockRestore()
 })
 
+test("CliRenderer split-footer terminal-native does not batch byte chunks with snapshot commits", async () => {
+  const result = await createTestRenderer({
+    width: 20,
+    height: 8,
+    screenMode: "split-footer",
+    footerHeight: 3,
+    externalOutputMode: "capture-stdout",
+    externalOutputRendering: "terminal-native",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  const lib = (renderer as any).lib
+  const snapshotCommitSpy = spyOn(lib, "commitSplitFooterSnapshot")
+  const byteChunkCommitSpy = spyOn(lib, "commitSplitFooterByteChunk")
+
+  try {
+    renderer.writeToScrollback(textScrollbackWrite(""))
+    ;(renderer as any).stdout.write("\x1b[31mhello\x1b[0m\n")
+
+    await result.renderOnce()
+
+    expect(snapshotCommitSpy).toHaveBeenCalledTimes(1)
+    expect(byteChunkCommitSpy).toHaveBeenCalledTimes(1)
+
+    const snapshotArgs = snapshotCommitSpy.mock.calls[0] as [
+      unknown,
+      unknown,
+      number,
+      boolean,
+      boolean,
+      number,
+      boolean,
+      boolean,
+      boolean,
+    ]
+    const byteChunkArgs = byteChunkCommitSpy.mock.calls[0] as [
+      unknown,
+      Uint8Array,
+      Uint32Array,
+      boolean,
+      boolean,
+      number,
+      boolean,
+      boolean,
+      boolean,
+    ]
+
+    expect(snapshotArgs[7]).toBe(true)
+    expect(snapshotArgs[8]).toBe(true)
+    expect(new TextDecoder().decode(byteChunkArgs[1])).toBe("\x1b[31mhello\x1b[0m")
+    expect(byteChunkArgs[7]).toBe(true)
+    expect(byteChunkArgs[8]).toBe(true)
+  } finally {
+    snapshotCommitSpy.mockRestore()
+    byteChunkCommitSpy.mockRestore()
+  }
+})
+
 test("CliRenderer split-footer terminal-native defers trailing newline until following output", async () => {
   const result = await createTestRenderer({
     width: 20,

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -148,6 +148,7 @@ test("CliRenderer applies explicit screen and output modes", async () => {
     screenMode: "split-footer",
     footerHeight: 6,
     externalOutputMode: "capture-stdout",
+    externalOutputRendering: "terminal-native",
     consoleMode: "disabled",
   })
 
@@ -156,6 +157,7 @@ test("CliRenderer applies explicit screen and output modes", async () => {
   expect(renderer.screenMode).toBe("split-footer")
   expect(renderer.footerHeight).toBe(6)
   expect(renderer.externalOutputMode).toBe("capture-stdout")
+  expect(renderer.externalOutputRendering).toBe("terminal-native")
   expect(renderer.consoleMode).toBe("disabled")
 })
 
@@ -1992,6 +1994,75 @@ test("CliRenderer split-footer routes captured output through snapshot native co
 
   lib.commitSplitFooterSnapshot = originalCommitSplitFooterSnapshot
   splitCommitSpy.mockRestore()
+})
+
+test("CliRenderer split-footer terminal-native captured stdout preserves logical writes", async () => {
+  const result = await createTestRenderer({
+    width: 4,
+    height: 8,
+    screenMode: "split-footer",
+    footerHeight: 3,
+    externalOutputMode: "capture-stdout",
+    externalOutputRendering: "terminal-native",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  const lib = (renderer as any).lib
+  const snapshotCommitSpy = spyOn(lib, "commitSplitFooterSnapshot")
+  const byteChunkCommitSpy = spyOn(lib, "commitSplitFooterByteChunk")
+
+  ;(renderer as any).stdout.write("\x1b[31mabcdef\x1b[0m\n")
+  await result.renderOnce()
+
+  expect(snapshotCommitSpy).not.toHaveBeenCalled()
+  expect(byteChunkCommitSpy).toHaveBeenCalledTimes(1)
+  const byteChunkArgs = byteChunkCommitSpy.mock.calls[0] as [unknown, Uint8Array, Uint32Array, boolean, boolean]
+  expect(new TextDecoder().decode(byteChunkArgs[1])).toBe("\x1b[31mabcdef\x1b[0m")
+  expect(Array.from(byteChunkArgs[2])).toEqual([6])
+  expect(byteChunkArgs[4]).toBe(false)
+  expect((renderer as any).renderOffset).toBe(2)
+
+  snapshotCommitSpy.mockRestore()
+  byteChunkCommitSpy.mockRestore()
+})
+
+test("CliRenderer split-footer terminal-native defers trailing newline until following output", async () => {
+  const result = await createTestRenderer({
+    width: 20,
+    height: 8,
+    screenMode: "split-footer",
+    footerHeight: 3,
+    externalOutputMode: "capture-stdout",
+    externalOutputRendering: "terminal-native",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  const lib = (renderer as any).lib
+  const byteChunkCommitSpy = spyOn(lib, "commitSplitFooterByteChunk")
+
+  try {
+    ;(renderer as any).stdout.write("line-1\n")
+    await result.renderOnce()
+
+    ;(renderer as any).stdout.write("line-2\n")
+    await result.renderOnce()
+
+    expect(byteChunkCommitSpy).toHaveBeenCalledTimes(2)
+
+    const firstArgs = byteChunkCommitSpy.mock.calls[0] as [unknown, Uint8Array, Uint32Array, boolean, boolean]
+    expect(new TextDecoder().decode(firstArgs[1])).toBe("line-1")
+    expect(Array.from(firstArgs[2])).toEqual([6])
+    expect(firstArgs[4]).toBe(false)
+
+    const secondArgs = byteChunkCommitSpy.mock.calls[1] as [unknown, Uint8Array, Uint32Array, boolean, boolean]
+    expect(new TextDecoder().decode(secondArgs[1])).toBe("\r\nline-2")
+    expect(Array.from(secondArgs[2])).toEqual([0, 6])
+    expect(secondArgs[4]).toBe(false)
+  } finally {
+    byteChunkCommitSpy.mockRestore()
+  }
 })
 
 test("CliRenderer split-footer native scrollback tracks wrapped tail state across commits", async () => {

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -230,6 +230,10 @@ function getOpenTUILib(libPath?: string) {
       args: ["ptr", "ptr", "u32", "bool", "bool", "u32", "bool", "bool", "bool"],
       returns: "u32",
     },
+    commitSplitFooterByteChunk: {
+      args: ["ptr", "ptr", "u32", "ptr", "u32", "bool", "bool", "u32", "bool", "bool", "bool"],
+      returns: "u32",
+    },
     getNextBuffer: {
       args: ["ptr"],
       returns: "ptr",
@@ -1625,6 +1629,17 @@ export interface RenderLib extends AudioEngineLib {
     beginFrame?: boolean,
     finalizeFrame?: boolean,
   ) => number
+  commitSplitFooterByteChunk: (
+    renderer: Pointer,
+    bytes: Uint8Array,
+    rowWidths: Uint32Array,
+    startOnNewLine: boolean,
+    trailingNewline: boolean,
+    pinnedRenderOffset: number,
+    force: boolean,
+    beginFrame?: boolean,
+    finalizeFrame?: boolean,
+  ) => number
   getNextBuffer: (renderer: Pointer) => OptimizedBuffer
   getCurrentBuffer: (renderer: Pointer) => OptimizedBuffer
   rendererSetPaletteState: (
@@ -2758,6 +2773,32 @@ class FFIRenderLib implements RenderLib {
       renderer,
       snapshot.ptr,
       rowColumns,
+      ffiBool(startOnNewLine),
+      ffiBool(trailingNewline),
+      pinnedRenderOffset,
+      ffiBool(force),
+      ffiBool(beginFrame),
+      ffiBool(finalizeFrame),
+    )
+  }
+
+  public commitSplitFooterByteChunk(
+    renderer: Pointer,
+    bytes: Uint8Array,
+    rowWidths: Uint32Array,
+    startOnNewLine: boolean,
+    trailingNewline: boolean,
+    pinnedRenderOffset: number,
+    force: boolean,
+    beginFrame: boolean = true,
+    finalizeFrame: boolean = true,
+  ): number {
+    return this.opentui.symbols.commitSplitFooterByteChunk(
+      renderer,
+      ptr(bytes),
+      bytes.length,
+      ptr(rowWidths),
+      rowWidths.length,
       ffiBool(startOnNewLine),
       ffiBool(trailingNewline),
       pinnedRenderOffset,

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -1632,7 +1632,7 @@ export interface RenderLib extends AudioEngineLib {
   commitSplitFooterByteChunk: (
     renderer: Pointer,
     bytes: Uint8Array,
-    rowWidths: Uint32Array,
+    rowColumnsByRow: Uint32Array,
     startOnNewLine: boolean,
     trailingNewline: boolean,
     pinnedRenderOffset: number,
@@ -2785,7 +2785,7 @@ class FFIRenderLib implements RenderLib {
   public commitSplitFooterByteChunk(
     renderer: Pointer,
     bytes: Uint8Array,
-    rowWidths: Uint32Array,
+    rowColumnsByRow: Uint32Array,
     startOnNewLine: boolean,
     trailingNewline: boolean,
     pinnedRenderOffset: number,
@@ -2797,8 +2797,8 @@ class FFIRenderLib implements RenderLib {
       renderer,
       ptr(bytes),
       bytes.length,
-      ptr(rowWidths),
-      rowWidths.length,
+      ptr(rowColumnsByRow),
+      rowColumnsByRow.length,
       ffiBool(startOnNewLine),
       ffiBool(trailingNewline),
       pinnedRenderOffset,

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -505,7 +505,7 @@ export fn commitSplitFooterByteChunk(
     rendererPtr: *renderer.CliRenderer,
     textPtr: [*]const u8,
     textLen: u32,
-    rowWidthsPtr: [*]const u32,
+    rowColumnsByRowPtr: [*]const u32,
     rowCount: u32,
     startOnNewLine: bool,
     trailingNewline: bool,
@@ -516,7 +516,7 @@ export fn commitSplitFooterByteChunk(
 ) u32 {
     return rendererPtr.commitSplitFooterByteChunkBatched(
         textPtr[0..textLen],
-        rowWidthsPtr[0..rowCount],
+        rowColumnsByRowPtr[0..rowCount],
         startOnNewLine,
         trailingNewline,
         pinnedRenderOffset,

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -501,6 +501,31 @@ export fn commitSplitFooterSnapshot(
     );
 }
 
+export fn commitSplitFooterByteChunk(
+    rendererPtr: *renderer.CliRenderer,
+    textPtr: [*]const u8,
+    textLen: u32,
+    rowWidthsPtr: [*]const u32,
+    rowCount: u32,
+    startOnNewLine: bool,
+    trailingNewline: bool,
+    pinnedRenderOffset: u32,
+    force: bool,
+    beginFrame: bool,
+    finalizeFrame: bool,
+) u32 {
+    return rendererPtr.commitSplitFooterByteChunkBatched(
+        textPtr[0..textLen],
+        rowWidthsPtr[0..rowCount],
+        startOnNewLine,
+        trailingNewline,
+        pinnedRenderOffset,
+        force,
+        beginFrame,
+        finalizeFrame,
+    );
+}
+
 export fn createOptimizedBuffer(width: u32, height: u32, respectAlpha: bool, widthMethod: u8, idPtr: [*]const u8, idLen: usize) ?*buffer.OptimizedBuffer {
     if (width == 0 or height == 0) {
         logger.warn("Invalid buffer dimensions: {}x{}", .{ width, height });

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -985,7 +985,7 @@ pub const CliRenderer = struct {
     pub fn commitSplitFooterByteChunkBatched(
         self: *CliRenderer,
         text: []const u8,
-        row_widths: []const u32,
+        row_columns_by_row: []const u32,
         start_on_new_line: bool,
         trailing_newline: bool,
         pinned_render_offset: u32,
@@ -1014,7 +1014,7 @@ pub const CliRenderer = struct {
             const redraw_footer = self.appendSplitFooterByteChunkCommit(
                 writer,
                 text,
-                row_widths,
+                row_columns_by_row,
                 start_on_new_line,
                 trailing_newline,
                 pinned_render_offset,
@@ -1037,7 +1037,7 @@ pub const CliRenderer = struct {
         if (!self.splitBatchActive) {
             return self.commitSplitFooterByteChunkBatched(
                 text,
-                row_widths,
+                row_columns_by_row,
                 start_on_new_line,
                 trailing_newline,
                 pinned_render_offset,
@@ -1051,7 +1051,7 @@ pub const CliRenderer = struct {
         const redraw_footer = self.appendSplitFooterByteChunkCommit(
             writer,
             text,
-            row_widths,
+            row_columns_by_row,
             start_on_new_line,
             trailing_newline,
             pinned_render_offset,
@@ -1389,7 +1389,7 @@ pub const CliRenderer = struct {
         self: *CliRenderer,
         writer: anytype,
         text: []const u8,
-        row_widths: []const u32,
+        row_columns_by_row: []const u32,
         start_on_new_line: bool,
         trailing_newline: bool,
         pinned_render_offset: u32,
@@ -1398,7 +1398,7 @@ pub const CliRenderer = struct {
         const previousSurfaceOffset = self.renderOffset;
         const previousOutputOffset = self.splitOutputOffset(previousSurfaceOffset);
         const previousOutputColumn = self.splitScrollback.tail_column;
-        const payload_has_content = text.len > 0 and row_widths.len > 0;
+        const payload_has_content = text.len > 0 and row_columns_by_row.len > 0;
         const starts_mid_line = previousOutputColumn > 0 and start_on_new_line;
         const starts_wrapped_line = previousOutputColumn >= self.width;
         const previousFooterTopLine: u32 = @max(previousSurfaceOffset + 1, @as(u32, 1));
@@ -1408,11 +1408,11 @@ pub const CliRenderer = struct {
                 self.splitScrollback.noteNewline();
             }
 
-            for (row_widths, 0..) |row_width, row_index| {
+            for (row_columns_by_row, 0..) |row_columns, row_index| {
                 self.splitScrollback.publishRow(
-                    row_width,
+                    row_columns,
                     self.width,
-                    row_index + 1 < row_widths.len or trailing_newline,
+                    row_index + 1 < row_columns_by_row.len or trailing_newline,
                 );
             }
 

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -982,6 +982,94 @@ pub const CliRenderer = struct {
         return self.renderOffset;
     }
 
+    pub fn commitSplitFooterByteChunkBatched(
+        self: *CliRenderer,
+        text: []const u8,
+        row_widths: []const u32,
+        start_on_new_line: bool,
+        trailing_newline: bool,
+        pinned_render_offset: u32,
+        force: bool,
+        begin_frame: bool,
+        finalize_frame: bool,
+    ) u32 {
+        if (begin_frame) {
+            const now = std.time.microTimestamp();
+            const deltaTimeMs = @as(f64, @floatFromInt(now - self.lastRenderTime));
+            const deltaTime = deltaTimeMs / 1000.0;
+
+            self.lastRenderTime = now;
+            self.renderDebugOverlay();
+
+            resetActiveOutputBuffer();
+            const writer = OutputBufferWriter.writer();
+            beginRenderFrame(writer);
+            var frame_started = true;
+            self.applyPendingSplitFooterTransition(writer, &frame_started);
+
+            self.splitBatchActive = !finalize_frame;
+            self.splitBatchRedrawFooter = false;
+            self.splitBatchDeltaTime = deltaTime;
+
+            const redraw_footer = self.appendSplitFooterByteChunkCommit(
+                writer,
+                text,
+                row_widths,
+                start_on_new_line,
+                trailing_newline,
+                pinned_render_offset,
+                force,
+            );
+
+            if (finalize_frame) {
+                self.prepareRenderFrame(redraw_footer, false, true);
+                self.finalizeRender(deltaTime);
+                self.splitBatchActive = false;
+                self.splitBatchRedrawFooter = false;
+                self.splitBatchDeltaTime = 0;
+            } else {
+                self.splitBatchRedrawFooter = redraw_footer;
+            }
+
+            return self.renderOffset;
+        }
+
+        if (!self.splitBatchActive) {
+            return self.commitSplitFooterByteChunkBatched(
+                text,
+                row_widths,
+                start_on_new_line,
+                trailing_newline,
+                pinned_render_offset,
+                force,
+                true,
+                true,
+            );
+        }
+
+        const writer = OutputBufferWriter.writer();
+        const redraw_footer = self.appendSplitFooterByteChunkCommit(
+            writer,
+            text,
+            row_widths,
+            start_on_new_line,
+            trailing_newline,
+            pinned_render_offset,
+            force,
+        );
+        self.splitBatchRedrawFooter = self.splitBatchRedrawFooter or redraw_footer;
+
+        if (finalize_frame) {
+            self.prepareRenderFrame(self.splitBatchRedrawFooter, false, true);
+            self.finalizeRender(self.splitBatchDeltaTime);
+            self.splitBatchActive = false;
+            self.splitBatchRedrawFooter = false;
+            self.splitBatchDeltaTime = 0;
+        }
+
+        return self.renderOffset;
+    }
+
     fn finalizeRender(self: *CliRenderer, deltaTime: f64) void {
         if (self.useThread) {
             self.renderMutex.lock();
@@ -1178,6 +1266,16 @@ pub const CliRenderer = struct {
         }
     }
 
+    fn writeByteChunkCommit(
+        self: *CliRenderer,
+        writer: anytype,
+        text: []const u8,
+    ) void {
+        _ = self;
+        writer.writeAll(text) catch {};
+        writer.writeAll(ansi.ANSI.reset) catch {};
+    }
+
     /// Shared append path for all split payload sources.
     ///
     /// Contract: append payload first, then position for footer repaint in the
@@ -1272,6 +1370,86 @@ pub const CliRenderer = struct {
                 if (use_bounded_scroll_region) {
                     // Restore default full-height scroll region for regular repaint
                     // and cursor operations after append is complete.
+                    writer.writeAll("\x1b[r") catch {};
+                }
+            }
+
+            self.renderOffset = next_render_offset;
+            if (redraw_footer) {
+                ansi.ANSI.moveToOutput(writer, 1, targetFooterTopLine) catch {};
+            }
+        } else {
+            self.renderOffset = next_render_offset;
+        }
+
+        return redraw_footer;
+    }
+
+    fn appendSplitFooterByteChunkCommit(
+        self: *CliRenderer,
+        writer: anytype,
+        text: []const u8,
+        row_widths: []const u32,
+        start_on_new_line: bool,
+        trailing_newline: bool,
+        pinned_render_offset: u32,
+        force: bool,
+    ) bool {
+        const previousSurfaceOffset = self.renderOffset;
+        const previousOutputOffset = self.splitOutputOffset(previousSurfaceOffset);
+        const previousOutputColumn = self.splitScrollback.tail_column;
+        const payload_has_content = text.len > 0 and row_widths.len > 0;
+        const starts_mid_line = previousOutputColumn > 0 and start_on_new_line;
+        const starts_wrapped_line = previousOutputColumn >= self.width;
+        const previousFooterTopLine: u32 = @max(previousSurfaceOffset + 1, @as(u32, 1));
+
+        if (payload_has_content) {
+            if (starts_mid_line) {
+                self.splitScrollback.noteNewline();
+            }
+
+            for (row_widths, 0..) |row_width, row_index| {
+                self.splitScrollback.publishRow(
+                    row_width,
+                    self.width,
+                    row_index + 1 < row_widths.len or trailing_newline,
+                );
+            }
+
+            self.splitScrollback.published_rows = @min(self.splitScrollback.published_rows, pinned_render_offset);
+        }
+
+        const next_output_offset = self.splitScrollback.renderOffset(pinned_render_offset);
+        const next_render_offset = self.clampSplitSurfaceOffset(previousSurfaceOffset, pinned_render_offset);
+        const targetFooterTopLine: u32 = @max(next_render_offset + 1, @as(u32, 1));
+        const redraw_footer = force or previousSurfaceOffset != next_render_offset;
+        const use_bounded_scroll_region = payload_has_content and
+            pinned_render_offset > 0 and
+            next_render_offset == pinned_render_offset and
+            next_output_offset == next_render_offset;
+
+        if (payload_has_content or force) {
+            if (payload_has_content) {
+                if (targetFooterTopLine > previousFooterTopLine) {
+                    var clear_line = previousFooterTopLine;
+                    while (clear_line < targetFooterTopLine) : (clear_line += 1) {
+                        ansi.ANSI.moveToOutput(writer, 1, clear_line) catch {};
+                        writer.writeAll("\x1b[2K") catch {};
+                    }
+                }
+
+                if (use_bounded_scroll_region) {
+                    writer.print("\x1b[1;{d}r", .{pinned_render_offset}) catch {};
+                }
+
+                moveToSplitOutputCursor(writer, previousOutputOffset, previousOutputColumn, self.width);
+                if (starts_mid_line or starts_wrapped_line) {
+                    writer.writeAll("\r\n") catch {};
+                }
+
+                self.writeByteChunkCommit(writer, text);
+
+                if (use_bounded_scroll_region) {
                     writer.writeAll("\x1b[r") catch {};
                 }
             }

--- a/packages/examples/src/split-footer-streaming-demo.ts
+++ b/packages/examples/src/split-footer-streaming-demo.ts
@@ -7,6 +7,7 @@ import {
   TextRenderable,
   createCliRenderer,
   type CliRenderer,
+  type ExternalOutputRendering,
   type KeyEvent,
   type ScrollbackSurface,
 } from "@opentui/core"
@@ -22,8 +23,10 @@ const DEFAULT_INTERVAL_MS = 180
 const MIN_INTERVAL_MS = 60
 const MAX_INTERVAL_MS = 1000
 const INTERVAL_STEP_MS = 40
+const DEFAULT_EXTERNAL_OUTPUT_RENDERING: ExternalOutputRendering = "emulated"
+const EXTERNAL_OUTPUT_RENDERING_ENV = process.env.OTUI_SPLIT_STREAMING_DEMO_RENDERING
 
-type StreamKind = "text" | "code" | "markdown"
+type StreamKind = "text" | "code" | "markdown" | "ansi"
 
 interface ScenarioDefinition {
   kind: StreamKind
@@ -36,8 +39,8 @@ interface ScenarioDefinition {
 interface ActiveRun {
   id: number
   scenario: ScenarioDefinition
-  surface: ScrollbackSurface
-  renderable: TextRenderable | CodeRenderable | MarkdownRenderable
+  surface: ScrollbackSurface | null
+  renderable: TextRenderable | CodeRenderable | MarkdownRenderable | null
   content: string
   chunkIndex: number
   committedRows: number
@@ -57,6 +60,7 @@ const PALETTE = {
   textAccent: "#66D9EF",
   codeAccent: "#FFD580",
   markdownAccent: "#C7A6FF",
+  ansiAccent: "#7CFFB2",
   error: "#FF9B9B",
 } as const
 
@@ -140,6 +144,23 @@ const SCENARIOS: Record<StreamKind, ScenarioDefinition> = {
       " in one chunk\n- second item closes the sample\n",
     ],
   },
+  ansi: {
+    kind: "ansi",
+    title: "ansi",
+    prefix: "ansi> ",
+    description: "Writes ANSI SGR color and style sequences through captured stdout.",
+    chunks: [
+      "\x1b[38;5;82mgreen stdout\x1b[0m and ",
+      "\x1b[38;5;213mbright magenta\x1b[0m on one logical row\n",
+      "\x1b[1m\x1b[38;5;39mbold blue\x1b[0m, ",
+      "\x1b[3mitalic default\x1b[0m, ",
+      "\x1b[4munderlined default\x1b[0m\n",
+      "carriage return demo: pending text",
+      "\r\x1b[38;5;220mcarriage return replacement\x1b[0m\n",
+      "\x1b[48;5;24m background blue \x1b[0m ",
+      "\x1b[48;5;88m background red \x1b[0m final row\n",
+    ],
+  },
 }
 
 function getScenarioAccent(kind: StreamKind): string {
@@ -150,6 +171,8 @@ function getScenarioAccent(kind: StreamKind): string {
       return PALETTE.codeAccent
     case "markdown":
       return PALETTE.markdownAccent
+    case "ansi":
+      return PALETTE.ansiAccent
   }
 }
 
@@ -191,7 +214,10 @@ class SplitFooterStreamingDemo {
   private pendingReplayReason: string | null = null
   private wrote = false
 
-  constructor(private renderer: CliRenderer) {
+  constructor(
+    private renderer: CliRenderer,
+    private readonly externalOutputRendering: ExternalOutputRendering = DEFAULT_EXTERNAL_OUTPUT_RENDERING,
+  ) {
     if (this.renderer.screenMode !== "split-footer") {
       this.renderer.screenMode = "split-footer"
     }
@@ -253,7 +279,11 @@ class SplitFooterStreamingDemo {
 
     this.refreshFooter()
     this.syncAutoTimer()
-    this.requestReplay("Started markdown sample.")
+    setTimeout(() => {
+      if (!this.destroyed) {
+        this.requestReplay("Started markdown sample.")
+      }
+    }, 0)
   }
 
   private get currentScenario(): ScenarioDefinition {
@@ -280,13 +310,13 @@ class SplitFooterStreamingDemo {
     this.footerTable.content = [
       footerRow(
         "mode",
-        `${scenario.title} · start ${this.inlinePrefix ? "inline-prefix" : "newline"} · auto ${this.autoAdvance ? `${this.intervalMs}ms` : "off"} · ${runState}`,
+        `${scenario.title} · ${this.externalOutputRendering} · start ${this.inlinePrefix ? "inline-prefix" : "newline"} · auto ${this.autoAdvance ? `${this.intervalMs}ms` : "off"} · ${runState}`,
         getScenarioAccent(this.currentKind),
       ),
       footerRow("status", this.lastStatus, this.lastStatus.startsWith("Error:") ? PALETTE.error : PALETTE.status),
       footerRow("stats", `${run?.content.length ?? 0} bytes · ${committedState}`, PALETTE.detail),
       footerRow("about", scenario.description, PALETTE.detail),
-      footerRow("scene", "1 text · 2 code · 3 markdown · i inline-prefix", PALETTE.hint),
+      footerRow("scene", "1 text · 2 code · 3 markdown · 4 ansi stdout · i inline-prefix", PALETTE.hint),
       footerRow("flow", "r replay · n next · a auto · [ slower · ] faster · resize -> r", PALETTE.hint),
     ]
   }
@@ -313,7 +343,7 @@ class SplitFooterStreamingDemo {
 
     this.activeRun.cancelled = true
 
-    if (!this.activeRun.surface.isDestroyed) {
+    if (this.activeRun.surface && !this.activeRun.surface.isDestroyed) {
       try {
         this.activeRun.surface.destroy()
       } catch {
@@ -361,13 +391,14 @@ class SplitFooterStreamingDemo {
       this.writeInlinePrefix(scenario, !spaced)
     }
 
-    const surface = this.renderer.createScrollbackSurface({
-      startOnNewLine: this.inlinePrefix ? false : !spaced,
-    })
+    let surface: ScrollbackSurface | null = null
+    let renderable: TextRenderable | CodeRenderable | MarkdownRenderable | null = null
 
-    let renderable: TextRenderable | CodeRenderable | MarkdownRenderable
     switch (scenario.kind) {
       case "text":
+        surface = this.renderer.createScrollbackSurface({
+          startOnNewLine: this.inlinePrefix ? false : !spaced,
+        })
         renderable = new TextRenderable(surface.renderContext, {
           id: `split-footer-stream-text-${this.nextRunId}`,
           content: "",
@@ -377,6 +408,9 @@ class SplitFooterStreamingDemo {
         })
         break
       case "code":
+        surface = this.renderer.createScrollbackSurface({
+          startOnNewLine: this.inlinePrefix ? false : !spaced,
+        })
         renderable = new CodeRenderable(surface.renderContext, {
           id: `split-footer-stream-code-${this.nextRunId}`,
           content: "",
@@ -390,6 +424,9 @@ class SplitFooterStreamingDemo {
         })
         break
       case "markdown":
+        surface = this.renderer.createScrollbackSurface({
+          startOnNewLine: this.inlinePrefix ? false : !spaced,
+        })
         renderable = new MarkdownRenderable(surface.renderContext, {
           id: `split-footer-stream-markdown-${this.nextRunId}`,
           content: "",
@@ -401,9 +438,13 @@ class SplitFooterStreamingDemo {
           treeSitterClient: this.treeSitterClient,
         })
         break
+      case "ansi":
+        break
     }
 
-    surface.root.add(renderable)
+    if (surface && renderable) {
+      surface.root.add(renderable)
+    }
 
     return {
       id: this.nextRunId++,
@@ -513,7 +554,7 @@ class SplitFooterStreamingDemo {
 
       if (isFinalChunk) {
         run.done = true
-        run.surface.destroy()
+        run.surface?.destroy()
         this.lastStatus = `${run.scenario.title} sample finished. Press R to replay.`
       } else {
         this.lastStatus = `${run.scenario.title} chunk ${run.chunkIndex}/${run.scenario.chunks.length} committed.`
@@ -549,10 +590,17 @@ class SplitFooterStreamingDemo {
       case "markdown":
         await this.flushMarkdownRun(run, done)
         return
+      case "ansi":
+        this.flushAnsiRun(run)
+        return
     }
   }
 
   private async flushTextRun(run: ActiveRun, done: boolean): Promise<void> {
+    if (!run.surface || !(run.renderable instanceof TextRenderable)) {
+      return
+    }
+
     const renderable = run.renderable as TextRenderable
     renderable.content = run.content
     run.surface.render()
@@ -566,6 +614,10 @@ class SplitFooterStreamingDemo {
   }
 
   private async flushCodeRun(run: ActiveRun, done: boolean): Promise<void> {
+    if (!run.surface || !(run.renderable instanceof CodeRenderable)) {
+      return
+    }
+
     const renderable = run.renderable as CodeRenderable
     renderable.content = run.content
     renderable.streaming = !done
@@ -580,6 +632,10 @@ class SplitFooterStreamingDemo {
   }
 
   private async flushMarkdownRun(run: ActiveRun, done: boolean): Promise<void> {
+    if (!run.surface || !(run.renderable instanceof MarkdownRenderable)) {
+      return
+    }
+
     const renderable = run.renderable as MarkdownRenderable
     renderable.content = run.content
     renderable.streaming = !done
@@ -599,6 +655,17 @@ class SplitFooterStreamingDemo {
 
     run.surface.commitRows(firstState.renderable.y, endRow)
     run.committedBlocks = targetBlockCount
+    this.wrote = true
+  }
+
+  private flushAnsiRun(run: ActiveRun): void {
+    const chunk = run.scenario.chunks[run.chunkIndex - 1]
+    if (!chunk) {
+      return
+    }
+
+    process.stdout.write(chunk)
+    run.committedRows = run.chunkIndex
     this.wrote = true
   }
 
@@ -661,6 +728,10 @@ class SplitFooterStreamingDemo {
       case "3":
         key.preventDefault()
         this.setScenario("markdown")
+        return
+      case "4":
+        key.preventDefault()
+        this.setScenario("ansi")
         return
       case "r":
         key.preventDefault()
@@ -733,12 +804,15 @@ class SplitFooterStreamingDemo {
 
 let activeDemo: SplitFooterStreamingDemo | null = null
 
-export function run(renderer: CliRenderer): void {
+export function run(
+  renderer: CliRenderer,
+  externalOutputRendering: ExternalOutputRendering = DEFAULT_EXTERNAL_OUTPUT_RENDERING,
+): void {
   if (activeDemo) {
     activeDemo.destroy()
   }
 
-  activeDemo = new SplitFooterStreamingDemo(renderer)
+  activeDemo = new SplitFooterStreamingDemo(renderer, externalOutputRendering)
 }
 
 export function destroy(_renderer: CliRenderer): void {
@@ -750,7 +824,22 @@ export function destroy(_renderer: CliRenderer): void {
   activeDemo = null
 }
 
+function resolveExternalOutputRendering(rendering: string | undefined): ExternalOutputRendering {
+  if (rendering === undefined) {
+    return DEFAULT_EXTERNAL_OUTPUT_RENDERING
+  }
+
+  if (rendering === "emulated" || rendering === "terminal-native") {
+    return rendering
+  }
+
+  throw new Error(
+    `Invalid OTUI_SPLIT_STREAMING_DEMO_RENDERING value "${rendering}". Expected "emulated" or "terminal-native".`,
+  )
+}
+
 if (import.meta.main) {
+  const externalOutputRendering = resolveExternalOutputRendering(EXTERNAL_OUTPUT_RENDERING_ENV)
   const renderer = await createCliRenderer({
     targetFps: 30,
     exitOnCtrlC: true,
@@ -758,10 +847,11 @@ if (import.meta.main) {
     screenMode: "split-footer",
     footerHeight: FOOTER_HEIGHT,
     externalOutputMode: "capture-stdout",
+    externalOutputRendering,
     consoleMode: "disabled",
   })
 
-  run(renderer)
+  run(renderer, externalOutputRendering)
   setupCommonDemoKeys(renderer)
   renderer.start()
 }


### PR DESCRIPTION
When `externalOutputRendering: "terminal-native"` in CliRendererConfig, commit bytes written to captured stdin with minimal transformation, instead of re-rendering them.

In this mode, we compute the layout effect of each chunk by splitting on `\n`, then using `strip-ansi` and `string-width` to get the width of the line before wrapping.

The outcome is that ANSI styling bytes written to stdout are rendered by the terminal itself without needing to implement ANSI->OpenTUI conversion.

Before (`bun run packages/examples/src/split-footer-streaming-demo.ts`):

<img width="1356" height="606" alt="CleanShot 2026-05-25 at 16 47 33@2x" src="https://github.com/user-attachments/assets/3a3d3b87-d77d-424f-8215-03d8a6c582c3" />

After (`OTUI_SPLIT_STREAMING_DEMO_RENDERING=terminal-native bun run packages/examples/src/split-footer-streaming-demo.ts`):

<img width="1394" height="608" alt="CleanShot 2026-05-25 at 16 48 34@2x" src="https://github.com/user-attachments/assets/9d20700c-3597-4b2c-9c04-067c6e7d6bc3" />
