### PR TITLE
fix(core): support web-tree-sitter 0.26 wasm path

### DIFF
--- a/packages/core/src/lib/tree-sitter/parser.worker.test.ts
+++ b/packages/core/src/lib/tree-sitter/parser.worker.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+
+import { resolveWebTreeSitterWasmPath } from "./web-tree-sitter-wasm.js"
+
+describe("parser worker web-tree-sitter wasm resolution", () => {
+  test("prefers the web-tree-sitter 0.26 wasm filename", () => {
+    const resolvedSpecifiers: string[] = []
+
+    const resolved = resolveWebTreeSitterWasmPath((specifier) => {
+      resolvedSpecifiers.push(specifier)
+      return `/node_modules/${specifier}`
+    })
+
+    expect(resolved).toBe("/node_modules/web-tree-sitter/web-tree-sitter.wasm")
+    expect(resolvedSpecifiers).toEqual(["web-tree-sitter/web-tree-sitter.wasm"])
+  })
+
+  test("falls back to the web-tree-sitter 0.25 wasm filename", () => {
+    const resolvedSpecifiers: string[] = []
+
+    const resolved = resolveWebTreeSitterWasmPath((specifier) => {
+      resolvedSpecifiers.push(specifier)
+      if (specifier === "web-tree-sitter/web-tree-sitter.wasm") {
+        throw new Error("new wasm filename is not exported")
+      }
+
+      return `/node_modules/${specifier}`
+    })
+
+    expect(resolved).toBe("/node_modules/web-tree-sitter/tree-sitter.wasm")
+    expect(resolvedSpecifiers).toEqual(["web-tree-sitter/web-tree-sitter.wasm", "web-tree-sitter/tree-sitter.wasm"])
+  })
+})

--- a/packages/core/src/lib/tree-sitter/parser.worker.ts
+++ b/packages/core/src/lib/tree-sitter/parser.worker.ts
@@ -15,6 +15,7 @@ import type {
 } from "./types.js"
 import { DownloadUtils } from "./download-utils.js"
 import { isBunfsPath, normalizeBunfsPath } from "../bunfs.js"
+import { importWebTreeSitterWasm, resolveWebTreeSitterWasmPath } from "./web-tree-sitter-wasm.js"
 import { resolveBundledFilePath } from "../../platform/runtime.js"
 import {
   isWorkerRuntime,
@@ -96,8 +97,8 @@ class ParserWorker {
       await mkdir(path.join(this.tsDataPath, "queries"), { recursive: true })
 
       let treeWasm = await resolveBundledFilePath(
-        () => import("web-tree-sitter/tree-sitter.wasm" as string, { with: { type: "wasm" } }),
-        () => import.meta.resolve("web-tree-sitter/tree-sitter.wasm"),
+        importWebTreeSitterWasm,
+        resolveWebTreeSitterWasmPath,
         import.meta.url,
       )
 

--- a/packages/core/src/lib/tree-sitter/web-tree-sitter-wasm.ts
+++ b/packages/core/src/lib/tree-sitter/web-tree-sitter-wasm.ts
@@ -1,0 +1,23 @@
+type WebTreeSitterWasmModule = {
+  default: string
+}
+
+type ResolveModuleSpecifier = (specifier: string) => string
+
+export async function importWebTreeSitterWasm(): Promise<WebTreeSitterWasmModule> {
+  try {
+    return await import("web-tree-sitter/web-tree-sitter.wasm" as string, { with: { type: "wasm" } })
+  } catch {
+    return import("web-tree-sitter/tree-sitter.wasm" as string, { with: { type: "wasm" } })
+  }
+}
+
+export function resolveWebTreeSitterWasmPath(
+  resolveModule: ResolveModuleSpecifier = (specifier) => import.meta.resolve(specifier),
+): string {
+  try {
+    return resolveModule("web-tree-sitter/web-tree-sitter.wasm")
+  } catch {
+    return resolveModule("web-tree-sitter/tree-sitter.wasm")
+  }
+}


### PR DESCRIPTION
## Summary

- Resolve `web-tree-sitter/web-tree-sitter.wasm` first for `web-tree-sitter@0.26+`.
- Fall back to `web-tree-sitter/tree-sitter.wasm` for `web-tree-sitter@0.25`.
- Add focused coverage for the preferred and fallback wasm path resolution.

Closes #1201.

## Testing

- `bun test src/lib/tree-sitter/parser.worker.test.ts src/lib/tree-sitter/client.test.ts`
- `bun test src/renderables/__tests__/Markdown.test.ts`
- `bun run fmt:check`
- `bun run lint`
- `bunx tsc -p packages/core/tsconfig.build.json --noEmit --pretty false`
- `bun test`
- Temporary `web-tree-sitter@0.26.3` install with `--no-save`: `bun test src/lib/tree-sitter/parser.worker.test.ts src/lib/tree-sitter/client.test.ts`

Not run: `bun run test:native` because `zig` is not installed in this environment.