### PR TITLE
utf8: add fullwidth comma (U+FF0C) to word break characters

### DIFF
--- a/packages/core/src/zig/utf8.zig
+++ b/packages/core/src/zig/utf8.zig
@@ -188,6 +188,7 @@ inline fn isUnicodeWrapBreak(cp: u21) bool {
         0x3001, // IDEOGRAPHIC COMMA
         0x3002, // IDEOGRAPHIC FULL STOP
         0xFF01, // FULLWIDTH EXCLAMATION MARK
+        0xFF0C, // FULLWIDTH COMMA
         0xFF1F, // FULLWIDTH QUESTION MARK
         => true,
         else => false,

--- a/packages/core/src/zig/utf8.zig
+++ b/packages/core/src/zig/utf8.zig
@@ -189,6 +189,7 @@ inline fn isUnicodeWrapBreak(cp: u21) bool {
         0x3002, // IDEOGRAPHIC FULL STOP
         0xFF01, // FULLWIDTH EXCLAMATION MARK
         0xFF0C, // FULLWIDTH COMMA
+        0xFF1A, // FULLWIDTH COLON
         0xFF1F, // FULLWIDTH QUESTION MARK
         => true,
         else => false,


### PR DESCRIPTION
In Chinese, Fullwidth Comma '，' is used more often than Ideographic Comma '、', but is not count as warp break.

This PR add this character as the warp break for convenience.