### PR TITLE
fix(core): skip letterspace after unknown glyphs in getCharacterPositions

### DIFF
--- a/packages/core/src/lib/ascii.font.test.ts
+++ b/packages/core/src/lib/ascii.font.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "bun:test"
+import { measureText, getCharacterPositions, fonts } from "./ascii.font.js"
+
+// "*" is not defined in the tiny font, so it exercises the unknown-character
+// fallback path that previously diverged between measureText/render and
+// getCharacterPositions.
+const FONT = "tiny" as keyof typeof fonts
+
+describe("ascii.font getCharacterPositions", () => {
+  test("last position matches measured width for known-only text", () => {
+    const text = "AB"
+    const positions = getCharacterPositions(text, FONT)
+    const { width } = measureText({ text, font: FONT })
+    expect(positions[positions.length - 1]).toBe(width)
+  })
+
+  test("does not drift after an unknown character", () => {
+    // Regression: unknown chars used to add letterspace in getCharacterPositions
+    // but not in measureText/renderFontToFrameBuffer, offsetting every glyph
+    // after the unknown char (here "*") by letterspace_size.
+    const text = "A*B"
+    const positions = getCharacterPositions(text, FONT)
+    const { width } = measureText({ text, font: FONT })
+
+    // The trailing position must equal the rendered/measured width.
+    expect(positions[positions.length - 1]).toBe(width)
+    // One position per character boundary, plus the leading 0.
+    expect(positions.length).toBe(text.length + 1)
+    // Positions are monotonically non-decreasing and never exceed the width.
+    for (let i = 1; i < positions.length; i++) {
+      expect(positions[i]).toBeGreaterThanOrEqual(positions[i - 1]!)
+      expect(positions[i]).toBeLessThanOrEqual(width)
+    }
+  })
+
+  test("stays aligned with multiple unknown characters", () => {
+    const text = "A* B*C"
+    const positions = getCharacterPositions(text, FONT)
+    const { width } = measureText({ text, font: FONT })
+    expect(positions[positions.length - 1]).toBe(width)
+  })
+})

--- a/packages/core/src/lib/ascii.font.ts
+++ b/packages/core/src/lib/ascii.font.ts
@@ -183,7 +183,10 @@ export function getCharacterPositions(text: string, font: keyof typeof fonts = "
 
     currentX += charWidth
 
-    if (i < text.length - 1) {
+    // Match measureText/renderFontToFrameBuffer: letterspace is only added after
+    // a rendered glyph. Unknown characters fall back to a blank advance without
+    // letterspace, so skip it here too to keep selection offsets aligned.
+    if (charDef && i < text.length - 1) {
       currentX += fontDef.letterspace_size
     }
 


### PR DESCRIPTION
`getCharacterPositions()` in `ascii.font.ts` added `letterspace_size` after every character, including unknown glyphs that fall back to a blank advance. But `measureText()` and `renderFontToFrameBuffer()` both skip letterspace for unknown characters. So any glyph following a character absent from the chosen font drifts by `letterspace_size`, and since these positions drive `ASCIIFontRenderable`'s selection highlight (startX/endX), selecting text containing an unknown character draws the highlight offset from the actual glyphs.

Repro (before): `measureText("A*B","tiny").width === 8`, but `getCharacterPositions("A*B","tiny")` returns `[0,4,6,9]` (last = 9). After the fix: `[0,4,6,8]`, matching the render.

Fix: gate the letterspace advance on `charDef` being defined, exactly as `measureText`/`renderFontToFrameBuffer` already do.

### How I verified
- New `ascii.font.test.ts` (3 cases) asserts the trailing `getCharacterPositions` value equals `measureText().width` for known-only `"AB"` (unchanged), `"A*B"` (regression), and `"A* B*C"` (multiple unknowns). `bun test src/lib/ascii.font.test.ts` → 3 pass.
- Negative control: reverting the gate fails 2/3 (drift = `letterspace_size` per unknown char); the known-only case still passes.
- `oxlint --deny-warnings` and `oxfmt --check` clean.
