### PR TITLE
terminal: probe OSC 52 clipboard support

### DIFF
--- a/packages/core/src/lib/clipboard.test.ts
+++ b/packages/core/src/lib/clipboard.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, afterEach } from "bun:test"
 import { createTestRenderer, type TestRenderer } from "../testing/test-renderer.js"
-import { ClipboardTarget, encodeOsc52Payload } from "./clipboard.js"
-import type { RenderLib } from "../zig.js"
+import { Clipboard, ClipboardTarget } from "./clipboard.js"
+import type { RendererHandle, RenderLib } from "../zig.js"
 
 describe("clipboard", () => {
   let renderer: TestRenderer | null = null
@@ -16,10 +16,20 @@ describe("clipboard", () => {
     renderer = null
   })
 
-  it("encodes payload as base64", () => {
-    const payload = encodeOsc52Payload("hello")
-    const decoded = new TextDecoder().decode(payload)
-    expect(decoded).toBe(Buffer.from("hello").toString("base64"))
+  it("passes raw UTF-8 bytes to the native encoder", () => {
+    let received: Uint8Array | undefined
+    const lib = {
+      encoder: new TextEncoder(),
+      getTerminalCapabilities: () => ({ osc52_support: "unknown" }),
+      copyToClipboardOSC52: (_renderer: RendererHandle, _target: number, textUtf8: Uint8Array) => {
+        received = textUtf8
+        return true
+      },
+    } as unknown as RenderLib
+    const clipboard = new Clipboard(lib, 0 as unknown as RendererHandle)
+
+    expect(clipboard.copyToClipboardOSC52("世界")).toBe(true)
+    expect(received).toEqual(new TextEncoder().encode("世界"))
   })
 
   it("treats negative XTGETTCAP Ms replies as inconclusive", async () => {

--- a/packages/core/src/lib/clipboard.test.ts
+++ b/packages/core/src/lib/clipboard.test.ts
@@ -6,9 +6,9 @@ import type { RenderLib } from "../zig.js"
 describe("clipboard", () => {
   let renderer: TestRenderer | null = null
 
-  const enableOsc52 = (testRenderer: TestRenderer) => {
+  const respondToOsc52Query = (testRenderer: TestRenderer, response: string) => {
     const lib = (testRenderer as unknown as { lib: RenderLib }).lib
-    lib.processCapabilityResponse(testRenderer.rendererPtr, "\x1bP>|kitty(0.40.1)\x1b\\")
+    lib.processCapabilityResponse(testRenderer.rendererPtr, response)
   }
 
   afterEach(() => {
@@ -22,16 +22,21 @@ describe("clipboard", () => {
     expect(decoded).toBe(Buffer.from("hello").toString("base64"))
   })
 
-  it("gates clipboard writes on OSC 52 support", async () => {
+  it("treats negative XTGETTCAP Ms replies as inconclusive", async () => {
     ;({ renderer } = await createTestRenderer({ remote: true }))
 
-    expect(renderer.isOsc52Supported()).toBe(false)
-    expect(renderer.copyToClipboardOSC52("test")).toBe(false)
-    expect(renderer.clearClipboardOSC52()).toBe(false)
-
-    enableOsc52(renderer)
-
     expect(renderer.isOsc52Supported()).toBe(true)
+    expect(renderer.copyToClipboardOSC52("test")).toBe(true)
+
+    respondToOsc52Query(renderer, "\x1bP0+r\x1b\\")
+    expect(renderer.copyToClipboardOSC52("test")).toBe(true)
+    expect(renderer.clearClipboardOSC52()).toBe(true)
+
+    respondToOsc52Query(renderer, "\x1bP0+r4d73\x1b\\")
+    expect(renderer.copyToClipboardOSC52("test")).toBe(true)
+
+    respondToOsc52Query(renderer, "\x1bP1+r4d73=2570312573\x1b\\")
+
     expect(renderer.copyToClipboardOSC52("test")).toBe(true)
     expect(renderer.copyToClipboardOSC52("test", ClipboardTarget.Primary)).toBe(true)
     expect(renderer.copyToClipboardOSC52("test", ClipboardTarget.Secondary)).toBe(true)

--- a/packages/core/src/lib/clipboard.ts
+++ b/packages/core/src/lib/clipboard.ts
@@ -10,11 +10,6 @@ export enum ClipboardTarget {
   Query = 3,
 }
 
-export function encodeOsc52Payload(text: string, encoder: TextEncoder = new TextEncoder()): Uint8Array {
-  const base64 = Buffer.from(text).toString("base64")
-  return encoder.encode(base64)
-}
-
 export class Clipboard {
   private lib: RenderLib
   private rendererPtr: RendererHandle
@@ -28,8 +23,8 @@ export class Clipboard {
     if (!this.isOsc52Supported()) {
       return false
     }
-    const payload = encodeOsc52Payload(text, this.lib.encoder)
-    return this.lib.copyToClipboardOSC52(this.rendererPtr, target, payload)
+    const textUtf8 = this.lib.encoder.encode(text)
+    return this.lib.copyToClipboardOSC52(this.rendererPtr, target, textUtf8)
   }
 
   public clearClipboardOSC52(target: ClipboardTarget = ClipboardTarget.Clipboard): boolean {

--- a/packages/core/src/lib/clipboard.ts
+++ b/packages/core/src/lib/clipboard.ts
@@ -41,6 +41,6 @@ export class Clipboard {
 
   public isOsc52Supported(): boolean {
     const caps = this.lib.getTerminalCapabilities(this.rendererPtr)
-    return Boolean(caps?.osc52)
+    return caps?.osc52_support !== "unsupported"
   }
 }

--- a/packages/core/src/lib/terminal-capability-detection.test.ts
+++ b/packages/core/src/lib/terminal-capability-detection.test.ts
@@ -32,6 +32,14 @@ describe("isCapabilityResponse", () => {
     expect(isCapabilityResponse("\x1bP>|tmux 3.5a\x1b\\")).toBe(true)
   })
 
+  test("detects XTGETTCAP Ms responses", () => {
+    expect(isCapabilityResponse("\x1bP1+r4d73=2570312573\x1b\\")).toBe(true)
+    expect(isCapabilityResponse("\x1bP0+r\x1b\\")).toBe(true)
+    expect(isCapabilityResponse("\x1bP0+r4D73\x1b\\")).toBe(true)
+    expect(isCapabilityResponse("\x1bP1+r544e=787465726d\x1b\\")).toBe(false)
+    expect(isCapabilityResponse("\x1bP1+r4d73=abc\x1b\\")).toBe(false)
+  })
+
   test("detects Kitty graphics responses", () => {
     expect(isCapabilityResponse("\x1b_Gi=1;OK\x1b\\")).toBe(true)
     expect(isCapabilityResponse("\x1b_Gi=1;EINVAL:Zero width/height not allowed\x1b\\")).toBe(true)

--- a/packages/core/src/lib/terminal-capability-detection.ts
+++ b/packages/core/src/lib/terminal-capability-detection.ts
@@ -37,6 +37,11 @@ export function isCapabilityResponse(sequence: string): boolean {
     return true
   }
 
+  // XTGETTCAP Ms: xterm returns a bare negative response, while some terminals repeat the capability name.
+  if (/\x1bP(?:1\+r4d73(?:=(?:[0-9a-fA-F]{2})*)?|0\+r(?:4d73)?)\x1b\\/i.test(sequence)) {
+    return true
+  }
+
   // Kitty graphics response: ESC _ G ... ESC \
   // Matches any graphics response including OK, errors, etc.
   // This is for filtering capability responses from user input

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -3857,7 +3857,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   public isOsc52Supported(): boolean {
-    return this._capabilities?.osc52 ?? this.clipboard.isOsc52Supported()
+    return this._capabilities ? this._capabilities.osc52_support !== "unsupported" : this.clipboard.isOsc52Supported()
   }
 
   public dumpHitGrid(): void {

--- a/packages/core/src/testing/terminal-capabilities.ts
+++ b/packages/core/src/testing/terminal-capabilities.ts
@@ -22,6 +22,7 @@ export function createTerminalCapabilities(overrides: TerminalCapabilitiesOverri
     bracketed_paste: false,
     hyperlinks: false,
     osc52: false,
+    osc52_support: "unknown",
     notifications: false,
     explicit_cursor_positioning: false,
     remote: false,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -57,6 +57,7 @@ export enum TargetChannel {
 
 export type WidthMethod = "wcwidth" | "unicode"
 export type TerminalMultiplexer = "none" | "tmux" | "zellij" | "screen" | "unknown"
+export type TerminalCapabilityState = "unknown" | "supported" | "unsupported"
 
 export interface TerminalInfo {
   name: string
@@ -80,6 +81,7 @@ export interface TerminalCapabilities {
   bracketed_paste: boolean
   hyperlinks: boolean
   osc52: boolean
+  osc52_support: TerminalCapabilityState
   notifications: boolean
   explicit_cursor_positioning: boolean
   remote: boolean

--- a/packages/core/src/zig-structs.ts
+++ b/packages/core/src/zig-structs.ts
@@ -87,6 +87,7 @@ export const VisualCursorStruct = defineStruct([
 
 const UnicodeMethodEnum = defineEnum({ wcwidth: 0, unicode: 1 }, "u8")
 const TerminalMultiplexerEnum = defineEnum({ none: 0, tmux: 1, zellij: 2, screen: 3, unknown: 4 }, "u8")
+const Osc52SupportEnum = defineEnum({ unknown: 0, supported: 1, unsupported: 2 }, "u8")
 
 export const TerminalCapabilitiesStruct = defineStruct([
   ["kitty_keyboard", "bool_u8"],
@@ -113,6 +114,7 @@ export const TerminalCapabilitiesStruct = defineStruct([
   ["term_version", "char*"],
   ["term_version_len", "u64", { lengthOf: "term_version" }],
   ["term_from_xtversion", "bool_u8"],
+  ["osc52_support", Osc52SupportEnum],
 ])
 
 export const EncodedCharStruct = defineStruct([

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -2105,7 +2105,7 @@ export interface RenderLib extends AudioEngineLib {
   setDebugOverlay: (renderer: RendererHandle, enabled: boolean, corner: DebugOverlayCorner) => void
   clearTerminal: (renderer: RendererHandle) => void
   setTerminalTitle: (renderer: RendererHandle, title: string) => void
-  copyToClipboardOSC52: (renderer: RendererHandle, target: number, payload: Uint8Array) => boolean
+  copyToClipboardOSC52: (renderer: RendererHandle, target: number, textUtf8: Uint8Array) => boolean
   clearClipboardOSC52: (renderer: RendererHandle, target: number) => boolean
   triggerNotification: (renderer: RendererHandle, message: string, title?: string) => boolean
   addToHitGrid: (renderer: RendererHandle, x: number, y: number, width: number, height: number, id: number) => void
@@ -3303,8 +3303,11 @@ class FFIRenderLib implements RenderLib {
     this.opentui.symbols.setTerminalTitle(renderer, ptrOrNull(titleBytes), titleBytes.byteLength)
   }
 
-  public copyToClipboardOSC52(renderer: Pointer, target: number, payload: Uint8Array): boolean {
-    return Boolean(this.opentui.symbols.copyToClipboardOSC52(renderer, target, ptrOrNull(payload), payload.byteLength))
+  public copyToClipboardOSC52(renderer: Pointer, target: number, textUtf8: Uint8Array): boolean {
+    if (textUtf8.byteLength > 0xffffffff) return false
+    return Boolean(
+      this.opentui.symbols.copyToClipboardOSC52(renderer, target, ptrOrNull(textUtf8), textUtf8.byteLength),
+    )
   }
 
   public clearClipboardOSC52(renderer: Pointer, target: number): boolean {

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -4719,6 +4719,7 @@ class FFIRenderLib implements RenderLib {
       bracketed_paste: caps.bracketed_paste,
       hyperlinks: caps.hyperlinks,
       osc52: caps.osc52,
+      osc52_support: caps.osc52_support,
       notifications: caps.notifications,
       explicit_cursor_positioning: caps.explicit_cursor_positioning,
       remote: caps.remote,

--- a/packages/core/src/zig/ansi.zig
+++ b/packages/core/src/zig/ansi.zig
@@ -320,10 +320,12 @@ pub const ANSI = struct {
     pub const decrqmUnicode = "\x1b[?2027$p";
     pub const decrqmColorScheme = "\x1b[?2031$p";
     pub const csiUQuery = "\x1b[?u";
+    pub const xtgettcapMs = "\x1bP+q4d73\x1b\\";
     pub const kittyGraphicsQuery = "\x1b_Gi=31337,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\\x1b[c";
     pub const notificationQueries = "\x1b]99;i=opentui-notifications:p=?;\x1b\\\x1b]1337;Capabilities\x1b\\";
 
-    pub const capabilityQueriesBase = decrqmSgrPixels ++
+    pub const capabilityQueriesBase = xtgettcapMs ++
+        decrqmSgrPixels ++
         decrqmUnicode ++
         decrqmColorScheme ++
         decrqmFocus ++

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -944,11 +944,11 @@ export fn setTerminalTitle(renderer_handle: NativeHandle, titlePtr: ?[*]const u8
     object_ptr.setTerminalTitle(title);
 }
 
-export fn copyToClipboardOSC52(renderer_handle: NativeHandle, target: u8, payloadPtr: ?[*]const u8, payloadLen: u32) bool {
+export fn copyToClipboardOSC52(renderer_handle: NativeHandle, target: u8, text_ptr: ?[*]const u8, text_len: u32) bool {
     const object_ptr = acquireRenderer(renderer_handle) orelse return false;
     const targetEnum = std.meta.intToEnum(terminal.ClipboardTarget, target) catch .clipboard;
-    const payload = sliceFromPtrLen(payloadPtr, payloadLen);
-    return object_ptr.copyToClipboardOSC52(targetEnum, payload);
+    const text_utf8 = sliceFromPtrLen(text_ptr, text_len);
+    return object_ptr.copyToClipboardOSC52(targetEnum, text_utf8);
 }
 
 export fn clearClipboardOSC52(renderer_handle: NativeHandle, target: u8) bool {

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -781,6 +781,7 @@ pub const ExternalCapabilities = extern struct {
     term_version_ptr: [*]const u8,
     term_version_len: usize,
     term_from_xtversion: bool,
+    osc52_support: u8,
 };
 
 export fn getTerminalCapabilities(renderer_handle: NativeHandle, capsPtr: *ExternalCapabilities) void {
@@ -809,6 +810,7 @@ export fn getTerminalCapabilities(renderer_handle: NativeHandle, capsPtr: *Exter
         .bracketed_paste = caps.bracketed_paste,
         .hyperlinks = caps.hyperlinks,
         .osc52 = caps.osc52,
+        .osc52_support = @intFromEnum(term.osc52_support),
         .notifications = caps.notifications,
         .explicit_cursor_positioning = caps.explicit_cursor_positioning,
         .remote = caps.remote,

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -1953,11 +1953,16 @@ pub const CliRenderer = struct {
         self.writeOut(stream.getWritten());
     }
 
-    pub fn copyToClipboardOSC52(self: *CliRenderer, target: Terminal.ClipboardTarget, payload: []const u8) bool {
-        var stream: std.ArrayListUnmanaged(u8) = .{};
-        defer stream.deinit(self.allocator);
-        self.terminal.writeClipboard(stream.writer(self.allocator), target, payload) catch return false;
-        self.writeOut(stream.items);
+    pub fn copyToClipboardOSC52(self: *CliRenderer, target: Terminal.ClipboardTarget, text_utf8: []const u8) bool {
+        const output_len = self.terminal.clipboardSequenceSize(text_utf8.len) catch return false;
+        const output_bytes = self.allocator.alloc(u8, output_len) catch return false;
+        defer self.allocator.free(output_bytes);
+
+        var stream = std.io.fixedBufferStream(output_bytes);
+        self.terminal.writeClipboard(stream.writer(), target, text_utf8) catch return false;
+        const written = stream.getWritten();
+        std.debug.assert(written.len == output_len);
+        self.writeOut(written);
         return true;
     }
 

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -1954,16 +1954,18 @@ pub const CliRenderer = struct {
     }
 
     pub fn copyToClipboardOSC52(self: *CliRenderer, target: Terminal.ClipboardTarget, payload: []const u8) bool {
-        var stream = std.io.fixedBufferStream(&self.writeOutBuf);
-        self.terminal.writeClipboard(stream.writer(), target, payload) catch return false;
-        self.writeOut(stream.getWritten());
+        var stream: std.ArrayListUnmanaged(u8) = .{};
+        defer stream.deinit(self.allocator);
+        self.terminal.writeClipboard(stream.writer(self.allocator), target, payload) catch return false;
+        self.writeOut(stream.items);
         return true;
     }
 
     pub fn clearClipboardOSC52(self: *CliRenderer, target: Terminal.ClipboardTarget) bool {
-        var stream = std.io.fixedBufferStream(&self.writeOutBuf);
-        self.terminal.writeClipboard(stream.writer(), target, "") catch return false;
-        self.writeOut(stream.getWritten());
+        var stream: std.ArrayListUnmanaged(u8) = .{};
+        defer stream.deinit(self.allocator);
+        self.terminal.writeClipboard(stream.writer(self.allocator), target, "") catch return false;
+        self.writeOut(stream.items);
         return true;
     }
 

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -69,6 +69,9 @@ pub const Osc52Support = enum(u8) {
 
 const NOTIFICATION_QUERY_ID = "opentui-notifications";
 pub const SCREEN_PASSTHROUGH_CHUNK_SIZE = 252;
+pub const CLIPBOARD_PAYLOAD_SIZE_MAX = std.math.maxInt(u32);
+const OSC52_FRAMING_SIZE = "\x1b]52;c;".len + "\x1b\\".len;
+const PASSTHROUGH_ESCAPED_OSC52_SIZE = OSC52_FRAMING_SIZE + 2;
 
 pub const MouseLevel = enum {
     none,
@@ -1439,28 +1442,51 @@ pub fn writeNotification(self: *Terminal, allocator: std.mem.Allocator, tty: any
     return true;
 }
 
-/// Write OSC 52 clipboard sequence to the terminal
+/// Return the exact number of bytes emitted by writeClipboard.
+pub fn clipboardSequenceSize(self: *Terminal, payload_len: usize) !usize {
+    if (payload_len > CLIPBOARD_PAYLOAD_SIZE_MAX) return error.ClipboardPayloadTooLarge;
+    const padded_len = try std.math.add(usize, payload_len, 2);
+    const encoded_len = try std.math.mul(usize, @divFloor(padded_len, 3), 4);
+    const sequence_len = try std.math.add(usize, encoded_len, OSC52_FRAMING_SIZE);
+
+    if (self.isInTmux()) {
+        const wrapped_len = try std.math.add(usize, sequence_len, 2);
+        return std.math.add(usize, wrapped_len, ansi.ANSI.tmuxDcsStart.len + ansi.ANSI.tmuxDcsEnd.len);
+    }
+
+    if (self.isInScreen()) {
+        const escaped_len = try std.math.add(usize, encoded_len, PASSTHROUGH_ESCAPED_OSC52_SIZE);
+        const chunk_count = @divFloor(escaped_len - 1, SCREEN_PASSTHROUGH_CHUNK_SIZE) + 1;
+        const envelopes_len = try std.math.mul(usize, chunk_count, ansi.ANSI.screenDcsStart.len + ansi.ANSI.screenDcsEnd.len);
+        return std.math.add(usize, escaped_len, envelopes_len);
+    }
+
+    return sequence_len;
+}
+
+/// Write OSC 52 clipboard sequence to the terminal from raw clipboard bytes.
 /// Supports tmux/screen passthrough, including nested tmux sessions
-pub fn writeClipboard(self: *Terminal, tty: anytype, target: ClipboardTarget, payload: []const u8) !void {
+pub fn writeClipboard(self: *Terminal, tty: anytype, target: ClipboardTarget, text_utf8: []const u8) !void {
     if (!self.canWriteClipboard()) {
         return error.NotSupported;
     }
+    _ = try self.clipboardSequenceSize(text_utf8.len);
 
     if (self.isInTmux()) {
         try tty.writeAll(ansi.ANSI.tmuxDcsStart);
-        try writeClipboardSequence(tty, target, payload, true);
+        try writeClipboardSequence(tty, target, text_utf8, true);
         try tty.writeAll(ansi.ANSI.tmuxDcsEnd);
         return;
     }
 
     if (self.isInScreen()) {
         var screen_writer = ScreenPassthroughWriter(@TypeOf(tty)).init(tty);
-        try writeClipboardSequence(&screen_writer, target, payload, false);
+        try writeClipboardSequence(&screen_writer, target, text_utf8, false);
         try screen_writer.finish();
         return;
     }
 
-    try writeClipboardSequence(tty, target, payload, false);
+    try writeClipboardSequence(tty, target, text_utf8, false);
 }
 
 fn ScreenPassthroughWriter(comptime Writer: type) type {
@@ -1505,12 +1531,26 @@ fn ScreenPassthroughWriter(comptime Writer: type) type {
     };
 }
 
-fn writeClipboardSequence(writer: anytype, target: ClipboardTarget, payload: []const u8, escape: bool) !void {
+fn writeClipboardSequence(writer: anytype, target: ClipboardTarget, text_utf8: []const u8, escape: bool) !void {
     try writeClipboardBytes(writer, "\x1b]52;", escape);
     try writer.writeByte(target.toChar());
     try writer.writeByte(';');
-    try writeClipboardBytes(writer, payload, escape);
+    try writeClipboardBase64(writer, text_utf8);
     try writeClipboardBytes(writer, "\x1b\\", escape);
+}
+
+fn writeClipboardBase64(writer: anytype, source: []const u8) !void {
+    const source_chunk_size = 3 * 1024;
+    var encoded_buffer: [4 * 1024]u8 = undefined;
+    var offset: usize = 0;
+
+    while (offset < source.len) {
+        const chunk_len = @min(source.len - offset, source_chunk_size);
+        const chunk = source[offset .. offset + chunk_len];
+        const encoded = std.base64.standard.Encoder.encode(&encoded_buffer, chunk);
+        try writer.writeAll(encoded);
+        offset += chunk_len;
+    }
 }
 
 fn writeClipboardBytes(writer: anytype, bytes: []const u8, escape: bool) !void {

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -61,7 +61,14 @@ pub const Multiplexer = enum(u8) {
     unknown,
 };
 
+pub const Osc52Support = enum(u8) {
+    unknown,
+    supported,
+    unsupported,
+};
+
 const NOTIFICATION_QUERY_ID = "opentui-notifications";
+pub const SCREEN_PASSTHROUGH_CHUNK_SIZE = 252;
 
 pub const MouseLevel = enum {
     none,
@@ -136,6 +143,7 @@ opts: Options = .{},
 host_env_map: ?std.process.EnvMap = null,
 remote: bool = false,
 multiplexer: Multiplexer = .none,
+osc52_support: Osc52Support = .unknown,
 is_foot: bool = false,
 skip_graphics_query: bool = false,
 skip_explicit_width_query: bool = false,
@@ -1041,6 +1049,7 @@ pub fn restoreTerminalModes(self: *Terminal, tty: anytype) !void {
 pub fn processCapabilityResponse(self: *Terminal, response: []const u8) void {
     self.parseOsc99NotificationQuery(response);
     self.parseItermCapabilities(response);
+    self.parseXtgettcapMs(response);
 
     // DECRPM responses
     if (std.mem.indexOf(u8, response, "1016;2$y")) |_| {
@@ -1198,6 +1207,40 @@ pub fn processCapabilityResponse(self: *Terminal, response: []const u8) void {
 
     if (!self.caps.hyperlinks and isHyperlinkTerm(response)) {
         self.caps.hyperlinks = true;
+    }
+}
+
+fn parseXtgettcapMs(self: *Terminal, response: []const u8) void {
+    const prefix = "\x1bP";
+    var scan_pos: usize = 0;
+    while (std.mem.indexOfPos(u8, response, scan_pos, prefix)) |start| {
+        const body_start = start + prefix.len;
+        const end = std.mem.indexOfPos(u8, response, body_start, "\x1b\\") orelse return;
+        const body = response[body_start..end];
+        scan_pos = end + 2;
+
+        if (body.len < 6 or body[0] != '1') continue;
+        if (!std.mem.eql(u8, body[1..3], "+r")) continue;
+
+        const result = body[3..];
+        const separator = std.mem.indexOfScalar(u8, result, '=');
+        const name = if (separator) |index| result[0..index] else result;
+        if (!std.ascii.eqlIgnoreCase(name, "4d73")) continue;
+
+        if (separator) |index| {
+            const value = result[index + 1 ..];
+            if (value.len % 2 != 0) continue;
+            for (value) |byte| {
+                if (!std.ascii.isHex(byte)) break;
+            } else {
+                self.osc52_support = .supported;
+                self.caps.osc52 = true;
+            }
+            continue;
+        }
+
+        self.osc52_support = .supported;
+        self.caps.osc52 = true;
     }
 }
 
@@ -1403,80 +1446,90 @@ pub fn writeClipboard(self: *Terminal, tty: anytype, target: ClipboardTarget, pa
         return error.NotSupported;
     }
 
-    var buf: [1024]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    const writer = stream.writer();
+    if (self.isInTmux()) {
+        try tty.writeAll(ansi.ANSI.tmuxDcsStart);
+        try writeClipboardSequence(tty, target, payload, true);
+        try tty.writeAll(ansi.ANSI.tmuxDcsEnd);
+        return;
+    }
 
-    // Build OSC 52 sequence: ESC]52;<target>;<payload>ESC\
-    try writer.writeAll("\x1b]52;");
+    if (self.isInScreen()) {
+        var screen_writer = ScreenPassthroughWriter(@TypeOf(tty)).init(tty);
+        try writeClipboardSequence(&screen_writer, target, payload, false);
+        try screen_writer.finish();
+        return;
+    }
+
+    try writeClipboardSequence(tty, target, payload, false);
+}
+
+fn ScreenPassthroughWriter(comptime Writer: type) type {
+    return struct {
+        writer: Writer,
+        buffer: [SCREEN_PASSTHROUGH_CHUNK_SIZE]u8 = undefined,
+        length: usize = 0,
+
+        const Self = @This();
+
+        fn init(writer: Writer) Self {
+            return .{ .writer = writer };
+        }
+
+        pub fn writeAll(self: *Self, bytes: []const u8) !void {
+            for (bytes) |byte| try self.writeByte(byte);
+        }
+
+        pub fn writeByte(self: *Self, byte: u8) !void {
+            const encoded_length: usize = if (byte == '\x1b') 2 else 1;
+            if (self.length + encoded_length > self.buffer.len) try self.flush();
+
+            if (byte == '\x1b') {
+                self.buffer[self.length] = '\x1b';
+                self.length += 1;
+            }
+            self.buffer[self.length] = byte;
+            self.length += 1;
+        }
+
+        fn finish(self: *Self) !void {
+            try self.flush();
+        }
+
+        fn flush(self: *Self) !void {
+            if (self.length == 0) return;
+            try self.writer.writeAll(ansi.ANSI.screenDcsStart);
+            try self.writer.writeAll(self.buffer[0..self.length]);
+            try self.writer.writeAll(ansi.ANSI.screenDcsEnd);
+            self.length = 0;
+        }
+    };
+}
+
+fn writeClipboardSequence(writer: anytype, target: ClipboardTarget, payload: []const u8, escape: bool) !void {
+    try writeClipboardBytes(writer, "\x1b]52;", escape);
     try writer.writeByte(target.toChar());
     try writer.writeByte(';');
-    try writer.writeAll(payload);
-    try writer.writeAll("\x1b\\");
+    try writeClipboardBytes(writer, payload, escape);
+    try writeClipboardBytes(writer, "\x1b\\", escape);
+}
 
-    const osc52 = stream.getWritten();
+fn writeClipboardBytes(writer: anytype, bytes: []const u8, escape: bool) !void {
+    if (!escape) {
+        try writer.writeAll(bytes);
+        return;
+    }
 
-    // Use the detected multiplexer from env vars, xtversion response, and remote option.
-    const is_tmux = self.isInTmux();
-
-    if (is_tmux) {
-        // For nested tmux, we use a fixed level of 1 as we don't have access
-        // to env vars here (by design - detection already happened in checkEnvironmentOverrides)
-        // In practice, single-level wrapping works for most cases
-        var wrapped_buf: [4096]u8 = undefined;
-        var wrapped_stream = std.io.fixedBufferStream(&wrapped_buf);
-        const wrap_writer = wrapped_stream.writer();
-        for (osc52) |c| {
-            if (c == '\x1b') {
-                try wrap_writer.writeByte('\x1b');
-            }
-            try wrap_writer.writeByte(c);
-        }
-        const doubled = wrapped_stream.getWritten();
-
-        try tty.writeAll(ansi.ANSI.tmuxDcsStart);
-        try tty.writeAll(doubled);
-        try tty.writeAll(ansi.ANSI.tmuxDcsEnd);
-    } else if (self.remote) {
-        try tty.writeAll(osc52);
-    } else {
-        var env_map_storage: ?std.process.EnvMap = null;
-        const env_map: *const std.process.EnvMap = self.opts.env_map orelse blk: {
-            env_map_storage = std.process.getEnvMap(std.heap.page_allocator) catch |err| {
-                logger.err("Failed to get environment map: {}", .{err});
-                return;
-            };
-            break :blk &env_map_storage.?;
-        };
-        defer if (env_map_storage) |*map| map.deinit();
-
-        if (env_map.get("STY")) |_| {
-            var wrapped_buf: [2048]u8 = undefined;
-            var wrapped_stream = std.io.fixedBufferStream(&wrapped_buf);
-            const wrapped_writer = wrapped_stream.writer();
-
-            for (osc52) |c| {
-                if (c == '\x1b') {
-                    try wrapped_writer.writeByte('\x1b');
-                }
-                try wrapped_writer.writeByte(c);
-            }
-            const doubled = wrapped_stream.getWritten();
-
-            try tty.writeAll(ansi.ANSI.screenDcsStart);
-            try tty.writeAll(doubled);
-            try tty.writeAll(ansi.ANSI.screenDcsEnd);
-        } else {
-            try tty.writeAll(osc52);
-        }
+    for (bytes) |byte| {
+        if (byte == '\x1b') try writer.writeByte('\x1b');
+        try writer.writeByte(byte);
     }
 }
 
 /// Check if we can write to the clipboard (TTY and OSC 52 supported)
 fn canWriteClipboard(self: *Terminal) bool {
     // In a real TTY environment, we'd check isTTY here
-    // For now, we just check if OSC 52 is supported
-    return self.caps.osc52;
+    // Missing or inconclusive capability responses must not block optimistic emission.
+    return self.osc52_support != .unsupported;
 }
 
 /// Parse xtversion response string and extract terminal name and version

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -89,6 +89,24 @@ test "renderer - create and destroy" {
     try std.testing.expectEqual(@as(u32, 24), cli_renderer.height);
 }
 
+test "renderer - clipboard allocates one exact encoded sequence" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+
+    var test_renderer = try TestRenderer.create(std.testing.allocator, 80, 24, pool);
+    defer test_renderer.deinit();
+
+    const payload = [_]u8{'A'} ** 2048;
+    try std.testing.expect(test_renderer.renderer.copyToClipboardOSC52(.clipboard, &payload));
+
+    const output = test_renderer.lastOutput();
+    try std.testing.expectEqual(std.base64.standard.Encoder.calcSize(payload.len) + 9, output.len);
+    try std.testing.expect(std.mem.startsWith(u8, output, "\x1b]52;c;QUFB"));
+    try std.testing.expect(std.mem.endsWith(u8, output, "QUE=\x1b\\"));
+}
+
 test "renderer - simple text rendering to currentRenderBuffer" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/core/src/zig/tests/terminal_test.zig
+++ b/packages/core/src/zig/tests/terminal_test.zig
@@ -813,7 +813,7 @@ test "writeClipboard - generates basic OSC52 sequence" {
     var writer = TestWriter.init(testing.allocator);
     defer writer.deinit();
 
-    try term.writeClipboard(&writer, .clipboard, "aGVsbG8=");
+    try term.writeClipboard(&writer, .clipboard, "hello");
 
     const output = writer.getWritten();
     // Should be: ESC]52;c;aGVsbG8=ESC\
@@ -986,7 +986,7 @@ test "writeClipboard - emits optimistically when XTGETTCAP state is unknown" {
 
     var writer = TestWriter.init(testing.allocator);
     defer writer.deinit();
-    try term.writeClipboard(&writer, .clipboard, "dGVzdA==");
+    try term.writeClipboard(&writer, .clipboard, "test");
 
     try testing.expectEqualStrings("\x1b]52;c;dGVzdA==\x1b\\", writer.getWritten());
 }
@@ -1006,7 +1006,8 @@ test "writeClipboard - writes large payload without a fixed buffer limit" {
     defer writer.deinit();
     try term.writeClipboard(&writer, .clipboard, payload);
 
-    try testing.expectEqual(@as(usize, payload.len + 9), writer.getWritten().len);
+    const encoded_len = std.base64.standard.Encoder.calcSize(payload.len);
+    try testing.expectEqual(encoded_len + 9, writer.getWritten().len);
     try testing.expect(std.mem.startsWith(u8, writer.getWritten(), "\x1b]52;c;"));
     try testing.expect(std.mem.endsWith(u8, writer.getWritten(), "\x1b\\"));
 }
@@ -1028,7 +1029,8 @@ test "writeClipboard - writes large payload through tmux passthrough" {
     try term.writeClipboard(&writer, .clipboard, payload);
 
     const output = writer.getWritten();
-    try testing.expectEqual(@as(usize, payload.len + 20), output.len);
+    const encoded_len = std.base64.standard.Encoder.calcSize(payload.len);
+    try testing.expectEqual(encoded_len + 20, output.len);
     try testing.expect(std.mem.startsWith(u8, output, "\x1bPtmux;\x1b\x1b]52;c;"));
     try testing.expect(std.mem.endsWith(u8, output, "\x1b\x1b\\\x1b\\"));
 }
@@ -1060,6 +1062,110 @@ test "writeClipboard - chunks large payload through GNU Screen passthrough" {
         try testing.expect(next_start - content_start <= Terminal.SCREEN_PASSTHROUGH_CHUNK_SIZE + ansi.ANSI.screenDcsEnd.len);
         frame_start = next_start;
     }
+}
+
+test "writeClipboard - base64 encodes raw UTF-8 bytes" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var env = std.process.EnvMap.init(testing.allocator);
+    defer env.deinit();
+    var term = Terminal.init(.{ .env_map = &env });
+
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+    try term.writeClipboard(&writer, .clipboard, "世界 café 🚀");
+
+    try testing.expectEqualStrings("\x1b]52;c;5LiW55WMIGNhZsOpIPCfmoA=\x1b\\", writer.getWritten());
+}
+
+test "writeClipboard - handles base64 padding and encoding chunk boundaries" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var env = std.process.EnvMap.init(testing.allocator);
+    defer env.deinit();
+    var term = Terminal.init(.{ .env_map = &env });
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    const cases = [_]struct { raw: []const u8, encoded: []const u8 }{
+        .{ .raw = "", .encoded = "" },
+        .{ .raw = "a", .encoded = "YQ==" },
+        .{ .raw = "ab", .encoded = "YWI=" },
+        .{ .raw = "abc", .encoded = "YWJj" },
+    };
+    for (cases) |case| {
+        writer.reset();
+        try term.writeClipboard(&writer, .clipboard, case.raw);
+        try testing.expectEqualStrings("\x1b]52;c;", writer.getWritten()[0..7]);
+        try testing.expectEqualStrings(case.encoded, writer.getWritten()[7 .. writer.getWritten().len - 2]);
+        try testing.expect(std.mem.endsWith(u8, writer.getWritten(), "\x1b\\"));
+    }
+
+    const payload = [_]u8{'A'} ** (3 * 1024 + 1);
+    const encoded_len = std.base64.standard.Encoder.calcSize(payload.len);
+    const expected = try testing.allocator.alloc(u8, encoded_len);
+    defer testing.allocator.free(expected);
+    _ = std.base64.standard.Encoder.encode(expected, &payload);
+
+    writer.reset();
+    try term.writeClipboard(&writer, .clipboard, &payload);
+    try testing.expectEqualSlices(u8, expected, writer.getWritten()[7 .. writer.getWritten().len - 2]);
+}
+
+test "clipboardSequenceSize - matches plain, tmux, and Screen output" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const payload = "size me 世界";
+    const environments = [_]struct { key: ?[]const u8, value: []const u8 }{
+        .{ .key = null, .value = "" },
+        .{ .key = "TMUX", .value = "/tmp/tmux-1000/default,12345,0" },
+        .{ .key = "STY", .value = "12345.pts-0.hostname" },
+    };
+
+    for (environments) |environment| {
+        var env = std.process.EnvMap.init(testing.allocator);
+        defer env.deinit();
+        if (environment.key) |key| try env.put(key, environment.value);
+        var term = Terminal.init(.{ .env_map = &env });
+
+        var writer = TestWriter.init(testing.allocator);
+        defer writer.deinit();
+        try term.writeClipboard(&writer, .clipboard, payload);
+
+        try testing.expectEqual(try term.clipboardSequenceSize(payload.len), writer.getWritten().len);
+    }
+}
+
+test "clipboardSequenceSize - rejects payloads beyond the FFI limit" {
+    if (std.math.maxInt(usize) == std.math.maxInt(u32)) return error.SkipZigTest;
+
+    var term: Terminal = .{};
+    try testing.expectError(
+        error.ClipboardPayloadTooLarge,
+        term.clipboardSequenceSize(@as(usize, Terminal.CLIPBOARD_PAYLOAD_SIZE_MAX) + 1),
+    );
+}
+
+test "writeClipboard - Screen framing crosses the 252-byte boundary" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var env = std.process.EnvMap.init(testing.allocator);
+    defer env.deinit();
+    try env.put("STY", "12345.pts-0.hostname");
+    var term = Terminal.init(.{ .env_map = &env });
+
+    const payload_one_chunk = [_]u8{'A'} ** 180;
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+    try term.writeClipboard(&writer, .clipboard, &payload_one_chunk);
+    try testing.expectEqual(@as(usize, 1), countSubstring(writer.getWritten(), ansi.ANSI.screenDcsStart));
+    try testing.expectEqual(try term.clipboardSequenceSize(payload_one_chunk.len), writer.getWritten().len);
+
+    writer.reset();
+    const payload_two_chunks = [_]u8{'A'} ** 181;
+    try term.writeClipboard(&writer, .clipboard, &payload_two_chunks);
+    try testing.expectEqual(@as(usize, 2), countSubstring(writer.getWritten(), ansi.ANSI.screenDcsStart));
+    try testing.expectEqual(try term.clipboardSequenceSize(payload_two_chunks.len), writer.getWritten().len);
 }
 
 test "writeClipboard - wraps in DCS passthrough for tmux" {

--- a/packages/core/src/zig/tests/terminal_test.zig
+++ b/packages/core/src/zig/tests/terminal_test.zig
@@ -503,6 +503,7 @@ test "queryTerminalSend - sends unwrapped queries when not in tmux" {
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[?1016$p") != null);
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[?2027$p") != null);
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[?u") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "\x1bP+q4d73\x1b\\") != null);
 
     // Should NOT contain tmux DCS wrapper
     try testing.expect(std.mem.indexOf(u8, output, "\x1bPtmux;") == null);
@@ -538,7 +539,8 @@ test "queryTerminalSend - sends DCS wrapped queries when in tmux" {
 
     // Should contain tmux DCS wrapper start and doubled ESC for queries
     // wrapForTmux wraps all queries together with one DCS envelope
-    try testing.expect(std.mem.indexOf(u8, output, "\x1bPtmux;\x1b\x1b[?1016$p") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "\x1bPtmux;\x1b\x1bP+q4d73\x1b\x1b\\") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b\x1b[?1016$p") != null);
 
     // Should NOT mark capability queries as pending (already sent wrapped)
     try testing.expect(!term.capability_queries_pending);
@@ -585,7 +587,8 @@ test "sendPendingQueries - sends wrapped queries after tmux detected via xtversi
     const output = writer.getWritten();
 
     // Should send DCS wrapped capability queries (wrapForTmux wraps all queries together)
-    try testing.expect(std.mem.indexOf(u8, output, "\x1bPtmux;\x1b\x1b[?1016$p") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "\x1bPtmux;\x1b\x1bP+q4d73\x1b\x1b\\") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b\x1b[?1016$p") != null);
 
     // Should send DCS wrapped graphics query
     try testing.expect(std.mem.indexOf(u8, output, "\x1bPtmux;\x1b\x1b_G") != null);
@@ -769,6 +772,31 @@ test "processCapabilityResponse - foot applies osc52 heuristic without explicit 
     try testing.expect(!term.caps.explicit_cursor_positioning);
 }
 
+test "processCapabilityResponse - XTGETTCAP Ms only establishes positive support" {
+    var supported: Terminal = .{};
+    supported.processCapabilityResponse("\x1bP1+r4d73=2570312573\x1b\\");
+    try testing.expectEqual(Terminal.Osc52Support.supported, supported.osc52_support);
+    try testing.expect(supported.caps.osc52);
+
+    var bare_negative: Terminal = .{};
+    bare_negative.processCapabilityResponse("\x1bP>|iTerm2 3.5.0\x1b\\");
+    bare_negative.processCapabilityResponse("\x1bP0+r\x1b\\");
+    try testing.expectEqual(Terminal.Osc52Support.unknown, bare_negative.osc52_support);
+    try testing.expect(bare_negative.caps.osc52);
+
+    var named_negative: Terminal = .{};
+    named_negative.processCapabilityResponse("\x1bP>|kitty(0.40.1)\x1b\\");
+    named_negative.processCapabilityResponse("\x1bP0+r4D73\x1b\\");
+    try testing.expectEqual(Terminal.Osc52Support.unknown, named_negative.osc52_support);
+    try testing.expect(named_negative.caps.osc52);
+
+    var unknown: Terminal = .{};
+    unknown.processCapabilityResponse("\x1bP1+r4d73=abc\x1b\\");
+    try testing.expectEqual(Terminal.Osc52Support.unknown, unknown.osc52_support);
+    unknown.processCapabilityResponse("\x1bP1+r544e=787465726d\x1b\\");
+    try testing.expectEqual(Terminal.Osc52Support.unknown, unknown.osc52_support);
+}
+
 // ============================================================================
 // CLIPBOARD (OSC 52) TESTS
 // ============================================================================
@@ -939,13 +967,99 @@ test "writeClipboard - returns error when OSC52 not supported" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
     var term = Terminal.init(.{});
-    term.caps.osc52 = false;
+    term.osc52_support = .unsupported;
 
     var writer = TestWriter.init(testing.allocator);
     defer writer.deinit();
 
     const result = term.writeClipboard(&writer, .clipboard, "test");
     try testing.expectError(error.NotSupported, result);
+}
+
+test "writeClipboard - emits optimistically when XTGETTCAP state is unknown" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var env = std.process.EnvMap.init(testing.allocator);
+    defer env.deinit();
+    var term = Terminal.init(.{ .env_map = &env });
+    try testing.expectEqual(Terminal.Osc52Support.unknown, term.osc52_support);
+
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+    try term.writeClipboard(&writer, .clipboard, "dGVzdA==");
+
+    try testing.expectEqualStrings("\x1b]52;c;dGVzdA==\x1b\\", writer.getWritten());
+}
+
+test "writeClipboard - writes large payload without a fixed buffer limit" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var env = std.process.EnvMap.init(testing.allocator);
+    defer env.deinit();
+    var term = Terminal.init(.{ .env_map = &env });
+
+    const payload = try testing.allocator.alloc(u8, 16 * 1024);
+    defer testing.allocator.free(payload);
+    @memset(payload, 'A');
+
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+    try term.writeClipboard(&writer, .clipboard, payload);
+
+    try testing.expectEqual(@as(usize, payload.len + 9), writer.getWritten().len);
+    try testing.expect(std.mem.startsWith(u8, writer.getWritten(), "\x1b]52;c;"));
+    try testing.expect(std.mem.endsWith(u8, writer.getWritten(), "\x1b\\"));
+}
+
+test "writeClipboard - writes large payload through tmux passthrough" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var env = std.process.EnvMap.init(testing.allocator);
+    defer env.deinit();
+    try env.put("TMUX", "/tmp/tmux-1000/default,12345,0");
+    var term = Terminal.init(.{ .env_map = &env });
+
+    const payload = try testing.allocator.alloc(u8, 16 * 1024);
+    defer testing.allocator.free(payload);
+    @memset(payload, 'A');
+
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+    try term.writeClipboard(&writer, .clipboard, payload);
+
+    const output = writer.getWritten();
+    try testing.expectEqual(@as(usize, payload.len + 20), output.len);
+    try testing.expect(std.mem.startsWith(u8, output, "\x1bPtmux;\x1b\x1b]52;c;"));
+    try testing.expect(std.mem.endsWith(u8, output, "\x1b\x1b\\\x1b\\"));
+}
+
+test "writeClipboard - chunks large payload through GNU Screen passthrough" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var env = std.process.EnvMap.init(testing.allocator);
+    defer env.deinit();
+    try env.put("STY", "12345.pts-0.hostname");
+    var term = Terminal.init(.{ .env_map = &env });
+
+    const payload = try testing.allocator.alloc(u8, 16 * 1024);
+    defer testing.allocator.free(payload);
+    @memset(payload, 'A');
+
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+    try term.writeClipboard(&writer, .clipboard, payload);
+
+    const output = writer.getWritten();
+    try testing.expect(countSubstring(output, ansi.ANSI.screenDcsStart) > 1);
+    try testing.expect(std.mem.endsWith(u8, output, ansi.ANSI.screenDcsEnd));
+
+    var frame_start: usize = 0;
+    while (std.mem.indexOfPos(u8, output, frame_start, ansi.ANSI.screenDcsStart)) |start| {
+        const content_start = start + ansi.ANSI.screenDcsStart.len;
+        const next_start = std.mem.indexOfPos(u8, output, content_start, ansi.ANSI.screenDcsStart) orelse output.len;
+        try testing.expect(next_start - content_start <= Terminal.SCREEN_PASSTHROUGH_CHUNK_SIZE + ansi.ANSI.screenDcsEnd.len);
+        frame_start = next_start;
+    }
 }
 
 test "writeClipboard - wraps in DCS passthrough for tmux" {

--- a/packages/examples/src/clipboard-paste-demo.ts
+++ b/packages/examples/src/clipboard-paste-demo.ts
@@ -1,0 +1,556 @@
+#!/usr/bin/env bun
+
+import {
+  bg,
+  bold,
+  BoxRenderable,
+  CliRenderEvents,
+  type CliRenderer,
+  createCliRenderer,
+  decodePasteBytes,
+  fg,
+  type KeyEvent,
+  type PasteEvent,
+  ScrollBoxRenderable,
+  type Selection,
+  stripAnsiSequences,
+  t,
+  TextareaRenderable,
+  TextRenderable,
+} from "@opentui/core"
+import { setupCommonDemoKeys } from "./lib/standalone-keys.js"
+
+const P = {
+  bg: "#08111f",
+  panel: "#0f1b2d",
+  border: "#34507c",
+  borderHot: "#22d3ee",
+  text: "#d7e3f7",
+  muted: "#7d8da8",
+  cyan: "#22d3ee",
+  lime: "#bef264",
+  rose: "#fb7185",
+  amber: "#fbbf24",
+  violet: "#a78bfa",
+} as const
+
+type Tone = "muted" | "info" | "ok" | "warn" | "bad"
+
+const TONE_COLOR: Record<Tone, string> = {
+  muted: P.muted,
+  info: P.cyan,
+  ok: P.lime,
+  warn: P.amber,
+  bad: P.rose,
+}
+
+const TONE_ICON: Record<Tone, string> = {
+  muted: "·",
+  info: "→",
+  ok: "✓",
+  warn: "…",
+  bad: "✗",
+}
+
+const MAX_LOG_ROWS = 80
+const SELECTION_BG = "#264f78"
+const SELECTION_FG = "#ffffff"
+
+interface Status {
+  tone: Tone
+  text: string
+}
+
+interface Fixture {
+  name: string
+  short: string
+  purpose: string
+  payload: string
+}
+
+const FIXTURES: readonly Fixture[] = [
+  {
+    name: "Unicode + LF",
+    short: "Unicode + LF",
+    purpose: "UTF-8 decoding and multiline insertion",
+    payload: "OpenTUI clipboard round-trip\nUnicode: 世界 café 🚀\nLine endings: LF\nEnd",
+  },
+  {
+    name: "CRLF + lone CR",
+    short: "CRLF + CR",
+    purpose: "Raw transport preserves CR; the editor normalizes to LF",
+    payload: "OpenTUI newline fixture\r\nCRLF line\rLone CR line\nLF line",
+  },
+  {
+    name: "ANSI text",
+    short: "ANSI",
+    purpose: "Raw event preserves ANSI; the textarea strips it on insertion",
+    payload: "OpenTUI ANSI fixture: \x1b[31mred\x1b[0m plain",
+  },
+  {
+    name: "Large (16 KiB)",
+    short: "Large 16 KiB",
+    purpose: "Exercises OSC 52 beyond the former fixed-buffer limit",
+    payload: `OpenTUI large OSC 52 payload\n${"0123456789abcdef".repeat(1024)}`,
+  },
+]
+
+const encoder = new TextEncoder()
+
+let container: BoxRenderable | null = null
+let tabsText: TextRenderable | null = null
+let fixtureText: TextRenderable | null = null
+let editor: TextareaRenderable | null = null
+let checksText: TextRenderable | null = null
+let logList: ScrollBoxRenderable | null = null
+let logRows: TextRenderable[] = []
+let logRowId = 0
+let keypressHandler: ((event: KeyEvent) => void) | null = null
+let pasteHandler: ((event: PasteEvent) => void) | null = null
+let capabilityHandler: (() => void) | null = null
+let selectionHandler: ((selection: Selection) => void) | null = null
+let selectedFixture = 0
+let fixturePayloadEmitted = false
+let lastLoggedCapability = ""
+let copyStatus: Status = { tone: "muted", text: "not attempted" }
+let pasteStatus: Status = { tone: "muted", text: "waiting for a PasteEvent" }
+let editorStatus: Status = { tone: "muted", text: "waiting for default insertion" }
+let roundTripStatus: Status = { tone: "muted", text: "not evaluated" }
+
+function fixture(): Fixture {
+  return FIXTURES[selectedFixture]!
+}
+
+function normalizeNewlines(value: string): string {
+  return value.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+}
+
+function escapedPreview(value: string, maxLength = 64): string {
+  const escaped = JSON.stringify(value)
+  return escaped.length <= maxLength ? escaped : `${escaped.slice(0, maxLength - 3)}...`
+}
+
+function byteLength(value: string): number {
+  return encoder.encode(value).length
+}
+
+function hexPrefix(bytes: Uint8Array, count = 12): string {
+  const slice = bytes.slice(0, count)
+  const hex = Array.from(slice, (byte) => byte.toString(16).padStart(2, "0")).join("")
+  return bytes.length > count ? `${hex}…` : hex
+}
+
+function timestamp(): string {
+  const now = new Date()
+  const hh = `${now.getHours()}`.padStart(2, "0")
+  const mm = `${now.getMinutes()}`.padStart(2, "0")
+  const ss = `${now.getSeconds()}`.padStart(2, "0")
+  const ms = `${now.getMilliseconds()}`.padStart(3, "0")
+  return `${hh}:${mm}:${ss}.${ms}`
+}
+
+function capabilityStatus(renderer: CliRenderer): Status {
+  const capabilities = renderer.capabilities
+  if (!capabilities) return { tone: "muted", text: "detecting" }
+  const hint = capabilities.osc52 ? "yes" : "no"
+  switch (capabilities.osc52_support) {
+    case "supported":
+      return { tone: "ok", text: `supported — emits (legacy hint: ${hint})` }
+    case "unsupported":
+      return { tone: "bad", text: `unsupported — emission blocked (legacy hint: ${hint})` }
+    default:
+      return { tone: "warn", text: `unknown — emits optimistically (legacy hint: ${hint})` }
+  }
+}
+
+function metadataLabel(event: PasteEvent): string {
+  if (!event.metadata) return "meta absent"
+  return `meta kind=${event.metadata.kind ?? "unset"} mime=${event.metadata.mimeType ?? "unset"}`
+}
+
+function statusChunk(status: Status) {
+  return fg(TONE_COLOR[status.tone])(`${TONE_ICON[status.tone]} ${status.text}`)
+}
+
+function label(text: string) {
+  return fg(P.muted)(text.padEnd(12))
+}
+
+function addLog(renderer: CliRenderer, tone: Tone, message: string, detail?: string): void {
+  if (!logList) return
+
+  const row = new TextRenderable(renderer, {
+    id: `clipboard-paste-log-${logRowId++}`,
+    content: t`${fg(P.muted)(timestamp())} ${fg(TONE_COLOR[tone])(`${TONE_ICON[tone]} ${message}`)}`,
+    flexGrow: 0,
+    flexShrink: 0,
+    selectionBg: SELECTION_BG,
+    selectionFg: SELECTION_FG,
+  })
+  logList.add(row)
+  logRows.push(row)
+
+  if (detail) {
+    const detailRow = new TextRenderable(renderer, {
+      id: `clipboard-paste-log-${logRowId++}`,
+      content: t`${fg(P.muted)(`             ${detail}`)}`,
+      flexGrow: 0,
+      flexShrink: 0,
+      selectionBg: SELECTION_BG,
+      selectionFg: SELECTION_FG,
+    })
+    logList.add(detailRow)
+    logRows.push(detailRow)
+  }
+
+  while (logRows.length > MAX_LOG_ROWS) {
+    const oldRow = logRows.shift()
+    oldRow?.destroyRecursively()
+  }
+}
+
+function updateTabs(): void {
+  if (!tabsText) return
+  const chunks = FIXTURES.map((entry, index) => {
+    const text = ` ${index + 1} ${entry.short} `
+    return index === selectedFixture ? bg(P.cyan)(fg(P.bg)(bold(text))) : fg(P.muted)(text)
+  })
+  tabsText.content = t`${chunks[0]!} ${chunks[1]!} ${chunks[2]!} ${chunks[3]!}`
+}
+
+function updateFixturePanel(): void {
+  if (!fixtureText) return
+  const current = fixture()
+  fixtureText.content = t`${bold(fg(P.text)(current.name))} ${fg(P.muted)(`— ${byteLength(current.payload)} UTF-8 bytes`)}
+${label("Purpose")} ${fg(P.text)(current.purpose)}
+${label("Expected")} ${fg(P.violet)(escapedPreview(current.payload))}`
+}
+
+function updateChecks(renderer: CliRenderer): void {
+  if (!checksText) return
+  const capability = capabilityStatus(renderer)
+  checksText.content = t`${label("Capability")} ${statusChunk(capability)}
+${label("Copy OSC 52")} ${statusChunk(copyStatus)}
+${label("Paste event")} ${statusChunk(pasteStatus)}
+${label("Editor text")} ${statusChunk(editorStatus)}
+${label("Round trip")} ${statusChunk(roundTripStatus)}`
+}
+
+function resetTest(renderer: CliRenderer, reason: string): void {
+  editor?.setText("")
+  fixturePayloadEmitted = false
+  copyStatus = { tone: "muted", text: "not attempted" }
+  pasteStatus = { tone: "muted", text: "waiting for a PasteEvent" }
+  editorStatus = { tone: "muted", text: "waiting for default insertion" }
+  roundTripStatus = { tone: "muted", text: "not evaluated" }
+  updateTabs()
+  updateFixturePanel()
+  updateChecks(renderer)
+  editor?.focus()
+  addLog(renderer, "muted", `${reason} — editor cleared, checks idle`)
+}
+
+function panel(renderer: CliRenderer, id: string, title: string, height?: number): BoxRenderable {
+  return new BoxRenderable(renderer, {
+    id,
+    title: ` ${title} `,
+    titleAlignment: "left",
+    border: true,
+    borderStyle: "rounded",
+    borderColor: P.border,
+    backgroundColor: P.panel,
+    paddingLeft: 1,
+    paddingRight: 1,
+    ...(height === undefined ? {} : { height }),
+  })
+}
+
+export function run(renderer: CliRenderer): void {
+  renderer.setBackgroundColor(P.bg)
+
+  container = new BoxRenderable(renderer, {
+    id: "clipboard-paste-container",
+    width: "100%",
+    height: "100%",
+    padding: 1,
+    flexDirection: "column",
+    backgroundColor: P.bg,
+  })
+
+  const header = new TextRenderable(renderer, {
+    id: "clipboard-paste-header",
+    height: 2,
+    marginBottom: 1,
+    content: t`${bold(fg(P.cyan)("CLIPBOARD + PASTE TEST BED"))} ${fg(P.muted)("— OSC 52 → PasteEvent → textarea")}
+${bold(fg(P.amber)("1-4"))} ${fg(P.muted)("fixture")}  ${bold(fg(P.amber)("Ctrl+Y"))} ${fg(P.muted)("copy")}  ${bold(fg(P.amber)("Ctrl+K"))} ${fg(P.muted)("clear")}  ${bold(fg(P.amber)("Ctrl+R"))} ${fg(P.muted)("reset")}  ${bold(fg(P.amber)("drag-select"))} ${fg(P.muted)("copies via OSC 52")}`,
+  })
+
+  tabsText = new TextRenderable(renderer, {
+    id: "clipboard-paste-tabs",
+    height: 1,
+    content: "",
+  })
+
+  const fixturePanel = panel(renderer, "clipboard-paste-fixture-panel", "Fixture", 5)
+  fixturePanel.marginBottom = 1
+  fixtureText = new TextRenderable(renderer, {
+    id: "clipboard-paste-fixture",
+    content: "",
+    selectionBg: SELECTION_BG,
+    selectionFg: SELECTION_FG,
+  })
+  fixturePanel.add(fixtureText)
+
+  const editorPanel = new BoxRenderable(renderer, {
+    id: "clipboard-paste-editor-box",
+    title: " Paste target ",
+    titleAlignment: "left",
+    border: true,
+    borderStyle: "rounded",
+    borderColor: P.borderHot,
+    backgroundColor: P.panel,
+    paddingLeft: 1,
+    paddingRight: 1,
+    height: 6,
+    marginBottom: 1,
+  })
+
+  editor = new TextareaRenderable(renderer, {
+    id: "clipboard-paste-editor",
+    width: "100%",
+    height: "100%",
+    placeholder: "Paste here... (Ctrl+R resets before an exact editor check)",
+    textColor: P.text,
+    backgroundColor: P.panel,
+    focusedBackgroundColor: P.panel,
+    cursorColor: P.amber,
+    wrapMode: "word",
+  })
+  editorPanel.add(editor)
+
+  const checksPanel = panel(renderer, "clipboard-paste-checks-panel", "Checks", 7)
+  checksPanel.marginBottom = 1
+  checksText = new TextRenderable(renderer, {
+    id: "clipboard-paste-checks",
+    content: "",
+    selectionBg: SELECTION_BG,
+    selectionFg: SELECTION_FG,
+  })
+  checksPanel.add(checksText)
+
+  const logPanel = new BoxRenderable(renderer, {
+    id: "clipboard-paste-log-panel",
+    title: " Events ",
+    titleAlignment: "left",
+    border: true,
+    borderStyle: "rounded",
+    borderColor: P.border,
+    backgroundColor: P.panel,
+    paddingLeft: 1,
+    paddingRight: 1,
+    flexGrow: 1,
+    flexShrink: 1,
+    minHeight: 5,
+    flexDirection: "column",
+  })
+
+  logList = new ScrollBoxRenderable(renderer, {
+    id: "clipboard-paste-log-list",
+    stickyScroll: true,
+    stickyStart: "bottom",
+    rootOptions: { backgroundColor: P.panel, border: false },
+    wrapperOptions: { backgroundColor: P.panel },
+    viewportOptions: { backgroundColor: P.panel },
+    contentOptions: { backgroundColor: P.panel },
+    scrollbarOptions: {
+      trackOptions: {
+        foregroundColor: P.cyan,
+        backgroundColor: P.border,
+      },
+    },
+    height: "100%",
+    width: "auto",
+    flexGrow: 1,
+    flexShrink: 1,
+  })
+  logPanel.add(logList)
+
+  container.add(header)
+  container.add(tabsText)
+  container.add(fixturePanel)
+  container.add(editorPanel)
+  container.add(checksPanel)
+  container.add(logPanel)
+  renderer.root.add(container)
+
+  pasteHandler = (event) => {
+    const current = fixture()
+    const pasted = decodePasteBytes(event.bytes)
+    const exact = pasted === current.payload
+    const normalized = normalizeNewlines(pasted) === normalizeNewlines(current.payload)
+    pasteStatus = exact
+      ? { tone: "ok", text: `raw and normalized match — ${event.bytes.length} bytes` }
+      : normalized
+        ? { tone: "warn", text: `normalized match only — raw differs (${event.bytes.length} bytes)` }
+        : { tone: "bad", text: `no fixture match — ${event.bytes.length} bytes` }
+    roundTripStatus =
+      fixturePayloadEmitted && exact
+        ? { tone: "ok", text: "observed after emission (terminal acceptance unacknowledged)" }
+        : { tone: "warn", text: "not established — needs emission plus an exact raw match" }
+    editorStatus = { tone: "warn", text: "pending default focused-renderable handling" }
+    updateChecks(renderer)
+    addLog(
+      renderer,
+      pasteStatus.tone,
+      `paste ← ${event.bytes.length} B · ${metadataLabel(event)} · raw ${exact ? "✓" : "✗"} norm ${normalized ? "✓" : "✗"}`,
+      `${escapedPreview(pasted, 44)} · hex ${hexPrefix(event.bytes, 8)}`,
+    )
+
+    queueMicrotask(() => {
+      if (!editor || editor.isDestroyed) return
+      const expected = normalizeNewlines(stripAnsiSequences(current.payload))
+      const pass = editor.plainText === expected
+      editorStatus = pass
+        ? { tone: "ok", text: `matches expected editor text — ${byteLength(editor.plainText)} bytes retained` }
+        : {
+            tone: "bad",
+            text: `expected ${byteLength(expected)} bytes, retained ${byteLength(editor.plainText)} — ${escapedPreview(editor.plainText, 36)}`,
+          }
+      updateChecks(renderer)
+      addLog(
+        renderer,
+        pass ? "ok" : "bad",
+        pass
+          ? `editor retained ${byteLength(editor.plainText)} B (ANSI stripped, newlines normalized)`
+          : `editor mismatch — expected ${byteLength(expected)} B, retained ${byteLength(editor.plainText)} B`,
+      )
+    })
+  }
+
+  keypressHandler = (event) => {
+    if (!event.ctrl && /^[1-4]$/.test(event.name)) {
+      event.preventDefault()
+      selectedFixture = Number(event.name) - 1
+      const current = fixture()
+      resetTest(renderer, `fixture → ${selectedFixture + 1} ${current.name} (${byteLength(current.payload)} B)`)
+      return
+    }
+
+    if (event.ctrl && event.name === "y") {
+      event.preventDefault()
+      const current = fixture()
+      const emitted = renderer.copyToClipboardOSC52(current.payload)
+      fixturePayloadEmitted = emitted
+      copyStatus = emitted
+        ? { tone: "info", text: `emitted ${byteLength(current.payload)} UTF-8 bytes` }
+        : { tone: "bad", text: "local emission failed" }
+      roundTripStatus = emitted
+        ? { tone: "warn", text: "waiting for an exact paste after emission" }
+        : { tone: "muted", text: "not evaluated" }
+      updateChecks(renderer)
+      addLog(
+        renderer,
+        emitted ? "info" : "bad",
+        emitted
+          ? `osc52 copy → emitted ${byteLength(current.payload)} B (default clipboard target)`
+          : "osc52 copy → local emission failed",
+      )
+      return
+    }
+
+    if (event.ctrl && event.name === "k") {
+      event.preventDefault()
+      fixturePayloadEmitted = false
+      const emitted = renderer.clearClipboardOSC52()
+      copyStatus = emitted
+        ? { tone: "info", text: "emitted clear request" }
+        : { tone: "bad", text: "clear emission failed" }
+      roundTripStatus = { tone: "muted", text: "not applicable to clear requests" }
+      updateChecks(renderer)
+      addLog(renderer, emitted ? "info" : "bad", emitted ? "osc52 clear → emitted" : "osc52 clear → emission failed")
+      return
+    }
+
+    if (event.ctrl && event.name === "r") {
+      event.preventDefault()
+      resetTest(renderer, "reset")
+    }
+  }
+
+  capabilityHandler = () => {
+    updateChecks(renderer)
+    const capabilities = renderer.capabilities
+    if (!capabilities) return
+    const snapshot = `${capabilities.osc52_support}/${capabilities.osc52 ? "hint-yes" : "hint-no"}`
+    if (snapshot !== lastLoggedCapability) {
+      lastLoggedCapability = snapshot
+      addLog(
+        renderer,
+        "info",
+        `capabilities → osc52_support=${capabilities.osc52_support} legacy-hint=${capabilities.osc52 ? "yes" : "no"}`,
+      )
+    }
+  }
+
+  selectionHandler = (selection) => {
+    if (selection.isDragging) return
+    const text = selection.getSelectedText()
+    if (!text || text.trim().length === 0) return
+
+    renderer.clearSelection()
+    const emitted = renderer.copyToClipboardOSC52(text)
+    if (emitted) {
+      fixturePayloadEmitted = false
+      copyStatus = { tone: "info", text: `emitted selection (${byteLength(text)} UTF-8 bytes)` }
+      if (roundTripStatus.text.startsWith("waiting")) {
+        roundTripStatus = { tone: "muted", text: "superseded by selection copy" }
+      }
+    } else {
+      copyStatus = { tone: "bad", text: "selection copy emission failed" }
+    }
+    updateChecks(renderer)
+    addLog(
+      renderer,
+      emitted ? "info" : "bad",
+      emitted ? `selection copy → emitted ${byteLength(text)} B` : "selection copy → local emission failed",
+      escapedPreview(text, 56),
+    )
+  }
+
+  renderer.on(CliRenderEvents.CAPABILITIES, capabilityHandler)
+  renderer.on(CliRenderEvents.SELECTION, selectionHandler)
+  renderer.keyInput.on("paste", pasteHandler)
+  renderer.keyInput.on("keypress", keypressHandler)
+  resetTest(renderer, "ready")
+}
+
+export function destroy(renderer: CliRenderer): void {
+  if (pasteHandler) renderer.keyInput.off("paste", pasteHandler)
+  if (keypressHandler) renderer.keyInput.off("keypress", keypressHandler)
+  if (capabilityHandler) renderer.off(CliRenderEvents.CAPABILITIES, capabilityHandler)
+  if (selectionHandler) renderer.off(CliRenderEvents.SELECTION, selectionHandler)
+  renderer.clearSelection()
+  container?.destroyRecursively()
+  container = null
+  tabsText = null
+  fixtureText = null
+  editor = null
+  checksText = null
+  logList = null
+  logRows = []
+  logRowId = 0
+  lastLoggedCapability = ""
+  pasteHandler = null
+  keypressHandler = null
+  capabilityHandler = null
+  selectionHandler = null
+}
+
+if (import.meta.main) {
+  const renderer = await createCliRenderer({
+    exitOnCtrlC: true,
+    targetFps: 30,
+  })
+  run(renderer)
+  setupCommonDemoKeys(renderer)
+}

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -70,6 +70,7 @@ import { setupCommonDemoKeys } from "./lib/standalone-keys.js"
 import * as corePluginSlotsDemo from "./core-plugin-slots-demo.js"
 import * as wideGraphemeOverlayDemo from "./wide-grapheme-overlay-demo.js"
 import * as nativeAudioDemo from "./native-audio-demo.js"
+import * as clipboardPasteDemo from "./clipboard-paste-demo.js"
 
 type ExampleCategory =
   | "Layout & Composition"
@@ -571,6 +572,13 @@ const EXAMPLE_SECTIONS: ExampleSection[] = [
       description: "WAV-based native mixer with sound groups and live meter stats",
       run: nativeAudioDemo.run,
       destroy: nativeAudioDemo.destroy,
+    },
+    {
+      name: "Clipboard & Paste Test Bed",
+      description:
+        "OSC 52 copy, paste transport, and editor semantics diagnostics with a selectable, copyable event log",
+      run: clipboardPasteDemo.run,
+      destroy: clipboardPasteDemo.destroy,
     },
     {
       name: "Focus Restore Demo",


### PR DESCRIPTION
Treat missing or negative replies as inconclusive so clipboard writes remain
available unless support is explicitly rejected. Stream large payloads through
tmux and bounded GNU Screen frames to avoid fixed-buffer failures.
