### PR TITLE
fix: TUI leaves terminal in mouse-reporting/raw mode; keystrokes / mo…

### DIFF
--- a/packages/core/src/NativeSpanFeed.ts
+++ b/packages/core/src/NativeSpanFeed.ts
@@ -85,6 +85,8 @@ export class NativeSpanFeed {
   private idleResolvers: Array<() => void> = []
   private pendingHandlerError: unknown = null
   private pendingHandlerErrorQueued = false
+  private closePromise: Promise<void> | null = null
+  private closeResolver: (() => void) | null = null
 
   private constructor(streamPtr: Pointer) {
     this.streamPtr = streamPtr
@@ -126,8 +128,19 @@ export class NativeSpanFeed {
     return this.pendingAsyncHandlers > 0 || this.pendingDataAvailable || this.hasPinnedChunks()
   }
 
-  close(): void {
-    if (this.destroyed) return
+  private getClosePromise(): Promise<void> {
+    if (this.destroyed) return Promise.resolve()
+    if (!this.closePromise) {
+      this.closePromise = new Promise<void>((resolve) => {
+        this.closeResolver = resolve
+      })
+    }
+    return this.closePromise
+  }
+
+  close(): Promise<void> {
+    const closed = this.getClosePromise()
+    if (this.destroyed) return closed
     if (this.inCallback || this.draining || this.pendingAsyncHandlers > 0) {
       this.pendingClose = true
       if (!this.closeQueued) {
@@ -137,9 +150,10 @@ export class NativeSpanFeed {
           this.processPendingClose()
         })
       }
-      return
+      return closed
     }
     this.performClose()
+    return closed
   }
 
   private processPendingClose(): void {
@@ -177,6 +191,11 @@ export class NativeSpanFeed {
     this.errorHandlers.clear()
     this.pendingDataAvailable = false
     this.resolveIdleIfNeeded()
+    const resolver = this.closeResolver
+    if (resolver) {
+      this.closeResolver = null
+      resolver()
+    }
   }
 
   private isIdle(): boolean {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1,3 +1,5 @@
+import { writeSync } from "node:fs"
+
 import { ANSI } from "./ansi.js"
 import { Renderable, RootRenderable } from "./Renderable.js"
 import { BoxRenderable } from "./renderables/Box.js"
@@ -528,6 +530,27 @@ const DEFAULT_FORWARDED_ENV_KEYS = [
 const NATIVE_RENDER_STATUS_SKIPPED = 1
 const NATIVE_RENDER_STATUS_FAILED = 2
 
+const TERMINAL_HARD_RESTORE =
+  "\x1b[?2026l" +
+  "\x1b[?1003l" +
+  "\x1b[?1002l" +
+  "\x1b[?1000l" +
+  "\x1b[?1006l" +
+  "\x1b[?1016l" +
+  "\x1b[?1004l" +
+  "\x1b[?2004l" +
+  "\x1b[?2031l" +
+  "\x1b[?2027l" +
+  "\x1b[<u" +
+  "\x1b[>4;0m" +
+  "\x1b[r" +
+  "\x1b[?25h" +
+  "\x1b[0m" +
+  "\x1b[0 q" +
+  "\x1b]112\x07" +
+  "\x1b]12;default\x07" +
+  "\x1b[?1049l"
+
 // Kitty keyboard protocol flags
 // See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
 const KITTY_FLAG_DISAMBIGUATE = 0b1 // Report disambiguated escape codes
@@ -728,8 +751,21 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private _isDestroyed: boolean = false
   private _destroyPending: boolean = false
   private _destroyFinalized: boolean = false
+  private _destroyCompletionEmitted: boolean = false
   private _destroyCleanupPrepared: boolean = false
+  private _terminalRestorePrepared: boolean = false
   private _streamLeaseAcquired: boolean = false
+  // `closed` resolves only after finalizeDestroy() has completed, including
+  // any async flush of TERMINAL_HARD_RESTORE on non-fd Writables. `destroy()`
+  // returns this same promise so callers may either `await renderer.destroy()`
+  // or `renderer.destroy(); await renderer.closed`.
+  private _closedPromise: Promise<void> | null = null
+  private _closedResolver: (() => void) | null = null
+  // Tracks completion of the hard restore write. For fd-backed stdouts the
+  // write is synchronous via fs.writeSync and this stays Promise.resolve().
+  // For custom Writables we capture the stream write callback so `closed`
+  // does not resolve before the bytes are actually flushed.
+  private _hardRestoreFlushed: Promise<void> = Promise.resolve()
   public nextRenderBuffer: OptimizedBuffer
   public currentRenderBuffer: OptimizedBuffer
   private _isRunning: boolean = false
@@ -892,9 +928,12 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private handleError: (error: Error) => void = ((error: Error) => {
     console.error(error)
 
-    if (this._openConsoleOnError) {
-      this.console.show()
+    if (!this._openConsoleOnError) {
+      void this.destroy()
+      return
     }
+
+    this.console.show()
   }).bind(this)
 
   private dumpOutputCache(optionalMessage: string = ""): void {
@@ -936,6 +975,45 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       sleep(100).then(() => {
         this.dumpOutputCache("=== CAPTURED OUTPUT ===\n")
       })
+    }
+  }).bind(this)
+
+  // Last-resort synchronous terminal restore that runs on `process.on("exit")`.
+  // Covers paths that bypass normal destroy(): uncaughtException with no
+  // handler that recovers, unhandledRejection with --unhandled-rejections=strict,
+  // an explicit process.exit() called by the host application, or the natural
+  // event-loop-empty exit. The 'exit' event handler must be synchronous (Node
+  // ignores async work after it returns), which is fine because writeSync is
+  // synchronous. Idempotency is guaranteed by _terminalRestorePrepared.
+  // SIGKILL cannot be intercepted; this is the best we can do from JS.
+  //
+  // process.on("exit") can only guarantee restoration for fd-backed stdout.
+  // For custom Writables, callers must use await renderer.destroy() before
+  // closing the transport or exiting the process.
+  private processExitHandler: () => void = (() => {
+    if (!this._terminalIsSetup) return
+
+    try {
+      this.stdin.setRawMode?.(false)
+    } catch {
+      // best effort
+    }
+
+    try {
+      this.stdin.pause()
+    } catch {
+      // best effort
+    }
+
+    if (this._terminalRestorePrepared) return
+    this._terminalRestorePrepared = true
+    const fd = (this.stdout as NodeJS.WriteStream & { fd?: number }).fd
+    if (typeof fd === "number") {
+      try {
+        writeSync(fd, TERMINAL_HARD_RESTORE)
+      } catch {
+        // best effort
+      }
     }
   }).bind(this)
 
@@ -1170,6 +1248,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     process.on("uncaughtException", this.handleError)
     process.on("unhandledRejection", this.handleError)
     process.on("beforeExit", this.exitHandler)
+    // Synchronous last-resort restore. Cheap to register and idempotent with
+    // normal destroy() teardown via _terminalRestorePrepared.
+    process.on("exit", this.processExitHandler)
 
     const useKittyForParsing = kittyConfig !== null
     this._keyHandler = new InternalKeyHandler()
@@ -4118,19 +4199,54 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
   }
 
-  public destroy(): void {
-    if (this._isDestroyed) return
+  // `closed` resolves only after the renderer has been fully torn down:
+  // terminal modes restored (and on non-fd Writables, the restore bytes
+  // flushed through the underlying stream), native renderer destroyed,
+  // feed closed, and the `destroy` event emitted. Safe to access before
+  // destroy(); the same promise is returned later.
+  //
+  // Strong guarantee: when stdout exposes a numeric fd (the common case
+  // for process.stdout), terminal restore bytes have hit the kernel by the
+  // time this resolves and the calling process may safely process.exit().
+  // For custom Writables the promise still awaits the stream's write
+  // callback, but the host must keep its transport alive long enough for
+  // the callback to fire.
+  public get closed(): Promise<void> {
+    if (!this._closedPromise) {
+      if (this._destroyFinalized) {
+        this._closedPromise = Promise.resolve()
+      } else {
+        this._closedPromise = new Promise<void>((resolve) => {
+          this._closedResolver = resolve
+        })
+      }
+    }
+    return this._closedPromise
+  }
+
+  // Returns a promise resolving under the same contract as `closed`.
+  // Existing callers that ignore the return value keep working. New callers can
+  // await renderer.destroy() or await renderer.closed for completion-safe teardown.
+  public destroy(): Promise<void> {
+    if (this._isDestroyed) return this.closed
     this._isDestroyed = true
     this._destroyPending = true
     this._palettePublishGeneration++
 
+    // Materialize the closed promise BEFORE any teardown work so that the
+    // resolver is bound and can be fired from finalizeDestroy(). Capturing
+    // it here also ensures the returned promise is identical to
+    // `renderer.closed` for the lifetime of this instance.
+    const closedPromise = this.closed
+
     if (this.rendering) {
       // Restore terminal/input state immediately, but defer full native teardown until the frame unwinds.
       this.prepareDestroyDuringRender()
-      return
+      return closedPromise
     }
 
     this.finalizeDestroy()
+    return closedPromise
   }
 
   private cleanupBeforeDestroy(): void {
@@ -4144,6 +4260,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     process.removeListener("unhandledRejection", this.handleError)
     process.removeListener("warning", this.warningHandler)
     process.removeListener("beforeExit", this.exitHandler)
+    process.removeListener("exit", this.processExitHandler)
     this.removeExitListeners()
 
     if (this.resizeTimeoutId !== null) {
@@ -4209,9 +4326,68 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
   }
 
+  private writeHardTerminalRestore(): void {
+    if (!this._terminalIsSetup) return
+
+    const fd = (this.stdout as NodeJS.WriteStream & { fd?: number }).fd
+    if (typeof fd === "number") {
+      try {
+        // Fast path: synchronous fd write bypasses the Writable pipeline and
+        // libuv buffers entirely. Bytes hit the kernel before this returns,
+        // so callers may safely process.exit() immediately afterwards.
+        writeSync(fd, TERMINAL_HARD_RESTORE)
+        this._hardRestoreFlushed = Promise.resolve()
+        return
+      } catch (e) {
+        console.error("Error writing synchronous terminal restore during destroy:", e)
+      }
+    }
+
+    // Fallback path: custom Writable without a numeric fd (e.g. an SSH
+    // transport, an in-memory buffer, or a wrapped pipe). We cannot do a
+    // truly synchronous write here, but we still call .write() immediately
+    // and capture the flush callback so `renderer.closed` does not resolve
+    // before the underlying stream has finished draining the restore bytes.
+    this._hardRestoreFlushed = new Promise<void>((resolve) => {
+      let settled = false
+      const done = (): void => {
+        if (settled) return
+        settled = true
+        resolve()
+      }
+      try {
+        this.realStdoutWrite.call(this.stdout, TERMINAL_HARD_RESTORE, undefined, () => done())
+      } catch (e) {
+        console.error("Error writing terminal restore during destroy:", e)
+        done()
+      }
+    })
+  }
+
+  private prepareTerminalRestoreForDestroy(): void {
+    if (this._terminalRestorePrepared) return
+    this._terminalRestorePrepared = true
+
+    this.writeHardTerminalRestore()
+
+    if (this._feed) {
+      try {
+        this._feed.drainAll()
+      } catch (e) {
+        console.error("Error draining NativeSpanFeed terminal restore during destroy:", e)
+      }
+    }
+  }
+
   private prepareDestroyDuringRender(): void {
     this.cleanupBeforeDestroy()
-    this.lib.suspendRenderer(this.rendererPtr)
+    this.prepareTerminalRestoreForDestroy()
+
+    try {
+      this.lib.suspendRenderer(this.rendererPtr)
+    } catch (e) {
+      console.error("Error suspending renderer during destroy:", e)
+    }
   }
 
   private finalizeDestroy(): void {
@@ -4221,6 +4397,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this._destroyPending = false
 
     this.cleanupBeforeDestroy()
+    this.prepareTerminalRestoreForDestroy()
 
     // Clean up palette detector
     if (this._paletteDetector) {
@@ -4236,8 +4413,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.resolveXtVersionWaiters()
 
     this.themeModeState.dispose()
-
-    this.emit(CliRenderEvents.DESTROY)
 
     try {
       this.root.destroyRecursively()
@@ -4281,6 +4456,14 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     //      before `feed.close()`, otherwise `close()` will wait for any
     //      in-flight writes that reference chunks about to be freed.
     //
+    // Note: `prepareTerminalRestoreForDestroy()` already wrote the hard
+    // restore sequence directly to the stdout fd (or via the fallback path)
+    // and called `_feed.drainAll()` once before we got here. That happens
+    // BEFORE step (a) below and is what makes destroy() completion-safe for
+    // terminal modes (mouse, raw, alt-screen, kitty-keyboard). The steps
+    // below additionally flush any in-flight render frames and the native
+    // renderer's own shutdown bytes so the feed and native side are clean.
+    //
     // The correct order is:
     //   a) drain any frames already committed but not yet delivered
     //   b) call lib.destroyRenderer — this commits shutdown bytes into the feed
@@ -4293,14 +4476,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     // owned by the TS side and only released by `feed.close()` at step (e).
     // Consequently, step (c)'s drain operates on still-valid chunk memory;
     // there is no use-after-free window between (b) and (e).
-    //
-    // Caller note: `feed.close()` is queued as a microtask when async handlers
-    // from the final drain are still pending. If the caller tears down the
-    // underlying Writable synchronously right after `destroy()` returns (e.g.
-    // `channel.close()` on the very next line, or `process.exit()`), the
-    // shutdown bytes may not have flushed yet. For async teardown, allow one
-    // microtask tick (e.g. `await new Promise(queueMicrotask)`) before closing
-    // the transport.
+    let feedClosed: Promise<void> = Promise.resolve()
+
     if (this._feed) {
       try {
         this._feed.drainAll()
@@ -4322,8 +4499,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     if (this._feed) {
+      const feed = this._feed
       try {
-        this._feed.drainAll()
+        feed.drainAll()
       } catch (e) {
         console.error("Error draining NativeSpanFeed shutdown frames:", e)
       }
@@ -4331,7 +4509,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this._detachFeed = null
       this._detachFeedError?.()
       this._detachFeedError = null
-      this._feed.close()
+      feedClosed = feed.close()
       this._feed = null
     }
 
@@ -4341,6 +4519,22 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this._streamLeaseAcquired = false
     }
 
+    // Resolve idle waiters now that state is final (feed is nulled, but the
+    // deferred completion event/promise still fire later via microtask).
+    this.resolveIdleIfNeeded()
+
+    void Promise.all([this._hardRestoreFlushed, feedClosed]).then(
+      () => this.finishDestroyCompletion(),
+      () => this.finishDestroyCompletion(),
+    )
+  }
+
+  private finishDestroyCompletion(): void {
+    if (this._destroyCompletionEmitted) return
+    this._destroyCompletionEmitted = true
+
+    this.emit(CliRenderEvents.DESTROY)
+
     if (this._onDestroy) {
       try {
         this._onDestroy()
@@ -4349,8 +4543,13 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       }
     }
 
-    // Resolve any pending idle() calls
     this.resolveIdleIfNeeded()
+
+    const resolver = this._closedResolver
+    if (resolver) {
+      this._closedResolver = null
+      resolver()
+    }
   }
 
   private startRenderLoop(): void {

--- a/packages/core/src/tests/renderer.destroy-during-render.test.ts
+++ b/packages/core/src/tests/renderer.destroy-during-render.test.ts
@@ -1,8 +1,63 @@
 import { test, expect } from "bun:test"
-import { Readable } from "node:stream"
+import { openSync, readFileSync, closeSync, unlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Readable, Writable } from "node:stream"
 import { Renderable } from "../Renderable.js"
 import type { OptimizedBuffer } from "../buffer.js"
+import { CliRenderer, CliRenderEvents } from "../renderer.js"
 import { createTestRenderer, type TestRenderer } from "../testing/test-renderer.js"
+
+const decoder = new TextDecoder()
+
+class RecordingWriteStream extends Writable {
+  public readonly isTTY = true
+  public readonly columns: number
+  public readonly rows: number
+  public output = ""
+
+  constructor(columns = 80, rows = 24) {
+    super()
+    this.columns = columns
+    this.rows = rows
+  }
+
+  override _write(chunk: any, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    this.output += typeof chunk === "string" ? chunk : decoder.decode(chunk)
+    callback()
+  }
+
+  getColorDepth(): number {
+    return 24
+  }
+}
+
+function countOccurrences(text: string, search: string): number {
+  return text.split(search).length - 1
+}
+
+class FdWriteStream extends Writable {
+  public readonly fd: number
+  public readonly isTTY = true
+  public columns = 80
+  public rows = 24
+  public capturedOutput = ""
+
+  constructor(fd: number) {
+    super()
+    this.fd = fd
+  }
+
+  override _write(chunk: any, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    const str = typeof chunk === "string" ? chunk : decoder.decode(chunk)
+    this.capturedOutput += str
+    callback()
+  }
+
+  getColorDepth(): number {
+    return 24
+  }
+}
 
 class DestroyingRenderable extends Renderable {
   protected renderSelf(_buffer: OptimizedBuffer, _deltaTime: number): void {}
@@ -18,16 +73,27 @@ test("destroying renderer during frame callback should synchronously clean up te
     return stdin
   }
 
-  const { renderer } = await createTestRenderer({ stdin })
+  const stdout = new RecordingWriteStream()
+  const { renderer } = await createTestRenderer({
+    stdin,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    screenMode: "alternate-screen",
+  })
+  await renderer.setupTerminal()
   const lib = (renderer as any).lib as { suspendRenderer: (rendererPtr: unknown) => void }
   const originalSuspendRenderer = lib.suspendRenderer.bind(lib)
   let suspendCalls = 0
   let cleanupObserved = false
+  let outputAtDestroyEvent = ""
 
   lib.suspendRenderer = (rendererPtr: unknown) => {
     suspendCalls++
     originalSuspendRenderer(rendererPtr)
   }
+
+  renderer.once(CliRenderEvents.DESTROY, () => {
+    outputAtDestroyEvent = stdout.output
+  })
 
   renderer.setFrameCallback(async () => {
     renderer.destroy()
@@ -35,6 +101,7 @@ test("destroying renderer during frame callback should synchronously clean up te
 
     expect(rawModeCalls.at(-1)).toBe(false)
     expect(suspendCalls).toBe(1)
+    expect(stdout.output).toContain("\x1b[?1006l")
   })
 
   renderer.start()
@@ -42,6 +109,40 @@ test("destroying renderer during frame callback should synchronously clean up te
   await new Promise((resolve) => setTimeout(resolve, 100))
 
   expect(cleanupObserved).toBe(true)
+  expect(outputAtDestroyEvent).toContain("\x1b[?1006l")
+})
+
+test("destroy event should fire after hard terminal restore output is written", async () => {
+  const stdout = new RecordingWriteStream()
+  const { renderer } = await createTestRenderer({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    screenMode: "alternate-screen",
+  })
+  await renderer.setupTerminal()
+
+  let outputAtDestroyEvent = ""
+  const destroyed = new Promise<void>((resolve) =>
+    renderer.once(CliRenderEvents.DESTROY, () => {
+      outputAtDestroyEvent = stdout.output
+      resolve()
+    }),
+  )
+
+  const closed = renderer.destroy()
+  await destroyed
+  await closed
+
+  expect(outputAtDestroyEvent).toContain("\x1b[?1003l")
+  expect(outputAtDestroyEvent).toContain("\x1b[?1006l")
+  expect(outputAtDestroyEvent).toContain("\x1b[?2004l")
+  expect(outputAtDestroyEvent).toContain("\x1b[<u")
+  expect(outputAtDestroyEvent).toContain("\x1b[r")
+  expect(outputAtDestroyEvent).toContain("\x1b[?1049l")
+  expect(countOccurrences(stdout.output, "\x1b[?1006l")).toBe(1)
+
+  const outputAfterFirstDestroy = stdout.output
+  await renderer.destroy()
+  expect(stdout.output).toBe(outputAfterFirstDestroy)
 })
 
 test("destroying renderer during frame callback should not crash", async () => {
@@ -144,4 +245,295 @@ test("destroying renderer during renderBefore should not crash", async () => {
   await new Promise((resolve) => setTimeout(resolve, 100))
 
   expect(destroyedDuringRenderBefore).toBe(true)
+})
+
+test("writeSync(fd) path should write hard terminal restore directly to file descriptor", async () => {
+  const tmpPath = join(tmpdir(), `opentui-hard-restore-test-${Date.now()}.txt`)
+  let fd: number | null = null
+
+  try {
+    fd = openSync(tmpPath, "w")
+    const stdin = new Readable({ read() {} }) as NodeJS.ReadStream
+    const stdout = new FdWriteStream(fd)
+
+    const renderer = new CliRenderer(stdin, stdout as unknown as NodeJS.WriteStream, 80, 24, {
+      screenMode: "alternate-screen",
+      consoleMode: "disabled",
+      exitOnCtrlC: false,
+      exitSignals: [],
+      bufferedOutput: "memory",
+    })
+
+    await renderer.setupTerminal()
+    renderer.destroy()
+
+    const contents = readFileSync(tmpPath, "utf-8")
+
+    expect(contents).toContain("\x1b[?1003l")
+    expect(contents).toContain("\x1b[?1006l")
+    expect(contents).toContain("\x1b[?2004l")
+    expect(contents).toContain("\x1b[<u")
+    expect(contents).toContain("\x1b[r")
+    expect(contents).toContain("\x1b[?1049l")
+
+    expect(stdout.capturedOutput).not.toContain("\x1b[?1006l")
+  } finally {
+    if (fd !== null) {
+      try { closeSync(fd) } catch {}
+    }
+    try { unlinkSync(tmpPath) } catch {}
+  }
+})
+
+test("writeSync(fd) path is fully synchronous: bytes are on disk before destroy() returns", async () => {
+  const tmpPath = join(tmpdir(), `opentui-hard-restore-sync-${Date.now()}.txt`)
+  let fd: number | null = null
+
+  try {
+    fd = openSync(tmpPath, "w")
+    const stdin = new Readable({ read() {} }) as NodeJS.ReadStream
+    const stdout = new FdWriteStream(fd)
+
+    const renderer = new CliRenderer(stdin, stdout as unknown as NodeJS.WriteStream, 80, 24, {
+      screenMode: "alternate-screen",
+      consoleMode: "disabled",
+      exitOnCtrlC: false,
+      exitSignals: [],
+      bufferedOutput: "memory",
+    })
+
+    await renderer.setupTerminal()
+    // No await on destroy; no microtask yield. The whole point of the
+    // writeSync(fd) path is that mode-disable bytes hit the kernel before
+    // control returns to the caller, so subsequent synchronous file reads
+    // already observe them.
+    renderer.destroy()
+    const contents = readFileSync(tmpPath, "utf-8")
+
+    expect(contents).toContain("\x1b[?1006l")
+    expect(contents).toContain("\x1b[?1049l")
+  } finally {
+    if (fd !== null) {
+      try { closeSync(fd) } catch {}
+    }
+    try { unlinkSync(tmpPath) } catch {}
+  }
+})
+
+test("destroy() returns a promise that resolves after teardown", async () => {
+  const stdout = new RecordingWriteStream()
+  const { renderer } = await createTestRenderer({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    screenMode: "alternate-screen",
+  })
+  await renderer.setupTerminal()
+
+  const result = renderer.destroy()
+  expect(result).toBeInstanceOf(Promise)
+  await result
+  // After the awaited destroy(), the hard restore must already be observable
+  // in the recorded output.
+  expect(stdout.output).toContain("\x1b[?1006l")
+  expect(stdout.output).toContain("\x1b[?1049l")
+})
+
+test("renderer.closed resolves after destroy and remains the same promise", async () => {
+  const stdout = new RecordingWriteStream()
+  const { renderer } = await createTestRenderer({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    screenMode: "alternate-screen",
+  })
+  await renderer.setupTerminal()
+
+  const closedEarly = renderer.closed
+  expect(closedEarly).toBeInstanceOf(Promise)
+
+  // Should not be resolved yet — renderer is alive.
+  const raceMarker = Symbol("not-yet")
+  const race = await Promise.race([closedEarly.then(() => "resolved"), Promise.resolve(raceMarker)])
+  expect(race).toBe(raceMarker)
+
+  const destroyPromise = renderer.destroy()
+  // destroy() returns the same promise identity as `closed`.
+  expect(destroyPromise).toBe(renderer.closed)
+  expect(destroyPromise).toBe(closedEarly)
+
+  await destroyPromise
+
+  // After completion, `closed` keeps returning a resolved promise (cached).
+  await expect(renderer.closed).resolves.toBeUndefined()
+})
+
+test("renderer.closed waits for the async write callback on non-fd Writables", async () => {
+  // Stream that defers its _write callback so we can observe whether `closed`
+  // really gates on the flush.
+  class SlowWriteStream extends Writable {
+    public readonly isTTY = true
+    public readonly columns = 80
+    public readonly rows = 24
+    public output = ""
+    public lastCallback: ((err?: Error | null) => void) | null = null
+    public deferredChunks: Array<{ chunk: string; cb: (err?: Error | null) => void }> = []
+
+    override _write(chunk: any, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+      const str = typeof chunk === "string" ? chunk : decoder.decode(chunk)
+      this.output += str
+      if (str.includes("\x1b[?1006l")) {
+        // Defer the restore-write callback explicitly to test the gating.
+        this.deferredChunks.push({ chunk: str, cb: callback })
+        return
+      }
+      callback()
+    }
+
+    getColorDepth(): number {
+      return 24
+    }
+
+    flushDeferred(): void {
+      const pending = this.deferredChunks.splice(0)
+      for (const { cb } of pending) cb()
+    }
+  }
+
+  const stdout = new SlowWriteStream()
+  const { renderer } = await createTestRenderer({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    screenMode: "alternate-screen",
+  })
+  await renderer.setupTerminal()
+
+  let closedResolved = false
+  renderer.closed.then(() => {
+    closedResolved = true
+  })
+
+  renderer.destroy()
+
+  // Synchronously after destroy(), the restore bytes have been queued to the
+  // stream (stdout.output contains them) but the write callback has NOT
+  // fired yet. So `closed` must still be pending.
+  expect(stdout.output).toContain("\x1b[?1006l")
+  // Allow microtasks to run; closed should NOT resolve while the callback
+  // is being held.
+  await new Promise((resolve) => setImmediate(resolve))
+  expect(closedResolved).toBe(false)
+
+  // Release the deferred callback. `closed` should now resolve.
+  stdout.flushDeferred()
+  await renderer.closed
+  expect(closedResolved).toBe(true)
+})
+
+test("destroy() called twice returns the same promise and does not double-write", async () => {
+  const stdout = new RecordingWriteStream()
+  const { renderer } = await createTestRenderer({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    screenMode: "alternate-screen",
+  })
+  await renderer.setupTerminal()
+
+  const first = renderer.destroy()
+  const second = renderer.destroy()
+  expect(first).toBe(second)
+
+  await first
+  const outputAfter = stdout.output
+
+  const third = renderer.destroy()
+  await third
+  expect(stdout.output).toBe(outputAfter)
+})
+
+test("destroy() succeeds even when native suspendRenderer throws during active render", async () => {
+  const stdin = new Readable({ read() {} }) as NodeJS.ReadStream & {
+    setRawMode: (enabled: boolean) => NodeJS.ReadStream
+  }
+  stdin.setRawMode = () => stdin
+
+  const stdout = new RecordingWriteStream()
+  const { renderer } = await createTestRenderer({
+    stdin,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    screenMode: "alternate-screen",
+  })
+  await renderer.setupTerminal()
+
+  const lib = (renderer as any).lib as { suspendRenderer: (rendererPtr: unknown) => void }
+  const originalSuspendRenderer = lib.suspendRenderer
+  lib.suspendRenderer = () => {
+    throw new Error("simulated suspend failure")
+  }
+
+  try {
+    let frameCallbackError: unknown = null
+    renderer.setFrameCallback(async () => {
+      try {
+        // destroy() during an active frame triggers prepareDestroyDuringRender.
+        // Even if the subsequent suspendRenderer throws, the hard restore must
+        // have been written synchronously beforehand.
+        renderer.destroy()
+      } catch (e) {
+        frameCallbackError = e
+      }
+    })
+
+    renderer.start()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(frameCallbackError).toBe(null)
+    expect(stdout.output).toContain("\x1b[?1006l")
+    expect(stdout.output).toContain("\x1b[?1049l")
+
+    // The renderer should still be able to finalize cleanly.
+    await renderer.closed
+  } finally {
+    // Restore the singleton-lib method so subsequent tests in the same
+    // process are not affected.
+    lib.suspendRenderer = originalSuspendRenderer
+  }
+})
+
+test("destroy event fires after native destroy", async () => {
+  const stdout = new RecordingWriteStream()
+  const { renderer } = await createTestRenderer({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    screenMode: "alternate-screen",
+  })
+  await renderer.setupTerminal()
+
+  const lib = (renderer as any).lib as { destroyRenderer: (rendererPtr: unknown) => void }
+  const originalDestroyRenderer = lib.destroyRenderer.bind(lib)
+  let nativeDestroyed = false
+  let observedAtEvent = false
+
+  lib.destroyRenderer = (rendererPtr: unknown) => {
+    nativeDestroyed = true
+    originalDestroyRenderer(rendererPtr)
+  }
+
+  try {
+    renderer.once(CliRenderEvents.DESTROY, () => {
+      observedAtEvent = nativeDestroyed
+    })
+
+    await renderer.destroy()
+    expect(observedAtEvent).toBe(true)
+  } finally {
+    lib.destroyRenderer = originalDestroyRenderer
+  }
+})
+
+test("closed resolves after destroy event", async () => {
+  const stdout = new RecordingWriteStream()
+  const { renderer } = await createTestRenderer({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    screenMode: "alternate-screen",
+  })
+  await renderer.setupTerminal()
+
+  const order: string[] = []
+  renderer.once(CliRenderEvents.DESTROY, () => order.push("event"))
+  await renderer.destroy().then(() => order.push("closed"))
+  expect(order).toEqual(["event", "closed"])
 })

--- a/packages/core/src/tests/renderer.exit-restore.fixture.ts
+++ b/packages/core/src/tests/renderer.exit-restore.fixture.ts
@@ -1,0 +1,88 @@
+// Fixture for verifying that OpenTUI restores terminal modes via its
+// `process.on("exit")` handler even when the host application never calls
+// renderer.destroy() — e.g. an explicit process.exit from arbitrary
+// application code, or a real uncaughtException crash (after the host
+// removes OpenTUI's swallowing listener).
+//
+// CLI: <fixturePath> <tmpStdoutPath> <exitMode>
+//   tmpStdoutPath: a file path the fixture will open as stdout (must be writable).
+//   exitMode: one of "exit", "host-uncaught".
+import { openSync, closeSync, writeSync } from "node:fs"
+import { Readable, Writable } from "node:stream"
+import { CliRenderer } from "../renderer.js"
+
+const tmpStdoutPath = process.argv[2]
+const exitMode = process.argv[3] ?? "exit"
+
+if (!tmpStdoutPath) {
+  console.error("missing tmpStdoutPath")
+  process.exit(2)
+}
+
+const fd = openSync(tmpStdoutPath, "w")
+
+class FdStream extends Writable {
+  public readonly isTTY = true
+  public columns = 80
+  public rows = 24
+  public readonly fd: number
+  constructor(fd: number) {
+    super()
+    this.fd = fd
+  }
+  override _write(_chunk: any, _enc: BufferEncoding, cb: (err?: Error | null) => void): void {
+    cb()
+  }
+  getColorDepth(): number {
+    return 24
+  }
+}
+
+const stdin = new Readable({ read() {} }) as NodeJS.ReadStream & {
+  setRawMode: (enabled: boolean) => NodeJS.ReadStream
+}
+stdin.setRawMode = (enabled) => {
+  if (!enabled) {
+    writeSync(fd, "RAW_MODE_FALSE\n")
+  }
+  return stdin
+}
+
+const stdout = new FdStream(fd)
+
+const renderer = new CliRenderer(stdin, stdout as unknown as NodeJS.WriteStream, 80, 24, {
+  screenMode: "alternate-screen",
+  consoleMode: "disabled",
+  exitOnCtrlC: false,
+  exitSignals: [],
+})
+
+await renderer.setupTerminal()
+
+// IMPORTANT: do NOT call renderer.destroy() and do NOT register an `exit`
+// handler that calls it. The whole point of this fixture is to verify
+// OpenTUI's internal process.on("exit") handler restores the terminal
+// without any application-level cooperation.
+
+if (exitMode === "host-uncaught") {
+  // Remove every uncaughtException listener (including the one OpenTUI
+  // registered to suppress Node's default crash behavior). This simulates
+  // a host application that wants exceptions to actually crash the process.
+  process.removeAllListeners("uncaughtException")
+  setImmediate(() => {
+    throw new Error("simulated uncaught exception")
+  })
+} else {
+  // Direct process.exit without calling renderer.destroy(). The exit
+  // handler installed by OpenTUI must do the restore.
+  process.exit(0)
+}
+
+// Best-effort close on graceful paths; the kernel will close on exit anyway.
+process.on("exit", () => {
+  try {
+    closeSync(fd)
+  } catch {
+    // ignore
+  }
+})

--- a/packages/core/src/tests/renderer.exit-restore.test.ts
+++ b/packages/core/src/tests/renderer.exit-restore.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, extname, join, resolve, sep } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const testFilePath = fileURLToPath(import.meta.url)
+const testDir = dirname(testFilePath)
+const fixturePath = join(testDir, `renderer.exit-restore.fixture${extname(testFilePath)}`)
+const packageRoot = testFilePath.includes(`${sep}.node-test${sep}`)
+  ? resolve(testDir, "..", "..", "..")
+  : resolve(testDir, "..", "..")
+const workspaceRoot = resolve(packageRoot, "..", "..")
+
+function getFixtureRuntimeArgs(): string[] {
+  if (process.versions.bun) {
+    return []
+  }
+  return [
+    "--permission",
+    `--allow-fs-read=${workspaceRoot}`,
+    `--allow-fs-write=${tmpdir()}`,
+    "--allow-child-process",
+    "--allow-worker",
+    "--allow-ffi",
+    "--experimental-ffi",
+  ]
+}
+
+function runFixture(exitMode: "exit" | "host-uncaught"): { exitCode: number | null; stdoutFile: string } {
+  const dir = mkdtempSync(join(tmpdir(), "opentui-exit-restore-"))
+  const stdoutPath = join(dir, "stdout.bin")
+  try {
+    const result = spawnSync(process.execPath, [...getFixtureRuntimeArgs(), fixturePath, stdoutPath, exitMode], {
+      cwd: packageRoot,
+      env: process.env,
+      timeout: 5000,
+    })
+    const contents = readFileSync(stdoutPath, "utf-8")
+    return { exitCode: result.status, stdoutFile: contents }
+  } finally {
+    try {
+      rmSync(dir, { recursive: true, force: true })
+    } catch {
+      // ignore
+    }
+  }
+}
+
+describe("OpenTUI process.on('exit') terminal restore", () => {
+  it("restores terminal on explicit process.exit() without renderer.destroy()", () => {
+    const { exitCode, stdoutFile } = runFixture("exit")
+    expect(exitCode).toBe(0)
+    expect(stdoutFile).toContain("RAW_MODE_FALSE")
+    expect(stdoutFile).toContain("\x1b[?1006l")
+    expect(stdoutFile).toContain("\x1b[?1003l")
+    expect(stdoutFile).toContain("\x1b[?1049l")
+    expect(stdoutFile).toContain("\x1b[<u")
+  })
+
+  it("restores terminal when host removes OpenTUI's uncaughtException handler and the process crashes", () => {
+    // OpenTUI registers its own uncaughtException listener that suppresses
+    // Node's default crash behavior, so a bare `throw` would otherwise be
+    // swallowed. A host application that wants Node's default behavior must
+    // remove OpenTUI's listener — in which case the process really does
+    // crash, fires `process.on("exit")`, and our last-resort restore runs.
+    const { exitCode, stdoutFile } = runFixture("host-uncaught")
+    expect(exitCode).not.toBe(0)
+    expect(stdoutFile).toContain("RAW_MODE_FALSE")
+    expect(stdoutFile).toContain("\x1b[?1006l")
+    expect(stdoutFile).toContain("\x1b[?1049l")
+  })
+})

--- a/packages/solid/index.ts
+++ b/packages/solid/index.ts
@@ -31,13 +31,13 @@ const mountSolidRoot = (renderer: CliRenderer, node: () => JSX.Element) => {
 
   renderer.once("destroy", runDispose)
 
-  renderer.destroy = () => {
+  renderer.destroy = (): Promise<void> => {
     if (mounting) {
       destroyRequested = true
-      return
+      return renderer.closed
     }
 
-    originalDestroy()
+    return originalDestroy()
   }
 
   try {


### PR DESCRIPTION
…use events print as ^[[<... after exit or crash [#10610](https://github.com/anomalyco/opencode/issues/10610)

Also related to: https://github.com/anomalyco/opencode/issues/30133