### PR TITLE
fix(core): allow _hasManualScroll reset when reaching bottom during concurrent operations (#1088 follow-up)

### DIFF
--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -225,7 +225,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
     } else if (this.scrollTop >= maxScrollTop) {
       this._stickyScrollTop = false
       this._stickyScrollBottom = true
-      if (!this._isApplyingStickyScroll && this._stickyStart === "bottom") {
+      if (this._stickyStart === "bottom") {
         this._hasManualScroll = false
       }
     } else {

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -1720,4 +1720,48 @@ console.log(processor.reduce((acc, val) => acc + val, 0))`
       }
     }
   })
+
+  test("updateStickyState resets _hasManualScroll when reaching bottom even during concurrent sticky operations", async () => {
+    const scrollBox = new ScrollBoxRenderable(testRenderer, {
+      width: 40,
+      height: 10,
+      stickyScroll: true,
+      stickyStart: "bottom",
+    })
+
+    testRenderer.root.add(scrollBox)
+
+    // Add enough content to make scrolling possible
+    for (let i = 0; i < 30; i++) {
+      scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
+    }
+    await renderOnce()
+
+    const maxScrollTop = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
+
+    // Simulate: user scrolled to bottom while concurrent sticky operation was running
+    scrollBox.verticalScrollBar.scrollPosition = maxScrollTop
+    ;(scrollBox as any)._hasManualScroll = true
+    ;(scrollBox as any)._isApplyingStickyScroll = true
+
+    // Trigger updateStickyState (called when scrollTop changes)
+    const updateStickyState = (scrollBox as any).updateStickyState.bind(scrollBox)
+    updateStickyState()
+
+    // With fix: flag should reset even though _isApplyingStickyScroll was true
+    expect((scrollBox as any)._hasManualScroll).toBe(false)
+    expect((scrollBox as any)._stickyScrollBottom).toBe(true)
+
+    // Clear the flag for subsequent behavior check
+    ;(scrollBox as any)._isApplyingStickyScroll = false
+
+    // Adding more content should now cause viewport to stay locked to bottom
+    for (let i = 30; i < 40; i++) {
+      scrollBox.add(new TextRenderable(testRenderer, { id: `line-${i}`, content: `Line ${i}` }))
+    }
+    await renderOnce()
+
+    const newMaxScrollTop = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height)
+    expect(scrollBox.scrollTop).toBe(newMaxScrollTop)
+  })
 })


### PR DESCRIPTION
## Related Issues
- anomalyco/opencode#29992 (regression discovered after #1088)
- #1088 (original sticky scroll fix)

## Issue
After merging #1088 and releasing in v0.2.16, testing revealed a related issue where sticky auto-scroll fails to re-engage when users scroll to the absolute bottom of content and then new content arrives (e.g., tool call results).

Root cause: In `updateStickyState()`, the guard `!this._isApplyingStickyScroll` prevents `_hasManualScroll` from being reset when the user reaches bottom **if** any sticky operation happened to be running concurrently. This creates a race condition that #1088 didn't address.

## Fix
Remove the overly conservative `_isApplyingStickyScroll` guard from the bottom-reset logic in `updateStickyState()`. When the user physically reaches the bottom of scrollable content, we should always recognize that state regardless of timing with concurrent operations.

The actual position-setting logic lives in `applyStickyStart()` which already has its own try/finally protection, so removing this guard doesn't introduce race conditions. It just allows proper state recognition.

## Testing
Added regression test verifying `_hasManualScroll` resets correctly even when `_isApplyingStickyScroll` is true during concurrent operations. Pre-patch test fails, post-patch all 42 tests pass.

## Impact
Minimal risk. Single condition removal in one code path.