### PR TITLE
fix(core/markdown): compact tight nested lists

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -807,7 +807,7 @@ export class MarkdownRenderable extends Renderable {
   }
 
   private getListChildMarkdownRaw(token: MarkedToken): string {
-    return token.type === "paragraph" ? this.normalizeScrollbackMarkdownBlockRaw(token.raw) : token.raw
+    return this.normalizeScrollbackMarkdownBlockRaw(token.raw)
   }
 
   private applyListItemMarker(row: BoxRenderable, input: ListItemRenderInput): void {

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -783,7 +783,7 @@ export class MarkdownRenderable extends Renderable {
     id: string,
   ): boolean {
     if ((token.type === "text" || token.type === "paragraph") && renderable instanceof CodeRenderable) {
-      this.applyMarkdownCodeRenderable(renderable, this.getListChildMarkdownRaw(token), 0)
+      this.applyMarkdownCodeRenderable(renderable, this.normalizeScrollbackMarkdownBlockRaw(token.raw), 0)
       return true
     }
 
@@ -806,10 +806,6 @@ export class MarkdownRenderable extends Renderable {
     }
   }
 
-  private getListChildMarkdownRaw(token: MarkedToken): string {
-    return this.normalizeScrollbackMarkdownBlockRaw(token.raw)
-  }
-
   private applyListItemMarker(row: BoxRenderable, input: ListItemRenderInput): void {
     const marker = row.getChildren()[0]
     if (!(marker instanceof TextRenderable)) return
@@ -826,7 +822,7 @@ export class MarkdownRenderable extends Renderable {
 
   private createListChildRenderable(token: MarkedToken, id: string): Renderable | null {
     if (token.type === "text" || token.type === "paragraph") {
-      return this.createMarkdownCodeRenderable(this.getListChildMarkdownRaw(token), id)
+      return this.createMarkdownCodeRenderable(this.normalizeScrollbackMarkdownBlockRaw(token.raw), id)
     }
     if (token.type === "list") return this.createListRenderable(token as Tokens.List, id)
     if (token.type === "code") return this.createCodeRenderable(token as Tokens.Code, id)

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -3665,3 +3665,46 @@ test("top-level list does not insert blank line before nested list when source h
     - Topic is now shown prominently near the top of the TUI."
   `)
 })
+
+test("top-level lists keep tight multi-level nesting compact", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-tight-multi-level-nested-list",
+    content: `- Main section:
+  - Supporting point:
+    - Third-level detail
+    - Another detail with **emphasis**
+  - Another supporting point:
+    1. First numbered item
+    2. Second numbered item:
+       - Nested bullet beneath a numbered item
+- Second section:
+  - Short detail
+  - Lead-in item:
+    - Explanation below the lead-in`,
+    syntaxStyle,
+    streaming: true,
+    internalBlockMode: "top-level",
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    - Main section:
+      - Supporting point:
+        - Third-level detail
+        - Another detail with emphasis
+      - Another supporting point:
+        1. First numbered item
+        2. Second numbered item:
+           - Nested bullet beneath a numbered item
+    - Second section:
+      - Short detail
+      - Lead-in item:
+        - Explanation below the lead-in"
+  `)
+})


### PR DESCRIPTION
## Summary

- Add a regression covering tight multi-level nested lists rendered with the OpenCode `internalBlockMode: "top-level"` and `streaming: true` configuration.
- Normalize trailing newlines for tight-list `text` children as well as loose-list `paragraph` children.
- Inline the now-unnecessary list-child wrapper once both token shapes share the same normalization.

## Why #1094 Did Not Cover This

#1094 fixed the blank-row symptom for a loose nested list whose source contains a blank line before its child list. Marked represents that parent content as a `paragraph` token.

This reproducer uses a tight nested list with no source blank line. Marked represents the same parent-content position as a `text` token. The existing normalization applied only to `paragraph`, leaving the trailing newline on `text` and producing an empty rendered row before each nested list.

## Before

```text
- Main section:

  - Supporting point:

    - Third-level detail
    - Another detail with emphasis
  - Another supporting point:

    1. First numbered item
    2. Second numbered item:

       - Nested bullet beneath a numbered item
- Second section:

  - Short detail
  - Lead-in item:

    - Explanation below the lead-in
```

## After

```text
- Main section:
  - Supporting point:
    - Third-level detail
    - Another detail with emphasis
  - Another supporting point:
    1. First numbered item
    2. Second numbered item:
       - Nested bullet beneath a numbered item
- Second section:
  - Short detail
  - Lead-in item:
    - Explanation below the lead-in
```

## R/G/R Verification

- RED commit `2b03ee50` adds only the regression test; against `v0.2.15` it fails with six inserted blank rows matching the Before output.
- GREEN commit `3833b39d` applies the minimal normalization fix.
- REFACTOR commit `fec798d4` removes `getListChildMarkdownRaw`, which no longer carries distinct behavior after both textual child token shapes normalize identically.
- `bun test src/renderables/__tests__/Markdown.test.ts` on the runnable `v0.2.15` worktree: `138 pass, 0 fail`.
- `bun run fmt:check packages/core/src/renderables/Markdown.ts packages/core/src/renderables/__tests__/Markdown.test.ts` passes.

The `v0.2.15` validation seam is intentional: it is the shipped OpenTUI version currently consumed by OpenCode. Current `main` has an unreleased native ABI change (`getRenderStats`) that prevents running the TypeScript renderer suite against the published `0.2.15` dylib in a clean worktree.