### PR TITLE
fix(core): respect useKittyKeyboard: null to disable the Kitty protocol

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1047,7 +1047,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     if (process.platform === "linux") config.useThread = false
     lib.setUseThread(rendererPtr, config.useThread)
 
-    const kittyConfig = config.useKittyKeyboard ?? {}
+    // Explicit `undefined` check (not `??`) so a caller-supplied `null` is
+    // preserved rather than collapsed to `{}`. `null` means "disable Kitty";
+    // `?? {}` would turn that into enabled (buildKittyKeyboardFlags({}) !== 0).
+    const kittyConfig = config.useKittyKeyboard === undefined ? {} : config.useKittyKeyboard
     const kittyFlags = buildKittyKeyboardFlags(kittyConfig)
     lib.setKittyKeyboardFlags(rendererPtr, kittyFlags)
 

--- a/packages/core/src/tests/renderer.kitty-config.test.ts
+++ b/packages/core/src/tests/renderer.kitty-config.test.ts
@@ -1,0 +1,28 @@
+import { test, expect, afterEach } from "bun:test"
+import { createTestRenderer, type TestRenderer } from "../testing.js"
+
+let renderer: TestRenderer | undefined
+
+afterEach(() => {
+  renderer?.destroy()
+  renderer = undefined
+})
+
+// Regression test: `config.useKittyKeyboard ?? {}` collapsed a caller-supplied
+// `null` to `{}`, which *enabled* Kitty (buildKittyKeyboardFlags({}) === 0b101)
+// instead of disabling it (buildKittyKeyboardFlags(null) === 0). The explicit
+// `=== undefined` check preserves `null` so Kitty is actually disabled.
+test("useKittyKeyboard: null disables the Kitty keyboard protocol", async () => {
+  ;({ renderer } = await createTestRenderer({ width: 20, height: 5, useKittyKeyboard: null }))
+  expect(renderer.useKittyKeyboard).toBe(false)
+})
+
+test("useKittyKeyboard undefined (default) enables the Kitty keyboard protocol", async () => {
+  ;({ renderer } = await createTestRenderer({ width: 20, height: 5 }))
+  expect(renderer.useKittyKeyboard).toBe(true)
+})
+
+test("useKittyKeyboard: {} enables the Kitty keyboard protocol", async () => {
+  ;({ renderer } = await createTestRenderer({ width: 20, height: 5, useKittyKeyboard: {} }))
+  expect(renderer.useKittyKeyboard).toBe(true)
+})


### PR DESCRIPTION
## Summary
Fix `useKittyKeyboard: null` being ignored.

`const kittyConfig = config.useKittyKeyboard ?? {}` collapses a caller-supplied
`null` to `{}`, which has two consequences:

- `buildKittyKeyboardFlags({}) === 0b101` (Kitty **enabled**) instead of
  `buildKittyKeyboardFlags(null) === 0` (disabled) — so passing
  `useKittyKeyboard: null` does **not** disable the Kitty keyboard protocol.
- It defeats the downstream `const useKittyForParsing = kittyConfig !== null`
  gate, which can then never be `false`.

Switching to an explicit `=== undefined` check preserves a caller-supplied
`null` so Kitty is actually disabled.

## Changes
- `packages/core/src/renderer.ts`: `useKittyKeyboard ?? {}` →
  `useKittyKeyboard === undefined ? {} : useKittyKeyboard`.
- `packages/core/src/tests/renderer.kitty-config.test.ts`: new tests asserting
  `null` disables and `undefined` / `{}` enable Kitty (via
  `renderer.useKittyKeyboard`).

## Notes
- Bug fix, so opening directly for review per CONTRIBUTING.md.
- Split out of #1132 (which now only contains the unrelated `setupTerminal` feature).
