### PR TITLE
fix(core): prevent phantom hyperlinks from detectLinks contentPos drift

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -489,6 +489,22 @@
 
     "@opentui/core": ["@opentui/core@workspace:packages/core"],
 
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.4.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-is+O+sS/l3E9cZXyM9pRF1WhqnE+hYSPYoZkbseR9CthJcaWPGi3R3jUJa1cLj325252jWgxVupnDqFUtKg36w=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.4.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ACi42h81DurSeybUAD1XyKT6xmXZcKeTxS54lZFi0CVZh46w0g99vNj8PlQzIFXvvFLT0e0IlRS//eWSWS2zGQ=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.4.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-RjOx2HcjLRtGSy9WrAGSdr5M9SpJuPifPORpImx6Mciovw0ltnE0uoYjIyor82uf6/LExWC7YA2AcAl+YBxayA=="],
+
+    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.4.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-heNciL2ngPU+kq1h01PHLsxn6Fr8iqTFtbxSdVbhaY3XihuIjkuXyEhFeuoa1lsXY7Bb2gpWnX5EQVWnZsAuDQ=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.4.2", "", { "os": "linux", "cpu": "x64" }, "sha512-9s0s/ooK+AhWP306By3gu+XhzcVEThC2sqKMPK1nQmGDujQhd+xOrtbtfCVcJSx62UzAovC2VNqypvP8vHByOg=="],
+
+    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.4.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Cjv6Bv7l3p/KLNJr5RyqCS0FmRlAGJnkA2IK3S+HkHhCOv/O02S1G+DBUY6POnyjp1eNy95vauustApobhdbig=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.4.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-mfJZrJ0TNPFRZUzXNsxAPe1YdiWsy/vbTl93+yeXGHPI1B8Qnk9V5hpzSxxEyBGhlTHSfGNtgiO+VrrdRC3kZA=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.4.2", "", { "os": "win32", "cpu": "x64" }, "sha512-P2oguG3ng3OMjAdasFSA3GhHaQXtzDUsIRDGbzWFOimpZ/zMemidp+JQ0V8V6XwK6Utk5G0aQ03oBaRCoLyYDw=="],
+
     "@opentui/examples": ["@opentui/examples@workspace:packages/examples"],
 
     "@opentui/keymap": ["@opentui/keymap@workspace:packages/keymap"],

--- a/packages/core/src/lib/detect-links.test.ts
+++ b/packages/core/src/lib/detect-links.test.ts
@@ -4,8 +4,15 @@ import type { TextChunk } from "../text-buffer.js"
 import type { SimpleHighlight } from "./tree-sitter/types.js"
 import { RGBA } from "./RGBA.js"
 
-function chunk(text: string): TextChunk {
-  return { __isChunk: true, text, fg: RGBA.fromInts(255, 255, 255, 255), attributes: 0 }
+function chunk(text: string, sourceStart?: number, sourceEnd?: number): TextChunk {
+  return {
+    __isChunk: true,
+    text,
+    fg: RGBA.fromInts(255, 255, 255, 255),
+    attributes: 0,
+    sourceStart,
+    sourceEnd,
+  }
 }
 
 describe("detectLinks", () => {
@@ -65,34 +72,160 @@ describe("detectLinks", () => {
     expect(result).toBe(chunks)
   })
 
-  test("should detect links when chunks have concealed text", () => {
-    // Original content: [Click here](https://example.com)
-    // With concealment, `[` and `]` are concealed to empty strings,
-    // and `(` and `)` are concealed to empty strings.
-    // This means chunk text lengths don't match original byte offsets.
+  test("should detect links when chunks have concealed text (legacy indexOf path)", () => {
     const content = "[Click here](https://example.com)"
     const highlights: SimpleHighlight[] = [
-      [0, 1, "markup.link"], // [
-      [1, 11, "markup.link.label"], // Click here
-      [11, 13, "markup.link"], // ](
-      [13, 32, "markup.link.url"], // https://example.com
-      [32, 33, "markup.link"], // )
+      [0, 1, "markup.link"],
+      [1, 11, "markup.link.label"],
+      [11, 13, "markup.link"],
+      [13, 32, "markup.link.url"],
+      [32, 33, "markup.link"],
     ]
-    // Simulate concealed chunks: `[` -> "", `](` -> " ", `)` -> ""
-    // The URL and label chunks remain unchanged.
+    // Simulate concealed chunks WITHOUT sourceStart/sourceEnd (legacy path)
     const chunks = [
-      chunk(""), // concealed `[`
-      chunk("Click here"), // label, unchanged
-      chunk(" "), // concealed `](`
-      chunk("https://example.com"), // URL, unchanged
-      chunk(""), // concealed `)`
+      chunk(""),
+      chunk("Click here"),
+      chunk(" "),
+      chunk("https://example.com"),
+      chunk(""),
     ]
 
     const result = detectLinks(chunks, { content, highlights })
 
-    // The URL chunk should still get its link despite concealed offsets
     expect(result.find((c) => c.text === "https://example.com")!.link).toEqual({ url: "https://example.com" })
-    // The label chunk should also get the link
     expect(result.find((c) => c.text === "Click here")!.link).toEqual({ url: "https://example.com" })
+  })
+
+  // --- New tests for sourceStart/sourceEnd precise offset matching ---
+
+  test("should use sourceStart/sourceEnd for precise link detection", () => {
+    const content = "[Click here](https://example.com)"
+    const highlights: SimpleHighlight[] = [
+      [0, 1, "markup.link"],
+      [1, 11, "markup.link.label"],
+      [11, 13, "markup.link"],
+      [13, 32, "markup.link.url"],
+      [32, 33, "markup.link"],
+    ]
+    // Chunks with precise source offsets (as produced by treeSitterToTextChunks)
+    const chunks = [
+      chunk("", 0, 1),           // concealed `[`
+      chunk("Click here", 1, 11), // label
+      chunk(" ", 11, 13),         // concealed `](`
+      chunk("https://example.com", 13, 32), // URL
+      chunk("", 32, 33),          // concealed `)`
+    ]
+
+    const result = detectLinks(chunks, { content, highlights })
+
+    expect(result.find((c) => c.text === "https://example.com")!.link).toEqual({ url: "https://example.com" })
+    expect(result.find((c) => c.text === "Click here")!.link).toEqual({ url: "https://example.com" })
+  })
+
+  test("should NOT linkify whitespace-only concealed chunks even when they overlap URL range", () => {
+    const content = "[Click here](https://example.com)"
+    const highlights: SimpleHighlight[] = [
+      [0, 1, "markup.link"],
+      [1, 11, "markup.link.label"],
+      [11, 13, "markup.link"],
+      [13, 32, "markup.link.url"],
+      [32, 33, "markup.link"],
+    ]
+    const chunks = [
+      chunk("", 0, 1),
+      chunk("Click here", 1, 11),
+      chunk(" ", 11, 13),          // whitespace chunk overlapping link syntax range
+      chunk("https://example.com", 13, 32),
+      chunk("", 32, 33),
+    ]
+
+    const result = detectLinks(chunks, { content, highlights })
+
+    // The whitespace chunk ` ` should NOT get a link — it's a conceal replacement
+    const spaceChunk = result.find((c) => c.text === " ")!
+    expect(spaceChunk.link).toBeUndefined()
+  })
+
+  test("should handle multiple links without position drift", () => {
+    const content = "See [a](https://a.com) and [b](https://b.com) here"
+    const highlights: SimpleHighlight[] = [
+      [4, 5, "markup.link"],       // [
+      [5, 6, "markup.link.label"], // a
+      [6, 8, "markup.link"],       // ](
+      [8, 21, "markup.link.url"],  // https://a.com
+      [21, 22, "markup.link"],     // )
+      [27, 28, "markup.link"],     // [
+      [28, 29, "markup.link.label"], // b
+      [29, 31, "markup.link"],     // ](
+      [31, 44, "markup.link.url"], // https://b.com
+      [44, 45, "markup.link"],     // )
+    ]
+    const chunks = [
+      chunk("See ", 0, 4),
+      chunk("", 4, 5),              // concealed [
+      chunk("a", 5, 6),             // label
+      chunk(" ", 6, 8),             // concealed ](
+      chunk("https://a.com", 8, 21),
+      chunk("", 21, 22),            // concealed )
+      chunk(" and ", 22, 27),
+      chunk("", 27, 28),            // concealed [
+      chunk("b", 28, 29),           // label
+      chunk(" ", 29, 31),           // concealed ](
+      chunk("https://b.com", 31, 44),
+      chunk("", 44, 45),            // concealed )
+      chunk(" here", 45, 50),
+    ]
+
+    const result = detectLinks(chunks, { content, highlights })
+
+    expect(result.find((c) => c.text === "a")!.link).toEqual({ url: "https://a.com" })
+    expect(result.find((c) => c.text === "https://a.com")!.link).toEqual({ url: "https://a.com" })
+    expect(result.find((c) => c.text === "b")!.link).toEqual({ url: "https://b.com" })
+    expect(result.find((c) => c.text === "https://b.com")!.link).toEqual({ url: "https://b.com" })
+    // Non-link text must NOT have links
+    expect(result.find((c) => c.text === "See ")!.link).toBeUndefined()
+    expect(result.find((c) => c.text === " and ")!.link).toBeUndefined()
+    expect(result.find((c) => c.text === " here")!.link).toBeUndefined()
+  })
+
+  test("should not produce phantom links on unrelated text (regression)", () => {
+    // This simulates the scenario where indexOf drift caused phantom links:
+    // text after a link accidentally matched at a URL position.
+    const content = "Check [docs](https://docs.example.com) for the API docs reference"
+    const highlights: SimpleHighlight[] = [
+      [6, 7, "markup.link"],        // [
+      [7, 11, "markup.link.label"], // docs
+      [11, 13, "markup.link"],      // ](
+      [13, 37, "markup.link.url"],  // https://docs.example.com
+      [37, 38, "markup.link"],      // )
+    ]
+    const chunks = [
+      chunk("Check ", 0, 6),
+      chunk("", 6, 7),
+      chunk("docs", 7, 11),         // label — should get link
+      chunk(" ", 11, 13),           // concealed ](
+      chunk("https://docs.example.com", 13, 37),
+      chunk("", 37, 38),
+      chunk(" for the API ", 38, 51),
+      chunk("docs", 51, 55),        // "docs" again in plain text — must NOT get link
+      chunk(" reference", 55, 65),
+    ]
+
+    const result = detectLinks(chunks, { content, highlights })
+
+    // First "docs" (the label) should have a link
+    const labelChunk = result[2]
+    expect(labelChunk.text).toBe("docs")
+    expect(labelChunk.link).toEqual({ url: "https://docs.example.com" })
+
+    // Second "docs" (plain text) must NOT have a link
+    const plainChunk = result[7]
+    expect(plainChunk.text).toBe("docs")
+    expect(plainChunk.link).toBeUndefined()
+
+    // Surrounding text must not have links
+    expect(result.find((c) => c.text === "Check ")!.link).toBeUndefined()
+    expect(result.find((c) => c.text === " for the API ")!.link).toBeUndefined()
+    expect(result.find((c) => c.text === " reference")!.link).toBeUndefined()
   })
 })

--- a/packages/core/src/lib/detect-links.ts
+++ b/packages/core/src/lib/detect-links.ts
@@ -31,25 +31,42 @@ export function detectLinks(
 
   if (ranges.length === 0) return chunks
 
-  // Use content.indexOf to find each chunk's position in the original content.
-  // This handles concealed text correctly because concealed chunks are either
-  // empty (length 0, skipped) or single-char replacements (length 1, skipped).
-  // Non-concealed chunks with length > 1 are exact substrings of content in order.
-  let contentPos = 0
-  for (const chunk of chunks) {
-    if (chunk.text.length <= 1) continue
+  // When chunks carry sourceStart/sourceEnd (set by treeSitterToTextChunks),
+  // use exact offset overlap — no indexOf drift possible.
+  const hasSourceOffsets = chunks.length > 0 && chunks[0].sourceStart !== undefined
 
-    const idx = content.indexOf(chunk.text, contentPos)
-    if (idx < 0) continue
-
-    for (const range of ranges) {
-      if (idx < range.end && idx + chunk.text.length > range.start) {
-        chunk.link = { url: range.url }
-        break
+  if (hasSourceOffsets) {
+    for (const chunk of chunks) {
+      const start = chunk.sourceStart!
+      const end = chunk.sourceEnd!
+      if (start === end) continue
+      for (const range of ranges) {
+        if (start < range.end && end > range.start) {
+          // Don't linkify chunks that are purely whitespace / punctuation from conceal
+          if (chunk.text.trim().length === 0) break
+          chunk.link = { url: range.url }
+          break
+        }
       }
     }
+  } else {
+    // Legacy fallback: indexOf-based matching for chunks without source offsets.
+    let contentPos = 0
+    for (const chunk of chunks) {
+      if (chunk.text.length <= 1) continue
 
-    contentPos = idx + chunk.text.length
+      const idx = content.indexOf(chunk.text, contentPos)
+      if (idx < 0) continue
+
+      for (const range of ranges) {
+        if (idx < range.end && idx + chunk.text.length > range.start) {
+          chunk.link = { url: range.url }
+          break
+        }
+      }
+
+      contentPos = idx + chunk.text.length
+    }
   }
 
   return chunks

--- a/packages/core/src/lib/tree-sitter-styled-text.ts
+++ b/packages/core/src/lib/tree-sitter-styled-text.ts
@@ -117,6 +117,8 @@ export function treeSitterToTextChunks(
                   dim: defaultStyle.dim,
                 })
               : 0,
+            sourceStart: currentOffset,
+            sourceEnd: boundary.offset,
           })
         }
       } else {
@@ -197,6 +199,8 @@ export function treeSitterToTextChunks(
                 dim: finalStyle.dim,
               })
             : 0,
+          sourceStart: currentOffset,
+          sourceEnd: boundary.offset,
         })
       }
     } else if (currentOffset < boundary.offset) {
@@ -215,6 +219,8 @@ export function treeSitterToTextChunks(
               dim: style.dim,
             })
           : 0,
+        sourceStart: currentOffset,
+        sourceEnd: boundary.offset,
       })
     }
 
@@ -273,6 +279,8 @@ export function treeSitterToTextChunks(
             dim: style.dim,
           })
         : 0,
+      sourceStart: currentOffset,
+      sourceEnd: content.length,
     })
   }
 

--- a/packages/core/src/text-buffer.ts
+++ b/packages/core/src/text-buffer.ts
@@ -11,6 +11,8 @@ export interface TextChunk {
   bg?: RGBA
   attributes?: number
   link?: { url: string }
+  sourceStart?: number
+  sourceEnd?: number
 }
 
 export class TextBuffer {


### PR DESCRIPTION
treeSitterToTextChunks now annotates each chunk with sourceStart/sourceEnd (the original content byte offsets), and detectLinks uses these precise offsets for overlap checks instead of indexOf-based fuzzy matching.

The old indexOf path drifted when concealed single-char chunks were skipped without advancing contentPos, causing unrelated chunks (whitespace, common words) to match at wrong positions and inherit link attributes — rendering invisible but clickable OSC 8 hyperlink regions in the terminal.

Also filters out whitespace-only chunks from receiving link attributes, even when they legitimately overlap a URL range (they are conceal replacements for markdown syntax markers like `](` → ` `).