### PR TITLE
ci: split native tests from package matrix

### DIFF
--- a/.github/workflows/bench-native-smoke.yml
+++ b/.github/workflows/bench-native-smoke.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   BUN_VERSION: 1.3.14

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -52,41 +52,6 @@ jobs:
           path: packages/core/node_modules/@opentui/
           retention-days: 1
 
-  native-test:
-    name: Native Test (${{ matrix.os }})
-    strategy:
-      matrix:
-        os: [blacksmith-12vcpu-macos-15, blacksmith-8vcpu-ubuntu-2404, blacksmith-8vcpu-windows-2025]
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Setup Zig
-        uses: mlugg/setup-zig@v2
-        with:
-          version: ${{ env.ZIG_VERSION }}
-          # Keep Zig's cache path on the workspace drive, but do not restore/save
-          # stale .zig-cache archives on Windows; Zig 0.15.2 can fail with missing cache files.
-          use-cache: ${{ runner.os != 'Windows' }}
-          cache-key: build-core-native-test
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Run native tests
-        run: |
-          cd packages/core/src/zig
-          zig build test --summary all
-
   test:
     name: Test (${{ matrix.os }})
     needs: build
@@ -140,6 +105,11 @@ jobs:
           ls -la packages/core/node_modules/@opentui/
           ls -la packages/core/node_modules/@opentui/core-${{ matrix.platform }}/
 
+      - name: Run native tests
+        run: |
+          cd packages/core/src/zig
+          zig build test --summary all
+
       - name: Build TypeScript library
         run: |
           cd packages/core
@@ -159,7 +129,7 @@ jobs:
   # Gate job for branch protection
   build-complete:
     name: Core - Build and Test
-    needs: [native-test, test]
+    needs: [test]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: always()
     steps:
@@ -167,10 +137,6 @@ jobs:
         run: |
           if [ "${{ needs.test.result }}" != "success" ]; then
             echo "Tests failed"
-            exit 1
-          fi
-          if [ "${{ needs.native-test.result }}" != "success" ]; then
-            echo "Native tests failed"
             exit 1
           fi
           echo "All tests passed"

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NODE_VERSION: 26.3.0
@@ -48,6 +52,41 @@ jobs:
           path: packages/core/node_modules/@opentui/
           retention-days: 1
 
+  native-test:
+    name: Native Test (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [blacksmith-12vcpu-macos-15, blacksmith-8vcpu-ubuntu-2404, blacksmith-8vcpu-windows-2025]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
+          # Keep Zig's cache path on the workspace drive, but do not restore/save
+          # stale .zig-cache archives on Windows; Zig 0.15.2 can fail with missing cache files.
+          use-cache: ${{ runner.os != 'Windows' }}
+          cache-key: build-core-native-test
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run native tests
+        run: |
+          cd packages/core/src/zig
+          zig build test --summary all
+
   test:
     name: Test (${{ matrix.os }})
     needs: build
@@ -83,8 +122,6 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
-          # Keep Zig's cache path on the workspace drive, but do not restore/save
-          # stale .zig-cache archives on Windows; Zig 0.15.2 can fail with missing cache files.
           use-cache: ${{ runner.os != 'Windows' }}
           cache-key: build-core-test
 
@@ -102,11 +139,6 @@ jobs:
           echo "Checking for ${{ matrix.platform }} native library..."
           ls -la packages/core/node_modules/@opentui/
           ls -la packages/core/node_modules/@opentui/core-${{ matrix.platform }}/
-
-      - name: Run native tests
-        run: |
-          cd packages/core/src/zig
-          zig build test --summary all
 
       - name: Build TypeScript library
         run: |
@@ -127,7 +159,7 @@ jobs:
   # Gate job for branch protection
   build-complete:
     name: Core - Build and Test
-    needs: [test]
+    needs: [native-test, test]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: always()
     steps:
@@ -135,6 +167,10 @@ jobs:
         run: |
           if [ "${{ needs.test.result }}" != "success" ]; then
             echo "Tests failed"
+            exit 1
+          fi
+          if [ "${{ needs.native-test.result }}" != "success" ]; then
+            echo "Native tests failed"
             exit 1
           fi
           echo "All tests passed"

--- a/.github/workflows/build-keymap.yml
+++ b/.github/workflows/build-keymap.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NODE_VERSION: 26.3.0

--- a/.github/workflows/build-qrcode.yml
+++ b/.github/workflows/build-qrcode.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # Workaround for bug in Zig 0.15.2 (fixed in next version)

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/build-solid.yml
+++ b/.github/workflows/build-solid.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NODE_VERSION: 26.3.0

--- a/.github/workflows/format-lint.yml
+++ b/.github/workflows/format-lint.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   fmt:
     name: Format Check


### PR DESCRIPTION
Run native tests independently from packaged platform checks so failures
surface without waiting for artifact builds. Cancel superseded pull request
runs to avoid spending runner capacity on stale revisions.
