### PR TITLE
tests: add a failing test for streaming markdown in scrollbox

### DIFF
--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -874,7 +874,13 @@ export class MarkdownRenderable extends Renderable {
     id: string,
   ): boolean {
     if ((token.type === "text" || token.type === "paragraph") && renderable instanceof CodeRenderable) {
-      this.applyMarkdownCodeRenderable(renderable, this.normalizeScrollbackMarkdownBlockRaw(token.raw), 0)
+      this.applyMarkdownCodeRenderable(
+        renderable,
+        this.normalizeScrollbackMarkdownBlockRaw(token.raw),
+        0,
+        undefined,
+        this.createInitialStyledText(token),
+      )
       return true
     }
 

--- a/packages/core/src/renderables/__tests__/Markdown.streaming.snapshot.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.streaming.snapshot.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, expect, test } from "bun:test"
+import { SyntaxStyle } from "../../syntax-style.js"
+import { createTestRenderer, MockTreeSitterClient, type TestRenderer } from "../../testing.js"
+import { BoxRenderable } from "../Box.js"
+import { CodeRenderable } from "../Code.js"
+import { MarkdownRenderable } from "../Markdown.js"
+import { ScrollBoxRenderable } from "../ScrollBox.js"
+
+let renderer: TestRenderer | undefined
+
+afterEach(() => {
+  renderer?.destroy()
+  renderer = undefined
+})
+
+const pendingHighlights = (markdown: MarkdownRenderable) => {
+  const children = [...markdown.getChildren()]
+  const pending: CodeRenderable[] = []
+  while (children.length > 0) {
+    const child = children.pop()!
+    if (child instanceof CodeRenderable && child.isHighlighting) pending.push(child)
+    children.push(...child.getChildren())
+  }
+  return pending
+}
+
+test("streaming ordered list keeps growing text visible while markdown highlighting is pending", async () => {
+  const setup = await createTestRenderer({ width: 100, height: 16 })
+  renderer = setup.renderer
+  const treeSitterClient = new MockTreeSitterClient()
+  treeSitterClient.setMockResult({ highlights: [] })
+  const scrollbox = new ScrollBoxRenderable(renderer, {
+    width: 100,
+    height: 16,
+    viewportCulling: true,
+    stickyScroll: true,
+    stickyStart: "bottom",
+  })
+  const container = new BoxRenderable(renderer, {
+    width: "100%",
+    paddingLeft: 3,
+    marginTop: 1,
+    flexShrink: 0,
+  })
+  const markdown = new MarkdownRenderable(renderer, {
+    content: `1. Trigger the permission prompt: uninstall and
+2. Create a schedule with a confirm-to-start segment: tap +, name it "Test
+3. Test the foreground
+4. Test the background case: start the schedule again, press the side
+5. Test the cancel: start the schedule, wait for the confirm-to-start segment, but stay in the app and tap the in
+6. Test app lifecycle edge case: start a schedule with a confirm-to-start segment, wait`,
+    syntaxStyle: SyntaxStyle.fromTheme([]),
+    treeSitterClient,
+    streaming: true,
+    internalBlockMode: "top-level",
+  })
+
+  container.add(markdown)
+  scrollbox.add(container)
+  renderer.root.add(scrollbox)
+
+  await setup.renderOnce()
+  const initialHighlights = pendingHighlights(markdown)
+  treeSitterClient.resolveAllHighlightOnce()
+  await Promise.all(initialHighlights.map((code) => code.highlightingDone))
+  await setup.renderOnce()
+
+  markdown.content = `1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.
+2. Create a schedule with a confirm-to-start segment: tap +, name it "Test", and save it.
+3. Test the foreground case: start the schedule and use the in-app Start button.
+4. Test the background case: start the schedule again, then press the side button.
+5. Test the cancel: stay in the app and tap the in-app Start button before the notification appears.
+6. Test app lifecycle edge case: wait for the segment, then send the app to the background.`
+  await setup.renderOnce()
+  const frameWhileHighlighting = setup.captureCharFrame().split("\n")
+
+  const updatedHighlights = pendingHighlights(markdown)
+  treeSitterClient.resolveAllHighlightOnce()
+  await Promise.all(updatedHighlights.map((code) => code.highlightingDone))
+  await setup.renderOnce()
+  const settledFrame = setup.captureCharFrame().split("\n")
+
+  expect(settledFrame).toMatchSnapshot("after highlighting settles")
+  expect(frameWhileHighlighting).toMatchSnapshot("while updated highlighting is pending")
+})

--- a/packages/core/src/renderables/__tests__/Markdown.streaming.snapshot.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.streaming.snapshot.test.ts
@@ -28,7 +28,7 @@ const captureState = (markdown: MarkdownRenderable, frame: string) => ({
   frame: frame.split("\n"),
 })
 
-test("streaming ordered list shows current text while replacement highlighting is pending", async () => {
+test("streaming ordered list does not depend on replacement highlighting to show current text", async () => {
   const setup = await createTestRenderer({ width: 100, height: 16 })
   renderer = setup.renderer
   const treeSitterClient = new MockTreeSitterClient()

--- a/packages/core/src/renderables/__tests__/Markdown.streaming.snapshot.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.streaming.snapshot.test.ts
@@ -4,7 +4,6 @@ import { createTestRenderer, MockTreeSitterClient, type TestRenderer } from "../
 import { BoxRenderable } from "../Box.js"
 import { CodeRenderable } from "../Code.js"
 import { MarkdownRenderable } from "../Markdown.js"
-import { ScrollBoxRenderable } from "../ScrollBox.js"
 
 let renderer: TestRenderer | undefined
 
@@ -24,18 +23,16 @@ const pendingHighlights = (markdown: MarkdownRenderable) => {
   return pending
 }
 
-test("streaming ordered list keeps growing text visible while markdown highlighting is pending", async () => {
+const captureState = (markdown: MarkdownRenderable, frame: string) => ({
+  pendingHighlights: pendingHighlights(markdown).length,
+  frame: frame.split("\n"),
+})
+
+test("streaming ordered list shows current text while replacement highlighting is pending", async () => {
   const setup = await createTestRenderer({ width: 100, height: 16 })
   renderer = setup.renderer
   const treeSitterClient = new MockTreeSitterClient()
   treeSitterClient.setMockResult({ highlights: [] })
-  const scrollbox = new ScrollBoxRenderable(renderer, {
-    width: 100,
-    height: 16,
-    viewportCulling: true,
-    stickyScroll: true,
-    stickyStart: "bottom",
-  })
   const container = new BoxRenderable(renderer, {
     width: "100%",
     paddingLeft: 3,
@@ -43,7 +40,9 @@ test("streaming ordered list keeps growing text visible while markdown highlight
     flexShrink: 0,
   })
   const markdown = new MarkdownRenderable(renderer, {
-    content: `1. Trigger the permission prompt: uninstall and
+    content: `Status: response is streaming.
+
+1. Trigger the permission prompt: uninstall and
 2. Create a schedule with a confirm-to-start segment: tap +, name it "Test
 3. Test the foreground
 4. Test the background case: start the schedule again, press the side
@@ -56,30 +55,33 @@ test("streaming ordered list keeps growing text visible while markdown highlight
   })
 
   container.add(markdown)
-  scrollbox.add(container)
-  renderer.root.add(scrollbox)
+  renderer.root.add(container)
 
   await setup.renderOnce()
   const initialHighlights = pendingHighlights(markdown)
   treeSitterClient.resolveAllHighlightOnce()
   await Promise.all(initialHighlights.map((code) => code.highlightingDone))
   await setup.renderOnce()
+  const initialState = captureState(markdown, setup.captureCharFrame())
 
-  markdown.content = `1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.
+  markdown.content = `Status: response source is complete.
+
+1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.
 2. Create a schedule with a confirm-to-start segment: tap +, name it "Test", and save it.
 3. Test the foreground case: start the schedule and use the in-app Start button.
 4. Test the background case: start the schedule again, then press the side button.
 5. Test the cancel: stay in the app and tap the in-app Start button before the notification appears.
 6. Test app lifecycle edge case: wait for the segment, then send the app to the background.`
   await setup.renderOnce()
-  const frameWhileHighlighting = setup.captureCharFrame().split("\n")
+  const pendingState = captureState(markdown, setup.captureCharFrame())
 
   const updatedHighlights = pendingHighlights(markdown)
   treeSitterClient.resolveAllHighlightOnce()
   await Promise.all(updatedHighlights.map((code) => code.highlightingDone))
   await setup.renderOnce()
-  const settledFrame = setup.captureCharFrame().split("\n")
+  const completedState = captureState(markdown, setup.captureCharFrame())
 
-  expect(settledFrame).toMatchSnapshot("after highlighting settles")
-  expect(frameWhileHighlighting).toMatchSnapshot("while updated highlighting is pending")
+  expect(initialState).toMatchSnapshot("after initial highlight completes")
+  expect(completedState).toMatchSnapshot("after updated highlight completes")
+  expect(pendingState).toMatchSnapshot("while updated highlighting is pending")
 })

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1446,7 +1446,7 @@ test("streaming structured lists reuse existing renderables while appending", as
   expect(firstTextAfter).toBe(firstTextBefore)
 })
 
-test("streaming structured list updates keep previous item text visible while highlighting", async () => {
+test("streaming structured list updates keep current item text visible while highlighting", async () => {
   const mockTreeSitterClient = new MockTreeSitterClient()
   const md = createMarkdownRenderable({
     id: "markdown-streaming-structured-list-no-flicker",
@@ -1485,9 +1485,9 @@ test("streaming structured list updates keep previous item text visible while hi
   const framesBeforeHighlight = recorder.recordedFrames.map((recorded) => recorded.frame)
   expect(framesBeforeHighlight.length).toBeGreaterThan(0)
   for (const frame of framesBeforeHighlight) {
-    expect(frame).toContain("- alp")
-    expect(frame).toContain("- bet")
-    expect(frame).toContain("- gam")
+    expect(frame).toContain("- alpha")
+    expect(frame).toContain("- beta")
+    expect(frame).toContain("- gamma")
   }
 
   expect(mockTreeSitterClient.isHighlighting()).toBe(true)
@@ -1502,7 +1502,7 @@ test("streaming structured list updates keep previous item text visible while hi
   expect(finalFrame).toContain("- gamma")
 })
 
-test("streaming nested structured list updates keep previous nested text visible while highlighting", async () => {
+test("streaming nested structured list updates keep current nested text visible while highlighting", async () => {
   const mockTreeSitterClient = new MockTreeSitterClient()
   const initialContent = `1. First ordered item with \`inline code\`.
 2. Second ordered item before a nested list:
@@ -1557,8 +1557,8 @@ test("streaming nested structured list updates keep previous nested text visible
   expect(framesBeforeHighlight.length).toBeGreaterThan(0)
   for (const frame of framesBeforeHighlight) {
     expect(frame).toContain("2. Second ordered item before a nested list:")
-    expect(frame).toContain("- Nested bullet with a long phrase.")
-    expect(frame).toContain("- Nested bullet before fenced co")
+    expect(frame).toContain("- Nested bullet with a long phrase that should wrap")
+    expect(frame).toContain("- Nested bullet before fenced code:")
   }
 
   expect(mockTreeSitterClient.isHighlighting()).toBe(true)

--- a/packages/core/src/renderables/__tests__/__snapshots__/Markdown.streaming.snapshot.test.ts.snap
+++ b/packages/core/src/renderables/__tests__/__snapshots__/Markdown.streaming.snapshot.test.ts.snap
@@ -1,0 +1,45 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`streaming ordered list keeps growing text visible while markdown highlighting is pending: after highlighting settles 1`] = `
+[
+  "                                                                                                    ",
+  "   1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.             ",
+  "   2. Create a schedule with a confirm-to-start segment: tap +, name it "Test", and save it.        ",
+  "   3. Test the foreground case: start the schedule and use the in-app Start button.                 ",
+  "   4. Test the background case: start the schedule again, then press the side button.               ",
+  "   5. Test the cancel: stay in the app and tap the in-app Start button before the notification      ",
+  "      appears.                                                                                      ",
+  "   6. Test app lifecycle edge case: wait for the segment, then send the app to the background.      ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "",
+]
+`;
+
+exports[`streaming ordered list keeps growing text visible while markdown highlighting is pending: while updated highlighting is pending 1`] = `
+[
+  "                                                                                                    ",
+  "   1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.             ",
+  "   2. Create a schedule with a confirm-to-start segment: tap +, name it "Test", and save it.        ",
+  "   3. Test the foreground case: start the schedule and use the in-app Start button.                 ",
+  "   4. Test the background case: start the schedule again, then press the side button.               ",
+  "   5. Test the cancel: stay in the app and tap the in-app Start button before the notification      ",
+  "      appears.                                                                                      ",
+  "   6. Test app lifecycle edge case: wait for the segment, then send the app to the background.      ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "",
+]
+`;

--- a/packages/core/src/renderables/__tests__/__snapshots__/Markdown.streaming.snapshot.test.ts.snap
+++ b/packages/core/src/renderables/__tests__/__snapshots__/Markdown.streaming.snapshot.test.ts.snap
@@ -1,45 +1,76 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`streaming ordered list keeps growing text visible while markdown highlighting is pending: after highlighting settles 1`] = `
-[
-  "                                                                                                    ",
-  "   1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.             ",
-  "   2. Create a schedule with a confirm-to-start segment: tap +, name it "Test", and save it.        ",
-  "   3. Test the foreground case: start the schedule and use the in-app Start button.                 ",
-  "   4. Test the background case: start the schedule again, then press the side button.               ",
-  "   5. Test the cancel: stay in the app and tap the in-app Start button before the notification      ",
-  "      appears.                                                                                      ",
-  "   6. Test app lifecycle edge case: wait for the segment, then send the app to the background.      ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "",
-]
+exports[`streaming ordered list shows current text while replacement highlighting is pending: after initial highlight completes 1`] = `
+{
+  "frame": [
+    "                                                                                                    ",
+    "   Status: response is streaming.                                                                   ",
+    "                                                                                                    ",
+    "   1. Trigger the permission prompt: uninstall and                                                  ",
+    "   2. Create a schedule with a confirm-to-start segment: tap +, name it "Test                       ",
+    "   3. Test the foreground                                                                           ",
+    "   4. Test the background case: start the schedule again, press the side                            ",
+    "   5. Test the cancel: start the schedule, wait for the confirm-to-start segment, but stay in the   ",
+    "      app and tap the in                                                                            ",
+    "   6. Test app lifecycle edge case: start a schedule with a confirm-to-start segment, wait          ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "",
+  ],
+  "pendingHighlights": 0,
+}
 `;
 
-exports[`streaming ordered list keeps growing text visible while markdown highlighting is pending: while updated highlighting is pending 1`] = `
-[
-  "                                                                                                    ",
-  "   1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.             ",
-  "   2. Create a schedule with a confirm-to-start segment: tap +, name it "Test", and save it.        ",
-  "   3. Test the foreground case: start the schedule and use the in-app Start button.                 ",
-  "   4. Test the background case: start the schedule again, then press the side button.               ",
-  "   5. Test the cancel: stay in the app and tap the in-app Start button before the notification      ",
-  "      appears.                                                                                      ",
-  "   6. Test app lifecycle edge case: wait for the segment, then send the app to the background.      ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "                                                                                                    ",
-  "",
-]
+exports[`streaming ordered list shows current text while replacement highlighting is pending: while updated highlighting is pending 1`] = `
+{
+  "frame": [
+    "                                                                                                    ",
+    "   Status: response source is complete.                                                             ",
+    "                                                                                                    ",
+    "   1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.             ",
+    "   2. Create a schedule with a confirm-to-start segment: tap +, name it "Test", and save it.        ",
+    "   3. Test the foreground case: start the schedule and use the in-app Start button.                 ",
+    "   4. Test the background case: start the schedule again, then press the side button.               ",
+    "   5. Test the cancel: stay in the app and tap the in-app Start button before the notification      ",
+    "      appears.                                                                                      ",
+    "   6. Test app lifecycle edge case: wait for the segment, then send the app to the background.      ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "",
+  ],
+  "pendingHighlights": 7,
+}
+`;
+
+exports[`streaming ordered list shows current text while replacement highlighting is pending: after updated highlight completes 1`] = `
+{
+  "frame": [
+    "                                                                                                    ",
+    "   Status: response source is complete.                                                             ",
+    "                                                                                                    ",
+    "   1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.             ",
+    "   2. Create a schedule with a confirm-to-start segment: tap +, name it "Test", and save it.        ",
+    "   3. Test the foreground case: start the schedule and use the in-app Start button.                 ",
+    "   4. Test the background case: start the schedule again, then press the side button.               ",
+    "   5. Test the cancel: stay in the app and tap the in-app Start button before the notification      ",
+    "      appears.                                                                                      ",
+    "   6. Test app lifecycle edge case: wait for the segment, then send the app to the background.      ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "",
+  ],
+  "pendingHighlights": 0,
+}
 `;

--- a/packages/core/src/renderables/__tests__/__snapshots__/Markdown.streaming.snapshot.test.ts.snap
+++ b/packages/core/src/renderables/__tests__/__snapshots__/Markdown.streaming.snapshot.test.ts.snap
@@ -1,6 +1,6 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`streaming ordered list shows current text while replacement highlighting is pending: after initial highlight completes 1`] = `
+exports[`streaming ordered list does not depend on replacement highlighting to show current text: after initial highlight completes 1`] = `
 {
   "frame": [
     "                                                                                                    ",
@@ -25,32 +25,7 @@ exports[`streaming ordered list shows current text while replacement highlightin
 }
 `;
 
-exports[`streaming ordered list shows current text while replacement highlighting is pending: while updated highlighting is pending 1`] = `
-{
-  "frame": [
-    "                                                                                                    ",
-    "   Status: response source is complete.                                                             ",
-    "                                                                                                    ",
-    "   1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.             ",
-    "   2. Create a schedule with a confirm-to-start segment: tap +, name it "Test", and save it.        ",
-    "   3. Test the foreground case: start the schedule and use the in-app Start button.                 ",
-    "   4. Test the background case: start the schedule again, then press the side button.               ",
-    "   5. Test the cancel: stay in the app and tap the in-app Start button before the notification      ",
-    "      appears.                                                                                      ",
-    "   6. Test app lifecycle edge case: wait for the segment, then send the app to the background.      ",
-    "                                                                                                    ",
-    "                                                                                                    ",
-    "                                                                                                    ",
-    "                                                                                                    ",
-    "                                                                                                    ",
-    "                                                                                                    ",
-    "",
-  ],
-  "pendingHighlights": 7,
-}
-`;
-
-exports[`streaming ordered list shows current text while replacement highlighting is pending: after updated highlight completes 1`] = `
+exports[`streaming ordered list does not depend on replacement highlighting to show current text: after updated highlight completes 1`] = `
 {
   "frame": [
     "                                                                                                    ",
@@ -72,5 +47,30 @@ exports[`streaming ordered list shows current text while replacement highlightin
     "",
   ],
   "pendingHighlights": 0,
+}
+`;
+
+exports[`streaming ordered list does not depend on replacement highlighting to show current text: while updated highlighting is pending 1`] = `
+{
+  "frame": [
+    "                                                                                                    ",
+    "   Status: response source is complete.                                                             ",
+    "                                                                                                    ",
+    "   1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.             ",
+    "   2. Create a schedule with a confirm-to-start segment: tap +, name it "Test", and save it.        ",
+    "   3. Test the foreground case: start the schedule and use the in-app Start button.                 ",
+    "   4. Test the background case: start the schedule again, then press the side button.               ",
+    "   5. Test the cancel: stay in the app and tap the in-app Start button before the notification      ",
+    "      appears.                                                                                      ",
+    "   6. Test app lifecycle edge case: wait for the segment, then send the app to the background.      ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "                                                                                                    ",
+    "",
+  ],
+  "pendingHighlights": 7,
 }
 `;

--- a/packages/solid/tests/__snapshots__/scrollbox-markdown-streaming.snapshot.test.tsx.snap
+++ b/packages/solid/tests/__snapshots__/scrollbox-markdown-streaming.snapshot.test.tsx.snap
@@ -1,0 +1,45 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`streaming ordered list keeps growing text visible while markdown highlighting is pending: after highlighting settles 1`] = `
+[
+  "                                                                                                    ",
+  "   1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.             ",
+  "   2. Create a schedule with a confirm-to-start segment: tap +, name it "Test", and save it.        ",
+  "   3. Test the foreground case: start the schedule and use the in-app Start button.                 ",
+  "   4. Test the background case: start the schedule again, then press the side button.               ",
+  "   5. Test the cancel: stay in the app and tap the in-app Start button before the notification      ",
+  "      appears.                                                                                      ",
+  "   6. Test app lifecycle edge case: wait for the segment, then send the app to the background.      ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "",
+]
+`;
+
+exports[`streaming ordered list keeps growing text visible while markdown highlighting is pending: while updated highlighting is pending 1`] = `
+[
+  "                                                                                                    ",
+  "   1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.             ",
+  "   2. Create a schedule with a confirm-to-start segment: tap +, name it "Test", and save it.        ",
+  "   3. Test the foreground case: start the schedule and use the in-app Start button.                 ",
+  "   4. Test the background case: start the schedule again, then press the side button.               ",
+  "   5. Test the cancel: stay in the app and tap the in-app Start button before the notification      ",
+  "      appears.                                                                                      ",
+  "   6. Test app lifecycle edge case: wait for the segment, then send the app to the background.      ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "                                                                                                    ",
+  "",
+]
+`;

--- a/packages/solid/tests/scrollbox-markdown-streaming.snapshot.test.tsx
+++ b/packages/solid/tests/scrollbox-markdown-streaming.snapshot.test.tsx
@@ -1,12 +1,23 @@
 import { afterEach, expect, test } from "bun:test"
 import { MockTreeSitterClient } from "@opentui/core/testing"
-import { SyntaxStyle } from "@opentui/core"
+import { CodeRenderable, MarkdownRenderable, SyntaxStyle } from "@opentui/core"
 import { createSignal } from "solid-js"
 import { testRender } from "../index.js"
 
 let setup: Awaited<ReturnType<typeof testRender>> | undefined
 
 const snapshotFrame = (frame: string) => frame.split("\n")
+
+const pendingHighlights = (markdown: MarkdownRenderable) => {
+  const children = [...markdown.getChildren()]
+  const pending: CodeRenderable[] = []
+  while (children.length > 0) {
+    const child = children.pop()!
+    if (child instanceof CodeRenderable && child.isHighlighting) pending.push(child)
+    children.push(...child.getChildren())
+  }
+  return pending
+}
 
 afterEach(() => {
   setup?.renderer.destroy()
@@ -16,6 +27,8 @@ afterEach(() => {
 test("streaming ordered list keeps growing text visible while markdown highlighting is pending", async () => {
   const treeSitterClient = new MockTreeSitterClient()
   treeSitterClient.setMockResult({ highlights: [] })
+  const syntaxStyle = SyntaxStyle.fromTheme([])
+  let markdown: MarkdownRenderable | undefined
   const [content, setContent] = createSignal(`1. Trigger the permission prompt: uninstall and
 2. Create a schedule with a confirm-to-start segment: tap +, name it "Test
 3. Test the foreground
@@ -29,7 +42,8 @@ test("streaming ordered list keeps growing text visible while markdown highlight
         <scrollbox viewportCulling stickyScroll stickyStart="bottom" flexGrow={1}>
           <box paddingLeft={3} marginTop={1} flexShrink={0}>
             <markdown
-              syntaxStyle={SyntaxStyle.fromTheme([])}
+              ref={(value) => (markdown = value)}
+              syntaxStyle={syntaxStyle}
               treeSitterClient={treeSitterClient}
               streaming
               internalBlockMode="top-level"
@@ -43,9 +57,9 @@ test("streaming ordered list keeps growing text visible while markdown highlight
   )
 
   await setup.renderOnce()
+  const initialHighlights = pendingHighlights(markdown!)
   treeSitterClient.resolveAllHighlightOnce()
-  await Promise.resolve()
-  await Promise.resolve()
+  await Promise.all(initialHighlights.map((code) => code.highlightingDone))
   await setup.renderOnce()
   expect(setup.captureCharFrame()).toContain("1. Trigger the permission prompt: uninstall and")
 
@@ -58,9 +72,10 @@ test("streaming ordered list keeps growing text visible while markdown highlight
   await setup.renderOnce()
   const frameWhileHighlighting = snapshotFrame(setup.captureCharFrame())
 
+  const updatedHighlights = pendingHighlights(markdown!)
+  expect(updatedHighlights.length).toBeGreaterThan(0)
   treeSitterClient.resolveAllHighlightOnce()
-  await Promise.resolve()
-  await Promise.resolve()
+  await Promise.all(updatedHighlights.map((code) => code.highlightingDone))
   await setup.renderOnce()
   const settledFrame = snapshotFrame(setup.captureCharFrame())
 

--- a/packages/solid/tests/scrollbox-markdown-streaming.snapshot.test.tsx
+++ b/packages/solid/tests/scrollbox-markdown-streaming.snapshot.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, expect, test } from "bun:test"
+import { MockTreeSitterClient } from "@opentui/core/testing"
+import { SyntaxStyle } from "@opentui/core"
+import { createSignal } from "solid-js"
+import { testRender } from "../index.js"
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined
+
+const snapshotFrame = (frame: string) => frame.split("\n")
+
+afterEach(() => {
+  setup?.renderer.destroy()
+  setup = undefined
+})
+
+test("streaming ordered list keeps growing text visible while markdown highlighting is pending", async () => {
+  const treeSitterClient = new MockTreeSitterClient()
+  treeSitterClient.setMockResult({ highlights: [] })
+  const [content, setContent] = createSignal(`1. Trigger the permission prompt: uninstall and
+2. Create a schedule with a confirm-to-start segment: tap +, name it "Test
+3. Test the foreground
+4. Test the background case: start the schedule again, press the side
+5. Test the cancel: start the schedule, wait for the confirm-to-start segment, but stay in the app and tap the in
+6. Test app lifecycle edge case: start a schedule with a confirm-to-start segment, wait`)
+
+  setup = await testRender(
+    () => (
+      <box width={100} height={16}>
+        <scrollbox viewportCulling stickyScroll stickyStart="bottom" flexGrow={1}>
+          <box paddingLeft={3} marginTop={1} flexShrink={0}>
+            <markdown
+              syntaxStyle={SyntaxStyle.fromTheme([])}
+              treeSitterClient={treeSitterClient}
+              streaming
+              internalBlockMode="top-level"
+              content={content()}
+            />
+          </box>
+        </scrollbox>
+      </box>
+    ),
+    { width: 100, height: 16 },
+  )
+
+  await setup.renderOnce()
+  treeSitterClient.resolveAllHighlightOnce()
+  await Promise.resolve()
+  await Promise.resolve()
+  await setup.renderOnce()
+  expect(setup.captureCharFrame()).toContain("1. Trigger the permission prompt: uninstall and")
+
+  setContent(`1. Trigger the permission prompt: uninstall and reinstall the app, then relaunch it.
+2. Create a schedule with a confirm-to-start segment: tap +, name it "Test", and save it.
+3. Test the foreground case: start the schedule and use the in-app Start button.
+4. Test the background case: start the schedule again, then press the side button.
+5. Test the cancel: stay in the app and tap the in-app Start button before the notification appears.
+6. Test app lifecycle edge case: wait for the segment, then send the app to the background.`)
+  await setup.renderOnce()
+  const frameWhileHighlighting = snapshotFrame(setup.captureCharFrame())
+
+  treeSitterClient.resolveAllHighlightOnce()
+  await Promise.resolve()
+  await Promise.resolve()
+  await setup.renderOnce()
+  const settledFrame = snapshotFrame(setup.captureCharFrame())
+
+  expect(settledFrame).toMatchSnapshot("after highlighting settles")
+  expect(frameWhileHighlighting).toMatchSnapshot("while updated highlighting is pending")
+})


### PR DESCRIPTION
Add tests for streaming Markdown should synchronously display the current styled source while asynchronous highlighting is pending.