### PR TITLE
ci: fix Zig cache restore on Blacksmith

### DIFF
--- a/.github/workflows/bench-native-smoke.yml
+++ b/.github/workflows/bench-native-smoke.yml
@@ -35,7 +35,14 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
-          cache-key: bench-native-smoke
+          use-cache: false
+
+      - name: Restore Zig cache
+        uses: actions/cache@v5
+        with:
+          path: .zig-cache
+          key: zig-v1-${{ runner.os }}-${{ env.ZIG_VERSION }}-${{ github.run_id }}-${{ github.job }}
+          restore-keys: zig-v1-${{ runner.os }}-${{ env.ZIG_VERSION }}-
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -35,7 +35,14 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
-          cache-key: build-core-native
+          use-cache: false
+
+      - name: Restore Zig cache
+        uses: actions/cache@v5
+        with:
+          path: .zig-cache
+          key: zig-v1-${{ runner.os }}-${{ env.ZIG_VERSION }}-${{ github.run_id }}-${{ github.job }}
+          restore-keys: zig-v1-${{ runner.os }}-${{ env.ZIG_VERSION }}-
 
       - name: Install dependencies
         run: bun install
@@ -87,8 +94,15 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
-          use-cache: ${{ runner.os != 'Windows' }}
-          cache-key: build-core-test
+          use-cache: false
+
+      - name: Restore Zig cache
+        if: runner.os != 'Windows'
+        uses: actions/cache@v5
+        with:
+          path: .zig-cache
+          key: zig-v1-${{ runner.os }}-${{ env.ZIG_VERSION }}-${{ github.run_id }}-${{ github.job }}
+          restore-keys: zig-v1-${{ runner.os }}-${{ env.ZIG_VERSION }}-
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/build-keymap.yml
+++ b/.github/workflows/build-keymap.yml
@@ -40,10 +40,15 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
-          # Keep Zig's cache path on the workspace drive, but do not restore/save
-          # stale .zig-cache archives on Windows; Zig 0.15.2 can fail with missing cache files.
-          use-cache: ${{ runner.os != 'Windows' }}
-          cache-key: build-keymap
+          use-cache: false
+
+      - name: Restore Zig cache
+        if: runner.os != 'Windows'
+        uses: actions/cache@v5
+        with:
+          path: .zig-cache
+          key: zig-v1-${{ runner.os }}-0.15.2-${{ github.run_id }}-${{ github.job }}
+          restore-keys: zig-v1-${{ runner.os }}-0.15.2-
 
       - name: Install dependencies
         run: bun install
@@ -71,7 +76,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -87,6 +92,14 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          use-cache: false
+
+      - name: Restore Zig cache
+        uses: actions/cache@v5
+        with:
+          path: .zig-cache
+          key: zig-v1-${{ runner.os }}-0.15.2-${{ github.run_id }}-${{ github.job }}
+          restore-keys: zig-v1-${{ runner.os }}-0.15.2-
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -33,7 +33,14 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: ${{ env.ZIG_VERSION }}
-          cache-key: build-native
+          use-cache: false
+
+      - name: Restore Zig cache
+        uses: actions/cache@v5
+        with:
+          path: .zig-cache
+          key: zig-v1-${{ runner.os }}-${{ env.ZIG_VERSION }}-${{ github.run_id }}-${{ github.job }}
+          restore-keys: zig-v1-${{ runner.os }}-${{ env.ZIG_VERSION }}-
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/build-qrcode.yml
+++ b/.github/workflows/build-qrcode.yml
@@ -42,10 +42,15 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
-          # Keep Zig's cache path on the workspace drive, but do not restore/save
-          # stale .zig-cache archives on Windows; Zig 0.15.2 can fail with missing cache files.
-          use-cache: ${{ runner.os != 'Windows' }}
-          cache-key: build-qrcode
+          use-cache: false
+
+      - name: Restore Zig cache
+        if: runner.os != 'Windows'
+        uses: actions/cache@v5
+        with:
+          path: .zig-cache
+          key: zig-v1-${{ runner.os }}-0.15.2-${{ github.run_id }}-${{ github.job }}
+          restore-keys: zig-v1-${{ runner.os }}-0.15.2-
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -39,10 +39,15 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
-          # Keep Zig's cache path on the workspace drive, but do not restore/save
-          # stale .zig-cache archives on Windows; Zig 0.15.2 can fail with missing cache files.
-          use-cache: ${{ runner.os != 'Windows' }}
-          cache-key: build-react
+          use-cache: false
+
+      - name: Restore Zig cache
+        if: runner.os != 'Windows'
+        uses: actions/cache@v5
+        with:
+          path: .zig-cache
+          key: zig-v1-${{ runner.os }}-0.15.2-${{ github.run_id }}-${{ github.job }}
+          restore-keys: zig-v1-${{ runner.os }}-0.15.2-
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/build-solid.yml
+++ b/.github/workflows/build-solid.yml
@@ -40,10 +40,15 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
-          # Keep Zig's cache path on the workspace drive, but do not restore/save
-          # stale .zig-cache archives on Windows; Zig 0.15.2 can fail with missing cache files.
-          use-cache: ${{ runner.os != 'Windows' }}
-          cache-key: build-solid
+          use-cache: false
+
+      - name: Restore Zig cache
+        if: runner.os != 'Windows'
+        uses: actions/cache@v5
+        with:
+          path: .zig-cache
+          key: zig-v1-${{ runner.os }}-0.15.2-${{ github.run_id }}-${{ github.job }}
+          restore-keys: zig-v1-${{ runner.os }}-0.15.2-
 
       - name: Install dependencies
         run: bun install
@@ -68,7 +73,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -84,6 +89,14 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          use-cache: false
+
+      - name: Restore Zig cache
+        uses: actions/cache@v5
+        with:
+          path: .zig-cache
+          key: zig-v1-${{ runner.os }}-0.15.2-${{ github.run_id }}-${{ github.job }}
+          restore-keys: zig-v1-${{ runner.os }}-0.15.2-
 
       - name: Install dependencies
         run: bun install
@@ -108,7 +121,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -124,6 +137,14 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          use-cache: false
+
+      - name: Restore Zig cache
+        uses: actions/cache@v5
+        with:
+          path: .zig-cache
+          key: zig-v1-${{ runner.os }}-0.15.2-${{ github.run_id }}-${{ github.job }}
+          restore-keys: zig-v1-${{ runner.os }}-0.15.2-
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -33,7 +33,14 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
-          cache-key: npm-release
+          use-cache: false
+
+      - name: Restore Zig cache
+        uses: actions/cache@v5
+        with:
+          path: .zig-cache
+          key: zig-v1-${{ runner.os }}-0.15.2-${{ github.run_id }}-${{ github.job }}
+          restore-keys: zig-v1-${{ runner.os }}-0.15.2-
 
       - name: Generate snapshot version
         id: version_scheme

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -34,7 +34,14 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
-          cache-key: pkg-pr-new
+          use-cache: false
+
+      - name: Restore Zig cache
+        uses: actions/cache@v5
+        with:
+          path: .zig-cache
+          key: zig-v1-${{ runner.os }}-0.15.2-${{ github.run_id }}-${{ github.job }}
+          restore-keys: zig-v1-${{ runner.os }}-0.15.2-
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
Use Blacksmith-compatible cache restoration so CI jobs can reuse Zig
artifacts instead of rebuilding them on every run.
