### PR TITLE
Add replayable test session recorder

### DIFF
--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -6,4 +6,11 @@ export * from "./testing/mock-tree-sitter-client.js"
 export * from "./testing/terminal-capabilities.js"
 export * from "./testing/spy.js"
 export { ManualClock } from "./testing/manual-clock.js"
-export { TestRecorder, type RecordedFrame } from "./testing/test-recorder.js"
+export {
+  TestRecorder,
+  type RecordedBuffers,
+  type RecordedFrame,
+  type RecordBuffersOptions,
+  type TestRecorderOptions,
+} from "./testing/test-recorder.js"
+export * from "./testing/test-session-recorder.js"

--- a/packages/core/src/testing/examples/test-session-recorder-demo-app.test.ts
+++ b/packages/core/src/testing/examples/test-session-recorder-demo-app.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+
+import { createTestRenderer } from "../test-renderer.js"
+import { replayTestSession, TestSessionRecorder } from "../test-session-recorder.js"
+import { mountTestSessionRecorderDemoApp } from "./test-session-recorder-demo-app.js"
+
+test("records and replays the minimal session recorder demo app", async () => {
+  const source = await createTestRenderer({ width: 32, height: 8 })
+  const sourceApp = mountTestSessionRecorderDemoApp(source.renderer)
+  const recorder = new TestSessionRecorder(source, {
+    metadata: { name: "minimal recorder demo" },
+    recordFrames: false,
+  })
+
+  try {
+    await source.renderOnce()
+
+    recorder.start()
+    await source.mockInput.typeText("abc")
+    await recorder.flush()
+    source.mockInput.pressBackspace()
+    await recorder.flush()
+    source.mockInput.pressEnter()
+    await recorder.flush()
+    recorder.checkpoint("submitted ab")
+    recorder.stop()
+
+    expect(sourceApp.getValue()).toBe("ab")
+    expect(recorder.session.steps.map((step) => step.type)).toEqual([
+      "stdin",
+      "stdin",
+      "stdin",
+      "wait",
+      "stdin",
+      "wait",
+      "stdin",
+      "wait",
+      "checkpoint",
+    ])
+  } finally {
+    if (recorder.isRecording) {
+      recorder.stop()
+    }
+    sourceApp.destroy()
+    source.renderer.destroy()
+  }
+
+  const target = await createTestRenderer({ width: 32, height: 8 })
+  const targetApp = mountTestSessionRecorderDemoApp(target.renderer)
+
+  try {
+    await target.renderOnce()
+    const replay = await replayTestSession(recorder.session, target, { assertCheckpoints: true })
+
+    expect(targetApp.getValue()).toBe("ab")
+    expect(replay.checkedCheckpoints).toBe(1)
+    expect(target.captureCharFrame()).toBe(recorder.session.finalFrame)
+  } finally {
+    targetApp.destroy()
+    target.renderer.destroy()
+  }
+})

--- a/packages/core/src/testing/examples/test-session-recorder-demo-app.ts
+++ b/packages/core/src/testing/examples/test-session-recorder-demo-app.ts
@@ -1,0 +1,79 @@
+import { CliRenderEvents, createCliRenderer, type CliRenderer } from "../../renderer.js"
+import { TextRenderable } from "../../renderables/Text.js"
+import type { KeyEvent } from "../../lib/KeyHandler.js"
+
+export interface TestSessionRecorderDemoApp {
+  text: TextRenderable
+  getValue: () => string
+  destroy: () => void
+}
+
+export function mountTestSessionRecorderDemoApp(renderer: CliRenderer): TestSessionRecorderDemoApp {
+  let value = ""
+  let submissions = 0
+
+  const text = new TextRenderable(renderer, {
+    id: "test-session-recorder-demo",
+    left: 0,
+    top: 0,
+    width: "100%",
+    height: 6,
+    content: "",
+  })
+
+  function update(): void {
+    text.content = [
+      "Test session recorder demo",
+      `Value: ${value || "(empty)"}`,
+      `Submitted: ${submissions}`,
+      `Size: ${renderer.width}x${renderer.height}`,
+      "Type text, Backspace deletes, Enter submits.",
+      "Press Ctrl+C to exit.",
+    ].join("\n")
+    text.requestRender()
+  }
+
+  function onKeyPress(key: KeyEvent): void {
+    if (key.name === "backspace") {
+      value = value.slice(0, -1)
+      update()
+      return
+    }
+
+    if (key.name === "return" || key.name === "linefeed") {
+      submissions++
+      update()
+      return
+    }
+
+    if (key.sequence.length === 1 && !key.ctrl && !key.meta) {
+      value += key.sequence
+      update()
+    }
+  }
+
+  function onResize(): void {
+    update()
+  }
+
+  renderer.root.add(text)
+  renderer.keyInput.on("keypress", onKeyPress)
+  renderer.on(CliRenderEvents.RESIZE, onResize)
+  update()
+
+  return {
+    text,
+    getValue: () => value,
+    destroy: () => {
+      renderer.keyInput.off("keypress", onKeyPress)
+      renderer.off(CliRenderEvents.RESIZE, onResize)
+      renderer.root.remove(text.id)
+    },
+  }
+}
+
+if (import.meta.main) {
+  const renderer = await createCliRenderer({ exitOnCtrlC: true })
+  mountTestSessionRecorderDemoApp(renderer)
+  renderer.start()
+}

--- a/packages/core/src/testing/test-session-recorder.test.ts
+++ b/packages/core/src/testing/test-session-recorder.test.ts
@@ -1,0 +1,229 @@
+import { Buffer } from "node:buffer"
+import { EventEmitter } from "node:events"
+
+import { describe, expect, test } from "bun:test"
+
+import type { TestRendererSetup } from "./test-renderer.js"
+import {
+  exportReplayTest,
+  replayTestSession,
+  TEST_SESSION_RECORDING_VERSION,
+  TestSessionRecorder,
+  type RecordedTestSession,
+} from "./test-session-recorder.js"
+
+interface FakeSetup extends TestRendererSetup {
+  emittedInput: Buffer[]
+  resizes: { width: number; height: number }[]
+  flushCount: number
+  frame: string
+}
+
+function createFakeSetup(width: number = 20, height: number = 6): FakeSetup {
+  const stdin = new EventEmitter() as NodeJS.ReadStream
+  const renderer = new EventEmitter() as TestRendererSetup["renderer"]
+  const emittedInput: Buffer[] = []
+  const resizes: { width: number; height: number }[] = []
+  let currentWidth = width
+  let currentHeight = height
+  let flushCount = 0
+  let frame = ""
+
+  stdin.on("data", (data: Buffer | string | Uint8Array) => {
+    const bytes = Buffer.isBuffer(data) ? Buffer.from(data) : Buffer.from(data)
+    emittedInput.push(bytes)
+    frame += bytes.toString("utf8")
+  })
+
+  Object.defineProperties(renderer, {
+    stdin: { value: stdin, configurable: true },
+    width: { get: () => currentWidth, configurable: true },
+    height: { get: () => currentHeight, configurable: true },
+  })
+
+  const setup = {
+    renderer,
+    mockInput: undefined,
+    mockMouse: undefined,
+    renderOnce: async () => {},
+    flush: async () => {
+      flushCount++
+    },
+    waitFor: async () => {},
+    waitForFrame: async () => frame,
+    waitForVisualIdle: async () => {
+      flushCount++
+    },
+    externalOutput: {
+      take: () => [],
+      takeText: () => "",
+      clear: () => {},
+    },
+    getNativeStats: () => ({}) as ReturnType<TestRendererSetup["getNativeStats"]>,
+    captureCharFrame: () => frame,
+    captureSpans: () => ({ cols: currentWidth, rows: currentHeight, cursor: [0, 0], lines: [] }),
+    resize: (nextWidth: number, nextHeight: number) => {
+      currentWidth = nextWidth
+      currentHeight = nextHeight
+      resizes.push({ width: nextWidth, height: nextHeight })
+    },
+    get emittedInput() {
+      return emittedInput
+    },
+    get resizes() {
+      return resizes
+    },
+    get flushCount() {
+      return flushCount
+    },
+    get frame() {
+      return frame
+    },
+    set frame(value: string) {
+      frame = value
+    },
+  }
+
+  return setup as unknown as FakeSetup
+}
+
+describe("TestSessionRecorder", () => {
+  test("records stdin emitted through the renderer stdin stream", () => {
+    const setup = createFakeSetup()
+    const recorder = new TestSessionRecorder(setup, { recordFrames: false, now: () => 10 })
+
+    recorder.start()
+    setup.renderer.stdin.emit("data", Buffer.from("a"))
+    setup.renderer.stdin.emit("data", Buffer.from("\r"))
+    recorder.stop()
+
+    const session = recorder.session
+    expect(session.version).toBe(TEST_SESSION_RECORDING_VERSION)
+    expect(session.steps.map((step) => step.type)).toEqual(["stdin", "stdin"])
+    expect(session.steps[0]).toMatchObject({ type: "stdin", dataText: "a" })
+    expect(session.steps[1]).toMatchObject({ type: "stdin", dataText: "\r" })
+    expect(session.finalFrame).toBe("a\r")
+  })
+
+  test("records resize calls made through the test renderer setup", () => {
+    const setup = createFakeSetup(10, 4)
+    const recorder = new TestSessionRecorder(setup, { recordFrames: false })
+
+    recorder.start()
+    setup.resize(40, 12)
+    recorder.stop()
+
+    expect(setup.resizes).toEqual([{ width: 40, height: 12 }])
+    expect(recorder.session.steps).toContainEqual(expect.objectContaining({ type: "resize", width: 40, height: 12 }))
+  })
+
+  test("records explicit waits and checkpoints", async () => {
+    const setup = createFakeSetup()
+    const recorder = new TestSessionRecorder(setup, { recordFrames: false })
+
+    recorder.start()
+    setup.renderer.stdin.emit("data", Buffer.from("hello"))
+    await recorder.flush()
+    const checkpoint = recorder.checkpoint("typed hello")
+    recorder.stop()
+
+    expect(checkpoint.frame).toBe("hello")
+    expect(recorder.session.steps.map((step) => step.type)).toEqual(["stdin", "wait", "checkpoint"])
+    expect(setup.flushCount).toBe(1)
+  })
+
+  test("supports custom clocks that start at zero", () => {
+    const setup = createFakeSetup()
+    let time = 0
+    const recorder = new TestSessionRecorder(setup, { recordFrames: false, now: () => time })
+
+    recorder.start()
+    time = 25
+    setup.renderer.stdin.emit("data", Buffer.from("x"))
+    recorder.stop()
+
+    expect(recorder.session.steps[0]).toMatchObject({ type: "stdin", timestamp: 25 })
+    expect(recorder.session.duration).toBe(25)
+  })
+
+  test("preserves an empty final frame captured at stop", () => {
+    const setup = createFakeSetup()
+    const recorder = new TestSessionRecorder(setup, { recordFrames: false })
+
+    recorder.start()
+    recorder.stop()
+    setup.frame = "changed after stop"
+
+    expect(recorder.session.finalFrame).toBe("")
+  })
+
+  test("restores patched stdin and resize functions after stop", () => {
+    const setup = createFakeSetup()
+    const originalEmit = setup.renderer.stdin.emit
+    const originalResize = setup.resize
+    const recorder = new TestSessionRecorder(setup, { recordFrames: false })
+
+    recorder.start()
+    expect(setup.renderer.stdin.emit).not.toBe(originalEmit)
+    expect(setup.resize).not.toBe(originalResize)
+
+    recorder.stop()
+    expect(setup.renderer.stdin.emit).toBe(originalEmit)
+    expect(setup.resize).toBe(originalResize)
+  })
+
+  test("replays stdin and resize steps", async () => {
+    const source = createFakeSetup(20, 6)
+    const recorder = new TestSessionRecorder(source, { recordFrames: false })
+
+    recorder.start()
+    source.renderer.stdin.emit("data", Buffer.from("abc"))
+    source.resize(30, 8)
+    recorder.stop()
+
+    const target = createFakeSetup(20, 6)
+    const result = await replayTestSession(recorder.session, target, { flushAtEnd: false })
+
+    expect(Buffer.concat(target.emittedInput).toString("utf8")).toBe("abc")
+    expect(target.resizes).toEqual([{ width: 30, height: 8 }])
+    expect(result.finalFrame).toBe("abc")
+    expect(result.replayedSteps).toBe(2)
+  })
+
+  test("can assert recorded checkpoints during replay", async () => {
+    const setup = createFakeSetup()
+    const session: RecordedTestSession = {
+      version: TEST_SESSION_RECORDING_VERSION,
+      width: 20,
+      height: 6,
+      duration: 0,
+      steps: [
+        { type: "stdin", timestamp: 0, dataBase64: Buffer.from("ok").toString("base64"), dataText: "ok" },
+        { type: "checkpoint", timestamp: 0, name: "ok frame", frameNumber: 0, frame: "ok" },
+      ],
+      finalFrame: "ok",
+    }
+
+    const result = await replayTestSession(session, setup, { assertCheckpoints: true, flushAtEnd: false })
+    expect(result.checkedCheckpoints).toBe(1)
+  })
+
+  test("exports a replayable Bun test file", () => {
+    const session: RecordedTestSession = {
+      version: TEST_SESSION_RECORDING_VERSION,
+      width: 20,
+      height: 6,
+      duration: 0,
+      steps: [],
+      metadata: { name: "replay smoke" },
+      finalFrame: "",
+    }
+
+    const source = exportReplayTest(session, { setupCode: "  await mountApp(setup.renderer)\n" })
+
+    expect(source).toContain('import { test, expect } from "bun:test"')
+    expect(source).toContain("createTestRenderer")
+    expect(source).toContain("await mountApp(setup.renderer)")
+    expect(source).toContain("expect(setup.captureCharFrame()).toBe(session.finalFrame)")
+  })
+})

--- a/packages/core/src/testing/test-session-recorder.ts
+++ b/packages/core/src/testing/test-session-recorder.ts
@@ -1,0 +1,574 @@
+import { Buffer } from "node:buffer"
+
+import { CliRenderEvents, type CliRendererFrameEvent } from "../renderer.js"
+import type { TestRendererSetup, TestVisualIdleOptions } from "./test-renderer.js"
+
+export const TEST_SESSION_RECORDING_VERSION = 1 as const
+
+export type RecordedTestSessionVersion = typeof TEST_SESSION_RECORDING_VERSION
+export type CapturedSessionSpans = ReturnType<TestRendererSetup["captureSpans"]>
+
+export interface RecordedTestSessionMetadata {
+  name?: string
+  tags?: string[]
+  source?: string
+  [key: string]: unknown
+}
+
+export interface RecordedSessionBaseStep {
+  timestamp: number
+}
+
+export interface RecordedSessionInputStep extends RecordedSessionBaseStep {
+  type: "stdin"
+  dataBase64: string
+  dataText?: string
+}
+
+export interface RecordedSessionResizeStep extends RecordedSessionBaseStep {
+  type: "resize"
+  width: number
+  height: number
+}
+
+export interface RecordedSessionWaitStep extends RecordedSessionBaseStep {
+  type: "wait"
+  kind: "flush" | "visual-idle"
+  options?: TestVisualIdleOptions
+}
+
+export interface RecordedSessionFrameStep extends RecordedSessionBaseStep {
+  type: "frame"
+  frame: string
+  frameNumber: number
+  frameId?: number
+  spans?: CapturedSessionSpans
+}
+
+export interface RecordedSessionCheckpointStep extends RecordedSessionBaseStep {
+  type: "checkpoint"
+  name?: string
+  frame: string
+  frameNumber: number
+  spans?: CapturedSessionSpans
+}
+
+export interface RecordedSessionNoteStep extends RecordedSessionBaseStep {
+  type: "note"
+  message: string
+}
+
+export type RecordedSessionStep =
+  | RecordedSessionInputStep
+  | RecordedSessionResizeStep
+  | RecordedSessionWaitStep
+  | RecordedSessionFrameStep
+  | RecordedSessionCheckpointStep
+  | RecordedSessionNoteStep
+
+export interface RecordedTestSession {
+  version: RecordedTestSessionVersion
+  width: number
+  height: number
+  duration: number
+  steps: RecordedSessionStep[]
+  metadata?: RecordedTestSessionMetadata
+  finalFrame: string
+  finalSpans?: CapturedSessionSpans
+}
+
+export interface TestSessionRecorderOptions {
+  metadata?: RecordedTestSessionMetadata
+  recordFrames?: boolean
+  recordSpans?: boolean
+  frameLimit?: number
+  now?: () => number
+}
+
+export interface TestSessionRecorderStartOptions {
+  clear?: boolean
+}
+
+export interface ReplayTestSessionOptions {
+  flushAfterInput?: boolean
+  flushAfterResize?: boolean
+  flushAtEnd?: boolean
+  assertCheckpoints?: boolean
+  onStep?: (step: RecordedSessionStep, index: number) => void | Promise<void>
+}
+
+export interface ReplayTestSessionResult {
+  finalFrame: string
+  checkedCheckpoints: number
+  replayedSteps: number
+}
+
+export interface ExportReplayTestOptions {
+  testName?: string
+  importPath?: string
+  setupCode?: string
+  assertFinalFrame?: boolean
+  assertCheckpoints?: boolean
+  flushAfterInput?: boolean
+  flushAfterResize?: boolean
+}
+
+type RendererStdin = TestRendererSetup["renderer"]["stdin"] & {
+  emit(eventName: string | symbol, ...args: unknown[]): boolean
+}
+
+type RendererWithEvents = TestRendererSetup["renderer"] & {
+  on(eventName: string | symbol, listener: (...args: unknown[]) => void): TestRendererSetup["renderer"]
+  off(eventName: string | symbol, listener: (...args: unknown[]) => void): TestRendererSetup["renderer"]
+  once(eventName: string | symbol, listener: (...args: unknown[]) => void): TestRendererSetup["renderer"]
+}
+
+type ResizeFn = TestRendererSetup["resize"]
+
+const DEFAULT_EXPORT_IMPORT_PATH = "@opentui/core/testing"
+
+function normalizePositiveInteger(value: number | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error("frameLimit must be a non-negative finite number")
+  }
+
+  return Math.floor(value)
+}
+
+function normalizeInputData(data: unknown): Buffer | undefined {
+  if (typeof data === "string") {
+    return Buffer.from(data)
+  }
+
+  if (Buffer.isBuffer(data)) {
+    return Buffer.from(data)
+  }
+
+  if (data instanceof Uint8Array) {
+    return Buffer.from(data)
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength)
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data)
+  }
+
+  return undefined
+}
+
+function cloneStep(step: RecordedSessionStep): RecordedSessionStep {
+  return structuredClone(step)
+}
+
+function cloneMetadata(metadata: RecordedTestSessionMetadata | undefined): RecordedTestSessionMetadata | undefined {
+  return metadata ? structuredClone(metadata) : undefined
+}
+
+function cloneSpans(spans: CapturedSessionSpans | undefined): CapturedSessionSpans | undefined {
+  return spans ? structuredClone(spans) : undefined
+}
+
+async function drainImmediateWork(): Promise<void> {
+  await Promise.resolve()
+  await new Promise<void>((resolve) => process.nextTick(resolve))
+  await Promise.resolve()
+}
+
+function countActionSteps(steps: RecordedSessionStep[]): number {
+  return steps.filter((step) => step.type === "stdin" || step.type === "resize" || step.type === "wait").length
+}
+
+function createCheckpointError(name: string | undefined, expected: string, actual: string): Error {
+  const label = name ? ` "${name}"` : ""
+  return new Error(
+    [
+      `Recorded checkpoint${label} did not match replayed frame.`,
+      "",
+      "Expected:",
+      expected,
+      "",
+      "Actual:",
+      actual,
+    ].join("\n"),
+  )
+}
+
+export class TestSessionRecorder {
+  private readonly setup: TestRendererSetup
+  private readonly metadata: RecordedTestSessionMetadata | undefined
+  private readonly recordFrames: boolean
+  private readonly recordSpans: boolean
+  private readonly frameLimit: number | undefined
+  private readonly now: () => number
+  private readonly stepsInternal: RecordedSessionStep[] = []
+  private recording = false
+  private startTime: number | undefined
+  private duration = 0
+  private frameNumber = 0
+  private initialWidth: number | undefined
+  private initialHeight: number | undefined
+  private finalFrame: string | undefined
+  private finalSpans: CapturedSessionSpans | undefined
+  private originalStdinEmit: RendererStdin["emit"] | undefined
+  private originalResize: ResizeFn | undefined
+  private patchedStdin: RendererStdin | undefined
+
+  private readonly onFrame = (event: CliRendererFrameEvent): void => {
+    if (!this.recording || !this.recordFrames) {
+      return
+    }
+
+    if (this.frameLimit !== undefined && this.frameNumber >= this.frameLimit) {
+      return
+    }
+
+    this.stepsInternal.push({
+      type: "frame",
+      timestamp: this.elapsed(),
+      frame: this.setup.captureCharFrame(),
+      frameNumber: this.frameNumber++,
+      frameId: event.frameId,
+      spans: this.recordSpans ? this.setup.captureSpans() : undefined,
+    })
+  }
+
+  private readonly onDestroy = (): void => {
+    this.stop()
+  }
+
+  public constructor(setup: TestRendererSetup, options: TestSessionRecorderOptions = {}) {
+    this.setup = setup
+    this.metadata = cloneMetadata(options.metadata)
+    this.recordFrames = options.recordFrames ?? true
+    this.recordSpans = options.recordSpans ?? false
+    this.frameLimit = normalizePositiveInteger(options.frameLimit)
+    this.now = options.now ?? (() => performance.now())
+  }
+
+  public start(options: TestSessionRecorderStartOptions = {}): void {
+    if (this.recording) {
+      return
+    }
+
+    if (options.clear ?? true) {
+      this.clear()
+    }
+
+    this.initialWidth = this.setup.renderer.width
+    this.initialHeight = this.setup.renderer.height
+    this.startTime = this.now()
+    this.duration = 0
+    this.recording = true
+    this.patchStdin()
+    this.patchResize()
+
+    const renderer = this.setup.renderer as RendererWithEvents
+    if (this.recordFrames) {
+      renderer.on(CliRenderEvents.FRAME, this.onFrame as (...args: unknown[]) => void)
+    }
+    renderer.once(CliRenderEvents.DESTROY, this.onDestroy)
+  }
+
+  public stop(): void {
+    if (!this.recording) {
+      return
+    }
+
+    this.duration = this.elapsed()
+    this.recording = false
+    this.finalFrame = this.setup.captureCharFrame()
+    this.finalSpans = this.recordSpans ? this.setup.captureSpans() : undefined
+
+    const renderer = this.setup.renderer as RendererWithEvents
+    renderer.off(CliRenderEvents.FRAME, this.onFrame as (...args: unknown[]) => void)
+    renderer.off(CliRenderEvents.DESTROY, this.onDestroy)
+
+    this.restorePatches()
+  }
+
+  public clear(): void {
+    this.stepsInternal.length = 0
+    this.duration = 0
+    this.frameNumber = 0
+    this.finalFrame = undefined
+    this.finalSpans = undefined
+  }
+
+  public get isRecording(): boolean {
+    return this.recording
+  }
+
+  public get steps(): RecordedSessionStep[] {
+    return this.stepsInternal.map(cloneStep)
+  }
+
+  public get session(): RecordedTestSession {
+    return this.toSession()
+  }
+
+  public checkpoint(name?: string): RecordedSessionCheckpointStep {
+    const step: RecordedSessionCheckpointStep = {
+      type: "checkpoint",
+      timestamp: this.elapsed(),
+      name,
+      frame: this.setup.captureCharFrame(),
+      frameNumber: this.frameNumber++,
+      spans: this.recordSpans ? this.setup.captureSpans() : undefined,
+    }
+
+    if (this.recording) {
+      this.stepsInternal.push(step)
+    }
+
+    return cloneStep(step) as RecordedSessionCheckpointStep
+  }
+
+  public note(message: string): void {
+    if (!this.recording) {
+      return
+    }
+
+    this.stepsInternal.push({
+      type: "note",
+      timestamp: this.elapsed(),
+      message,
+    })
+  }
+
+  public resize(width: number, height: number): void {
+    this.setup.resize(width, height)
+  }
+
+  public async flush(): Promise<void> {
+    if (this.recording) {
+      this.stepsInternal.push({
+        type: "wait",
+        timestamp: this.elapsed(),
+        kind: "flush",
+      })
+    }
+
+    await this.setup.flush()
+  }
+
+  public async waitForVisualIdle(options?: TestVisualIdleOptions): Promise<void> {
+    if (this.recording) {
+      this.stepsInternal.push({
+        type: "wait",
+        timestamp: this.elapsed(),
+        kind: "visual-idle",
+        options: options ? structuredClone(options) : undefined,
+      })
+    }
+
+    await this.setup.waitForVisualIdle(options)
+  }
+
+  public toSession(): RecordedTestSession {
+    const finalFrame = this.finalFrame ?? this.setup.captureCharFrame()
+    const finalSpans = this.finalSpans ?? (this.recordSpans ? this.setup.captureSpans() : undefined)
+
+    return {
+      version: TEST_SESSION_RECORDING_VERSION,
+      width: this.initialWidth ?? this.setup.renderer.width,
+      height: this.initialHeight ?? this.setup.renderer.height,
+      duration: this.recording ? this.elapsed() : this.duration,
+      steps: this.stepsInternal.map(cloneStep),
+      metadata: cloneMetadata(this.metadata),
+      finalFrame,
+      finalSpans: cloneSpans(finalSpans),
+    }
+  }
+
+  public exportReplayTest(options: ExportReplayTestOptions = {}): string {
+    return exportReplayTest(this.toSession(), options)
+  }
+
+  private patchStdin(): void {
+    const stdin = this.setup.renderer.stdin as RendererStdin
+    if (this.originalStdinEmit) {
+      return
+    }
+
+    const recorder = this
+    this.patchedStdin = stdin
+    this.originalStdinEmit = stdin.emit
+
+    stdin.emit = function patchedEmit(this: RendererStdin, eventName: string | symbol, ...args: unknown[]): boolean {
+      if (recorder.recording && eventName === "data") {
+        const bytes = normalizeInputData(args[0])
+        if (bytes) {
+          recorder.stepsInternal.push({
+            type: "stdin",
+            timestamp: recorder.elapsed(),
+            dataBase64: bytes.toString("base64"),
+            dataText: bytes.toString("utf8"),
+          })
+        }
+      }
+
+      return recorder.originalStdinEmit!.call(this, eventName, ...args)
+    } as RendererStdin["emit"]
+  }
+
+  private patchResize(): void {
+    if (this.originalResize) {
+      return
+    }
+
+    const recorder = this
+    this.originalResize = this.setup.resize
+    this.setup.resize = ((width: number, height: number): void => {
+      if (recorder.recording) {
+        recorder.stepsInternal.push({
+          type: "resize",
+          timestamp: recorder.elapsed(),
+          width,
+          height,
+        })
+      }
+
+      recorder.originalResize!(width, height)
+    }) as ResizeFn
+  }
+
+  private restorePatches(): void {
+    if (this.originalStdinEmit && this.patchedStdin) {
+      this.patchedStdin.emit = this.originalStdinEmit
+      this.originalStdinEmit = undefined
+      this.patchedStdin = undefined
+    }
+
+    if (this.originalResize) {
+      this.setup.resize = this.originalResize
+      this.originalResize = undefined
+    }
+  }
+
+  private elapsed(): number {
+    if (this.startTime === undefined) {
+      return 0
+    }
+
+    return Math.max(0, this.now() - this.startTime)
+  }
+}
+
+export async function replayTestSession(
+  session: RecordedTestSession,
+  setup: TestRendererSetup,
+  options: ReplayTestSessionOptions = {},
+): Promise<ReplayTestSessionResult> {
+  if (session.version !== TEST_SESSION_RECORDING_VERSION) {
+    throw new Error(`Unsupported OpenTUI test session recording version: ${session.version}`)
+  }
+
+  const flushAfterInput = options.flushAfterInput ?? false
+  const flushAfterResize = options.flushAfterResize ?? true
+  const flushAtEnd = options.flushAtEnd ?? true
+  let checkedCheckpoints = 0
+
+  for (let index = 0; index < session.steps.length; index++) {
+    const step = session.steps[index]
+    await options.onStep?.(step, index)
+
+    switch (step.type) {
+      case "stdin": {
+        const bytes = Buffer.from(step.dataBase64, "base64")
+        setup.renderer.stdin.emit("data", bytes)
+        await drainImmediateWork()
+        if (flushAfterInput) {
+          await setup.flush()
+        }
+        break
+      }
+      case "resize": {
+        setup.resize(step.width, step.height)
+        await drainImmediateWork()
+        if (flushAfterResize) {
+          await setup.flush()
+        }
+        break
+      }
+      case "wait": {
+        if (step.kind === "flush") {
+          await setup.flush()
+        } else {
+          await setup.waitForVisualIdle(step.options)
+        }
+        break
+      }
+      case "checkpoint": {
+        if (options.assertCheckpoints) {
+          await setup.flush()
+          const actual = setup.captureCharFrame()
+          if (actual !== step.frame) {
+            throw createCheckpointError(step.name, step.frame, actual)
+          }
+          checkedCheckpoints++
+        }
+        break
+      }
+      case "frame":
+      case "note": {
+        break
+      }
+    }
+  }
+
+  if (flushAtEnd) {
+    await setup.flush()
+  }
+
+  return {
+    finalFrame: setup.captureCharFrame(),
+    checkedCheckpoints,
+    replayedSteps: countActionSteps(session.steps),
+  }
+}
+
+export function exportReplayTest(session: RecordedTestSession, options: ExportReplayTestOptions = {}): string {
+  const testName = options.testName ?? session.metadata?.name ?? "replays recorded OpenTUI session"
+  const importPath = options.importPath ?? DEFAULT_EXPORT_IMPORT_PATH
+  const assertFinalFrame = options.assertFinalFrame ?? true
+  const assertCheckpoints = options.assertCheckpoints ?? false
+  const setupCode =
+    options.setupCode ?? "  // TODO: mount your app/renderables under test before replaying the session.\n"
+  const replayOptions = {
+    assertCheckpoints,
+    flushAfterInput: options.flushAfterInput,
+    flushAfterResize: options.flushAfterResize,
+  }
+  const definedReplayOptions = Object.fromEntries(
+    Object.entries(replayOptions).filter(([, value]) => value !== undefined && value !== false),
+  )
+  const replayOptionsText = JSON.stringify(definedReplayOptions, null, 2)
+  const replayCall =
+    replayOptionsText === "{}"
+      ? "await replayTestSession(session, setup)"
+      : `await replayTestSession(session, setup, ${replayOptionsText.replace(/\n/g, "\n    ")})`
+  const finalAssertion = assertFinalFrame ? "    expect(setup.captureCharFrame()).toBe(session.finalFrame)\n" : ""
+  const bunImport = assertFinalFrame ? 'import { test, expect } from "bun:test"' : 'import { test } from "bun:test"'
+
+  return `${bunImport}
+import { createTestRenderer, replayTestSession, type RecordedTestSession } from "${importPath}"
+
+const session = ${JSON.stringify(session, null, 2)} satisfies RecordedTestSession
+
+test(${JSON.stringify(testName)}, async () => {
+  const setup = await createTestRenderer({ width: session.width, height: session.height })
+  try {
+${setupCode}${setupCode.endsWith("\n") ? "" : "\n"}    ${replayCall}
+${finalAssertion}  } finally {
+    setup.renderer.destroy()
+  }
+})
+`
+}

--- a/packages/web/src/content/docs/core-concepts/test-recording.mdx
+++ b/packages/web/src/content/docs/core-concepts/test-recording.mdx
@@ -1,0 +1,84 @@
+---
+title: Test Recording
+description: Record input, resize, frame checkpoints, and export replayable tests
+order: 13
+skill:
+  intents: [test-recording, replay, session-recorder, snapshots, input]
+---
+
+# Test Recording
+
+`TestSessionRecorder` records a deterministic test session on top of `createTestRenderer()`.
+It captures raw stdin bytes from keyboard and mouse mocks, terminal resizes, explicit waits, checkpoints, and optionally every rendered frame.
+
+Use the existing `TestRecorder` when you only need frame capture. Use `TestSessionRecorder` when you want to turn an interaction into a replayable regression test.
+
+```typescript
+import { createTestRenderer, TestSessionRecorder } from "@opentui/core/testing"
+
+const setup = await createTestRenderer({ width: 80, height: 24 })
+const recorder = new TestSessionRecorder(setup, {
+  metadata: { name: "command palette accepts query" },
+  recordFrames: true,
+})
+
+recorder.start()
+setup.mockInput.pressKey("k", { ctrl: true })
+await recorder.flush()
+await setup.mockInput.typeText("settings")
+await recorder.flush()
+recorder.checkpoint("filtered settings results")
+recorder.stop()
+
+const session = recorder.session
+const testSource = recorder.exportReplayTest({
+  setupCode: "  await mountApp(setup.renderer)\n",
+})
+```
+
+## Replay
+
+```typescript
+import { test, expect } from "bun:test"
+import { createTestRenderer, replayTestSession, type RecordedTestSession } from "@opentui/core/testing"
+
+const session = {
+  // paste the exported session JSON here
+} satisfies RecordedTestSession
+
+test("replays command palette regression", async () => {
+  const setup = await createTestRenderer({ width: session.width, height: session.height })
+  try {
+    await mountApp(setup.renderer)
+    await replayTestSession(session, setup, { assertCheckpoints: true })
+    expect(setup.captureCharFrame()).toBe(session.finalFrame)
+  } finally {
+    setup.renderer.destroy()
+  }
+})
+```
+
+## What gets recorded
+
+| Step         | Source                                                            | Replay behavior                         |
+| ------------ | ----------------------------------------------------------------- | --------------------------------------- |
+| `stdin`      | `renderer.stdin.emit("data", bytes)` from keyboard or mouse mocks | Re-emits the same bytes                 |
+| `resize`     | `setup.resize(width, height)`                                     | Calls `resize()` and flushes by default |
+| `wait`       | `recorder.flush()` or `recorder.waitForVisualIdle()`              | Waits using the same helper             |
+| `checkpoint` | `recorder.checkpoint(name)`                                       | Optional assertion during replay        |
+| `frame`      | Render frame events when `recordFrames` is true                   | Stored for debugging; not replayed      |
+| `note`       | `recorder.note(message)`                                          | Stored as human context; not replayed   |
+
+## Notes
+
+The exported test includes a `setupCode` placeholder because the recorder cannot know how to mount your app. Mount the same renderables, React tree, or Solid tree before calling `replayTestSession()`.
+
+For large sessions, set `recordFrames: false` or pass a `frameLimit` to keep the fixture small.
+
+## Minimal Example
+
+See `packages/core/src/testing/examples/test-session-recorder-demo-app.ts` for a tiny app that renders typed input, submit count, and terminal size.
+
+Run it from the repo root with `bun packages/core/src/testing/examples/test-session-recorder-demo-app.ts`, then type text, Backspace, and Enter. Press Ctrl+C to exit.
+
+The matching `packages/core/src/testing/examples/test-session-recorder-demo-app.test.ts` records a session against one test renderer, replays it into a fresh renderer, asserts a checkpoint, and compares the final frame.


### PR DESCRIPTION
## Summary

Adds an additive `TestSessionRecorder` API on top of the existing `createTestRenderer()` testing surface.

The existing frame-only `TestRecorder` API is left intact. The new session recorder captures:

- raw stdin bytes, stored canonically as base64
- terminal resize calls through `TestRendererSetup.resize()`
- explicit waits via `flush()` and `waitForVisualIdle()`
- named checkpoints for replay-time assertions
- optional rendered frames and spans for debugging

It also includes `replayTestSession()` for replaying a recorded session into another test renderer and `exportReplayTest()` for generating a Bun test skeleton.

## Why

This is useful for turning keyboard-driven TUI bugs into stable regression tests: record input and resize steps once, mount the app under test with mocked data, then replay the interaction against a fresh renderer and assert checkpoints/final frames.

A concrete downstream fit is OpenCode. Its TUI has complex keyboard-driven flows (command palette, model/session dialogs, prompt input, resize-sensitive layouts, diff views, provider/plugin routes) and already uses OpenTUI with mocked test renderer setup in its test suite. This recorder would make those flows easier to preserve as replayable regression tests while keeping backend/API/LLM calls mocked.

The intended shape for apps like OpenCode is:

- real TUI/rendering/keymap/dialog/route logic
- mocked SDK/fetch/events/config
- fixed terminal sizes
- recorded keyboard/resize/checkpoint sessions
- no live network or provider calls

## Included Example

Adds a minimal runnable demo app at:

```bash
bun packages/core/src/testing/examples/test-session-recorder-demo-app.ts
```

The matching test records the app in one renderer, replays it into a fresh renderer, asserts the checkpoint, and compares the final frame.

## Validation

```bash
bun test ./packages/core/src/testing/examples/test-session-recorder-demo-app.test.ts ./packages/core/src/testing/test-session-recorder.test.ts
bun run lint
bun run fmt:check
git diff --check
```