### PR TITLE
renderer: prevent calls after destruction

### DIFF
--- a/packages/core/src/renderables/__tests__/Textarea.destroyed-events.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.destroyed-events.test.ts
@@ -1,10 +1,60 @@
 import { describe, expect, it, beforeEach, afterEach } from "bun:test"
+import { BoxRenderable } from "../Box.js"
+import { TextRenderable } from "../Text.js"
+import { TextareaRenderable } from "../Textarea.js"
 import { createTestRenderer, type TestRenderer, type MockInput } from "../../testing/test-renderer.js"
 import { createTextareaRenderable } from "./renderable-test-utils.js"
 
 let currentRenderer: TestRenderer
 let renderOnce: () => Promise<void>
 let currentMockInput: MockInput
+
+type DeferredGraphemeMode = "ascii" | "unicode" | "unicode-sync"
+
+function removeReplacementChild(parent: BoxRenderable, child: TextRenderable | BoxRenderable, deferred: boolean) {
+  parent.remove(child.id)
+  if (!deferred) {
+    child.destroyRecursively()
+    return
+  }
+
+  process.nextTick(() => {
+    if (!child.parent) child.destroyRecursively()
+  })
+}
+
+async function runDeferredGraphemeReplacement(mode: DeferredGraphemeMode) {
+  const root = new BoxRenderable(currentRenderer, { width: "100%", height: "100%", flexDirection: "column" })
+  const hint = new TextRenderable(currentRenderer, { content: mode === "ascii" ? "up/down" : "up/down ↑↓" })
+  const deferred = mode !== "unicode-sync"
+  root.add(hint)
+  currentRenderer.root.add(root)
+  await renderOnce()
+
+  removeReplacementChild(root, hint, deferred)
+  const editorShell = new BoxRenderable(currentRenderer, { width: "100%" })
+  const editor = new TextareaRenderable(currentRenderer, {
+    width: "100%",
+    minHeight: 1,
+    maxHeight: 4,
+    keyBindings: [{ name: "return", action: "submit" }],
+    onSubmit() {
+      removeReplacementChild(root, editorShell, deferred)
+      root.add(new TextRenderable(currentRenderer, { content: mode === "ascii" ? "up/down" : "up/down ↑↓" }))
+    },
+  })
+  editorShell.add(editor)
+  root.add(editorShell)
+  editor.focus()
+  await renderOnce()
+  editor.insertText("typed")
+  await renderOnce()
+  editor.submit()
+  await renderOnce()
+  currentRenderer.destroy()
+  await new Promise<void>((resolve) => process.nextTick(resolve))
+  expect(editor.isDestroyed).toBe(true)
+}
 
 describe("Textarea - Destroyed Renderable Event Tests", () => {
   beforeEach(async () => {
@@ -670,6 +720,20 @@ describe("Textarea - Destroyed Renderable Event Tests", () => {
       // Operations after destroy should either throw or be ignored
       // The important thing is we should be able to detect destroyed state
       expect(editor.isDestroyed).toBe(true)
+    })
+  })
+
+  describe("Deferred destruction with graphemes", () => {
+    it("should destroy an ASCII textarea replacement after deferred removal", async () => {
+      await runDeferredGraphemeReplacement("ascii")
+    })
+
+    it("should destroy a synchronously removed Unicode textarea replacement", async () => {
+      await runDeferredGraphemeReplacement("unicode-sync")
+    })
+
+    it("should destroy a deferred Unicode textarea replacement", async () => {
+      await runDeferredGraphemeReplacement("unicode")
     })
   })
 })

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1423,6 +1423,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   public requestRender() {
+    if (this._isDestroyed) {
+      return
+    }
+
     if (this._controlState === RendererControlState.EXPLICIT_SUSPENDED) {
       return
     }
@@ -3514,6 +3518,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
   }
   public setMousePointer(style: MousePointerStyle): void {
+    if (this._isDestroyed) return
+
     this._currentMousePointerStyle = style
     this.lib.setCursorStyleOptions(this.rendererPtr, { cursor: style })
   }
@@ -3761,11 +3767,15 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   public static setCursorPosition(renderer: CliRenderer, x: number, y: number, visible: boolean = true): void {
+    if (renderer._isDestroyed) return
+
     const lib = resolveRenderLib()
     lib.setCursorPosition(renderer.rendererPtr, x, y, visible)
   }
 
   public static setCursorStyle(renderer: CliRenderer, options: CursorStyleOptions): void {
+    if (renderer._isDestroyed) return
+
     const lib = resolveRenderLib()
     lib.setCursorStyleOptions(renderer.rendererPtr, options)
     if (options.cursor !== undefined) {
@@ -3774,15 +3784,21 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   public static setCursorColor(renderer: CliRenderer, color: RGBA): void {
+    if (renderer._isDestroyed) return
+
     const lib = resolveRenderLib()
     lib.setCursorColor(renderer.rendererPtr, color)
   }
 
   public setCursorPosition(x: number, y: number, visible: boolean = true): void {
+    if (this._isDestroyed) return
+
     this.lib.setCursorPosition(this.rendererPtr, x, y, visible)
   }
 
   public setCursorStyle(options: CursorStyleOptions): void {
+    if (this._isDestroyed) return
+
     this.lib.setCursorStyleOptions(this.rendererPtr, options)
     if (options.cursor !== undefined) {
       this._currentMousePointerStyle = options.cursor
@@ -3790,6 +3806,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   public setCursorColor(color: RGBA): void {
+    if (this._isDestroyed) return
+
     this.lib.setCursorColor(this.rendererPtr, color)
   }
 


### PR DESCRIPTION
Deferred teardown of a detached focused textarea can run after the renderer frees its native state. Ignore renderer operations once destruction starts so cleanup cannot call through a freed pointer and crash on shutdown