### PR TITLE
fix: scroll position and selection

### DIFF
--- a/packages/core/src/renderables/Select.test.ts
+++ b/packages/core/src/renderables/Select.test.ts
@@ -524,6 +524,38 @@ describe("SelectRenderable", () => {
     })
   })
 
+  describe("Scroll Indicator", () => {
+    const manyOptions: SelectOption[] = Array.from({ length: 20 }, (_, index) => ({
+      name: `Item ${index}`,
+      description: "",
+    }))
+
+    test.each([
+      { selectedIndex: 0, expectedRow: 1 },
+      { selectedIndex: 2, expectedRow: 1 },
+      { selectedIndex: 7, expectedRow: 2 },
+      { selectedIndex: 12, expectedRow: 3 },
+      { selectedIndex: 17, expectedRow: 4 },
+      { selectedIndex: 19, expectedRow: 4 },
+    ])("renders the viewport position for selected index $selectedIndex", async ({ selectedIndex, expectedRow }) => {
+      const { select } = await createSelectRenderable(currentRenderer, {
+        width: 20,
+        height: 5,
+        options: manyOptions,
+        showScrollIndicator: true,
+        showDescription: false,
+      })
+
+      select.setSelectedIndex(selectedIndex)
+      await renderOnce()
+
+      const indicatorRow = captureCharFrame()
+        .split("\n")
+        .findIndex((line) => line.includes("█"))
+      expect(indicatorRow).toBe(expectedRow)
+    })
+  })
+
   describe("Property Changes", () => {
     test("should update showScrollIndicator", async () => {
       const { select } = await createSelectRenderable(currentRenderer, {

--- a/packages/core/src/renderables/Select.test.ts
+++ b/packages/core/src/renderables/Select.test.ts
@@ -105,6 +105,26 @@ describe("SelectRenderable", () => {
       expect(select.getSelectedOption()).toEqual(sampleOptions[2])
     })
 
+    test("should scroll an initial off-screen selection into view", async () => {
+      const options: SelectOption[] = Array.from({ length: 20 }, (_, index) => ({
+        name: `Item ${index}`,
+        description: "",
+      }))
+
+      await createSelectRenderable(currentRenderer, {
+        width: 20,
+        height: 5,
+        options,
+        selectedIndex: 12,
+        showDescription: false,
+        showScrollIndicator: true,
+      })
+
+      const frame = captureCharFrame().split("\n")
+      expect(frame.some((line) => line.includes("▶ Item 12"))).toBe(true)
+      expect(frame.findIndex((line) => line.includes("█"))).toBe(3)
+    })
+
     test("should initialize with custom options", async () => {
       const { select } = await createSelectRenderable(currentRenderer, {
         width: 20,

--- a/packages/core/src/renderables/Select.ts
+++ b/packages/core/src/renderables/Select.ts
@@ -232,7 +232,8 @@ export class SelectRenderable extends Renderable {
   ): void {
     if (!this.frameBuffer) return
 
-    const scrollPercent = this._selectedIndex / Math.max(1, this._options.length - 1)
+    const maxScrollOffset = this._options.length - this.maxVisibleItems
+    const scrollPercent = this.scrollOffset / maxScrollOffset
     const indicatorHeight = Math.max(1, contentHeight - 2)
     const indicatorY = contentY + 1 + Math.floor(scrollPercent * indicatorHeight)
     const indicatorX = contentX + contentWidth - 1

--- a/packages/core/src/renderables/Select.ts
+++ b/packages/core/src/renderables/Select.ts
@@ -152,6 +152,7 @@ export class SelectRenderable extends Renderable {
     const mergedBindings = mergeKeyBindings(defaultSelectKeybindings, this._keyBindings)
     this._keyBindingsMap = buildKeyBindingsMap(mergedBindings, this._keyAliasMap)
 
+    this.updateScrollOffset()
     this.requestRender() // Initial render needed
   }
 


### PR DESCRIPTION
Base the SelectRenderable scroll indicator on scrollOffset rather than
selectedIndex so it reflects the visible viewport, including when the
viewport is clamped near the start or end of the list.

Fixes https://github.com/anomalyco/opentui/issues/1040
Incorporates https://github.com/anomalyco/opentui/pull/1172