### PR TITLE
fix(core): extract embedded native lib before dlopen on macOS (bun compile)

### DIFF
--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -69,6 +69,33 @@ let targetLibPath = nativePackage.default
 
 if (isBunfsPath(targetLibPath)) {
   targetLibPath = targetLibPath.replace("../", "")
+
+  // When the native library is embedded by `bun build --compile`, it lives in
+  // Bun's virtual filesystem (`/$bunfs/...`). macOS `dlopen` cannot load a
+  // shared library from that virtual path, so extract it to a real temp file
+  // before opening it. (Linux can dlopen the bunfs path directly.)
+  if (process.platform === "darwin") {
+    const name = targetLibPath.split(/[\\/]/).pop() || "libopentui"
+    const data = new Uint8Array(await Bun.file(targetLibPath).arrayBuffer())
+    const candidateDirs = [
+      ...new Set([process.env.TMPDIR, "/tmp", "/private/tmp"].filter((d): d is string => Boolean(d))),
+    ]
+    let lastError: unknown
+    for (const dir of candidateDirs) {
+      try {
+        const extracted = `${dir.replace(/\/$/, "")}/${process.pid}-${name}`
+        writeFileSync(extracted, data)
+        targetLibPath = extracted
+        lastError = undefined
+        break
+      } catch (error) {
+        lastError = error
+      }
+    }
+    if (lastError) {
+      throw lastError
+    }
+  }
 }
 
 if (!existsSync(targetLibPath)) {


### PR DESCRIPTION
## Summary
Fixes loading the native library when an app is packaged with
`bun build --compile` on macOS.

When OpenTUI is bundled into a single-file Bun executable, the native
`libopentui` shared library is embedded in Bun's virtual filesystem and resolves
to a `/$bunfs/...` path. On macOS, `dlopen` **cannot** load a shared library
from that virtual path, so FFI initialization fails at startup.

This change detects the bunfs path and, on darwin, extracts the embedded library
to a real temp file (first writable of `$TMPDIR`, `/tmp`, `/private/tmp`) before
it is opened. Linux can `dlopen` the bunfs path directly and is left unchanged.

## Changes
- `packages/core/src/zig.ts`
  - In the `isBunfsPath(targetLibPath)` branch, on `process.platform === "darwin"`,
    copy the embedded library to `<tmpdir>/<pid>-<name>` and point `targetLibPath`
    at the extracted file. Uses the already-imported `writeFileSync`.

## Notes
- The temp file is named with `process.pid` to avoid collisions between
  concurrent processes.
- Opening as **draft** — happy to adjust temp-dir selection / cleanup strategy
  (e.g. unlink on exit) per maintainer preference.
