### PR TITLE
core: disable render cache for layout overrides

### DIFF
--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -224,6 +224,10 @@ function bumpRenderListRevision(ctx: RenderContext): void {
   generationContext.__otuiRenderListRevision = getRenderListRevision(ctx) + 1
 }
 
+interface RenderListTraversalState {
+  reusable: boolean
+}
+
 export abstract class Renderable extends BaseRenderable {
   static renderablesByNumber: Map<number, Renderable> = new Map()
 
@@ -1392,7 +1396,11 @@ export abstract class Renderable extends BaseRenderable {
     return this._childrenInLayoutOrder.length
   }
 
-  public updateLayout(deltaTime: number, renderList: RenderCommand[] = []): void {
+  public updateLayout(
+    deltaTime: number,
+    renderList: RenderCommand[] = [],
+    traversalState?: RenderListTraversalState,
+  ): void {
     if (!this.visible) return
 
     this.onUpdate(deltaTime)
@@ -1450,7 +1458,10 @@ export abstract class Renderable extends BaseRenderable {
     // unless a subclass actually performs viewport/style-based child filtering.
     if (!this._hasVisibleChildFilter()) {
       for (const child of this._childrenInZIndexOrder) {
-        child.updateLayout(deltaTime, renderList)
+        if (child.updateLayout !== Renderable.prototype.updateLayout) {
+          if (traversalState) traversalState.reusable = false
+        }
+        child.updateLayout(deltaTime, renderList, traversalState)
       }
     } else {
       // Refresh every child's layout before culling reads their screen
@@ -1465,7 +1476,10 @@ export abstract class Renderable extends BaseRenderable {
       const visibleChildSet = new Set(visibleChildren)
       for (const child of this._childrenInZIndexOrder) {
         if (!visibleChildSet.has(child.num)) continue
-        child.updateLayout(deltaTime, renderList)
+        if (child.updateLayout !== Renderable.prototype.updateLayout) {
+          if (traversalState) traversalState.reusable = false
+        }
+        child.updateLayout(deltaTime, renderList, traversalState)
       }
     }
 
@@ -1751,6 +1765,7 @@ export type RenderCommand =
 
 export class RootRenderable extends Renderable {
   private renderList: RenderCommand[] = []
+  private renderListTraversalState: RenderListTraversalState = { reusable: false }
   private appliedLayoutGeneration: number = -1
   private appliedRenderListRevision: number = -1
   private renderListReusable: boolean = false
@@ -1809,7 +1824,8 @@ export class RootRenderable extends Renderable {
 
     if (!canReuseRenderList) {
       this.renderList.length = 0
-      super.updateLayout(deltaTime, this.renderList)
+      this.renderListTraversalState.reusable = true
+      super.updateLayout(deltaTime, this.renderList, this.renderListTraversalState)
       this.appliedLayoutGeneration = layoutGeneration
       this.appliedRenderListRevision = getRenderListRevision(this._ctx)
       this.renderListReusable = this.canReuseCurrentRenderList()
@@ -1870,6 +1886,7 @@ export class RootRenderable extends Renderable {
 
   private canReuseCurrentRenderList(): boolean {
     if (this._liveCount > 0) return false
+    if (!this.renderListTraversalState.reusable) return false
 
     for (const command of this.renderList) {
       if (command.action !== "render") continue

--- a/packages/core/src/tests/renderable.test.ts
+++ b/packages/core/src/tests/renderable.test.ts
@@ -7,6 +7,7 @@ import {
   RenderableEvents,
   isRenderable,
   type BaseRenderableOptions,
+  type RenderCommand,
   type RenderableOptions,
 } from "../Renderable.js"
 import { createTestRenderer, type TestRenderer, type MockMouse, type MockInput } from "../testing/test-renderer.js"
@@ -64,6 +65,25 @@ class CountingRenderable extends Renderable {
 
   public getScreenPosition(): { x: number; y: number } {
     return { x: this.screenX, y: this.screenY }
+  }
+}
+
+class CustomLayoutRenderable extends Renderable {
+  public layoutCount = 0
+  public customLayout?: () => void
+
+  public updateLayout(deltaTime: number, renderList: RenderCommand[]): void {
+    this.layoutCount += 1
+    this.customLayout?.()
+    super.updateLayout(deltaTime, renderList)
+  }
+}
+
+class CustomLayoutWithoutSuperRenderable extends Renderable {
+  public layoutCount = 0
+
+  public updateLayout(): void {
+    this.layoutCount += 1
   }
 }
 
@@ -1564,6 +1584,52 @@ describe("Renderable - Complex Layout Update Scenarios", () => {
 })
 
 describe("RootRenderable", () => {
+  test("does not cache traversal when a child overrides updateLayout", async () => {
+    const renderable = new CustomLayoutRenderable(testRenderer, { id: "custom-layout" })
+    testRenderer.root.add(renderable)
+
+    await renderOnce()
+    const layoutCount = renderable.layoutCount
+    renderable.requestRender()
+    await renderOnce()
+
+    expect(renderable.layoutCount).toBe(layoutCount + 1)
+  })
+
+  test("detects an updateLayout override that omits super", async () => {
+    const renderable = new CustomLayoutWithoutSuperRenderable(testRenderer, { id: "custom-layout-without-super" })
+    testRenderer.root.add(renderable)
+
+    await renderOnce()
+    const layoutCount = renderable.layoutCount
+    renderable.requestRender()
+    await renderOnce()
+
+    expect(renderable.layoutCount).toBe(layoutCount + 1)
+  })
+
+  test("keeps traversal state isolated during a nested root rebuild", async () => {
+    const nestedRoot = new RootRenderable(testRenderer)
+    const nestedChild = new TestRenderable(testRenderer, { id: "nested-child" })
+    nestedRoot.add(nestedChild)
+    nestedRoot.render(testRenderer.currentRenderBuffer, 0)
+
+    const renderable = new CustomLayoutRenderable(testRenderer, { id: "reentrant-custom-layout" })
+    testRenderer.root.add(renderable)
+    await renderOnce()
+
+    nestedChild.opacity = 0.5
+    renderable.customLayout = () => nestedRoot.render(testRenderer.currentRenderBuffer, 0)
+    await renderOnce()
+
+    const layoutCount = renderable.layoutCount
+    renderable.requestRender()
+    await renderOnce()
+
+    expect(renderable.layoutCount).toBe(layoutCount + 1)
+    nestedRoot.destroyRecursively()
+  })
+
   test("creates with proper setup", () => {
     const root = new RootRenderable(testRenderer)
     expect(root.id).toBe("__root__")


### PR DESCRIPTION
Rebuild the traversal when a child overrides layout so render requests do not skip custom updates.