### PR TITLE
perf(core): avoid always-pending re-render in ScrollBox.recalculateBarProps

### DIFF
--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -138,6 +138,13 @@ export class ScrollBoxRenderable extends BoxRenderable {
   private _stickyScrollBottom: boolean = false
   private _stickyScrollLeft: boolean = false
   private _stickyScrollRight: boolean = false
+
+  // Snapshot of content/viewport size at the last recalculateBarProps() so the
+  // deferred re-render below can be skipped when nothing relevant changed.
+  private _lastBarRecalcScrollHeight: number = -1
+  private _lastBarRecalcScrollWidth: number = -1
+  private _lastBarRecalcViewportHeight: number = -1
+  private _lastBarRecalcViewportWidth: number = -1
   private _stickyStart?: "bottom" | "top" | "left" | "right"
   private _hasManualScroll: boolean = false
   private _isApplyingStickyScroll: boolean = false
@@ -819,9 +826,28 @@ export class ScrollBoxRenderable extends BoxRenderable {
     // and update all renderables in one go before rendering.
     // OR: Move this logic to the viewport. IMHO the wrapper and viewport are overkill and not necessary.
     //     The Scrollbox can be the viewport, we are using translations on the content anyway.
-    process.nextTick(() => {
-      this.requestRender()
-    })
+    //
+    // Gate the deferred re-render so it only fires when it can actually change
+    // output: when the viewport dimensions changed (the resize workaround above)
+    // or when sticky scroll is active and the content grew (auto-scroll during
+    // streaming). Otherwise a render was always left pending between content
+    // updates and the renderer never settled.
+    const contentHeight = this.content.height
+    const contentWidth = this.content.width
+    const viewportHeight = this.viewport.height
+    const viewportWidth = this.viewport.width
+    const viewportChanged =
+      viewportHeight !== this._lastBarRecalcViewportHeight || viewportWidth !== this._lastBarRecalcViewportWidth
+    const contentGrew = contentHeight > this._lastBarRecalcScrollHeight || contentWidth > this._lastBarRecalcScrollWidth
+    this._lastBarRecalcScrollHeight = contentHeight
+    this._lastBarRecalcScrollWidth = contentWidth
+    this._lastBarRecalcViewportHeight = viewportHeight
+    this._lastBarRecalcViewportWidth = viewportWidth
+    if (viewportChanged || (this._stickyScroll && contentGrew)) {
+      process.nextTick(() => {
+        this.requestRender()
+      })
+    }
   }
 
   // Setters for reactive properties

--- a/packages/core/src/tests/scrollbox-bar-recalc-gate.test.ts
+++ b/packages/core/src/tests/scrollbox-bar-recalc-gate.test.ts
@@ -1,0 +1,80 @@
+import { test, expect, beforeEach, afterEach } from "bun:test"
+import { createTestRenderer, type TestRenderer } from "../testing.js"
+import { ScrollBoxRenderable } from "../renderables/ScrollBox.js"
+import { TextRenderable } from "../renderables/Text.js"
+
+let renderer: TestRenderer
+let renderOnce: () => Promise<void>
+
+beforeEach(async () => {
+  ;({ renderer, renderOnce } = await createTestRenderer({ width: 80, height: 24 }))
+})
+
+afterEach(() => {
+  renderer.destroy()
+})
+
+async function makeSettledScrollBox(stickyScroll: boolean): Promise<ScrollBoxRenderable> {
+  const scrollBox = new ScrollBoxRenderable(renderer, {
+    width: 40,
+    height: 10,
+    scrollY: true,
+    stickyScroll,
+    stickyStart: stickyScroll ? "bottom" : undefined,
+  })
+  for (let i = 0; i < 30; i++) {
+    scrollBox.add(new TextRenderable(renderer, { content: `Line ${i}`, height: 1 }))
+  }
+  renderer.root.add(scrollBox)
+  // Render until the deferred re-render settles so _lastBarRecalc* are recorded.
+  await renderOnce()
+  await renderOnce()
+  return scrollBox
+}
+
+function spyRequestRender(scrollBox: ScrollBoxRenderable): () => number {
+  let calls = 0
+  const original = scrollBox.requestRender.bind(scrollBox)
+  scrollBox.requestRender = () => {
+    calls++
+    return original()
+  }
+  return () => calls
+}
+
+const flushNextTick = () => new Promise<void>((resolve) => process.nextTick(resolve))
+
+test("recalculateBarProps does not schedule a re-render when nothing changed", async () => {
+  const scrollBox = await makeSettledScrollBox(true)
+  const getCalls = spyRequestRender(scrollBox)
+
+  // Same content + viewport as the settled state -> no deferred render.
+  ;(scrollBox as unknown as { recalculateBarProps(): void }).recalculateBarProps()
+  await flushNextTick()
+
+  expect(getCalls()).toBe(0)
+})
+
+test("recalculateBarProps schedules a re-render when the viewport changed", async () => {
+  const scrollBox = await makeSettledScrollBox(false)
+  const getCalls = spyRequestRender(scrollBox)
+
+  // Simulate a viewport dimension change since the last recalculation.
+  ;(scrollBox as unknown as { _lastBarRecalcViewportHeight: number })._lastBarRecalcViewportHeight = -999
+  ;(scrollBox as unknown as { recalculateBarProps(): void }).recalculateBarProps()
+  await flushNextTick()
+
+  expect(getCalls()).toBeGreaterThan(0)
+})
+
+test("recalculateBarProps schedules a re-render when sticky scroll content grew", async () => {
+  const scrollBox = await makeSettledScrollBox(true)
+  const getCalls = spyRequestRender(scrollBox)
+
+  // Simulate content growth since the last recalculation under sticky scroll.
+  ;(scrollBox as unknown as { _lastBarRecalcScrollHeight: number })._lastBarRecalcScrollHeight = -1
+  ;(scrollBox as unknown as { recalculateBarProps(): void }).recalculateBarProps()
+  await flushNextTick()
+
+  expect(getCalls()).toBeGreaterThan(0)
+})


### PR DESCRIPTION
## Summary
`recalculateBarProps()` unconditionally scheduled a
`process.nextTick(() => this.requestRender())` at the end of every call. During
chat-style streaming with sticky-scroll-to-bottom and a continuously growing
child, this left a render permanently pending between content updates — the
renderer never settled to idle, burning CPU.

This change records the content/viewport dimensions seen at each call and only
schedules the deferred re-render when it can actually change output:
- **viewport dimensions changed** — preserves the resize workaround the existing
  comment describes; or
- **sticky scroll is active and content grew** — preserves auto-scroll-to-bottom
  during streaming.

The four `_lastBarRecalc*` fields initialize to `-1`, so the first call always
fires.

## Changes
- `packages/core/src/renderables/ScrollBox.ts`
  - Add `_lastBarRecalcScrollHeight/Width` and `_lastBarRecalcViewportHeight/Width`.
  - Gate the trailing `process.nextTick(requestRender)` on the conditions above.

## Notes
- Behavior-preserving for the cases the original `nextTick` was protecting
  (resize + sticky streaming); it only removes redundant always-pending renders.
- Opening as **draft** to gauge interest before adding tests.
