### PR TITLE
fix(renderer): clear stale hit targets on resize

### DIFF
--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -193,6 +193,7 @@ pub const CliRenderer = struct {
     hitGridHeight: u32,
     hitScissorStack: std.ArrayListUnmanaged(buf.ClipRect),
     hitGridDirty: bool = false,
+    hitGridResizeInvalidated: bool = false,
 
     lastCursorStyleTag: ?u8 = null,
     lastCursorBlinking: ?bool = null,
@@ -577,14 +578,16 @@ pub const CliRenderer = struct {
             const newCurrentHitGrid = try self.allocator.alloc(u32, newHitGridSize);
             errdefer self.allocator.free(newCurrentHitGrid);
             const newNextHitGrid = try self.allocator.alloc(u32, newHitGridSize);
-            @memset(newCurrentHitGrid, 0);
-            @memset(newNextHitGrid, 0);
 
             self.allocator.free(self.currentHitGrid);
             self.allocator.free(self.nextHitGrid);
             self.currentHitGrid = newCurrentHitGrid;
             self.nextHitGrid = newNextHitGrid;
         }
+
+        @memset(self.currentHitGrid, 0);
+        @memset(self.nextHitGrid, 0);
+        self.hitGridResizeInvalidated = true;
 
         // Always update dimensions. The backing buffer is at least as large as
         // width*height, so this is safe even when the terminal shrinks. Without
@@ -1580,7 +1583,7 @@ pub const CliRenderer = struct {
 
         // Compare hit grids before swap to detect changes. This allows TypeScript to
         // know if hover state needs rechecking without manually tracking dirty state.
-        self.hitGridDirty = !std.mem.eql(u32, self.currentHitGrid, self.nextHitGrid);
+        self.hitGridDirty = self.hitGridResizeInvalidated or !std.mem.eql(u32, self.currentHitGrid, self.nextHitGrid);
 
         // Swap hit grids: nextHitGrid (built this frame) becomes the active grid for
         // hit testing. The old currentHitGrid becomes nextHitGrid and is cleared for
@@ -1655,7 +1658,9 @@ pub const CliRenderer = struct {
     /// This is set by comparing the previous and current hit grids after render.
     /// TypeScript can use this to decide if hover state needs rechecking.
     pub fn getHitGridDirty(self: *CliRenderer) bool {
-        return self.hitGridDirty;
+        const dirty = self.hitGridDirty;
+        self.hitGridResizeInvalidated = false;
+        return dirty;
     }
 
     /// Return the renderable ID at screen position (x, y), or 0 if none.

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -347,6 +347,32 @@ test "renderer - resize updates dimensions" {
     try std.testing.expectEqual(@as(u32, 40), cli_renderer.height);
 }
 
+test "renderer - resize clears stale hit grid coordinates" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var test_cli_renderer = try TestRenderer.create(
+        std.testing.allocator,
+        4,
+        2,
+        pool,
+    );
+    defer test_cli_renderer.deinit();
+    const cli_renderer = test_cli_renderer.renderer;
+
+    cli_renderer.addToCurrentHitGridClipped(2, 0, 1, 1, 99);
+    try std.testing.expectEqual(@as(u32, 99), cli_renderer.checkHit(2, 0));
+
+    try cli_renderer.resize(2, 2);
+
+    try std.testing.expectEqual(@as(u32, 0), cli_renderer.checkHit(0, 1));
+
+    _ = cli_renderer.render(false);
+    try std.testing.expect(cli_renderer.getHitGridDirty());
+}
+
 test "renderer - background color setting" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();


### PR DESCRIPTION
Clear both hit grids when renderer dimensions change so row-major IDs
cannot resolve at unrelated coordinates under the new width. Preserve
resize invalidation until a successful frame consumes it, ensuring hover
state is reconciled after output retries.

Related to #812
