### PR TITLE
fix(core): keep detached TextNode renders from being silently dropped

### DIFF
--- a/packages/core/src/renderables/TextNode.test.ts
+++ b/packages/core/src/renderables/TextNode.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test"
-import { TextNodeRenderable, isTextNodeRenderable } from "./TextNode.js"
+import { TextNodeRenderable, RootTextNodeRenderable, isTextNodeRenderable } from "./TextNode.js"
+import type { RenderContext } from "../types.js"
+import type { TextRenderable } from "./Text.js"
 import { RGBA } from "../lib/RGBA.js"
 import { StyledText, red, bold, t } from "../lib/styled-text.js"
 
@@ -1079,5 +1081,67 @@ describe("TextNodeRenderable", () => {
       // Verify correct position
       expect(root.children.indexOf(insertChild)).toBe(4)
     })
+  })
+})
+
+describe("TextNodeRenderable render request propagation", () => {
+  function makeCtx() {
+    let count = 0
+    const ctx = {
+      requestRender: () => {
+        count++
+      },
+    } as unknown as RenderContext
+    return { ctx, getCount: () => count }
+  }
+
+  function makeRoot(ctx: RenderContext) {
+    return new RootTextNodeRenderable(ctx, { id: "root" }, undefined as unknown as TextRenderable)
+  }
+
+  it("forwards a detached node's render request to the retained RenderContext", () => {
+    const { ctx, getCount } = makeCtx()
+    const root = makeRoot(ctx)
+
+    const child = new TextNodeRenderable({ id: "child" })
+    root.add(child)
+
+    // Simulate a transient detach during a list re-diff / reorder / re-key.
+    root.remove("child")
+    expect(child.parent).toBeNull()
+
+    // The detached node is still being mutated (e.g. streaming text deltas).
+    const before = getCount()
+    child.add("streamed delta")
+
+    // Without the ctx fallback this render request would be silently dropped.
+    expect(getCount()).toBeGreaterThan(before)
+  })
+
+  it("propagates the RenderContext to nested descendants so they self-heal when detached", () => {
+    const { ctx, getCount } = makeCtx()
+    const root = makeRoot(ctx)
+
+    const parent = new TextNodeRenderable({ id: "parent" })
+    const grandchild = new TextNodeRenderable({ id: "grandchild" })
+    parent.add(grandchild)
+    root.add(parent)
+
+    // Detach the whole subtree.
+    root.remove("parent")
+    expect(parent.parent).toBeNull()
+
+    const before = getCount()
+    grandchild.add("deep delta")
+    expect(getCount()).toBeGreaterThan(before)
+  })
+
+  it("does not reach the RenderContext for a node that was never attached", () => {
+    const { ctx, getCount } = makeCtx()
+    expect(typeof ctx.requestRender).toBe("function")
+
+    const orphan = new TextNodeRenderable({ id: "orphan" })
+    orphan.add("text")
+    expect(getCount()).toBe(0)
   })
 })

--- a/packages/core/src/renderables/TextNode.ts
+++ b/packages/core/src/renderables/TextNode.ts
@@ -40,6 +40,7 @@ export class TextNodeRenderable extends BaseRenderable {
   private _link?: { url: string }
   private _children: (string | TextNodeRenderable)[] = []
   public parent: TextNodeRenderable | null = null
+  protected _ctx?: RenderContext
 
   constructor(options: TextNodeOptions) {
     super(options)
@@ -61,7 +62,28 @@ export class TextNodeRenderable extends BaseRenderable {
 
   public requestRender(): void {
     this.markDirty()
-    this.parent?.requestRender()
+    if (this.parent) {
+      this.parent.requestRender()
+    } else {
+      // Detached (parent === null) but possibly still being mutated: fall back to
+      // the retained RenderContext so the render request is not silently dropped.
+      this._ctx?.requestRender()
+    }
+  }
+
+  /**
+   * Propagate the active RenderContext down this text-node subtree. The reference is
+   * retained even after the node is later detached (parent === null) so a still-updating
+   * detached node can keep reaching the renderer via requestRender().
+   */
+  protected setRenderContext(ctx: RenderContext | undefined): void {
+    if (this._ctx === ctx) return
+    this._ctx = ctx
+    for (const child of this._children) {
+      if (typeof child !== "string") {
+        child.setRenderContext(ctx)
+      }
+    }
   }
 
   public add(obj: TextNodeRenderable | StyledText | string, index?: number): number {
@@ -82,6 +104,7 @@ export class TextNodeRenderable extends BaseRenderable {
       if (index !== undefined) {
         this._children.splice(index, 0, obj)
         obj.parent = this
+        obj.setRenderContext(this._ctx)
         this.requestRender()
         return index
       }
@@ -89,6 +112,7 @@ export class TextNodeRenderable extends BaseRenderable {
       const insertIndex = this._children.length
       this._children.push(obj)
       obj.parent = this
+      obj.setRenderContext(this._ctx)
       this.requestRender()
       return insertIndex
     }
@@ -97,14 +121,20 @@ export class TextNodeRenderable extends BaseRenderable {
       const textNodes = styledTextToTextNodes(obj)
       if (index !== undefined) {
         this._children.splice(index, 0, ...textNodes)
-        textNodes.forEach((node) => (node.parent = this))
+        textNodes.forEach((node) => {
+          node.parent = this
+          node.setRenderContext(this._ctx)
+        })
         this.requestRender()
         return index
       }
 
       const insertIndex = this._children.length
       this._children.push(...textNodes)
-      textNodes.forEach((node) => (node.parent = this))
+      textNodes.forEach((node) => {
+        node.parent = this
+        node.setRenderContext(this._ctx)
+      })
       this.requestRender()
       return insertIndex
     }
@@ -116,6 +146,7 @@ export class TextNodeRenderable extends BaseRenderable {
     this._children[index] = obj
     if (typeof obj !== "string") {
       obj.parent = this
+      obj.setRenderContext(this._ctx)
     }
     this.requestRender()
   }
@@ -138,10 +169,14 @@ export class TextNodeRenderable extends BaseRenderable {
     } else if (isTextNodeRenderable(child)) {
       this._children.splice(anchorIndex, 0, child)
       child.parent = this
+      child.setRenderContext(this._ctx)
     } else if (child instanceof StyledText) {
       const textNodes = styledTextToTextNodes(child)
       this._children.splice(anchorIndex, 0, ...textNodes)
-      textNodes.forEach((node) => (node.parent = this))
+      textNodes.forEach((node) => {
+        node.parent = this
+        node.setRenderContext(this._ctx)
+      })
     } else {
       throw new Error("Child must be a string, TextNodeRenderable, or StyledText instance")
     }
@@ -316,6 +351,7 @@ export class RootTextNodeRenderable extends TextNodeRenderable {
   ) {
     super(options)
     this.textParent = textParent
+    this._ctx = ctx
   }
 
   public requestRender(): void {


### PR DESCRIPTION
Fixes #1147

`TextNodeRenderable.requestRender()` did `this.parent?.requestRender()`, which becomes a silent no-op exactly when a node is transiently detached (`parent === null`) while still being mutated — the normal state during a SolidJS `<For>`/`<Index>` re-key. The render request is lost, so streaming text can freeze mid-update until the tree rebuilds.

Each node now retains the active `RenderContext` (threaded down on every attach — `add`, `replace`, `insertBefore`, including the `StyledText` fan-out, and seeded in `RootTextNodeRenderable`). When `parent` is `null`, `requestRender()` falls back to that retained context, so a detached-but-still-updating node self-heals. A node that was never attached still reaches no context, and the attached happy path is unchanged.

### How I verified
- Added a `render request propagation` block to `TextNode.test.ts` (3 cases): a detached node forwards to its retained context; a nested descendant self-heals when the whole subtree is detached; a never-attached orphan never reaches a context.
- `bun test src/renderables/TextNode.test.ts` → 55 pass; broader `TextNode + Markdown` suites → 210 pass / 0 fail.
- Negative control: reverting only `TextNode.ts` makes the two behavioral tests fail (render request count plateaus at 2), confirming they guard the fix.
- `oxlint --deny-warnings` and `oxfmt --check` clean on the changed files.
