### PR TITLE
fix(core): clamp up/down movement at first/last line boundaries

### DIFF
--- a/packages/core/src/renderables/EditBufferRenderable.ts
+++ b/packages/core/src/renderables/EditBufferRenderable.ts
@@ -730,7 +730,14 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
   public moveCursorUp(options?: { select?: boolean }): boolean {
     const select = options?.select ?? false
     this.updateSelectionForMovement(select, true)
-    this.editorView.moveUpVisual()
+    if (this.editorView.getVisualCursor().visualRow === 0) {
+      const cursor = this.editorView.getCursor()
+      if (cursor.row !== 0 || cursor.col !== 0) {
+        this.editBuffer.setCursor(0, 0)
+      }
+    } else {
+      this.editorView.moveUpVisual()
+    }
     this.updateSelectionForMovement(select, false)
     this.requestRender()
     return true
@@ -739,7 +746,15 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
   public moveCursorDown(options?: { select?: boolean }): boolean {
     const select = options?.select ?? false
     this.updateSelectionForMovement(select, true)
-    this.editorView.moveDownVisual()
+    if (this.editorView.getVisualCursor().visualRow >= this.editorView.getTotalVirtualLineCount() - 1) {
+      const cursor = this.editorView.getCursor()
+      const eol = this.editBuffer.getEOL()
+      if (cursor.row !== eol.row || cursor.col !== eol.col) {
+        this.editBuffer.setCursor(eol.row, eol.col)
+      }
+    } else {
+      this.editorView.moveDownVisual()
+    }
     this.updateSelectionForMovement(select, false)
     this.requestRender()
     return true

--- a/packages/core/src/renderables/__tests__/Textarea.keybinding.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.keybinding.test.ts
@@ -3272,4 +3272,126 @@ describe("Textarea - Keybinding Tests", () => {
       expect(visualSelection).not.toBe(logicalSelection)
     })
   })
+
+  describe("Arrow Boundary Clamping", () => {
+    it("shift+up on first line extends selection to start", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "Hello",
+        width: 40,
+        height: 10,
+        selectable: true,
+      })
+
+      editor.focus()
+      editor.editBuffer.setCursor(0, 3)
+
+      currentMockInput.pressArrow("up", { shift: true })
+
+      expect(editor.logicalCursor.row).toBe(0)
+      expect(editor.logicalCursor.col).toBe(0)
+      expect(editor.getSelectedText()).toBe("Hell")
+    })
+
+    it("shift+down on last line extends selection to end", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "Line 1\nLine 2\nLine 3",
+        width: 40,
+        height: 10,
+        selectable: true,
+      })
+
+      editor.focus()
+      editor.editBuffer.setCursor(2, 2)
+
+      currentMockInput.pressArrow("down", { shift: true })
+
+      expect(editor.logicalCursor.row).toBe(2)
+      expect(editor.logicalCursor.col).toBe(6)
+      expect(editor.getSelectedText()).toBe("ne 3")
+    })
+
+    it("plain up on first line clamps cursor to start", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "Hello",
+        width: 40,
+        height: 10,
+      })
+
+      editor.focus()
+      editor.editBuffer.setCursor(0, 3)
+
+      currentMockInput.pressArrow("up")
+
+      expect(editor.logicalCursor.row).toBe(0)
+      expect(editor.logicalCursor.col).toBe(0)
+    })
+
+    it("plain down on last line clamps cursor to end", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "Line 1\nLine 2\nLine 3",
+        width: 40,
+        height: 10,
+      })
+
+      editor.focus()
+      editor.editBuffer.setCursor(2, 2)
+
+      currentMockInput.pressArrow("down")
+
+      expect(editor.logicalCursor.row).toBe(2)
+      expect(editor.logicalCursor.col).toBe(6)
+    })
+
+    it("shift+up when already at start of first line selects nothing", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "Hello",
+        width: 40,
+        height: 10,
+        selectable: true,
+      })
+
+      editor.focus()
+      editor.editBuffer.setCursor(0, 0)
+
+      currentMockInput.pressArrow("up", { shift: true })
+
+      expect(editor.logicalCursor.col).toBe(0)
+      expect(editor.getSelectedText()).toBe("")
+    })
+
+    it("shift+down when already at end of last line selects nothing", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "Line 1\nLine 2\nLine 3",
+        width: 40,
+        height: 10,
+        selectable: true,
+      })
+
+      editor.focus()
+      editor.editBuffer.setCursor(2, 6)
+
+      currentMockInput.pressArrow("down", { shift: true })
+
+      expect(editor.logicalCursor.col).toBe(6)
+      expect(editor.getSelectedText()).toBe("")
+    })
+
+    it("shift+up on first line of multi-line selects to column 0", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "Line 1\nLine 2\nLine 3",
+        width: 40,
+        height: 10,
+        selectable: true,
+      })
+
+      editor.focus()
+      editor.editBuffer.setCursor(0, 4)
+
+      currentMockInput.pressArrow("up", { shift: true })
+
+      expect(editor.logicalCursor.row).toBe(0)
+      expect(editor.logicalCursor.col).toBe(0)
+      expect(editor.getSelectedText()).toBe("Line ")
+    })
+  })
 })


### PR DESCRIPTION
## Problem

`up`/`down` (and `shift+up`/`shift+down`) at the first/last visual line did nothing — the cursor stayed put instead of reaching the buffer start/end. For the shift variants this meant no selection was extended at the boundaries, which is inconsistent with standard editor behavior.

## Root cause

`moveCursorUp`/`moveCursorDown` delegate to `editorView.moveUpVisual()`/`moveDownVisual()`, which early-return at the first/last visual row (`packages/core/src/zig/editor-view.zig:550/589`). For the select variant this left anchor == focus, producing an empty selection.

## Fix

In `EditBufferRenderable.moveCursorUp`/`moveCursorDown`, detect the boundary via the visual cursor and clamp instead of no-op'ing:

- `up` at visual row 0 → `setCursor(0, 0)`
- `down` at the last visual row → `setCursor(eol)`

This sits between the two `updateSelectionForMovement` calls (mirroring the existing `gotoLineHome`/`gotoLineEnd` pattern), so `shift+up`/`shift+down` extend the selection and plain `up`/`down` clamp too. The native Zig layer is untouched, so its boundary tests and the `desired_visual_col` state machine are unaffected.

## Testing

7 new tests in `Textarea.keybinding.test.ts` ("Arrow Boundary Clamping"): shift+up/down extension to the buffer bounds, plain up/down clamping, and no-op guards when already at the extremes.

- Full keybinding suite: 155/155 pass
- Related EditBuffer / Textarea / editor-view suites: 242/242 pass
- `oxlint`: 0 warnings/errors · `oxfmt`: clean

TS-only change; no native rebuild required.