### PR TITLE
feat(core): add opt-in smartPunctuation (double-space period) to Textarea

### DIFF
--- a/packages/core/src/renderables/Textarea.ts
+++ b/packages/core/src/renderables/Textarea.ts
@@ -140,6 +140,13 @@ export interface TextareaOptions extends EditBufferOptions {
   keyBindings?: KeyBinding[]
   keyAliasMap?: TextareaKeyAliasMap
   onSubmit?: (event: SubmitEvent) => void
+  /**
+   * When enabled, typing two spaces after a word inserts a period followed by a
+   * space (`". "`) instead of two spaces, mirroring the native macOS/iOS
+   * "Add period with double-space" behavior. Pressing backspace immediately
+   * after the auto-insert reverts it back to two spaces. Defaults to `false`.
+   */
+  smartPunctuation?: boolean
 }
 
 export class TextareaRenderable extends EditBufferRenderable {
@@ -155,6 +162,10 @@ export class TextareaRenderable extends EditBufferRenderable {
   private _actionHandlers: Map<TextareaAction, () => boolean>
   private _initialValueSet: boolean = false
   private _submitListener: ((event: SubmitEvent) => void) | undefined = undefined
+  private _smartPunctuation: boolean = false
+  // Cursor offset right after an auto-inserted ". "; -1 when no revert is pending.
+  // Only the immediately-following keypress may revert it.
+  private _autoPeriodRevertOffset: number = -1
 
   private static readonly defaults = {
     backgroundColor: "transparent",
@@ -192,6 +203,7 @@ export class TextareaRenderable extends EditBufferRenderable {
     this._keyBindingsMap = buildKeyBindingsMap(mergedBindings, this._keyAliasMap)
     this._actionHandlers = this.buildActionHandlers()
     this._submitListener = options.onSubmit
+    this._smartPunctuation = options.smartPunctuation ?? false
 
     if (options.initialValue) {
       this.setText(options.initialValue)
@@ -258,11 +270,72 @@ export class TextareaRenderable extends EditBufferRenderable {
     ])
   }
 
+  /**
+   * macOS/iOS-style "double-space period": when a space is typed and the
+   * character before the cursor is already a space preceded by a word character,
+   * replace that space with ". ". Returns true when the conversion was applied.
+   *
+   * Deliberately context-gated (no keystroke timing): timing-based gating is
+   * non-deterministic and unsupported by editor input-rule systems. The escape
+   * hatch is revert-on-immediate-backspace (handled in handleKeyPress).
+   */
+  private trySmartPeriod(): boolean {
+    if (!this._smartPunctuation) return false
+    if (this.hasSelection()) return false
+
+    const offset = this.logicalCursor.offset
+    if (offset < 2) return false
+
+    // Read a small window ending at the cursor. UTF-8 is self-synchronizing, so
+    // even if the window starts mid-codepoint the trailing characters decode
+    // correctly, making the last-two-character inspection robust.
+    const start = Math.max(0, offset - 16)
+    const before = this.getTextRange(start, offset)
+    if (before.length < 2) return false
+
+    const prevChar = before[before.length - 1]
+    const prevPrevChar = before[before.length - 2]
+
+    // Must be exactly one existing space, preceded by a letter or digit.
+    if (prevChar !== " ") return false
+    if (!/[\p{L}\p{N}]/u.test(prevPrevChar)) return false
+
+    this.deleteCharBackward()
+    this.insertText(". ")
+    this._autoPeriodRevertOffset = this.logicalCursor.offset
+    return true
+  }
+
   public handlePaste(event: PasteEvent): void {
+    this._autoPeriodRevertOffset = -1
     this.insertText(stripAnsiSequences(decodePasteBytes(event.bytes)))
   }
 
   public handleKeyPress(key: KeyEvent): boolean {
+    // Any keypress consumes the chance to revert a previous auto-period. Capture
+    // and clear the pending offset up front so only the immediately-following key
+    // can trigger the revert.
+    const revertOffset = this._autoPeriodRevertOffset
+    this._autoPeriodRevertOffset = -1
+
+    if (
+      this._smartPunctuation &&
+      revertOffset >= 0 &&
+      key.name === "backspace" &&
+      !key.ctrl &&
+      !key.meta &&
+      !key.super &&
+      !key.hyper &&
+      !this.hasSelection() &&
+      this.logicalCursor.offset === revertOffset
+    ) {
+      // Undo the ". " that was just auto-inserted, restoring the two spaces.
+      this.deleteCharBackward()
+      this.deleteCharBackward()
+      this.insertText("  ")
+      return true
+    }
+
     if (this.traits.suspend !== true) {
       const action = getKeyBindingAction(this._keyBindingsMap, key)
 
@@ -276,6 +349,9 @@ export class TextareaRenderable extends EditBufferRenderable {
 
     if (!key.ctrl && !key.meta && !key.super && !key.hyper) {
       if (key.name === "space") {
+        if (this.trySmartPeriod()) {
+          return true
+        }
         this.insertText(" ")
         return true
       }
@@ -405,6 +481,15 @@ export class TextareaRenderable extends EditBufferRenderable {
 
   public get onSubmit(): ((event: SubmitEvent) => void) | undefined {
     return this._submitListener
+  }
+
+  public set smartPunctuation(value: boolean) {
+    this._smartPunctuation = value
+    if (!value) this._autoPeriodRevertOffset = -1
+  }
+
+  public get smartPunctuation(): boolean {
+    return this._smartPunctuation
   }
 
   public set keyBindings(bindings: KeyBinding[]) {

--- a/packages/core/src/renderables/__tests__/Textarea.smart-punctuation.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.smart-punctuation.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test"
+import { createTestRenderer, type TestRenderer, type MockInput } from "../../testing/test-renderer.js"
+import { createTextareaRenderable } from "./renderable-test-utils.js"
+
+let currentRenderer: TestRenderer
+let renderOnce: () => Promise<void>
+let currentMockInput: MockInput
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 20))
+
+describe("Textarea - Smart Punctuation (double-space period)", () => {
+  beforeEach(async () => {
+    ;({
+      renderer: currentRenderer,
+      renderOnce,
+      mockInput: currentMockInput,
+    } = await createTestRenderer({
+      width: 80,
+      height: 24,
+    }))
+  })
+
+  afterEach(() => {
+    currentRenderer.destroy()
+  })
+
+  it("is disabled by default: two spaces stay two spaces", async () => {
+    const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+      initialValue: "hi",
+      width: 40,
+      height: 10,
+    })
+    editor.focus()
+    editor.gotoBufferEnd()
+
+    currentMockInput.pressKey(" ")
+    currentMockInput.pressKey(" ")
+    await settle()
+
+    expect(editor.plainText).toBe("hi  ")
+  })
+
+  it("converts double space after a letter to '. ' when enabled", async () => {
+    const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+      initialValue: "hi",
+      width: 40,
+      height: 10,
+      smartPunctuation: true,
+    })
+    editor.focus()
+    editor.gotoBufferEnd()
+
+    currentMockInput.pressKey(" ")
+    currentMockInput.pressKey(" ")
+    await settle()
+
+    expect(editor.plainText).toBe("hi. ")
+  })
+
+  it("converts double space after a digit", async () => {
+    const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+      initialValue: "v2",
+      width: 40,
+      height: 10,
+      smartPunctuation: true,
+    })
+    editor.focus()
+    editor.gotoBufferEnd()
+
+    currentMockInput.pressKey(" ")
+    currentMockInput.pressKey(" ")
+    await settle()
+
+    expect(editor.plainText).toBe("v2. ")
+  })
+
+  it("does not convert at line start (no preceding word char)", async () => {
+    const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+      initialValue: "",
+      width: 40,
+      height: 10,
+      smartPunctuation: true,
+    })
+    editor.focus()
+
+    currentMockInput.pressKey(" ")
+    currentMockInput.pressKey(" ")
+    await settle()
+
+    expect(editor.plainText).toBe("  ")
+  })
+
+  it("does not convert after punctuation", async () => {
+    const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+      initialValue: "hi.",
+      width: 40,
+      height: 10,
+      smartPunctuation: true,
+    })
+    editor.focus()
+    editor.gotoBufferEnd()
+
+    currentMockInput.pressKey(" ")
+    currentMockInput.pressKey(" ")
+    await settle()
+
+    expect(editor.plainText).toBe("hi.  ")
+  })
+
+  it("does not stack into '.. ' on a third space", async () => {
+    const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+      initialValue: "hi",
+      width: 40,
+      height: 10,
+      smartPunctuation: true,
+    })
+    editor.focus()
+    editor.gotoBufferEnd()
+
+    currentMockInput.pressKey(" ")
+    currentMockInput.pressKey(" ")
+    currentMockInput.pressKey(" ")
+    await settle()
+
+    expect(editor.plainText).toBe("hi.  ")
+  })
+
+  it("reverts to two spaces when backspace is pressed immediately after", async () => {
+    const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+      initialValue: "hi",
+      width: 40,
+      height: 10,
+      smartPunctuation: true,
+    })
+    editor.focus()
+    editor.gotoBufferEnd()
+
+    currentMockInput.pressKey(" ")
+    currentMockInput.pressKey(" ")
+    await settle()
+    expect(editor.plainText).toBe("hi. ")
+
+    currentMockInput.pressBackspace()
+    await settle()
+
+    expect(editor.plainText).toBe("hi  ")
+  })
+
+  it("can be toggled at runtime via the smartPunctuation setter", async () => {
+    const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+      initialValue: "hi",
+      width: 40,
+      height: 10,
+    })
+    editor.focus()
+    editor.gotoBufferEnd()
+    editor.smartPunctuation = true
+
+    currentMockInput.pressKey(" ")
+    currentMockInput.pressKey(" ")
+    await settle()
+
+    expect(editor.plainText).toBe("hi. ")
+  })
+})


### PR DESCRIPTION
## Summary

Adds an **opt-in `smartPunctuation`** option to `TextareaRenderable` that mirrors the native macOS/iOS "Add period with double-space" behavior: when enabled, typing two spaces after a word inserts `". "` instead of `"  "`. Pressing **Backspace immediately after** reverts it back to two spaces.

Implements the design discussed in #1177.

## Why this belongs in the widget

Downstream consumers (e.g. opencode's prompt) can't implement this cleanly, because individual space keystrokes are handled inside `Textarea.handleKeyPress` and never surface to the host app — the conversion has to live here.

## Behavior

- **Opt-in:** `smartPunctuation` defaults to `false`; existing behavior is unchanged. Also exposed as a runtime getter/setter.
- **Context-gated (no timing):** converts only when the char before the cursor is a space preceded by a letter/digit, with no active selection. It does **not** fire at line start, after punctuation, or stack into `".. "` on a third space.
- **Revert-on-backspace:** pressing Backspace immediately after an auto-insert restores the two literal spaces; any other keypress (or paste) consumes the revert opportunity.

### Why no keystroke timing

Per the research in #1177: Apple's implementation and every editor input-rule system (ProseMirror, CodeMirror, VS Code, etc.) gate this purely on preceding-character **context**, never on keystroke timing. Timing-based gating is non-deterministic, breaks paste/fast typists, and has no precedent for content transforms. (Android/AOSP is the lone exception with a loose 1100ms window, but it still relies on the same context gates + backspace-revert.)

## Tests

New `Textarea.smart-punctuation.test.ts` (8 cases): default-off, convert after letter, convert after digit, no-op at line start, no-op after punctuation, no triple-space stacking, backspace-revert, and runtime toggle.

- New tests: 8/8 pass
- Full Textarea suite: 576/576 pass (no regressions)
- `oxfmt` + `oxlint`: clean

Closes #1177
