### PR TITLE
link: retire slots after generation exhaustion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -465,6 +465,22 @@
 
     "@opentui/core": ["@opentui/core@workspace:packages/core"],
 
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.3.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4A7JYXUsZqhu9PPCe07E30ourSJYkitkwMujUyNKjM5e/dHNDVnz+5r5cO3M5snofLafc1DN7+9jEPn4UQzchQ=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.3.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-Jvm9E8n2sPhKEyKSXn9GlmJcj8WoJXJTooXb3djwjVaiimjihIj0XxHzCWhdqbDtQp+VxDFyCKoQagOOz20qhA=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.3.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-0uPuHCeZxm/O7+L+iNQl8zRAfehiwYstKkT9J0uTZO64/byBCLvy5lvn1DiE/72s/nTJ5nwpLN+pQs2/WYVKLQ=="],
+
+    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.3.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-sJYUzYcSOb5PCXRlhwsse/fdsMiVomNvIwq/2TDhAANef+YPO3Br+OH9kQRbuj0bjVDmUS36SGYWSTFu2lUO+A=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.3.4", "", { "os": "linux", "cpu": "x64" }, "sha512-btYIQeNdPbN4JCrCjVB/RwMGrnRY7qWB2piNEfALSByuULKNjPKQ33PYIj38Yd01zCvCV7FotIeXEGSHx3tgCA=="],
+
+    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.3.4", "", { "os": "linux", "cpu": "x64" }, "sha512-fhmUey4oJJ2+N62xlIgAPxAl36Fa7wYffqDOT4QLpm0jfyD5xzo+wL/hr2zUqaEI439R8Iq6jHNxf/Nsx1WuuQ=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.3.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-sh432vPU+eLp8eA4I0KWKKn7D0VHbk01YTg6mA9/ihCNYHntc6LZ8/sLvsPv8CvKscMotfIkh3M5YhdS36BuXw=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.3.4", "", { "os": "win32", "cpu": "x64" }, "sha512-dw8FcjUZaLAjw25P3/7BarobCh/QOHn3srYaWYQdysoqyvSlPkQumpI8kV/KgpJtdITU1GW02MQC4EeLIFFalA=="],
+
     "@opentui/examples": ["@opentui/examples@workspace:packages/examples"],
 
     "@opentui/keymap": ["@opentui/keymap@workspace:packages/keymap"],

--- a/packages/core/src/zig/link.zig
+++ b/packages/core/src/zig/link.zig
@@ -13,6 +13,7 @@ pub const SLOT_BITS: u5 = 16;
 pub const GEN_MASK: u32 = (@as(u32, 1) << GEN_BITS) - 1;
 pub const SLOT_MASK: u32 = (@as(u32, 1) << SLOT_BITS) - 1;
 pub const MAX_URL_LENGTH: usize = 512;
+const RETIRED_GENERATION = GEN_MASK + 1;
 
 pub const IdPayload = u32;
 
@@ -31,6 +32,7 @@ pub const LinkPool = struct {
     slots: std.ArrayListUnmanaged(u8),
     free_list: std.ArrayListUnmanaged(u32),
     num_slots: u32,
+    retired_slot_count: u32,
     interned_live_ids: std.StringHashMapUnmanaged(IdPayload),
 
     pub fn init(allocator: std.mem.Allocator) LinkPool {
@@ -45,6 +47,7 @@ pub const LinkPool = struct {
             .slots = .{},
             .free_list = .{},
             .num_slots = 0,
+            .retired_slot_count = 0,
             .interned_live_ids = .{},
         };
     }
@@ -62,6 +65,9 @@ pub const LinkPool = struct {
     }
 
     fn grow(self: *LinkPool) LinkPoolError!void {
+        const slot_count_max = SLOT_MASK + 1;
+        if (self.num_slots > slot_count_max - self.slots_per_page) return LinkPoolError.OutOfMemory;
+
         const add_bytes = self.slot_size_bytes * self.slots_per_page;
 
         try self.slots.ensureTotalCapacity(self.allocator, self.slots.items.len + add_bytes);
@@ -153,9 +159,8 @@ pub const LinkPool = struct {
         const p = self.slotPtr(slot_index);
         const header_ptr = @as(*SlotHeader, @ptrCast(@alignCast(p)));
 
-        // Increment generation when reusing a slot; reserve generation 0 so ID 0 remains an error sentinel in FFI.
-        var new_generation = (header_ptr.generation + 1) & GEN_MASK;
-        if (new_generation == 0) new_generation = 1;
+        std.debug.assert(header_ptr.generation < GEN_MASK);
+        const new_generation = header_ptr.generation + 1;
 
         header_ptr.* = .{
             .len = @intCast(url.len),
@@ -207,7 +212,12 @@ pub const LinkPool = struct {
         header_ptr.refcount -%= 1;
 
         if (header_ptr.refcount == 0) {
-            try self.free_list.append(self.allocator, unpacked.slot_index);
+            if (header_ptr.generation == GEN_MASK) {
+                header_ptr.generation = RETIRED_GENERATION;
+                self.retired_slot_count += 1;
+            } else {
+                try self.free_list.append(self.allocator, unpacked.slot_index);
+            }
         }
     }
 
@@ -245,7 +255,7 @@ pub const LinkPool = struct {
     }
 
     pub fn getLiveSlotCount(self: *const LinkPool) u64 {
-        return self.num_slots - @as(u32, @intCast(self.free_list.items.len));
+        return self.num_slots - @as(u32, @intCast(self.free_list.items.len)) - self.retired_slot_count;
     }
 };
 

--- a/packages/core/src/zig/tests/link_test.zig
+++ b/packages/core/src/zig/tests/link_test.zig
@@ -69,6 +69,36 @@ test "LinkPool - alloc never returns sentinel zero ID" {
     }
 }
 
+test "LinkPool - stale ID stays invalid after generation exhaustion" {
+    var pool = LinkPool.init(std.testing.allocator);
+    defer pool.deinit();
+
+    const stale_id = try pool.alloc("https://example.com/stale");
+    try pool.incref(stale_id);
+    try pool.decref(stale_id);
+
+    var exhausted_id: link.IdPayload = undefined;
+    var generation: u32 = 2;
+    while (generation <= link.GEN_MASK) : (generation += 1) {
+        const id = try pool.alloc("https://example.com/rotate");
+        try pool.incref(id);
+        try pool.decref(id);
+        if (generation == link.GEN_MASK) exhausted_id = id;
+    }
+
+    try std.testing.expectError(LinkPoolError.WrongGeneration, pool.incref(exhausted_id));
+    try std.testing.expectEqual(@as(u64, 0), pool.getLiveSlotCount());
+
+    const live_id = try pool.alloc("https://example.com/live");
+    try pool.incref(live_id);
+    defer pool.decref(live_id) catch {};
+
+    try std.testing.expect(stale_id != live_id);
+    try std.testing.expectError(LinkPoolError.WrongGeneration, pool.get(stale_id));
+    try std.testing.expectEqualSlices(u8, "https://example.com/live", try pool.get(live_id));
+    try std.testing.expectEqual(@as(u64, 1), pool.getLiveSlotCount());
+}
+
 test "LinkTracker - add/remove keeps one pool ref per ID" {
     var pool = LinkPool.init(std.testing.allocator);
     defer pool.deinit();


### PR DESCRIPTION
Generation wrap could make stale link IDs valid again and let them access
unrelated URLs. Retire exhausted slots so stale IDs remain invalid for the
lifetime of the pool.
