### PR TITLE
fix(core): allow null useKittyKeyboard to actually disable the protocol

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1054,7 +1054,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     if (process.platform === "linux") config.useThread = false
     lib.setUseThread(rendererPtr, config.useThread)
 
-    const kittyConfig = config.useKittyKeyboard ?? {}
+    const kittyConfig = config.useKittyKeyboard === undefined ? {} : config.useKittyKeyboard
     const kittyFlags = buildKittyKeyboardFlags(kittyConfig)
     lib.setKittyKeyboardFlags(rendererPtr, kittyFlags)
 


### PR DESCRIPTION
## Problem

\?? {}\ fallback in the renderer constructor converts an explicit \
ull\ \useKittyKeyboard\ back to \{}\, which \uildKittyKeyboardFlags\ treats as truthy and enables default flags (disambiguate + alternateKeys). This makes it **impossible for callers to actually disable the Kitty keyboard protocol** at renderer creation time.

## Fix

Changed the nullish fallback from \?? {}\ to \=== undefined ? {} : config.useKittyKeyboard\:

| Input | Before | After |
|---|---|---|
| \undefined\ (not passed) | \{}\ → flags=5 (enabled) | \{}\ → flags=5 (enabled) |
| \
ull\ (explicit disable) | \{}\ → flags=5 (enabled!) | \
ull\ → flags=0 (disabled) |
| \{ events: true }\ | \{ events: true }\ → flags=7 | \{ events: true }\ → flags=7 |

## Related

This is required by anomalyco/opencode to fix Windows IME crashes — OpenCode needs to pass \useKittyKeyboard: null\ on Windows to avoid conflict with CJK input methods, which is blocked by this bug.