### PR TITLE
Document SSH package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ This monorepo contains the following packages:
 - [`@opentui/three`](packages/three) - Three.js WebGPU renderer for OpenTUI.
 - [`@opentui/solid`](packages/solid) - The SolidJS reconciler for OpenTUI.
 - [`@opentui/react`](packages/react) - The React reconciler for OpenTUI.
+- [`@opentui/keymap`](packages/keymap) - Shared key binding, command, and sequence engine for OpenTUI and browser hosts.
+- [`@opentui/qrcode`](packages/qrcode) - QR code renderable and React/Solid adapters.
+- [`@opentui/ssh`](packages/ssh) - Serve OpenTUI apps over SSH.
 - [`@opentui/examples`](packages/examples) - Example browser and standalone examples executable build.
 
 ## Install
@@ -84,8 +87,8 @@ See the [Development Guide](packages/core/docs/development.md) for building, tes
 
 - [Website docs](https://opentui.com/docs/getting-started) - Guides and API references
 - [Development Guide](packages/core/docs/development.md) - Building, testing, and local dev linking
-- [Getting Started](packages/core/docs/getting-started.md) - API and usage guide
-- [Environment Variables](packages/core/docs/env-vars.md) - Configuration options
+- [Getting Started](packages/web/src/content/docs/getting-started.mdx) - API and usage guide
+- [Environment Variables](packages/web/src/content/docs/reference/env-vars.mdx) - Configuration options
 
 ## Showcase
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,11 +4,11 @@ OpenTUI is a native terminal UI core written in Zig with TypeScript bindings. Th
 
 ## Documentation
 
-- [Getting Started](docs/getting-started.md) - API and usage guide
+- [Getting Started](../../packages/web/src/content/docs/getting-started.mdx) - API and usage guide
 - [Development Guide](docs/development.md) - Building, testing, and contributing
-- [Tree-Sitter](docs/tree-sitter.md) - Syntax highlighting integration
-- [Renderables vs Constructs](docs/renderables-vs-constructs.md) - Understanding the component model
-- [Environment Variables](docs/env-vars.md) - Configuration options
+- [Tree-Sitter](../../packages/web/src/content/docs/reference/tree-sitter.mdx) - Syntax highlighting integration
+- [Renderables vs Constructs](../../packages/web/src/content/docs/core-concepts/renderables-vs-constructs.mdx) - Understanding the component model
+- [Environment Variables](../../packages/web/src/content/docs/reference/env-vars.mdx) - Configuration options
 
 ## Install
 

--- a/packages/ssh/README.md
+++ b/packages/ssh/README.md
@@ -2,6 +2,8 @@
 
 Serve OpenTUI apps over SSH.
 
+Website docs: https://opentui.com/docs/ssh/overview
+
 `@opentui/ssh` turns an incoming SSH session into a fully-wired OpenTUI
 [`CliRenderer`](../core) whose input/output is the SSH channel and whose
 dimensions track the client's PTY. What you render onto it is up to you — the

--- a/packages/web/src/content/SKILL.md
+++ b/packages/web/src/content/SKILL.md
@@ -41,7 +41,7 @@ Inside the OpenTUI repo, this skill root lives at `packages/web/src/content/`, s
 | `layout`, `flexbox`, `yoga`, `positioning`                 | `docs/core-concepts/layout.mdx`   |
 | `keyboard`, `input`, `keybindings`, `paste`, `focus`       | `docs/core-concepts/keyboard.mdx` |
 | `testing`, `test-renderer`, `snapshots`, `frames`          | `docs/core-concepts/testing.mdx`  |
-| `ssh`, `remote`, `server`, `host-key`, `authorized-keys`    | `docs/ssh/overview.mdx`           |
+| `ssh`, `remote`, `server`, `host-key`, `authorized-keys`   | `docs/ssh/overview.mdx`           |
 | `react`, `jsx`, `hooks`, `animation`, `testing`            | `docs/bindings/react.mdx`         |
 | `solid`, `signals`, `jsx`, `hooks`, `animation`, `testing` | `docs/bindings/solid.mdx`         |
 | `plugins`, `plugin`, `slots`, `registry`, `extensions`     | `docs/plugins/slots.mdx`          |

--- a/packages/web/src/content/SKILL.md
+++ b/packages/web/src/content/SKILL.md
@@ -21,6 +21,7 @@ Inside the OpenTUI repo, this skill root lives at `packages/web/src/content/`, s
 - Testing: `/docs/core-concepts/testing`
 - Audio: `/docs/core-concepts/audio`
 - Keymap: `/docs/keymap/overview`
+- SSH: `/docs/ssh/overview`
 - React: `/docs/bindings/react`
 - Solid: `/docs/bindings/solid`
 - Components: `/docs/components/text`, `/docs/components/input`
@@ -40,6 +41,7 @@ Inside the OpenTUI repo, this skill root lives at `packages/web/src/content/`, s
 | `layout`, `flexbox`, `yoga`, `positioning`                 | `docs/core-concepts/layout.mdx`   |
 | `keyboard`, `input`, `keybindings`, `paste`, `focus`       | `docs/core-concepts/keyboard.mdx` |
 | `testing`, `test-renderer`, `snapshots`, `frames`          | `docs/core-concepts/testing.mdx`  |
+| `ssh`, `remote`, `server`, `host-key`, `authorized-keys`    | `docs/ssh/overview.mdx`           |
 | `react`, `jsx`, `hooks`, `animation`, `testing`            | `docs/bindings/react.mdx`         |
 | `solid`, `signals`, `jsx`, `hooks`, `animation`, `testing` | `docs/bindings/solid.mdx`         |
 | `plugins`, `plugin`, `slots`, `registry`, `extensions`     | `docs/plugins/slots.mdx`          |
@@ -55,6 +57,7 @@ For concrete component requests, jump straight to `docs/components/<name>.mdx` a
 - `docs/core-concepts/renderer.mdx`
 - `docs/core-concepts/audio.mdx`
 - `docs/keymap/overview.mdx`
+- `docs/ssh/overview.mdx`
 - `docs/core-concepts/layout.mdx`
 - `docs/core-concepts/keyboard.mdx`
 - `docs/bindings/react.mdx`

--- a/packages/web/src/content/docs/getting-started.mdx
+++ b/packages/web/src/content/docs/getting-started.mdx
@@ -103,3 +103,9 @@ separate repositories.
 
 - [React](/docs/bindings/react)
 - [Solid.js](/docs/bindings/solid)
+
+### Extension packages
+
+- [Keymap](/docs/keymap/overview) - Shared shortcuts, commands, and key sequences
+- [SSH](/docs/ssh/overview) - Serve OpenTUI apps to SSH clients
+- [QR Code](/docs/components/qr-code) - Render scannable QR codes in terminal UIs

--- a/packages/web/src/content/docs/ssh/overview.mdx
+++ b/packages/web/src/content/docs/ssh/overview.mdx
@@ -60,19 +60,19 @@ ssh -p 2222 localhost
 
 The handler receives a `Session`:
 
-| Field | Description |
-| --- | --- |
-| `renderer` | `CliRenderer` bound to the SSH channel. Destroyed automatically on disconnect. |
-| `identity` | Auth result narrowed to the configured methods. |
-| `context` | Typed values contributed by upstream middleware. |
-| `term` | Client `TERM` value. |
-| `cols`, `rows` | Current terminal size. |
-| `hasPty` | Whether the client requested a PTY. |
-| `remoteAddress` | Client socket endpoint for logging, rate limiting, and policy. |
-| `onResize(cb)` | Runs after the renderer has already been resized. |
-| `onClose(cb)` | Runs when the client disconnects. Use it for app-owned cleanup. |
-| `write(data)` | Writes raw terminal bytes, bypassing frame diffing. |
-| `end()` | Force-closes this session. |
+| Field           | Description                                                                    |
+| --------------- | ------------------------------------------------------------------------------ |
+| `renderer`      | `CliRenderer` bound to the SSH channel. Destroyed automatically on disconnect. |
+| `identity`      | Auth result narrowed to the configured methods.                                |
+| `context`       | Typed values contributed by upstream middleware.                               |
+| `term`          | Client `TERM` value.                                                           |
+| `cols`, `rows`  | Current terminal size.                                                         |
+| `hasPty`        | Whether the client requested a PTY.                                            |
+| `remoteAddress` | Client socket endpoint for logging, rate limiting, and policy.                 |
+| `onResize(cb)`  | Runs after the renderer has already been resized.                              |
+| `onClose(cb)`   | Runs when the client disconnects. Use it for app-owned cleanup.                |
+| `write(data)`   | Writes raw terminal bytes, bypassing frame diffing.                            |
+| `end()`         | Force-closes this session.                                                     |
 
 Middleware receives a `MiddlewareSession` without `renderer`. The renderer is only created after the middleware chain authorizes the session.
 
@@ -134,14 +134,14 @@ createServer({
 
 Supported auth configs:
 
-| Config | Behavior |
-| --- | --- |
-| `auth: "open"` or omitted | No authentication. |
-| `publicKey: "any"` | Accept any verified public key and expose its fingerprint. |
-| `publicKey: { authorizedKeys }` | Allow keys from an `authorized_keys` path or string array. |
-| `publicKey: { allow }` | Run a dynamic allow/deny predicate after signature verification. |
-| `password` | Run a password predicate. |
-| `keyboardInteractive` | Run an SSH keyboard-interactive prompt flow. |
+| Config                          | Behavior                                                         |
+| ------------------------------- | ---------------------------------------------------------------- |
+| `auth: "open"` or omitted       | No authentication.                                               |
+| `publicKey: "any"`              | Accept any verified public key and expose its fingerprint.       |
+| `publicKey: { authorizedKeys }` | Allow keys from an `authorized_keys` path or string array.       |
+| `publicKey: { allow }`          | Run a dynamic allow/deny predicate after signature verification. |
+| `password`                      | Run a password predicate.                                        |
+| `keyboardInteractive`           | Run an SSH keyboard-interactive prompt flow.                     |
 
 Public-key auth verifies the client signature, so `publicKey: "any"` proves possession of the private key and identifies the session by fingerprint.
 

--- a/packages/web/src/content/docs/ssh/overview.mdx
+++ b/packages/web/src/content/docs/ssh/overview.mdx
@@ -1,0 +1,203 @@
+---
+title: SSH
+description: Serve OpenTUI apps to SSH clients
+order: 1
+navTitle: Overview
+skill:
+  entry: true
+  intents: [ssh, remote, server, host-key, authorized-keys]
+---
+
+# SSH
+
+`@opentui/ssh` turns each incoming SSH shell session into a pre-wired OpenTUI `CliRenderer`. Input, output, terminal size, resize events, and disconnect teardown are bound to the SSH channel, so your app can render with the imperative core API, React, or Solid.
+
+Install the package with core:
+
+```bash
+bun add @opentui/core @opentui/ssh
+```
+
+Supported runtimes are Bun 1.3.0 and newer, and Node.js 26.3.0.
+
+## Minimal Server
+
+`createServer(config).serve(handler)` returns a startable server. Configuration such as auth, host keys, timeouts, limits, and error reporting belongs in `createServer()`. The per-session app handler belongs in `serve()`.
+
+```ts
+import { BoxRenderable, TextRenderable } from "@opentui/core"
+import { createServer } from "@opentui/ssh"
+
+const server = createServer({
+  hostKey: { path: "./host_key" },
+  auth: { publicKey: "any" },
+}).serve((session) => {
+  const box = new BoxRenderable(session.renderer, {
+    width: "100%",
+    height: "100%",
+    border: true,
+    borderStyle: "rounded",
+    justifyContent: "center",
+    alignItems: "center",
+  })
+
+  box.add(new TextRenderable(session.renderer, { content: `Hello, ${session.identity.username}!` }))
+  session.renderer.root.add(box)
+})
+
+await server.listen(2222)
+```
+
+Connect from another terminal:
+
+```bash
+ssh -p 2222 localhost
+```
+
+`listen(port = 2222, host = "127.0.0.1")` returns `{ host, port, fingerprints }`. Pass `0` for an ephemeral port, or a host like `0.0.0.0` when intentionally exposing the server outside localhost. If you listen on a non-loopback host without auth, the package logs a warning.
+
+## Session
+
+The handler receives a `Session`:
+
+| Field | Description |
+| --- | --- |
+| `renderer` | `CliRenderer` bound to the SSH channel. Destroyed automatically on disconnect. |
+| `identity` | Auth result narrowed to the configured methods. |
+| `context` | Typed values contributed by upstream middleware. |
+| `term` | Client `TERM` value. |
+| `cols`, `rows` | Current terminal size. |
+| `hasPty` | Whether the client requested a PTY. |
+| `remoteAddress` | Client socket endpoint for logging, rate limiting, and policy. |
+| `onResize(cb)` | Runs after the renderer has already been resized. |
+| `onClose(cb)` | Runs when the client disconnects. Use it for app-owned cleanup. |
+| `write(data)` | Writes raw terminal bytes, bypassing frame diffing. |
+| `end()` | Force-closes this session. |
+
+Middleware receives a `MiddlewareSession` without `renderer`. The renderer is only created after the middleware chain authorizes the session.
+
+## Framework Hand-Offs
+
+The SSH package depends on `@opentui/core`, not on React or Solid. Framework roots adopt the renderer supplied by the session.
+
+### Imperative
+
+```ts
+import { BoxRenderable } from "@opentui/core"
+import { createServer } from "@opentui/ssh"
+
+createServer().serve((session) => {
+  session.renderer.root.add(new BoxRenderable(session.renderer, { border: true }))
+})
+```
+
+### React
+
+```tsx
+import { createRoot } from "@opentui/react"
+import { createServer } from "@opentui/ssh"
+
+createServer().serve((session) => {
+  const root = createRoot(session.renderer)
+  root.render(<App name={session.identity.username} />)
+  session.onClose(() => root.unmount())
+})
+```
+
+### Solid
+
+```tsx
+import { render } from "@opentui/solid"
+import { createServer } from "@opentui/ssh"
+
+createServer().serve(async (session) => {
+  await render(() => <App name={session.identity.username} />, session.renderer)
+})
+```
+
+## Auth
+
+Auth defaults to `"open"` for local development. Configure credential methods before exposing a server publicly:
+
+```ts
+createServer({
+  auth: {
+    publicKey: { authorizedKeys: "./authorized_keys" },
+    password: async ({ username, password }) => checkPassword(username, password),
+  },
+}).serve((session) => {
+  if (session.identity.method === "publickey") {
+    session.identity.fingerprint
+  }
+})
+```
+
+Supported auth configs:
+
+| Config | Behavior |
+| --- | --- |
+| `auth: "open"` or omitted | No authentication. |
+| `publicKey: "any"` | Accept any verified public key and expose its fingerprint. |
+| `publicKey: { authorizedKeys }` | Allow keys from an `authorized_keys` path or string array. |
+| `publicKey: { allow }` | Run a dynamic allow/deny predicate after signature verification. |
+| `password` | Run a password predicate. |
+| `keyboardInteractive` | Run an SSH keyboard-interactive prompt flow. |
+
+Public-key auth verifies the client signature, so `publicKey: "any"` proves possession of the private key and identifies the session by fingerprint.
+
+## Middleware
+
+Use `.use()` for cross-cutting session behavior: setup/teardown, gates, and context enrichment. Middleware runs in registration order, and `await next()` resolves when the session ends.
+
+```ts
+import { createServer, logging, type Middleware } from "@opentui/ssh"
+
+const requirePty: Middleware = (session, next) => {
+  if (!session.hasPty) session.deny("PTY required")
+  return next()
+}
+
+createServer({ auth: { publicKey: "any" } })
+  .use(logging())
+  .use(requirePty)
+  .use((session, next) => next({ startedAt: Date.now() }))
+  .serve((session) => {
+    session.context.startedAt
+    session.renderer.root
+  })
+```
+
+`logging()` is the built-in observability middleware. It emits connect and disconnect events, including duration, without replacing `onError`.
+
+## Host Keys And Shutdown
+
+Persist a host key in production so clients can verify the server identity:
+
+```ts
+createServer({
+  hostKey: { path: "./host_key" },
+}).serve(handler)
+```
+
+If the path is missing, the package generates and saves an ed25519 key. You can also provide PEM directly with `hostKey: { pem }`. Omitting `hostKey` creates an ephemeral key on each start, which is convenient for development but unsuitable for stable client trust.
+
+Use timeouts, session limits, and `close()` to bound server lifetime and resource use:
+
+```ts
+const server = createServer({
+  idleTimeout: "10m",
+  maxTimeout: "1h",
+  limits: {
+    session: {
+      perConnection: 1,
+      global: 100,
+    },
+  },
+  onError: (err) => console.error(err),
+}).serve(handler)
+
+await server.listen()
+await server.close()
+```
+
+For complete examples, see `packages/ssh/examples` and the package README at `packages/ssh/README.md`.

--- a/packages/web/src/lib/docs-index.ts
+++ b/packages/web/src/lib/docs-index.ts
@@ -8,6 +8,7 @@ export type DocSectionId =
   | "components"
   | "bindings"
   | "keymap"
+  | "ssh"
   | "reference"
 
 export interface SkillMetadata {
@@ -74,7 +75,8 @@ export const DOC_SECTION_CONFIG: Record<DocSectionId, { title: string; order: nu
   components: { title: "Components", order: 4 },
   bindings: { title: "Bindings", order: 5 },
   keymap: { title: "Keymap", order: 6 },
-  reference: { title: "Reference", order: 7 },
+  ssh: { title: "SSH", order: 7 },
+  reference: { title: "Reference", order: 8 },
 }
 
 let docsIndexPromise: Promise<DocsIndex> | undefined


### PR DESCRIPTION
Summary:
- Add a web docs SSH overview for @opentui/ssh, covering setup, sessions, framework hand-offs, auth, middleware, host keys, and shutdown.
- Add SSH to the web docs navigation/index and skill routing metadata.
- Update root/core/package READMEs so package listings and docs links include the current SSH and website docs surfaces.

Validation:
- bun run --cwd packages/web validate:docs
- git diff --check
