### PR TITLE
feat(core): renderer: add split-footer replay reset

### DIFF
--- a/packages/core/src/ansi.ts
+++ b/packages/core/src/ansi.ts
@@ -2,6 +2,10 @@ export const ANSI = {
   switchToAlternateScreen: "\x1b[?1049h",
   switchToMainScreen: "\x1b[?1049l",
   reset: "\x1b[0m",
+  resetScrollRegion: "\x1b[r",
+  home: "\x1b[H",
+  clearScreen: "\x1b[2J",
+  clearSavedLines: "\x1b[3J",
 
   scrollDown: (lines: number) => `\x1b[${lines}T`,
   scrollUp: (lines: number) => `\x1b[${lines}S`,

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -300,6 +300,10 @@ export interface ScrollbackSurface {
   destroy(): void
 }
 
+export interface SplitFooterReplayResetOptions {
+  clearSavedLines?: boolean
+}
+
 const DEFAULT_FOOTER_HEIGHT = 12
 const MAX_SCROLLBACK_SURFACE_HEIGHT_PASSES = 4
 const TRANSPARENT_RGBA = RGBA.fromValues(0, 0, 0, 0)
@@ -2194,6 +2198,36 @@ export class CliRenderer extends EventEmitter implements RenderContext {
         throw cleanupError
       }
     }
+  }
+
+  public resetSplitFooterForReplay(options: SplitFooterReplayResetOptions = {}): void {
+    if (this._isDestroyed) return
+    if (this._screenMode !== "split-footer" || this._externalOutputMode !== "capture-stdout") {
+      throw new Error(
+        'resetSplitFooterForReplay requires screenMode "split-footer" and externalOutputMode "capture-stdout"',
+      )
+    }
+    if (!this._terminalIsSetup || this._controlState === RendererControlState.EXPLICIT_SUSPENDED) {
+      throw new Error("resetSplitFooterForReplay requires an active terminal")
+    }
+
+    this.flushPendingSplitOutputBeforeTransition(true)
+    this.externalOutputQueue.clear()
+    this.abortSplitStartupCursorSeed()
+    this.clearPendingSplitFooterTransition()
+    this.resetSplitScrollback()
+    this.currentRenderBuffer.clear(this.backgroundColor)
+    this.nextRenderBuffer.clear(this.backgroundColor)
+    this.forceFullRepaintRequested = true
+    this.writeOut(
+      ANSI.resetScrollRegion +
+        ANSI.reset +
+        ANSI.home +
+        ANSI.clearScreen +
+        (options.clearSavedLines ? ANSI.clearSavedLines : "") +
+        ANSI.home,
+    )
+    this.requestRender()
   }
 
   private getSnapshotWidth(value: number | undefined, fallback: number): number {

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -758,6 +758,58 @@ test("CliRenderer flushes pending writeToScrollback output before resize applies
   lib.resizeRenderer = originalResizeRenderer
 })
 
+test("CliRenderer resetSplitFooterForReplay clears published scrollback and starts fresh", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  renderer.writeToScrollback(textScrollbackWrite("before-replay\n"))
+
+  const lib = (renderer as any).lib
+  const resetSpy = spyOn(lib, "resetSplitScrollback")
+  const writeOutSpy = spyOn(renderer as any, "writeOut")
+
+  renderer.resetSplitFooterForReplay({ clearSavedLines: true })
+
+  expect(resetSpy).toHaveBeenCalledWith((renderer as any).rendererPtr, 0, 6)
+  expect(writeOutSpy).toHaveBeenCalledWith("\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H")
+  expect((renderer as any).splitTailColumn).toBe(0)
+  expect((renderer as any).pendingSplitFooterTransition).toBeNull()
+
+  resetSpy.mockRestore()
+  writeOutSpy.mockRestore()
+})
+
+test("CliRenderer resetSplitFooterForReplay rejects suspended terminal ownership", async () => {
+  const result = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  renderer.suspend()
+  const writeOutSpy = spyOn(renderer as any, "writeOut")
+
+  expect(() => renderer!.resetSplitFooterForReplay({ clearSavedLines: true })).toThrow(
+    "resetSplitFooterForReplay requires an active terminal",
+  )
+  expect(writeOutSpy).not.toHaveBeenCalled()
+
+  writeOutSpy.mockRestore()
+})
+
 test("CliRenderer reuses generic suspend/resume native helpers in split-footer mode", async () => {
   const result = await createTestRenderer({
     width: 40,

--- a/packages/web/src/content/docs/core-concepts/renderer.mdx
+++ b/packages/web/src/content/docs/core-concepts/renderer.mdx
@@ -106,6 +106,8 @@ renderer.footerHeight = 15
 
 Split-footer bookkeeping lives in the native renderer. A shared `SplitScrollback` model tracks the rows it has already published and the current tail column, so the footer pins to the bottom of the terminal as scrollback grows. Captured stdout and [scrollback writers](#writing-to-scrollback) both produce styled `OptimizedBuffer` snapshots. The native side emits these as ANSI alongside the footer repaint in one atomic frame. The renderer flushes pending output before `resize`, `suspend`, mode transitions, and `destroy`.
 
+Applications that can reconstruct their scrollback may opt into a destructive resize replay. `renderer.resetSplitFooterForReplay({ clearSavedLines: true })` clears the visible viewport and terminal saved lines, resets split-footer scrollback bookkeeping, and leaves the footer ready for newly appended snapshots. This method is only valid in split-footer capture mode.
+
 ## External output mode
 
 The `externalOutputMode` option controls what happens to writes that go through the renderer's configured `stdout.write` while the renderer is active. It does not change `stderr`, the built-in console overlay, or renderer-owned frame bytes.


### PR DESCRIPTION
Let applications that rebuild scrollback after a destructive resize discard stale terminal history.