### PR TITLE
Select: add showSelectionIndicator option

### DIFF
--- a/packages/core/src/renderables/Select.test.ts
+++ b/packages/core/src/renderables/Select.test.ts
@@ -91,6 +91,7 @@ describe("SelectRenderable", () => {
       expect(select.showScrollIndicator).toBe(false)
       expect(select.showDescription).toBe(true)
       expect(select.wrapSelection).toBe(false)
+      expect(select.showSelectionIndicator).toBe(true)
     })
 
     test("should initialize with custom selected index", async () => {
@@ -164,6 +165,57 @@ describe("SelectRenderable", () => {
 
       expect(select.getSelectedIndex()).toBe(sampleOptions.length - 1)
       expect(select.getSelectedOption()).toEqual(sampleOptions[sampleOptions.length - 1])
+    })
+  })
+
+  describe("showSelectionIndicator", () => {
+    test("should render the indicator and its gutter by default", async () => {
+      await createSelectRenderable(currentRenderer, {
+        width: 20,
+        height: 5,
+        options: sampleOptions,
+        showDescription: false,
+      })
+
+      const frame = captureCharFrame().split("\n")
+      const selectedLine = frame.find((line) => line.includes("Option 1"))!
+      expect(selectedLine).toContain("▶ Option 1")
+      // left padding(1) + indicator width(2) = 3
+      expect(selectedLine.indexOf("Option 1")).toBe(3)
+    })
+
+    test("should drop the indicator and its gutter when disabled", async () => {
+      const { select } = await createSelectRenderable(currentRenderer, {
+        width: 20,
+        height: 5,
+        options: sampleOptions,
+        showDescription: false,
+        showSelectionIndicator: false,
+      })
+
+      expect(select.showSelectionIndicator).toBe(false)
+
+      const frame = captureCharFrame().split("\n")
+      const selectedLine = frame.find((line) => line.includes("Option 1"))!
+      expect(frame.every((line) => !line.includes("▶"))).toBe(true)
+      // no 2-column gutter (only padding(2))
+      expect(selectedLine.indexOf("Option 1")).toBe(1)
+    })
+
+    test("should toggle the indicator at runtime via the setter", async () => {
+      const { select } = await createSelectRenderable(currentRenderer, {
+        width: 20,
+        height: 5,
+        options: sampleOptions,
+        showDescription: false,
+      })
+
+      expect(captureCharFrame()).toContain("▶ Option 1")
+
+      select.showSelectionIndicator = false
+      await renderOnce()
+
+      expect(captureCharFrame()).not.toContain("▶")
     })
   })
 

--- a/packages/core/src/renderables/Select.ts
+++ b/packages/core/src/renderables/Select.ts
@@ -50,6 +50,7 @@ export interface SelectRenderableOptions extends RenderableOptions<SelectRendera
   showScrollIndicator?: boolean
   wrapSelection?: boolean
   showDescription?: boolean
+  showSelectionIndicator?: boolean
   font?: keyof typeof fonts
   itemSpacing?: number
   fastScrollStep?: number
@@ -68,6 +69,7 @@ export class SelectRenderable extends Renderable {
   private _options: SelectOption[] = []
   private _selectedIndex: number = 0
   private scrollOffset: number = 0
+  private _paddingLeft: number = 1
   private maxVisibleItems: number
 
   private _backgroundColor: RGBA
@@ -81,6 +83,8 @@ export class SelectRenderable extends Renderable {
   private _showScrollIndicator: boolean
   private _wrapSelection: boolean
   private _showDescription: boolean
+  private _showSelectionIndicator: boolean
+  private _selectionIndicator: string
   private _font?: keyof typeof fonts
   private _itemSpacing: number
   private linesPerItem: number
@@ -103,6 +107,7 @@ export class SelectRenderable extends Renderable {
     showScrollIndicator: false,
     wrapSelection: false,
     showDescription: true,
+    showSelectionIndicator: true,
     itemSpacing: 0,
     fastScrollStep: 5,
   } satisfies Partial<SelectRenderableOptions>
@@ -120,6 +125,8 @@ export class SelectRenderable extends Renderable {
     this._focusedTextColor = parseColor(options.focusedTextColor || this._defaultOptions.focusedTextColor)
 
     this._showScrollIndicator = options.showScrollIndicator ?? this._defaultOptions.showScrollIndicator
+    this._showSelectionIndicator = options.showSelectionIndicator ?? this._defaultOptions.showSelectionIndicator
+    this._selectionIndicator = "▶ "
     this._wrapSelection = options.wrapSelection ?? this._defaultOptions.wrapSelection
     this._showDescription = options.showDescription ?? this._defaultOptions.showDescription
     this._font = options.font
@@ -171,8 +178,6 @@ export class SelectRenderable extends Renderable {
     this.frameBuffer.clear(bgColor)
     if (this._options.length === 0) return
 
-    const contentX = 0
-    const contentY = 0
     const contentWidth = this.width
     const contentHeight = this.height
 
@@ -182,46 +187,46 @@ export class SelectRenderable extends Renderable {
       const actualIndex = this.scrollOffset + i
       const option = visibleOptions[i]
       const isSelected = actualIndex === this._selectedIndex
-      const itemY = contentY + i * this.linesPerItem
+      const itemY = i * this.linesPerItem
 
-      if (itemY + this.linesPerItem - 1 >= contentY + contentHeight) break
+      if (itemY + this.linesPerItem - 1 >= contentHeight) break
+
+      const baseTextColor = this._focused ? this._focusedTextColor : this._textColor
+      const nameColor = isSelected ? this._selectedTextColor : baseTextColor
 
       if (isSelected) {
         const contentHeight = this.linesPerItem - this._itemSpacing
-        this.frameBuffer.fillRect(contentX, itemY, contentWidth, contentHeight, this._selectedBackgroundColor)
+        this.frameBuffer.fillRect(0, itemY, contentWidth, contentHeight, this._selectedBackgroundColor)
+        if (this._showSelectionIndicator) {
+          this.frameBuffer.drawText(this._selectionIndicator, this._paddingLeft, itemY, nameColor)
+        }
       }
 
-      const nameContent = `${isSelected ? "▶ " : "  "}${option.name}`
-      const baseTextColor = this._focused ? this._focusedTextColor : this._textColor
-      const nameColor = isSelected ? this._selectedTextColor : baseTextColor
-      let descX = contentX + 3
+      const textX = this._showSelectionIndicator
+        ? this._paddingLeft + this._selectionIndicator.length
+        : this._paddingLeft
 
       if (this._font) {
-        const indicator = isSelected ? "▶ " : "  "
-        this.frameBuffer.drawText(indicator, contentX + 1, itemY, nameColor)
-
-        const indicatorWidth = 2
         renderFontToFrameBuffer(this.frameBuffer, {
           text: option.name,
-          x: contentX + 1 + indicatorWidth,
+          x: textX,
           y: itemY,
           color: nameColor,
           backgroundColor: isSelected ? this._selectedBackgroundColor : bgColor,
           font: this._font,
         })
-        descX = contentX + 1 + indicatorWidth
       } else {
-        this.frameBuffer.drawText(nameContent, contentX + 1, itemY, nameColor)
+        this.frameBuffer.drawText(option.name, textX, itemY, nameColor)
       }
 
-      if (this._showDescription && itemY + this.fontHeight < contentY + contentHeight) {
+      if (this._showDescription && itemY + this.fontHeight < contentHeight) {
         const descColor = isSelected ? this._selectedDescriptionColor : this._descriptionColor
-        this.frameBuffer.drawText(option.description, descX, itemY + this.fontHeight, descColor)
+        this.frameBuffer.drawText(option.description, textX, itemY + this.fontHeight, descColor)
       }
     }
 
     if (this._showScrollIndicator && this._options.length > this.maxVisibleItems) {
-      this.renderScrollIndicatorToFrameBuffer(contentX, contentY, contentWidth, contentHeight)
+      this.renderScrollIndicatorToFrameBuffer(0, 0, contentWidth, contentHeight)
     }
   }
 
@@ -383,6 +388,17 @@ export class SelectRenderable extends Renderable {
 
       this.maxVisibleItems = Math.max(1, Math.floor(this.height / this.linesPerItem))
       this.updateScrollOffset()
+      this.requestRender()
+    }
+  }
+
+  public get showSelectionIndicator(): boolean {
+    return this._showSelectionIndicator
+  }
+
+  public set showSelectionIndicator(show: boolean) {
+    if (this._showSelectionIndicator !== show) {
+      this._showSelectionIndicator = show
       this.requestRender()
     }
   }

--- a/packages/examples/src/select-demo.ts
+++ b/packages/examples/src/select-demo.ts
@@ -50,6 +50,7 @@ function updateDisplays() {
   const scrollIndicator = selectElement.showScrollIndicator ? "on" : "off"
   const description = selectElement.showDescription ? "on" : "off"
   const wrap = selectElement.wrapSelection ? "on" : "off"
+  const selectionIndicator = selectElement.showSelectionIndicator ? "on" : "off"
 
   const keyLegendText = t`${bold(fg("#FFFFFF")("Key Controls:"))}
 ↑/↓ or j/k: Navigate items
@@ -58,7 +59,8 @@ Enter: Select item
 F: Toggle focus
 D: Toggle descriptions
 S: Toggle scroll indicator
-W: Toggle wrap selection`
+W: Toggle wrap selection
+I: Toggle selection indicator`
 
   if (keyLegendDisplay) {
     keyLegendDisplay.content = keyLegendText
@@ -76,7 +78,7 @@ W: Toggle wrap selection`
 
 ${fg(focusColor)(focusText)}
 
-${fg("#CCCCCC")(`Scroll indicator: ${scrollIndicator} | Description: ${description} | Wrap: ${wrap}`)}
+${fg("#CCCCCC")(`Scroll indicator: ${scrollIndicator} | Description: ${description} | Wrap: ${wrap} | Selection indicator: ${selectionIndicator}`)}
 
 ${fg(lastActionColor)(lastActionText)}`
 
@@ -198,6 +200,12 @@ export function run(rendererInstance: CliRenderer): void {
       const newState = !selectElement?.wrapSelection
       selectElement!.wrapSelection = newState
       lastActionText = `Wrap selection ${newState ? "enabled" : "disabled"}`
+      lastActionColor = "#FFCC00"
+      updateDisplays()
+    } else if (key.name === "i") {
+      const newState = !selectElement?.showSelectionIndicator
+      selectElement!.showSelectionIndicator = newState
+      lastActionText = `Selection indicator ${newState ? "enabled" : "disabled"}`
       lastActionColor = "#FFCC00"
       updateDisplays()
     }


### PR DESCRIPTION
## Issue https://github.com/anomalyco/opentui/issues/1193

## Summary

Add a `showSelectionIndicator` boolean option to `SelectRenderable` that controls whether the `▶` glyph is rendered next to the currently selected item.

## API

```ts
const select = new SelectRenderable(renderer, {
  width: 40,
  height: 10,
  options,
  showSelectionIndicator: false, // hides ▶ and reclaims its 2-column gutter
})
```

**Default:** `true` (no behaviour change for existing consumers).

When set to `false`, the indicator glyph **and** its 2-column gutter are both removed, giving item text two extra columns of horizontal space.

## Screenshots

<img width="2880" height="1855" alt="Image" src="https://github.com/user-attachments/assets/556a4dab-05f6-49a1-8cac-1eb4febfe4d2" />

<img width="2880" height="1855" alt="Image" src="https://github.com/user-attachments/assets/4241232f-efd3-491e-b339-ef5091a6e971" />

## Incidental cleanup

Two refactors that aren't part of the feature but were needed to keep the render loop coherent once the configurable indicator was introduced:

1. Removed const contentX = 0 / const contentY = 0. Always 0, added as-is to every coordinate (a no-op).
2. Renamed descX → textX. It was seeded as the description's x-position but then reused as the start column for the item name too.