### PR TITLE
feat(core/markdown): add code block renderer helper

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -195,7 +195,7 @@ interface CustomRenderableResult {
   renderable?: Renderable
   tableContentCache?: TableContentCache
   tracksInterBlockMargin: boolean
-  usesDefaultRenderer: boolean
+  canUpdateInPlace: boolean
 }
 
 interface CustomRenderDefaultResult {
@@ -239,7 +239,8 @@ export interface BlockState {
   renderable: Renderable
   tableContentCache?: TableContentCache
   tracksInterBlockMargin?: boolean
-  usesDefaultRenderer: boolean
+  /** Whether built-in reconciliation can update this renderable without replacing it. */
+  canUpdateInPlace: boolean
 }
 
 export type { ParseState }
@@ -1431,54 +1432,54 @@ export class MarkdownRenderable extends Renderable {
   private createTopLevelDefaultRenderable(
     block: MarkdownRenderBlock,
     index: number,
-  ): { renderable: Renderable | undefined; tableContentCache?: TableContentCache; usesDefaultRenderer: boolean } {
+  ): { renderable: Renderable | undefined; tableContentCache?: TableContentCache; canUpdateInPlace: boolean } {
     const { token, marginTop } = block
     const id = `${this.id}-block-${index}`
 
     if (token.type === "code") {
       const renderable = this.createCodeRenderable(token, id)
       renderable.marginTop = marginTop
-      return { renderable, usesDefaultRenderer: true }
+      return { renderable, canUpdateInPlace: true }
     }
 
     if (token.type === "table") {
       const next = this.createTableBlock(token, id)
       next.renderable.marginTop = marginTop
-      return { ...next, usesDefaultRenderer: true }
+      return { ...next, canUpdateInPlace: true }
     }
 
     if (token.type === "blockquote") {
       const renderable = this.createBlockquoteRenderable(token, id)
       renderable.marginTop = marginTop
-      return { renderable, usesDefaultRenderer: true }
+      return { renderable, canUpdateInPlace: true }
     }
 
     if (token.type === "list") {
       const renderable = this.createListRenderable(token, id)
       renderable.marginTop = marginTop
-      return { renderable, usesDefaultRenderer: true }
+      return { renderable, canUpdateInPlace: true }
     }
 
     if (token.type === "hr") {
       const renderable = this.createHorizontalRuleRenderable(id)
       renderable.marginTop = marginTop
-      return { renderable, usesDefaultRenderer: true }
+      return { renderable, canUpdateInPlace: true }
     }
 
     const markdownRaw = this.getTopLevelBlockRaw(token)
     if (!markdownRaw) {
-      return { renderable: undefined, usesDefaultRenderer: true }
+      return { renderable: undefined, canUpdateInPlace: true }
     }
 
     const renderable = this.createMarkdownCodeRenderable(markdownRaw, id)
     renderable.marginTop = marginTop
-    return { renderable, usesDefaultRenderer: true }
+    return { renderable, canUpdateInPlace: true }
   }
 
   private createTopLevelRenderable(
     block: MarkdownRenderBlock,
     index: number,
-  ): { renderable: Renderable | undefined; tableContentCache?: TableContentCache; usesDefaultRenderer: boolean } {
+  ): { renderable: Renderable | undefined; tableContentCache?: TableContentCache; canUpdateInPlace: boolean } {
     if (!this._renderNode) {
       return this.createTopLevelDefaultRenderable(block, index)
     }
@@ -1495,7 +1496,7 @@ export class MarkdownRenderable extends Renderable {
     return {
       renderable: custom.renderable,
       tableContentCache: custom.tableContentCache,
-      usesDefaultRenderer: custom.usesDefaultRenderer,
+      canUpdateInPlace: custom.canUpdateInPlace,
     }
   }
 
@@ -1543,15 +1544,15 @@ export class MarkdownRenderable extends Renderable {
       return { renderable: this.createDefaultRenderable(token, index, nextToken) }
     })
     if (!custom.renderable) {
-      return { tracksInterBlockMargin: true, usesDefaultRenderer: true }
+      return { tracksInterBlockMargin: true, canUpdateInPlace: true }
     }
 
-    const usesDefaultRenderer = custom.renderable === custom.defaultResult?.renderable
+    const canUpdateInPlace = custom.renderable === custom.defaultResult?.renderable
 
     return {
       renderable: custom.renderable,
-      tracksInterBlockMargin: usesDefaultRenderer,
-      usesDefaultRenderer,
+      tracksInterBlockMargin: canUpdateInPlace,
+      canUpdateInPlace,
     }
   }
 
@@ -1560,16 +1561,16 @@ export class MarkdownRenderable extends Renderable {
       return this.createTopLevelDefaultRenderable(block, index)
     })
     if (!custom.renderable) {
-      return { tracksInterBlockMargin: true, usesDefaultRenderer: true }
+      return { tracksInterBlockMargin: true, canUpdateInPlace: true }
     }
 
-    const usesDefaultRenderer = custom.renderable === custom.defaultResult?.renderable
+    const canUpdateInPlace = custom.renderable === custom.defaultResult?.renderable
 
     return {
       renderable: custom.renderable,
-      tableContentCache: usesDefaultRenderer ? custom.defaultResult?.tableContentCache : undefined,
-      tracksInterBlockMargin: usesDefaultRenderer,
-      usesDefaultRenderer,
+      tableContentCache: canUpdateInPlace ? custom.defaultResult?.tableContentCache : undefined,
+      tracksInterBlockMargin: canUpdateInPlace,
+      canUpdateInPlace,
     }
   }
 
@@ -1730,13 +1731,13 @@ export class MarkdownRenderable extends Renderable {
       if (
         existing &&
         !forceTableRefresh &&
-        existing.usesDefaultRenderer &&
+        existing.canUpdateInPlace &&
         existing.token.type === block.token.type &&
         this.canUpdateBlockRenderable(existing.renderable, block.token)
       ) {
         if (this._renderNode) {
           const custom = this.createTopLevelCustomRenderable(block, blockIndex)
-          if (custom.renderable && !custom.usesDefaultRenderer) {
+          if (custom.renderable && !custom.canUpdateInPlace) {
             const marginTop =
               typeof custom.renderable.marginTop === "number"
                 ? Math.max(custom.renderable.marginTop, block.marginTop)
@@ -1752,7 +1753,7 @@ export class MarkdownRenderable extends Renderable {
               marginTop: block.marginTop,
               renderable: custom.renderable,
               tableContentCache: custom.tableContentCache,
-              usesDefaultRenderer: custom.usesDefaultRenderer,
+              canUpdateInPlace: custom.canUpdateInPlace,
             }
             blockIndex++
             continue
@@ -1783,7 +1784,7 @@ export class MarkdownRenderable extends Renderable {
           marginTop: block.marginTop,
           renderable: next.renderable,
           tableContentCache: next.tableContentCache,
-          usesDefaultRenderer: next.usesDefaultRenderer,
+          canUpdateInPlace: next.canUpdateInPlace,
         }
       }
       blockIndex++
@@ -1831,7 +1832,7 @@ export class MarkdownRenderable extends Renderable {
           marginTop: 0,
           renderable: fallback,
           tracksInterBlockMargin: true,
-          usesDefaultRenderer: true,
+          canUpdateInPlace: true,
         },
       ]
       return
@@ -1875,9 +1876,9 @@ export class MarkdownRenderable extends Renderable {
         continue
       }
 
-      if (existing && existing.usesDefaultRenderer && existing.token.type === token.type) {
+      if (existing && existing.canUpdateInPlace && existing.token.type === token.type) {
         const custom = this.createCustomRenderable(token, blockIndex, nextToken)
-        if (custom.renderable && !custom.usesDefaultRenderer) {
+        if (custom.renderable && !custom.canUpdateInPlace) {
           if (custom.renderable !== existing.renderable) {
             existing.renderable.destroyRecursively()
             this.add(custom.renderable, blockIndex)
@@ -1887,7 +1888,7 @@ export class MarkdownRenderable extends Renderable {
             tokenRaw: token.raw,
             renderable: custom.renderable,
             tracksInterBlockMargin: custom.tracksInterBlockMargin,
-            usesDefaultRenderer: custom.usesDefaultRenderer,
+            canUpdateInPlace: custom.canUpdateInPlace,
           }
           blockIndex++
           continue
@@ -1909,13 +1910,13 @@ export class MarkdownRenderable extends Renderable {
       let renderable: Renderable | undefined
       let tableContentCache: TableContentCache | undefined
       let tracksInterBlockMargin = true
-      let usesDefaultRenderer = true
+      let canUpdateInPlace = true
 
       const custom = this.createCustomRenderable(token, blockIndex, nextToken)
       if (custom.renderable) {
         renderable = custom.renderable
         tracksInterBlockMargin = custom.tracksInterBlockMargin
-        usesDefaultRenderer = custom.usesDefaultRenderer
+        canUpdateInPlace = custom.canUpdateInPlace
       }
 
       if (!renderable) {
@@ -1945,7 +1946,7 @@ export class MarkdownRenderable extends Renderable {
           renderable,
           tableContentCache,
           tracksInterBlockMargin,
-          usesDefaultRenderer,
+          canUpdateInPlace,
         }
       }
       blockIndex++

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -132,9 +132,67 @@ export interface RenderNodeContext {
   defaultRender: () => Renderable | null
 }
 
+export type MarkdownCodeBlockRenderer = (
+  token: Tokens.Code,
+  context: RenderNodeContext,
+) => Renderable | undefined | null
+
+export type MarkdownCodeBlockRendererMap =
+  | ReadonlyMap<string, MarkdownCodeBlockRenderer>
+  | Readonly<Record<string, MarkdownCodeBlockRenderer>>
+
+function getMarkdownCodeBlockRenderer(
+  renderers: MarkdownCodeBlockRendererMap,
+  language: string,
+): MarkdownCodeBlockRenderer | undefined {
+  if (renderers instanceof Map) {
+    return renderers.get(language)
+  }
+
+  const rendererRecord = renderers as Readonly<Record<string, MarkdownCodeBlockRenderer>>
+  return Object.prototype.hasOwnProperty.call(rendererRecord, language) ? rendererRecord[language] : undefined
+}
+
+function getMarkdownCodeBlockLanguageCandidates(infoString: string | undefined): string[] {
+  const candidates: string[] = []
+  const normalized = infoStringToFiletype(infoString ?? "")
+  if (normalized) candidates.push(normalized)
+
+  const raw = infoString?.trim().split(/\s+/, 1)[0]?.replace(/^\./, "").toLowerCase()
+  if (raw && raw !== normalized) candidates.push(raw)
+
+  return candidates
+}
+
+export function createMarkdownCodeBlockRenderer(
+  renderers: MarkdownCodeBlockRendererMap,
+): MarkdownOptions["renderNode"] {
+  return (token, context) => {
+    if (token.type !== "code") {
+      return undefined
+    }
+
+    for (const language of getMarkdownCodeBlockLanguageCandidates(token.lang)) {
+      const renderer = getMarkdownCodeBlockRenderer(renderers, language)
+      if (!renderer) continue
+
+      return renderer(token as Tokens.Code, context)
+    }
+
+    return undefined
+  }
+}
+
 interface TableContentCache {
   content: TextTableContent
   cellKeys: Uint32Array[]
+}
+
+interface CustomRenderableResult {
+  renderable?: Renderable
+  tableContentCache?: TableContentCache
+  tracksInterBlockMargin: boolean
+  usesDefaultRenderer: boolean
 }
 
 interface ResolvedTableRenderableOptions {
@@ -168,6 +226,7 @@ export interface BlockState {
   renderable: Renderable
   tableContentCache?: TableContentCache
   tracksInterBlockMargin?: boolean
+  usesDefaultRenderer: boolean
 }
 
 export type { ParseState }
@@ -1355,78 +1414,72 @@ export class MarkdownRenderable extends Renderable {
   private createTopLevelDefaultRenderable(
     block: MarkdownRenderBlock,
     index: number,
-  ): { renderable: Renderable | undefined; tableContentCache?: TableContentCache } {
+  ): { renderable: Renderable | undefined; tableContentCache?: TableContentCache; usesDefaultRenderer: boolean } {
     const { token, marginTop } = block
     const id = `${this.id}-block-${index}`
 
     if (token.type === "code") {
       const renderable = this.createCodeRenderable(token, id)
       renderable.marginTop = marginTop
-      return { renderable }
+      return { renderable, usesDefaultRenderer: true }
     }
 
     if (token.type === "table") {
       const next = this.createTableBlock(token, id)
       next.renderable.marginTop = marginTop
-      return next
+      return { ...next, usesDefaultRenderer: true }
     }
 
     if (token.type === "blockquote") {
       const renderable = this.createBlockquoteRenderable(token, id)
       renderable.marginTop = marginTop
-      return { renderable }
+      return { renderable, usesDefaultRenderer: true }
     }
 
     if (token.type === "list") {
       const renderable = this.createListRenderable(token, id)
       renderable.marginTop = marginTop
-      return { renderable }
+      return { renderable, usesDefaultRenderer: true }
     }
 
     if (token.type === "hr") {
       const renderable = this.createHorizontalRuleRenderable(id)
       renderable.marginTop = marginTop
-      return { renderable }
+      return { renderable, usesDefaultRenderer: true }
     }
 
     const markdownRaw = this.getTopLevelBlockRaw(token)
     if (!markdownRaw) {
-      return { renderable: undefined }
+      return { renderable: undefined, usesDefaultRenderer: true }
     }
 
     const renderable = this.createMarkdownCodeRenderable(markdownRaw, id)
     renderable.marginTop = marginTop
-    return { renderable }
+    return { renderable, usesDefaultRenderer: true }
   }
 
   private createTopLevelRenderable(
     block: MarkdownRenderBlock,
     index: number,
-  ): { renderable: Renderable | undefined; tableContentCache?: TableContentCache } {
+  ): { renderable: Renderable | undefined; tableContentCache?: TableContentCache; usesDefaultRenderer: boolean } {
     if (!this._renderNode) {
       return this.createTopLevelDefaultRenderable(block, index)
     }
 
-    let next: { renderable: Renderable | undefined; tableContentCache?: TableContentCache } | undefined
-    const context: RenderNodeContext = {
-      syntaxStyle: this._syntaxStyle,
-      conceal: this._conceal,
-      concealCode: this._concealCode,
-      treeSitterClient: this._treeSitterClient,
-      defaultRender: () => {
-        next = this.createTopLevelDefaultRenderable(block, index)
-        return next.renderable ?? null
-      },
-    }
-    const custom = this._renderNode(block.token, context)
-    if (custom) {
-      const marginTop =
-        typeof custom.marginTop === "number" ? Math.max(custom.marginTop, block.marginTop) : block.marginTop
-      this.applyMargins(custom, marginTop, 0)
-      return { renderable: custom }
-    }
+    const custom = this.createTopLevelCustomRenderable(block, index)
+    if (!custom.renderable) return this.createTopLevelDefaultRenderable(block, index)
 
-    return next ?? this.createTopLevelDefaultRenderable(block, index)
+    const marginTop =
+      typeof custom.renderable.marginTop === "number"
+        ? Math.max(custom.renderable.marginTop, block.marginTop)
+        : block.marginTop
+    this.applyMargins(custom.renderable, marginTop, 0)
+
+    return {
+      renderable: custom.renderable,
+      tableContentCache: custom.tableContentCache,
+      usesDefaultRenderer: custom.usesDefaultRenderer,
+    }
   }
 
   private createDefaultRenderable(token: MarkedToken, index: number, nextToken?: MarkedToken): Renderable | null {
@@ -1462,6 +1515,74 @@ export class MarkdownRenderable extends Renderable {
     }
 
     return this.createMarkdownCodeRenderable(token.raw, id, marginBottom)
+  }
+
+  private createCustomRenderable(
+    token: MarkedToken,
+    index: number,
+    nextToken: MarkedToken | undefined,
+  ): CustomRenderableResult {
+    if (!this._renderNode) return { tracksInterBlockMargin: true, usesDefaultRenderer: true }
+
+    let defaultRenderable: Renderable | null | undefined
+    const custom = this._renderNode(token, {
+      syntaxStyle: this._syntaxStyle,
+      conceal: this._conceal,
+      concealCode: this._concealCode,
+      treeSitterClient: this._treeSitterClient,
+      defaultRender: () => {
+        defaultRenderable = this.createDefaultRenderable(token, index, nextToken)
+        return defaultRenderable
+      },
+    })
+    if (!custom) {
+      this.destroyUnusedDefaultRenderable(defaultRenderable)
+      return { tracksInterBlockMargin: true, usesDefaultRenderer: true }
+    }
+
+    this.destroyUnusedDefaultRenderable(defaultRenderable, custom)
+
+    return {
+      renderable: custom,
+      tracksInterBlockMargin: custom === defaultRenderable,
+      usesDefaultRenderer: false,
+    }
+  }
+
+  private createTopLevelCustomRenderable(block: MarkdownRenderBlock, index: number): CustomRenderableResult {
+    if (!this._renderNode) return { tracksInterBlockMargin: true, usesDefaultRenderer: true }
+
+    let defaultRenderable:
+      | { renderable: Renderable | undefined; tableContentCache?: TableContentCache; usesDefaultRenderer: boolean }
+      | undefined
+    const custom = this._renderNode(block.token, {
+      syntaxStyle: this._syntaxStyle,
+      conceal: this._conceal,
+      concealCode: this._concealCode,
+      treeSitterClient: this._treeSitterClient,
+      defaultRender: () => {
+        defaultRenderable = this.createTopLevelDefaultRenderable(block, index)
+        return defaultRenderable.renderable ?? null
+      },
+    })
+    if (!custom) {
+      this.destroyUnusedDefaultRenderable(defaultRenderable?.renderable)
+      return { tracksInterBlockMargin: true, usesDefaultRenderer: true }
+    }
+
+    this.destroyUnusedDefaultRenderable(defaultRenderable?.renderable, custom)
+
+    return {
+      renderable: custom,
+      tableContentCache: custom === defaultRenderable?.renderable ? defaultRenderable?.tableContentCache : undefined,
+      tracksInterBlockMargin: custom === defaultRenderable?.renderable,
+      usesDefaultRenderer: false,
+    }
+  }
+
+  private destroyUnusedDefaultRenderable(renderable: Renderable | null | undefined, usedRenderable?: Renderable): void {
+    if (!renderable || renderable === usedRenderable || renderable.parent) return
+    renderable.destroyRecursively()
   }
 
   private updateBlockRenderable(
@@ -1596,10 +1717,33 @@ export class MarkdownRenderable extends Renderable {
       if (
         existing &&
         !forceTableRefresh &&
-        !this._renderNode &&
+        existing.usesDefaultRenderer &&
         existing.token.type === block.token.type &&
         this.canUpdateBlockRenderable(existing.renderable, block.token)
       ) {
+        if (this._renderNode) {
+          const custom = this.createTopLevelCustomRenderable(block, blockIndex)
+          if (custom.renderable) {
+            const marginTop =
+              typeof custom.renderable.marginTop === "number"
+                ? Math.max(custom.renderable.marginTop, block.marginTop)
+                : block.marginTop
+            this.applyMargins(custom.renderable, marginTop, 0)
+            existing.renderable.destroyRecursively()
+            this.add(custom.renderable, blockIndex)
+            this._blockStates[blockIndex] = {
+              token: block.token,
+              tokenRaw: block.token.raw,
+              marginTop: block.marginTop,
+              renderable: custom.renderable,
+              tableContentCache: custom.tableContentCache,
+              usesDefaultRenderer: custom.usesDefaultRenderer,
+            }
+            blockIndex++
+            continue
+          }
+        }
+
         this.updateBlockRenderable(existing, block.token, blockIndex, blocks[i + 1]?.token)
         existing.renderable.marginBottom = 0
         if (existing.marginTop !== block.marginTop) {
@@ -1623,6 +1767,7 @@ export class MarkdownRenderable extends Renderable {
           marginTop: block.marginTop,
           renderable: next.renderable,
           tableContentCache: next.tableContentCache,
+          usesDefaultRenderer: next.usesDefaultRenderer,
         }
       }
       blockIndex++
@@ -1670,6 +1815,7 @@ export class MarkdownRenderable extends Renderable {
           marginTop: 0,
           renderable: fallback,
           tracksInterBlockMargin: true,
+          usesDefaultRenderer: true,
         },
       ]
       return
@@ -1713,7 +1859,22 @@ export class MarkdownRenderable extends Renderable {
         continue
       }
 
-      if (existing && existing.token.type === token.type) {
+      if (existing && existing.usesDefaultRenderer && existing.token.type === token.type) {
+        const custom = this.createCustomRenderable(token, blockIndex, nextToken)
+        if (custom.renderable) {
+          existing.renderable.destroyRecursively()
+          this.add(custom.renderable, blockIndex)
+          this._blockStates[blockIndex] = {
+            token,
+            tokenRaw: token.raw,
+            renderable: custom.renderable,
+            tracksInterBlockMargin: custom.tracksInterBlockMargin,
+            usesDefaultRenderer: custom.usesDefaultRenderer,
+          }
+          blockIndex++
+          continue
+        }
+
         this.updateBlockRenderable(existing, token, blockIndex, nextToken)
         existing.token = token
         existing.tokenRaw = token.raw
@@ -1729,24 +1890,13 @@ export class MarkdownRenderable extends Renderable {
       let renderable: Renderable | undefined
       let tableContentCache: TableContentCache | undefined
       let tracksInterBlockMargin = true
+      let usesDefaultRenderer = true
 
-      if (this._renderNode) {
-        let defaultRenderable: Renderable | null | undefined
-        const context: RenderNodeContext = {
-          syntaxStyle: this._syntaxStyle,
-          conceal: this._conceal,
-          concealCode: this._concealCode,
-          treeSitterClient: this._treeSitterClient,
-          defaultRender: () => {
-            defaultRenderable = this.createDefaultRenderable(token, blockIndex, nextToken)
-            return defaultRenderable
-          },
-        }
-        const custom = this._renderNode(token, context)
-        if (custom) {
-          renderable = custom
-          tracksInterBlockMargin = custom === defaultRenderable
-        }
+      const custom = this.createCustomRenderable(token, blockIndex, nextToken)
+      if (custom.renderable) {
+        renderable = custom.renderable
+        tracksInterBlockMargin = custom.tracksInterBlockMargin
+        usesDefaultRenderer = custom.usesDefaultRenderer
       }
 
       if (!renderable) {
@@ -1776,6 +1926,7 @@ export class MarkdownRenderable extends Renderable {
           renderable,
           tableContentCache,
           tracksInterBlockMargin,
+          usesDefaultRenderer,
         }
       }
       blockIndex++

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -141,46 +141,49 @@ export type MarkdownCodeBlockRendererMap =
   | ReadonlyMap<string, MarkdownCodeBlockRenderer>
   | Readonly<Record<string, MarkdownCodeBlockRenderer>>
 
-function getMarkdownCodeBlockRenderer(
+type MarkdownRenderNode = NonNullable<MarkdownOptions["renderNode"]> & {
+  codeBlockOnly?: boolean
+}
+
+function normalizeMarkdownCodeBlockRenderers(
   renderers: MarkdownCodeBlockRendererMap,
-  language: string,
-): MarkdownCodeBlockRenderer | undefined {
-  if (renderers instanceof Map) {
-    return renderers.get(language)
+): ReadonlyMap<string, MarkdownCodeBlockRenderer> {
+  const rendererMap = new Map<string, MarkdownCodeBlockRenderer>()
+  const maybeMap = renderers as Partial<ReadonlyMap<string, MarkdownCodeBlockRenderer>>
+
+  if (typeof maybeMap.forEach === "function") {
+    maybeMap.forEach((renderer, language) => {
+      rendererMap.set(language, renderer)
+    })
+    return rendererMap
   }
 
   const rendererRecord = renderers as Readonly<Record<string, MarkdownCodeBlockRenderer>>
-  return Object.prototype.hasOwnProperty.call(rendererRecord, language) ? rendererRecord[language] : undefined
-}
+  for (const [language, renderer] of Object.entries(rendererRecord)) {
+    rendererMap.set(language, renderer)
+  }
 
-function getMarkdownCodeBlockLanguageCandidates(infoString: string | undefined): string[] {
-  const candidates: string[] = []
-  const normalized = infoStringToFiletype(infoString ?? "")
-  if (normalized) candidates.push(normalized)
-
-  const raw = infoString?.trim().split(/\s+/, 1)[0]?.replace(/^\./, "").toLowerCase()
-  if (raw && raw !== normalized) candidates.push(raw)
-
-  return candidates
+  return rendererMap
 }
 
 export function createMarkdownCodeBlockRenderer(
   renderers: MarkdownCodeBlockRendererMap,
 ): MarkdownOptions["renderNode"] {
-  return (token, context) => {
+  const rendererMap = normalizeMarkdownCodeBlockRenderers(renderers)
+
+  const renderNode: MarkdownRenderNode = (token, context) => {
     if (token.type !== "code") {
       return undefined
     }
 
-    for (const language of getMarkdownCodeBlockLanguageCandidates(token.lang)) {
-      const renderer = getMarkdownCodeBlockRenderer(renderers, language)
-      if (!renderer) continue
+    const language = infoStringToFiletype(token.lang ?? "")
+    if (!language) return undefined
 
-      return renderer(token as Tokens.Code, context)
-    }
-
-    return undefined
+    return rendererMap.get(language)?.(token as Tokens.Code, context)
   }
+
+  renderNode.codeBlockOnly = true
+  return renderNode
 }
 
 interface TableContentCache {
@@ -193,6 +196,16 @@ interface CustomRenderableResult {
   tableContentCache?: TableContentCache
   tracksInterBlockMargin: boolean
   usesDefaultRenderer: boolean
+}
+
+interface CustomRenderDefaultResult {
+  renderable: Renderable | null | undefined
+  tableContentCache?: TableContentCache
+}
+
+interface RenderNodeResult {
+  renderable?: Renderable
+  defaultResult?: CustomRenderDefaultResult
 }
 
 interface ResolvedTableRenderableOptions {
@@ -1012,8 +1025,12 @@ export class MarkdownRenderable extends Renderable {
     return raw.replace(TRAILING_MARKDOWN_BLOCK_NEWLINES_RE, "")
   }
 
+  private isCodeBlockOnlyRenderer(): boolean {
+    return (this._renderNode as MarkdownRenderNode | undefined)?.codeBlockOnly === true
+  }
+
   private buildRenderableTokens(tokens: MarkedToken[]): MarkedToken[] {
-    if (this._renderNode) {
+    if (this._renderNode && !this.isCodeBlockOnlyRenderer()) {
       return tokens.filter((token) => token.type !== "space")
     }
 
@@ -1522,62 +1539,58 @@ export class MarkdownRenderable extends Renderable {
     index: number,
     nextToken: MarkedToken | undefined,
   ): CustomRenderableResult {
-    if (!this._renderNode) return { tracksInterBlockMargin: true, usesDefaultRenderer: true }
+    const custom = this.renderCustomNode(token, () => {
+      return { renderable: this.createDefaultRenderable(token, index, nextToken) }
+    })
+    if (!custom.renderable) {
+      return { tracksInterBlockMargin: true, usesDefaultRenderer: true }
+    }
 
-    let defaultRenderable: Renderable | null | undefined
+    const usesDefaultRenderer = custom.renderable === custom.defaultResult?.renderable
+
+    return {
+      renderable: custom.renderable,
+      tracksInterBlockMargin: usesDefaultRenderer,
+      usesDefaultRenderer,
+    }
+  }
+
+  private createTopLevelCustomRenderable(block: MarkdownRenderBlock, index: number): CustomRenderableResult {
+    const custom = this.renderCustomNode(block.token, () => {
+      return this.createTopLevelDefaultRenderable(block, index)
+    })
+    if (!custom.renderable) {
+      return { tracksInterBlockMargin: true, usesDefaultRenderer: true }
+    }
+
+    const usesDefaultRenderer = custom.renderable === custom.defaultResult?.renderable
+
+    return {
+      renderable: custom.renderable,
+      tableContentCache: usesDefaultRenderer ? custom.defaultResult?.tableContentCache : undefined,
+      tracksInterBlockMargin: usesDefaultRenderer,
+      usesDefaultRenderer,
+    }
+  }
+
+  private renderCustomNode(token: MarkedToken, createDefault: () => CustomRenderDefaultResult): RenderNodeResult {
+    if (!this._renderNode) return {}
+
+    let defaultResult: CustomRenderDefaultResult | undefined
     const custom = this._renderNode(token, {
       syntaxStyle: this._syntaxStyle,
       conceal: this._conceal,
       concealCode: this._concealCode,
       treeSitterClient: this._treeSitterClient,
       defaultRender: () => {
-        defaultRenderable = this.createDefaultRenderable(token, index, nextToken)
-        return defaultRenderable
+        defaultResult = createDefault()
+        return defaultResult.renderable ?? null
       },
     })
-    if (!custom) {
-      this.destroyUnusedDefaultRenderable(defaultRenderable)
-      return { tracksInterBlockMargin: true, usesDefaultRenderer: true }
-    }
 
-    this.destroyUnusedDefaultRenderable(defaultRenderable, custom)
+    this.destroyUnusedDefaultRenderable(defaultResult?.renderable, custom ?? undefined)
 
-    return {
-      renderable: custom,
-      tracksInterBlockMargin: custom === defaultRenderable,
-      usesDefaultRenderer: false,
-    }
-  }
-
-  private createTopLevelCustomRenderable(block: MarkdownRenderBlock, index: number): CustomRenderableResult {
-    if (!this._renderNode) return { tracksInterBlockMargin: true, usesDefaultRenderer: true }
-
-    let defaultRenderable:
-      | { renderable: Renderable | undefined; tableContentCache?: TableContentCache; usesDefaultRenderer: boolean }
-      | undefined
-    const custom = this._renderNode(block.token, {
-      syntaxStyle: this._syntaxStyle,
-      conceal: this._conceal,
-      concealCode: this._concealCode,
-      treeSitterClient: this._treeSitterClient,
-      defaultRender: () => {
-        defaultRenderable = this.createTopLevelDefaultRenderable(block, index)
-        return defaultRenderable.renderable ?? null
-      },
-    })
-    if (!custom) {
-      this.destroyUnusedDefaultRenderable(defaultRenderable?.renderable)
-      return { tracksInterBlockMargin: true, usesDefaultRenderer: true }
-    }
-
-    this.destroyUnusedDefaultRenderable(defaultRenderable?.renderable, custom)
-
-    return {
-      renderable: custom,
-      tableContentCache: custom === defaultRenderable?.renderable ? defaultRenderable?.tableContentCache : undefined,
-      tracksInterBlockMargin: custom === defaultRenderable?.renderable,
-      usesDefaultRenderer: false,
-    }
+    return custom ? { renderable: custom, defaultResult } : {}
   }
 
   private destroyUnusedDefaultRenderable(renderable: Renderable | null | undefined, usedRenderable?: Renderable): void {
@@ -1723,14 +1736,16 @@ export class MarkdownRenderable extends Renderable {
       ) {
         if (this._renderNode) {
           const custom = this.createTopLevelCustomRenderable(block, blockIndex)
-          if (custom.renderable) {
+          if (custom.renderable && !custom.usesDefaultRenderer) {
             const marginTop =
               typeof custom.renderable.marginTop === "number"
                 ? Math.max(custom.renderable.marginTop, block.marginTop)
                 : block.marginTop
             this.applyMargins(custom.renderable, marginTop, 0)
-            existing.renderable.destroyRecursively()
-            this.add(custom.renderable, blockIndex)
+            if (custom.renderable !== existing.renderable) {
+              existing.renderable.destroyRecursively()
+              this.add(custom.renderable, blockIndex)
+            }
             this._blockStates[blockIndex] = {
               token: block.token,
               tokenRaw: block.token.raw,
@@ -1742,6 +1757,7 @@ export class MarkdownRenderable extends Renderable {
             blockIndex++
             continue
           }
+          this.destroyUnusedDefaultRenderable(custom.renderable)
         }
 
         this.updateBlockRenderable(existing, block.token, blockIndex, blocks[i + 1]?.token)
@@ -1861,9 +1877,11 @@ export class MarkdownRenderable extends Renderable {
 
       if (existing && existing.usesDefaultRenderer && existing.token.type === token.type) {
         const custom = this.createCustomRenderable(token, blockIndex, nextToken)
-        if (custom.renderable) {
-          existing.renderable.destroyRecursively()
-          this.add(custom.renderable, blockIndex)
+        if (custom.renderable && !custom.usesDefaultRenderer) {
+          if (custom.renderable !== existing.renderable) {
+            existing.renderable.destroyRecursively()
+            this.add(custom.renderable, blockIndex)
+          }
           this._blockStates[blockIndex] = {
             token,
             tokenRaw: token.raw,
@@ -1874,6 +1892,7 @@ export class MarkdownRenderable extends Renderable {
           blockIndex++
           continue
         }
+        this.destroyUnusedDefaultRenderable(custom.renderable)
 
         this.updateBlockRenderable(existing, token, blockIndex, nextToken)
         existing.token = token

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, beforeAll, beforeEach, afterEach, afterAll } from "bun:test"
 import { Edge } from "yoga-layout"
 import { Lexer } from "marked"
-import { MarkdownRenderable, type MarkdownOptions } from "../Markdown.js"
+import { createMarkdownCodeBlockRenderer, MarkdownRenderable, type MarkdownOptions } from "../Markdown.js"
 import { CodeRenderable } from "../Code.js"
 import { BoxRenderable } from "../Box.js"
 import { TextRenderable } from "../Text.js"
@@ -2045,6 +2045,144 @@ const x = 1;
     │CODE: const x = 1;                                        │
     └──────────────────────────────────────────────────────────┘"
   `)
+})
+
+test("custom code block renderable updates when fenced content changes", async () => {
+  const md = createMarkdownRenderable({
+    id: "custom-code-update",
+    content: "```widget\nfirst\n```",
+    syntaxStyle,
+    renderNode: (node, ctx) => {
+      if (node.type !== "code" || node.lang !== "widget") return ctx.defaultRender()
+
+      return new TextRenderable(renderer, {
+        id: "custom-widget",
+        content: `WIDGET: ${node.text}`,
+        width: "100%",
+      })
+    },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+  expect(captureFrame()).toContain("WIDGET: first")
+
+  md.content = "```widget\nsecond\n```"
+  await renderMarkdownRenderable(md)
+
+  const frame = captureFrame()
+  expect(frame).toContain("WIDGET: second")
+  expect(frame).not.toContain("WIDGET: first")
+})
+
+test("createMarkdownCodeBlockRenderer dispatches fenced code by language", async () => {
+  const md = createMarkdownRenderable({
+    id: "language-code-renderer",
+    content: `Before
+
+
+\`\`\`taskflow title=Deploy
+step test done
+step preview active
+\`\`\`
+
+\`\`\`tsx
+<Button />
+\`\`\`
+
+After`,
+    syntaxStyle,
+    renderNode: createMarkdownCodeBlockRenderer({
+      taskflow: (node) =>
+        new TextRenderable(renderer, {
+          id: "taskflow-renderer",
+          content: `TASKFLOW:\n${node.text.replaceAll("step ", "- ")}`,
+          width: "100%",
+        }),
+      typescriptreact: (node) =>
+        new TextRenderable(renderer, {
+          id: "tsx-renderer",
+          content: `TSX: ${node.text}`,
+          width: "100%",
+        }),
+    }),
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const frame = captureFrame()
+  expect(frame).toContain("Before")
+  expect(frame).toContain("TASKFLOW:")
+  expect(frame).toContain("- test done")
+  expect(frame).toContain("- preview active")
+  expect(frame).toContain("TSX: <Button />")
+  expect(frame).toContain("After")
+})
+
+test("default code blocks reuse their renderable when a custom renderer ignores them", async () => {
+  const md = createMarkdownRenderable({
+    id: "default-code-update-with-custom-renderer",
+    content: "```ts\nconst first = true\n```",
+    syntaxStyle,
+    renderNode: (node) => {
+      if (node.type !== "code" || node.lang !== "widget") return null
+      return new TextRenderable(renderer, { content: `WIDGET: ${node.text}` })
+    },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+  const initial = md._blockStates[0]?.renderable
+
+  md.content = "```ts\nconst second = true\n```"
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates[0]?.renderable).toBe(initial)
+  expect(captureFrame()).toContain("const second = true")
+})
+
+test("a default code block becomes custom once its updated content is handled", async () => {
+  const md = createMarkdownRenderable({
+    id: "default-to-custom-code-update",
+    content: "```widget\nincomplete\n```",
+    syntaxStyle,
+    renderNode: (node) => {
+      if (node.type !== "code" || node.lang !== "widget" || !node.text.includes("ready")) return null
+      return new TextRenderable(renderer, { content: `WIDGET: ${node.text}` })
+    },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+  expect(captureFrame()).toContain("incomplete")
+
+  md.content = "```widget\nready\n```"
+  await renderMarkdownRenderable(md)
+
+  expect(captureFrame()).toContain("WIDGET: ready")
+})
+
+test("a top-level default code block becomes custom once updated content is handled", async () => {
+  const md = createMarkdownRenderable({
+    id: "top-level-default-to-custom-code-update",
+    content: "```widget\nincomplete\n```",
+    syntaxStyle,
+    internalBlockMode: "top-level",
+    renderNode: (node) => {
+      if (node.type !== "code" || node.lang !== "widget" || !node.text.includes("ready")) return null
+      return new TextRenderable(renderer, { content: `WIDGET: ${node.text}` })
+    },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+  expect(captureFrame()).toContain("incomplete")
+
+  md.content = "```widget\nready\n```"
+  await renderMarkdownRenderable(md)
+
+  expect(captureFrame()).toContain("WIDGET: ready")
 })
 
 test("custom renderNode output survives top-level spacing updates", async () => {

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -2120,6 +2120,69 @@ After`,
   expect(frame).toContain("After")
 })
 
+test("createMarkdownCodeBlockRenderer accepts renderer maps", async () => {
+  const md = createMarkdownRenderable({
+    id: "language-code-renderer-map",
+    content: "```widget\nfrom map\n```",
+    syntaxStyle,
+    renderNode: createMarkdownCodeBlockRenderer(
+      new Map([
+        [
+          "widget",
+          (node) =>
+            new TextRenderable(renderer, {
+              id: "widget-map-renderer",
+              content: `MAP: ${node.text}`,
+              width: "100%",
+            }),
+        ],
+      ]),
+    ),
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  expect(captureFrame()).toContain("MAP: from map")
+})
+
+test("code block renderer preserves coalesced prose spacing", async () => {
+  const md = createMarkdownRenderable({
+    id: "language-code-renderer-coalesced-prose",
+    content: `First paragraph.
+
+Second paragraph.
+
+\`\`\`widget
+custom
+\`\`\`
+
+Third paragraph.`,
+    syntaxStyle,
+    renderNode: createMarkdownCodeBlockRenderer({
+      widget: (node) => new TextRenderable(renderer, { content: `WIDGET: ${node.text}`, width: "100%" }),
+    }),
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates.map((state) => state.token.type)).toEqual(["paragraph", "code", "paragraph"])
+
+  const lines = captureFrame()
+    .split("\n")
+    .map((line) => line.trimEnd())
+  expect("\n" + lines.join("\n").trimEnd()).toMatchInlineSnapshot(`
+    "
+    First paragraph.
+
+    Second paragraph.
+
+    WIDGET: custom
+    Third paragraph."
+  `)
+})
+
 test("default code blocks reuse their renderable when a custom renderer ignores them", async () => {
   const md = createMarkdownRenderable({
     id: "default-code-update-with-custom-renderer",
@@ -2129,6 +2192,25 @@ test("default code blocks reuse their renderable when a custom renderer ignores 
       if (node.type !== "code" || node.lang !== "widget") return null
       return new TextRenderable(renderer, { content: `WIDGET: ${node.text}` })
     },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+  const initial = md._blockStates[0]?.renderable
+
+  md.content = "```ts\nconst second = true\n```"
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates[0]?.renderable).toBe(initial)
+  expect(captureFrame()).toContain("const second = true")
+})
+
+test("default-render delegation reuses renderable on same-type updates", async () => {
+  const md = createMarkdownRenderable({
+    id: "default-render-delegation-update",
+    content: "```ts\nconst first = true\n```",
+    syntaxStyle,
+    renderNode: (_node, ctx) => ctx.defaultRender(),
   })
 
   renderer.root.add(md)

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -65,6 +65,7 @@ import * as diffDemo from "./diff-demo.js"
 import * as keypressDebugDemo from "./keypress-debug-demo.js"
 import * as extmarksDemo from "./extmarks-demo.js"
 import * as markdownDemo from "./markdown-demo.js"
+import * as markdownCodeBlockRendererDemo from "./markdown-code-block-renderer-demo.js"
 import * as qrcodeDemo from "./qrcode-demo.js"
 import * as linkDemo from "./link-demo.js"
 import * as opacityExample from "./opacity-example.js"
@@ -243,6 +244,12 @@ const examples: Example[] = [
     description: "Markdown rendering with table alignment, syntax highlighting, and theme switching",
     run: markdownDemo.run,
     destroy: markdownDemo.destroy,
+  },
+  {
+    name: "Markdown Code Block Renderer Demo",
+    description: "Custom fenced-code rendering for a fake taskflow DSL inside markdown",
+    run: markdownCodeBlockRendererDemo.run,
+    destroy: markdownCodeBlockRendererDemo.destroy,
   },
   {
     name: "QR Code Demo",

--- a/packages/examples/src/markdown-code-block-renderer-demo.ts
+++ b/packages/examples/src/markdown-code-block-renderer-demo.ts
@@ -42,17 +42,20 @@ const renderNode = createMarkdownCodeBlockRenderer({ taskflow: renderTaskFlow })
 \`\`\`
 `
 
-const syntaxStyle = SyntaxStyle.fromStyles({
-  default: { fg: RGBA.fromHex("#DDE7FF") },
-  "markup.heading": { fg: RGBA.fromHex("#93C5FD"), bold: true },
-  "markup.heading.1": { fg: RGBA.fromHex("#67E8F9"), bold: true },
-  "markup.raw": { fg: RGBA.fromHex("#A7F3D0") },
-  "markup.strong": { fg: RGBA.fromHex("#FDE68A"), bold: true },
-  "markup.link": { fg: RGBA.fromHex("#C4B5FD"), underline: true },
-  "markup.list": { fg: RGBA.fromHex("#F9A8D4") },
-})
-
 let root: BoxRenderable | null = null
+let syntaxStyle: SyntaxStyle | null = null
+
+function createSyntaxStyle(): SyntaxStyle {
+  return SyntaxStyle.fromStyles({
+    default: { fg: RGBA.fromHex("#DDE7FF") },
+    "markup.heading": { fg: RGBA.fromHex("#93C5FD"), bold: true },
+    "markup.heading.1": { fg: RGBA.fromHex("#67E8F9"), bold: true },
+    "markup.raw": { fg: RGBA.fromHex("#A7F3D0") },
+    "markup.strong": { fg: RGBA.fromHex("#FDE68A"), bold: true },
+    "markup.link": { fg: RGBA.fromHex("#C4B5FD"), underline: true },
+    "markup.list": { fg: RGBA.fromHex("#F9A8D4") },
+  })
+}
 
 function parseTaskFlow(source: string): TaskFlowDocument {
   const document: TaskFlowDocument = {
@@ -142,6 +145,7 @@ function createTaskFlowRenderer(renderer: CliRenderer): MarkdownCodeBlockRendere
 export function run(renderer: CliRenderer): void {
   renderer.start()
   renderer.setBackgroundColor("#020617")
+  syntaxStyle = createSyntaxStyle()
 
   root = new BoxRenderable(renderer, {
     id: "markdown-code-block-renderer-root",
@@ -170,8 +174,10 @@ export function run(renderer: CliRenderer): void {
 }
 
 export function destroy(): void {
-  root?.destroy()
+  root?.destroyRecursively()
+  syntaxStyle?.destroy()
   root = null
+  syntaxStyle = null
 }
 
 if (import.meta.main) {

--- a/packages/examples/src/markdown-code-block-renderer-demo.ts
+++ b/packages/examples/src/markdown-code-block-renderer-demo.ts
@@ -1,0 +1,184 @@
+import {
+  BoxRenderable,
+  CliRenderer,
+  MarkdownRenderable,
+  RGBA,
+  SyntaxStyle,
+  TextRenderable,
+  createCliRenderer,
+  createMarkdownCodeBlockRenderer,
+  type MarkdownCodeBlockRenderer,
+} from "@opentui/core"
+import { setupCommonDemoKeys } from "./lib/standalone-keys.js"
+
+interface TaskFlowStep {
+  label: string
+  status: "done" | "active" | "queued" | "blocked"
+}
+
+interface TaskFlowDocument {
+  title: string
+  owner: string
+  steps: TaskFlowStep[]
+}
+
+const markdownContent = `# Markdown Code Block Renderers
+
+This markdown document contains a fenced \`taskflow\` block. The source stays plain text, but the markdown renderer swaps that single language into a custom OpenTUI widget.
+
+\`\`\`taskflow
+title Ship markdown plug-ins
+owner terminal team
+step Parse fenced language done
+step Render custom widget active
+step Capture screenshot queued
+step Open pull request queued
+\`\`\`
+
+Everything around the custom fence is still rendered by the normal markdown pipeline, including **bold text**, links, and ordinary code fences.
+
+\`\`\`ts
+const renderNode = createMarkdownCodeBlockRenderer({ taskflow: renderTaskFlow })
+\`\`\`
+`
+
+const syntaxStyle = SyntaxStyle.fromStyles({
+  default: { fg: RGBA.fromHex("#DDE7FF") },
+  "markup.heading": { fg: RGBA.fromHex("#93C5FD"), bold: true },
+  "markup.heading.1": { fg: RGBA.fromHex("#67E8F9"), bold: true },
+  "markup.raw": { fg: RGBA.fromHex("#A7F3D0") },
+  "markup.strong": { fg: RGBA.fromHex("#FDE68A"), bold: true },
+  "markup.link": { fg: RGBA.fromHex("#C4B5FD"), underline: true },
+  "markup.list": { fg: RGBA.fromHex("#F9A8D4") },
+})
+
+let root: BoxRenderable | null = null
+
+function parseTaskFlow(source: string): TaskFlowDocument {
+  const document: TaskFlowDocument = {
+    title: "Untitled taskflow",
+    owner: "unknown",
+    steps: [],
+  }
+
+  for (const line of source.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+
+    if (trimmed.startsWith("title ")) {
+      document.title = trimmed.slice("title ".length)
+      continue
+    }
+
+    if (trimmed.startsWith("owner ")) {
+      document.owner = trimmed.slice("owner ".length)
+      continue
+    }
+
+    if (trimmed.startsWith("step ")) {
+      const rest = trimmed.slice("step ".length)
+      const statusStart = rest.lastIndexOf(" ")
+      if (statusStart === -1) continue
+
+      const label = rest.slice(0, statusStart)
+      const status = rest.slice(statusStart + 1) as TaskFlowStep["status"]
+      if (status === "done" || status === "active" || status === "queued" || status === "blocked") {
+        document.steps.push({ label, status })
+      }
+    }
+  }
+
+  return document
+}
+
+function stepStyle(status: TaskFlowStep["status"]): { marker: string; color: string } {
+  if (status === "done") return { marker: "OK", color: "#86EFAC" }
+  if (status === "active") return { marker: ">>", color: "#67E8F9" }
+  if (status === "blocked") return { marker: "!!", color: "#FDA4AF" }
+  return { marker: "--", color: "#CBD5E1" }
+}
+
+function createTaskFlowRenderer(renderer: CliRenderer): MarkdownCodeBlockRenderer {
+  return (token) => {
+    const flow = parseTaskFlow(token.text)
+    const card = new BoxRenderable(renderer, {
+      id: "taskflow-card",
+      width: "100%",
+      flexDirection: "column",
+      border: true,
+      borderStyle: "rounded",
+      borderColor: "#38BDF8",
+      backgroundColor: "#07111F",
+      paddingX: 2,
+      paddingY: 1,
+      marginBottom: 1,
+      title: `taskflow: ${flow.title}`,
+      titleAlignment: "left",
+    })
+
+    card.add(
+      new TextRenderable(renderer, {
+        content: `owner ${flow.owner}  |  ${flow.steps.length} steps`,
+        fg: "#93A4B8",
+        width: "100%",
+      }),
+    )
+
+    for (const step of flow.steps) {
+      const style = stepStyle(step.status)
+      card.add(
+        new TextRenderable(renderer, {
+          content: `${style.marker} ${step.label.padEnd(28)} ${step.status}`,
+          fg: style.color,
+          width: "100%",
+        }),
+      )
+    }
+
+    return card
+  }
+}
+
+export function run(renderer: CliRenderer): void {
+  renderer.start()
+  renderer.setBackgroundColor("#020617")
+
+  root = new BoxRenderable(renderer, {
+    id: "markdown-code-block-renderer-root",
+    width: "100%",
+    height: "100%",
+    flexDirection: "column",
+    paddingX: 2,
+    paddingY: 1,
+    backgroundColor: "#020617",
+  })
+  renderer.root.add(root)
+
+  root.add(
+    new MarkdownRenderable(renderer, {
+      id: "markdown-code-block-renderer-doc",
+      content: markdownContent,
+      syntaxStyle,
+      fg: "#DDE7FF",
+      bg: "#020617",
+      width: "100%",
+      renderNode: createMarkdownCodeBlockRenderer({
+        taskflow: createTaskFlowRenderer(renderer),
+      }),
+    }),
+  )
+}
+
+export function destroy(): void {
+  root?.destroy()
+  root = null
+}
+
+if (import.meta.main) {
+  const renderer = await createCliRenderer({
+    exitOnCtrlC: true,
+    targetFps: 60,
+  })
+  run(renderer)
+  setupCommonDemoKeys(renderer)
+}

--- a/packages/web/src/content/docs/components/markdown.mdx
+++ b/packages/web/src/content/docs/components/markdown.mdx
@@ -175,6 +175,44 @@ const markdown = new MarkdownRenderable(renderer, {
 })
 ```
 
+### Custom fenced-code languages
+
+Use `createMarkdownCodeBlockRenderer` when you only want to replace specific fenced-code languages. The language key is matched against the normalized fence info string, so a `tsx` fence maps to `typescriptreact`, and custom DSL names like `taskflow` can be matched directly.
+
+````typescript
+import { BoxRenderable, MarkdownRenderable, TextRenderable, createMarkdownCodeBlockRenderer } from "@opentui/core"
+
+const renderTaskFlow = (renderer) => (token) => {
+  const steps = token.text
+    .split("\n")
+    .filter((line) => line.startsWith("step "))
+    .map((line) => line.slice("step ".length))
+
+  const card = new BoxRenderable(renderer, {
+    border: true,
+    borderStyle: "rounded",
+    borderColor: "#38BDF8",
+    paddingX: 1,
+    flexDirection: "column",
+    width: "100%",
+  })
+
+  for (const step of steps) {
+    card.add(new TextRenderable(renderer, { content: `- ${step}`, width: "100%" }))
+  }
+
+  return card
+}
+
+const markdown = new MarkdownRenderable(renderer, {
+  content: "```taskflow\nstep Parse markdown done\nstep Render widget active\n```",
+  syntaxStyle,
+  renderNode: createMarkdownCodeBlockRenderer({
+    taskflow: renderTaskFlow(renderer),
+  }),
+})
+````
+
 ## Construct API
 
 > Not available yet. Use `MarkdownRenderable` for now.


### PR DESCRIPTION
## Summary
- add `createMarkdownCodeBlockRenderer` for language-specific fenced-code renderers
- keep custom markdown renderables refreshable when a default code block later becomes custom
- add a standalone `taskflow` DSL example plus docs for custom fenced-code languages

## Verification
- `bun test src/renderables/__tests__/Markdown.test.ts`
- `git diff --check`
- `termctrl` capture for `packages/examples/src/markdown-code-block-renderer-demo.ts`

## Notes
- `bun run build:examples` is currently blocked by a native Zig all-platform link failure (`__availability_version_check`, `_abort`, etc.) before example bundling.
- `bunx tsc --noEmit --project packages/examples/tsconfig.json` still reports existing unrelated example type errors outside this change set.