### PR TITLE
feat(core): add setupTerminal config flag to opt out of synchronous setup

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -183,6 +183,12 @@ export interface CliRendererConfig {
   // Set Kitty keyboard protocol flags, or null to disable them.
   useKittyKeyboard?: KittyKeyboardOptions | null
 
+  // Skip the synchronous terminal setup performed by `createCliRenderer`.
+  // Defaults to true. Set to false when an outer layer already owns terminal
+  // setup (e.g. a tmux `-CC` control-mode host) and the renderer should not
+  // touch raw mode / alternate screen on creation.
+  setupTerminal?: boolean
+
   // Fill the render buffer with this background color. Default transparent.
   backgroundColor?: ColorInput
 
@@ -673,7 +679,9 @@ export async function createCliRenderer(config: CliRendererConfig = {}): Promise
 
   const renderer = new CliRenderer(stdin, stdout, width, height, config)
   try {
-    await renderer.setupTerminal()
+    if (config.setupTerminal !== false) {
+      await renderer.setupTerminal()
+    }
     return renderer
   } catch (error) {
     try {


### PR DESCRIPTION
## Summary
Add `CliRendererConfig.setupTerminal?: boolean` (default `true`). When set to
`false`, `createCliRenderer` skips the synchronous `await renderer.setupTerminal()`
call so an outer layer that already owns the terminal can drive raw mode /
alternate-screen setup itself.

**Motivation:** running OpenTUI inside a tmux `-CC` (control mode) host, where
tmux owns terminal setup and a second synchronous setup from OpenTUI corrupts
state. The caller constructs the renderer with `setupTerminal: false` and
performs setup at the appropriate time.

## Changes
- `packages/core/src/renderer.ts`
  - Add `setupTerminal?: boolean` to `CliRendererConfig`.
  - Guard `setupTerminal()` in `createCliRenderer` with `config.setupTerminal !== false`.

## Notes
- Discussion: #1137
- Backwards compatible: default preserves current behavior.
- This is a feature, so opening as **draft** pending discussion in #1137.
- Not unit-tested: `setupTerminal` lives in `createCliRenderer`, which requires a
  real TTY to exercise; the change is covered by types. (The previously-bundled
  `useKittyKeyboard: null` bug fix has been split out into its own PR, #1140.)
