### PR TITLE
feat(core): double-click to select the word under the cursor

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -819,6 +819,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private lastOverRenderableNum: number = 0
   private lastOverRenderable?: Renderable
 
+  // Double-click tracking for word selection (see handleMouseEvent).
+  private _lastClickTime: number = 0
+  private _lastClickX: number = -1
+  private _lastClickY: number = -1
+
   private currentSelection: Selection | null = null
   private selectionContainers: Renderable[] = []
   private clipboard: Clipboard
@@ -3374,6 +3379,40 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     const sameElement = maybeRenderableId === this.lastOverRenderableNum
     this.lastOverRenderableNum = maybeRenderableId
     const maybeRenderable = Renderable.renderablesByNumber.get(maybeRenderableId)
+
+    // Double-click to select the word under the cursor. A "word" is the
+    // contiguous run of printable cells (codepoint > 32) around the click.
+    if (mouseEvent.type === "down" && mouseEvent.button === MouseButton.LEFT && !mouseEvent.modifiers.ctrl) {
+      const now = Date.now()
+      const isDoubleClick =
+        now - this._lastClickTime < 500 && mouseEvent.x === this._lastClickX && mouseEvent.y === this._lastClickY
+      this._lastClickTime = now
+      this._lastClickX = mouseEvent.x
+      this._lastClickY = mouseEvent.y
+
+      if (
+        isDoubleClick &&
+        maybeRenderable &&
+        maybeRenderable.selectable &&
+        !maybeRenderable.isDestroyed &&
+        this.currentRenderBuffer
+      ) {
+        const buf = this.currentRenderBuffer
+        const w = this.width
+        const y = mouseEvent.y
+        const cp = buf.buffers.char[y * w + mouseEvent.x]
+        if (cp > 32) {
+          let startX = mouseEvent.x
+          let endX = mouseEvent.x
+          while (startX > 0 && buf.buffers.char[y * w + startX - 1] > 32) startX--
+          while (endX < w - 1 && buf.buffers.char[y * w + endX + 1] > 32) endX++
+          this.clearSelection()
+          this.startSelection(maybeRenderable, startX, y)
+          this.updateSelection(maybeRenderable, endX + 1, y)
+          return true
+        }
+      }
+    }
 
     if (
       mouseEvent.type === "down" &&

--- a/packages/core/src/tests/renderer.double-click-selection.test.ts
+++ b/packages/core/src/tests/renderer.double-click-selection.test.ts
@@ -1,0 +1,60 @@
+import { test, expect, beforeEach, afterEach } from "bun:test"
+import { createTestRenderer, type TestRenderer, type MockMouse } from "../testing.js"
+import { TextRenderable } from "../renderables/Text.js"
+
+let renderer: TestRenderer
+let mockMouse: MockMouse
+let renderOnce: () => Promise<void>
+
+beforeEach(async () => {
+  ;({ renderer, mockMouse, renderOnce } = await createTestRenderer({ width: 40, height: 10 }))
+})
+
+afterEach(() => {
+  renderer.destroy()
+})
+
+function addText(content: string): TextRenderable {
+  const text = new TextRenderable(renderer, {
+    content,
+    width: 20,
+    height: 1,
+    selectable: true,
+    position: "absolute",
+    left: 0,
+    top: 0,
+  })
+  renderer.root.add(text)
+  return text
+}
+
+// "hello world" => h0 e1 l2 l3 o4 (space)5 w6 o7 r8 l9 d10
+
+test("double-click selects the word under the cursor (mid-line)", async () => {
+  addText("hello world")
+  await renderOnce()
+
+  // click on the 'r' in "world"
+  await mockMouse.doubleClick(8, 0)
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe("world")
+})
+
+test("double-click selects the first word", async () => {
+  addText("hello world")
+  await renderOnce()
+
+  // click on the second 'l' in "hello"
+  await mockMouse.doubleClick(2, 0)
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe("hello")
+})
+
+test("double-click expands only to printable cell boundaries", async () => {
+  // two single-character words separated by a space: "a bc"
+  addText("a bc")
+  await renderOnce()
+
+  await mockMouse.doubleClick(2, 0) // the 'b'
+  expect(renderer.getSelection()?.getSelectedText()).toBe("bc")
+})


### PR DESCRIPTION
## Summary
Adds double-click word selection to the renderer mouse handling.

A left-button `down` within **500ms** at the same `(x, y)` cell as the previous
click is treated as a double-click. On a double-click, the selection expands to
the **contiguous run of printable cells** (codepoint > 32) around the clicked
cell, scanning left/right in the current render buffer to find word boundaries.

## Behavior
- Triggers only on `MouseButton.LEFT`, no `ctrl` modifier.
- Only fires on a `selectable`, non-destroyed renderable (consistent with the
  existing single-click selection gate).
- No-op when the clicked cell is whitespace/empty (codepoint <= 32).
- Falls through to the normal single-click selection path otherwise.

## Changes
- `packages/core/src/renderer.ts`
  - Add `_lastClickTime / _lastClickX / _lastClickY` tracking fields.
  - Add the double-click expansion block before the single-click selection
    handler in `handleMouseEvent`.

## Notes
- Opening as **draft** to gauge interest before adding tests.
- The 500ms threshold could be made configurable on `CliRendererConfig` if desired.

---
Discussion: #1138
