### PR TITLE
fix(core): don't duplicate bare URLs in concealed markdown

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -457,12 +457,15 @@ export class MarkdownRenderable extends Renderable {
       case "link": {
         const linkHref = { url: token.href }
         if (this._conceal) {
+          const isBareUrl = token.text === token.href
           for (const child of token.tokens) {
             this.renderInlineTokenWithStyle(child as MarkedToken, chunks, "markup.link.label", linkHref)
           }
-          chunks.push(this.createChunk(" (", "markup.link", linkHref))
-          chunks.push(this.createChunk(token.href, "markup.link.url", linkHref))
-          chunks.push(this.createChunk(")", "markup.link", linkHref))
+          if (!isBareUrl) {
+            chunks.push(this.createChunk(" (", "markup.link", linkHref))
+            chunks.push(this.createChunk(token.href, "markup.link.url", linkHref))
+            chunks.push(this.createChunk(")", "markup.link", linkHref))
+          }
         } else {
           chunks.push(this.createChunk("[", "markup.link", linkHref))
           for (const child of token.tokens) {

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -753,6 +753,39 @@ test("table with links", async () => {
   `)
 })
 
+test("bare url is not duplicated in concealed mode", async () => {
+  const markdown = "Visit https://example.com today."
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    Visit https://example.com today."
+  `)
+})
+
+test("named link still shows href in concealed mode", async () => {
+  const markdown = "[click here](https://example.com)"
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    click here (https://example.com)"
+  `)
+})
+
+test("table with bare url is not duplicated", async () => {
+  const markdown = `| Name | Link |
+|---|---|
+| Site | https://example.com |`
+
+  expect(await renderMarkdown(markdown)).toMatchInlineSnapshot(`
+    "
+    ┌────┬───────────────────┐
+    │Name│Link               │
+    ├────┼───────────────────┤
+    │Site│https://example.com│
+    └────┴───────────────────┘"
+  `)
+})
+
 test("single row table (header + delimiter only)", async () => {
   const markdown = `| Only | Header |
 |---|---|`


### PR DESCRIPTION
## Problem

Fixes #1050.

In concealed mode (`conceal: true`, the default for `MarkdownRenderable`), the `link` case in `renderInlineToken` unconditionally appended ` (href)` after the link label. For **named** links like `[click here](https://example.com)` that's correct — it renders `click here (https://example.com)`. But for **bare/autolinked URLs** the label already *is* the href, so it rendered twice:

```
https://example.com (https://example.com)
```

This is most visible in **table cells**, where it wastes column width.

## Fix

Skip the parenthesized `(href)` suffix when the link's visible text equals the href (`token.text === token.href`, both required `string` fields on marked's `Link` token). Named links are unchanged.

## A note on the repro

The linked issue's reproduction uses a bare URL in a **paragraph**. In practice paragraphs are rendered via a syntax-highlighted `CodeRenderable` from the raw text and never reach the `link` rendering path, so they were never actually affected. The duplication only manifests in contexts that go through `renderInlineContent` (table cells, inline emphasis). The regression test added here is therefore a **table**, which is what genuinely exercises the bug.

## Tests

Added to `packages/core/src/renderables/__tests__/Markdown.test.ts`:

- `table with bare url is not duplicated` — the regression test (fails before this change, passes after).
- `bare url is not duplicated in concealed mode` — documents that paragraphs are unaffected.
- `named link still shows href in concealed mode` — guards the named-link behaviour.

The existing `table with links` test still passes, confirming named links continue to render `label (href)` with no regression.

```
bun test src/renderables/__tests__/Markdown.test.ts
150 pass, 0 fail
```

TypeScript-only change — no native build required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)