### PR TITLE
feat(core): support clickable Markdown URLs

### DIFF
--- a/packages/core/src/buffer.ts
+++ b/packages/core/src/buffer.ts
@@ -184,7 +184,7 @@ export class OptimizedBuffer {
         const cp = char[i]
         const cellFg = RGBA.fromArray(fg.slice(i * 4, i * 4 + 4))
         const cellBg = RGBA.fromArray(bg.slice(i * 4, i * 4 + 4))
-        const cellAttrs = attributes[i] & 0xff
+        const cellAttrs = attributes[i]
 
         // Continuation cells are placeholders for wide characters (emojis, CJK)
         const isContinuation = (cp & CHAR_FLAG_MASK) === CHAR_FLAG_CONTINUATION

--- a/packages/core/src/lib/detect-links.test.ts
+++ b/packages/core/src/lib/detect-links.test.ts
@@ -134,6 +134,68 @@ describe("detectLinks", () => {
     )
   })
 
+  test("detects a bare URL inside a label without an explicit destination", () => {
+    const content = "[https://example.com]"
+    const highlights: SimpleHighlight[] = [[1, content.length - 1, "markup.link.label"]]
+
+    const result = detectLinks([chunk(content)], { content, highlights })
+
+    expect(result.find((value) => value.link)?.link?.url).toBe("https://example.com")
+  })
+
+  test("does not override reference links with a bare URL from their label", () => {
+    const content = "[https://shown.example][ref]\n\n[ref]: https://target.example"
+    const shownEnd = content.indexOf("]")
+    const referenceStart = content.indexOf("[ref]")
+    const definitionStart = content.lastIndexOf("[ref]")
+    const destinationStart = content.lastIndexOf("https://")
+    const highlights: SimpleHighlight[] = [
+      [1, shownEnd, "markup.link.label"],
+      [referenceStart + 1, referenceStart + 4, "markup.link.label"],
+      [definitionStart + 1, definitionStart + 4, "markup.link.label"],
+      [destinationStart, content.length, "markup.link.url"],
+    ]
+
+    const result = detectLinks([chunk(content)], { content, highlights })
+
+    expect(result.every((value) => value.link?.url !== "https://shown.example")).toBe(true)
+  })
+
+  test("does not detect bare URLs in link titles or labels with unsupported explicit destinations", () => {
+    const longDestination = `https://target.example/${"a".repeat(512)}`
+    const content = `[https://shown.example]( ${longDestination} "https://title.example")`
+    const destinationStart = content.indexOf(longDestination)
+    const titleStart = content.indexOf('"')
+    const highlights: SimpleHighlight[] = [
+      [1, content.indexOf("]"), "markup.link.label"],
+      [destinationStart, destinationStart + longDestination.length, "markup.link.url"],
+      [titleStart, content.lastIndexOf('"') + 1, "markup.link.label"],
+    ]
+
+    const result = detectLinks([chunk(content)], { content, highlights })
+
+    expect(result.every((value) => value.link === undefined)).toBe(true)
+  })
+
+  test("pairs an explicit destination with its outer label when the label contains an image", () => {
+    const longDestination = `https://target.example/${"a".repeat(512)}`
+    const content = `[prefix ![alt](image.png) https://shown.example]( ${longDestination})`
+    const innerLabelStart = content.indexOf("[alt") + 1
+    const innerDestinationStart = content.indexOf("image.png")
+    const outerLabelEnd = content.lastIndexOf("](")
+    const outerDestinationStart = content.indexOf(longDestination)
+    const highlights: SimpleHighlight[] = [
+      [1, outerLabelEnd, "markup.link.label"],
+      [innerLabelStart, innerLabelStart + 3, "markup.link.label"],
+      [innerDestinationStart, innerDestinationStart + "image.png".length, "markup.link.url"],
+      [outerDestinationStart, outerDestinationStart + longDestination.length, "markup.link.url"],
+    ]
+
+    const result = detectLinks([chunk(content)], { content, highlights })
+
+    expect(result.every((value) => value.link?.url !== "https://shown.example")).toBe(true)
+  })
+
   test("detects case-insensitive schemes and apostrophes inside URL paths", () => {
     const content = "HTTP://EXAMPLE.COM/path https://example.com/O'Brien"
 
@@ -143,6 +205,26 @@ describe("detectLinks", () => {
       "HTTP://EXAMPLE.COM/path",
       "https://example.com/O'Brien",
     ])
+  })
+
+  test("does not include possessive or closing quote apostrophes in bare URLs", () => {
+    const content = "Visit https://example.com's docs, url('https://example.org'), or https://example.net/McDonald's."
+
+    const result = detectLinks([chunk(content)], { content, highlights: [] })
+
+    expect(result.filter((value) => value.link).map((value) => [value.text, value.link?.url])).toEqual([
+      ["https://example.com", "https://example.com"],
+      ["https://example.org", "https://example.org"],
+      ["https://example.net/McDonald's", "https://example.net/McDonald's"],
+    ])
+  })
+
+  test("trims alternating unmatched delimiters from a bare URL", () => {
+    const content = "https://example.com/path])])"
+
+    const result = detectLinks([chunk(content)], { content, highlights: [] })
+
+    expect(result.find((value) => value.link)?.link?.url).toBe("https://example.com/path")
   })
 
   test("does not guess source ranges for transformed chunks", () => {

--- a/packages/core/src/lib/detect-links.test.ts
+++ b/packages/core/src/lib/detect-links.test.ts
@@ -120,6 +120,45 @@ describe("detectLinks", () => {
     expect(result.every((value) => value.link === undefined)).toBe(true)
   })
 
+  test("gives an explicit link label precedence over a bare URL inside it", () => {
+    const content = "[https://shown.example extra](https://target.example)"
+    const destinationStart = content.lastIndexOf("https://")
+    const highlights: SimpleHighlight[] = [
+      [1, content.indexOf("]"), "markup.link.label"],
+      [destinationStart, content.length - 1, "markup.link.url"],
+    ]
+
+    const result = detectLinks([chunk(content)], { content, highlights })
+    expect(result.find((value) => value.text === "https://shown.example extra")?.link?.url).toBe(
+      "https://target.example",
+    )
+  })
+
+  test("detects case-insensitive schemes and apostrophes inside URL paths", () => {
+    const content = "HTTP://EXAMPLE.COM/path https://example.com/O'Brien"
+
+    const result = detectLinks([chunk(content)], { content, highlights: [] })
+
+    expect(result.filter((value) => value.link).map((value) => value.text)).toEqual([
+      "HTTP://EXAMPLE.COM/path",
+      "https://example.com/O'Brien",
+    ])
+  })
+
+  test("does not guess source ranges for transformed chunks", () => {
+    const content = "[label](https://example.com)"
+    const highlights: SimpleHighlight[] = [
+      [1, 6, "markup.link.label"],
+      [8, 27, "markup.link.url"],
+    ]
+    const transformed = [chunk("label"), chunk(" "), chunk("https://example.com")]
+
+    const result = detectLinks(transformed, { content, highlights })
+
+    expect(result).toBe(transformed)
+    expect(result.every((value) => value.link === undefined)).toBe(true)
+  })
+
   test("should set link on markup.link.url chunks", () => {
     const content = "[Click here](https://example.com)"
     const highlights: SimpleHighlight[] = [
@@ -199,7 +238,17 @@ describe("detectLinks", () => {
       chunk(""), // concealed `)`
     ]
 
-    const result = detectLinks(chunks, { content, highlights })
+    const result = detectLinks(chunks, {
+      content,
+      highlights,
+      sourceRanges: [
+        [0, 1],
+        [1, 11],
+        [11, 13],
+        [13, 32],
+        [32, 33],
+      ],
+    })
 
     // The URL chunk should still get its link despite concealed offsets
     expect(result.find((c) => c.text === "https://example.com")!.link).toEqual({ url: "https://example.com" })

--- a/packages/core/src/lib/detect-links.test.ts
+++ b/packages/core/src/lib/detect-links.test.ts
@@ -9,6 +9,117 @@ function chunk(text: string): TextChunk {
 }
 
 describe("detectLinks", () => {
+  test("detects bare HTTP URLs and splits surrounding text", () => {
+    const content = "See https://example.com/docs, then continue"
+    const chunks = [chunk(content)]
+
+    const result = detectLinks(chunks, { content, highlights: [], sourceRanges: [[0, content.length]] })
+
+    expect(result.map(({ text, link }) => [text, link?.url])).toEqual([
+      ["See ", undefined],
+      ["https://example.com/docs", "https://example.com/docs"],
+      [", then continue", undefined],
+    ])
+  })
+
+  test("keeps balanced URL parentheses and trims unmatched punctuation", () => {
+    const content = 'See https://example.com/a((b)). Then "https://example.org/x".'
+    const chunks = [chunk(content)]
+
+    const result = detectLinks(chunks, { content, highlights: [], sourceRanges: [[0, content.length]] })
+    const links = result.filter((value) => value.link).map((value) => value.link!.url)
+
+    expect(links).toEqual(["https://example.com/a((b))", "https://example.org/x"])
+  })
+
+  test("does not detect URLs in raw Markdown ranges or across control characters", () => {
+    const content = "`https://code.example` https://bad.example\u0007suffix"
+    const highlights: SimpleHighlight[] = [[0, 22, "markup.raw"]]
+    const chunks = [chunk(content)]
+
+    const result = detectLinks(chunks, { content, highlights, sourceRanges: [[0, content.length]] })
+
+    expect(result.every((value) => value.link === undefined)).toBe(true)
+  })
+
+  test("normalizes angle-bracket destinations and Markdown escapes", () => {
+    const content = String.raw`[label](<https://example.com/a\(b\)>)`
+    const destinationStart = content.indexOf("<")
+    const destinationEnd = content.lastIndexOf(">") + 1
+    const highlights: SimpleHighlight[] = [
+      [1, 6, "markup.link.label"],
+      [destinationStart, destinationEnd, "markup.link.url"],
+    ]
+    const chunks = [chunk(content)]
+
+    const result = detectLinks(chunks, { content, highlights, sourceRanges: [[0, content.length]] })
+    const linked = result.filter((value) => value.link)
+
+    expect(linked.length).toBeGreaterThan(0)
+    expect(linked.every((value) => value.link?.url === "https://example.com/a(b)")).toBe(true)
+  })
+
+  test("does not associate an unrelated label with a later autolink", () => {
+    const content = "[shortcut] then <https://example.com>"
+    const urlStart = content.indexOf("<")
+    const highlights: SimpleHighlight[] = [
+      [1, 9, "markup.link.label"],
+      [urlStart, content.length, "markup.link.url"],
+    ]
+    const chunks = [chunk(content)]
+
+    const result = detectLinks(chunks, { content, highlights, sourceRanges: [[0, content.length]] })
+    const shortcut = result.find((value) => value.text.includes("shortcut"))
+
+    expect(shortcut?.link).toBeUndefined()
+  })
+
+  test("percent-encodes spaces in angle-bracket destinations", () => {
+    const content = "[label](<https://example.com/a b>)"
+    const start = content.indexOf("<")
+    const highlights: SimpleHighlight[] = [
+      [1, 6, "markup.link.label"],
+      [start, content.indexOf(">") + 1, "markup.link.url"],
+    ]
+
+    const result = detectLinks([chunk(content)], { content, highlights, sourceRanges: [[0, content.length]] })
+
+    expect(result.find((value) => value.link)?.link?.url).toBe("https://example.com/a%20b")
+  })
+
+  test("preserves valid percent escapes in Markdown destinations", () => {
+    const content = "[label](https://example.com/a%20b)"
+    const start = content.indexOf("https://")
+    const highlights: SimpleHighlight[] = [
+      [1, 6, "markup.link.label"],
+      [start, content.indexOf(")"), "markup.link.url"],
+    ]
+
+    const result = detectLinks([chunk(content)], { content, highlights, sourceRanges: [[0, content.length]] })
+
+    expect(result.find((value) => value.link)?.link?.url).toBe("https://example.com/a%20b")
+  })
+
+  test("stops a bare URL before an adjacent raw Markdown range", () => {
+    const content = "https://outside.example`https://inside.example`"
+    const rawStart = content.indexOf("`")
+    const highlights: SimpleHighlight[] = [[rawStart, content.length, "markup.raw"]]
+
+    const result = detectLinks([chunk(content)], { content, highlights, sourceRanges: [[0, content.length]] })
+    const linked = result.filter((value) => value.link)
+
+    expect(linked.map((value) => value.text).join("")).toBe("https://outside.example")
+    expect(linked.every((value) => value.link?.url === "https://outside.example")).toBe(true)
+  })
+
+  test("does not detect a URL joined to an astral Unicode letter", () => {
+    const content = "𐐀https://example.com"
+
+    const result = detectLinks([chunk(content)], { content, highlights: [], sourceRanges: [[0, content.length]] })
+
+    expect(result.every((value) => value.link === undefined)).toBe(true)
+  })
+
   test("should set link on markup.link.url chunks", () => {
     const content = "[Click here](https://example.com)"
     const highlights: SimpleHighlight[] = [

--- a/packages/core/src/lib/detect-links.ts
+++ b/packages/core/src/lib/detect-links.ts
@@ -14,6 +14,12 @@ interface LinkRange {
   url: string
 }
 
+interface MarkdownDestination {
+  start: number
+  end: number
+  url?: string
+}
+
 export function detectLinks(
   chunks: TextChunk[],
   context: { content: string; highlights: SimpleHighlight[]; sourceRanges?: ReadonlyArray<SourceRange> },
@@ -56,6 +62,7 @@ export function detectLinks(
 function collectLinkRanges(content: string, highlights: SimpleHighlight[]): LinkRange[] {
   const ranges: LinkRange[] = []
   const explicitDestinations: LinkRange[] = []
+  const markdownDestinations: MarkdownDestination[] = []
   const labels: SourceRange[] = []
   const excludedBareRanges: SourceRange[] = []
 
@@ -69,31 +76,50 @@ function collectLinkRanges(content: string, highlights: SimpleHighlight[]): Link
     }
     if (!URL_SCOPES.includes(group)) continue
 
-    const url =
+    const normalized =
       group === "markup.link.url" ? normalizeMarkdownDestination(content.slice(start, end)) : content.slice(start, end)
-    if (isLinkTargetSupported(url)) {
-      explicitDestinations.push({ start, end, url })
-      excludedBareRanges.push([start, end])
-    }
+    const url = isLinkTargetSupported(normalized) ? normalized : undefined
+    if (url) explicitDestinations.push({ start, end, url })
+    if (group === "markup.link.url") markdownDestinations.push({ start, end, url })
+    excludedBareRanges.push([start, end])
   }
 
   labels.sort(compareSourceRanges)
-  explicitDestinations.sort((left, right) => left.start - right.start)
+  const labelsByEnd = [...labels].sort((left, right) => left[1] - right[1] || left[0] - right[0])
+  markdownDestinations.sort((left, right) => left.start - right.start)
+  const pairedLabels = new Set<SourceRange>()
   let labelIndex = 0
   let latestLabel: SourceRange | undefined
-  for (const destination of explicitDestinations) {
-    while (labelIndex < labels.length && labels[labelIndex][1] <= destination.start) {
-      latestLabel = labels[labelIndex++]
+  for (const destination of markdownDestinations) {
+    while (labelIndex < labelsByEnd.length && labelsByEnd[labelIndex][1] <= destination.start) {
+      latestLabel = labelsByEnd[labelIndex++]
     }
-    if (latestLabel && content.slice(latestLabel[1], destination.start) === "](") {
-      ranges.push({ start: latestLabel[0], end: latestLabel[1], url: destination.url })
+    if (latestLabel && /^\]\(\s*$/u.test(content.slice(latestLabel[1], destination.start))) {
+      pairedLabels.add(latestLabel)
+      if (destination.url) ranges.push({ start: latestLabel[0], end: latestLabel[1], url: destination.url })
     }
-    ranges.push(destination)
     latestLabel = undefined
   }
+  ranges.push(...explicitDestinations)
 
   excludedBareRanges.sort(compareSourceRanges)
   collectBareHttpUrls(content, excludedBareRanges, ranges)
+  const referenceDefinitions = new Set(
+    labels
+      .filter((label) => content[label[1]] === "]" && content[label[1] + 1] === ":")
+      .map((label) => labelKey(content, label)),
+  )
+  for (const label of labels) {
+    const isBracketLabel = content[label[0] - 1] === "[" && content[label[1]] === "]"
+    const isImageDescription = content[label[0] - 2] === "!"
+    const isReference = content[label[1] + 1] === "[" || referenceDefinitions.has(labelKey(content, label))
+    if (pairedLabels.has(label) || !isBracketLabel || isImageDescription || isReference) continue
+    const labelRanges: LinkRange[] = []
+    collectBareHttpUrls(content.slice(label[0], label[1]), [], labelRanges)
+    for (const range of labelRanges) {
+      ranges.push({ start: range.start + label[0], end: range.end + label[0], url: range.url })
+    }
+  }
   ranges.sort((left, right) => left.start - right.start || left.end - right.end)
   return ranges
 }
@@ -191,25 +217,55 @@ function previousCodePoint(content: string, end: number): string {
 }
 
 function trimUrlEnd(content: string, start: number, initialEnd: number): number {
-  let end = initialEnd
-  while (end > start && /[.,;:!?']/.test(content[end - 1])) end--
+  const balances = new Map<string, number>([
+    [")", 0],
+    ["]", 0],
+    ["}", 0],
+  ])
+  for (let index = start; index < initialEnd; index++) {
+    const character = content[index]
+    if (character === "(") balances.set(")", balances.get(")")! + 1)
+    else if (character === "[") balances.set("]", balances.get("]")! + 1)
+    else if (character === "{") balances.set("}", balances.get("}")! + 1)
+    else if (balances.has(character)) balances.set(character, balances.get(character)! - 1)
+  }
 
-  for (const [open, close] of [
-    ["(", ")"],
-    ["[", "]"],
-    ["{", "}"],
-  ] as const) {
-    let balance = 0
-    for (let index = start; index < end; index++) {
-      if (content[index] === open) balance++
-      else if (content[index] === close) balance--
-    }
-    while (balance < 0 && content[end - 1] === close) {
+  let end = initialEnd
+  let removedTerminalApostrophe = false
+  while (end > start) {
+    const character = content[end - 1]
+    if (/[.,;:!?']/.test(character)) {
+      removedTerminalApostrophe ||= character === "'"
       end--
-      balance++
+      continue
     }
+    if (
+      !removedTerminalApostrophe &&
+      end - start >= 2 &&
+      content[end - 2] === "'" &&
+      /s/i.test(character) &&
+      isAuthorityPossessive(content, start, end)
+    ) {
+      end -= 2
+      continue
+    }
+    const balance = balances.get(character)
+    if (balance !== undefined && balance < 0) {
+      balances.set(character, balance + 1)
+      end--
+      continue
+    }
+    break
   }
   return end
+}
+
+function isAuthorityPossessive(content: string, start: number, end: number): boolean {
+  const authorityStart = start + getHttpSchemeLength(content, start)
+  for (let index = authorityStart; index < end - 2; index++) {
+    if (content[index] === "/" || content[index] === "?" || content[index] === "#") return false
+  }
+  return true
 }
 
 function isHttpUrl(url: string): boolean {
@@ -280,4 +336,8 @@ function getExactSequentialSourceRanges(chunks: TextChunk[], content: string): S
 
 function compareSourceRanges(left: SourceRange, right: SourceRange): number {
   return left[0] - right[0] || left[1] - right[1]
+}
+
+function labelKey(content: string, range: SourceRange): string {
+  return content.slice(range[0], range[1]).trim().replace(/\s+/gu, " ").toLowerCase()
 }

--- a/packages/core/src/lib/detect-links.ts
+++ b/packages/core/src/lib/detect-links.ts
@@ -2,55 +2,265 @@ import type { TextChunk } from "../text-buffer.js"
 import type { SimpleHighlight } from "./tree-sitter/types.js"
 
 const URL_SCOPES = ["markup.link.url", "string.special.url"]
+const RAW_SCOPES = ["markup.raw", "markup.raw.block"]
+const MAX_LINK_TARGET_BYTES = 512
+
+type SourceRange = readonly [start: number, end: number]
+
+interface LinkRange {
+  start: number
+  end: number
+  url: string
+}
 
 export function detectLinks(
   chunks: TextChunk[],
-  context: { content: string; highlights: SimpleHighlight[] },
+  context: { content: string; highlights: SimpleHighlight[]; sourceRanges?: ReadonlyArray<SourceRange> },
 ): TextChunk[] {
-  const content = context.content
-  const highlights = context.highlights
-
-  const ranges: Array<{ start: number; end: number; url: string }> = []
-
-  for (let i = 0; i < highlights.length; i++) {
-    const [start, end, group] = highlights[i]
-    if (!URL_SCOPES.includes(group)) continue
-
-    const url = content.slice(start, end)
-    ranges.push({ start, end, url })
-
-    for (let j = i - 1; j >= 0; j--) {
-      const [labelStart, labelEnd, prev] = highlights[j]
-      if (prev === "markup.link.label") {
-        ranges.push({ start: labelStart, end: labelEnd, url })
-        break
-      }
-      if (!prev.startsWith("markup.link")) break
-    }
-  }
-
+  const ranges = collectLinkRanges(context.content, context.highlights)
   if (ranges.length === 0) return chunks
 
-  // Use content.indexOf to find each chunk's position in the original content.
-  // This handles concealed text correctly because concealed chunks are either
-  // empty (length 0, skipped) or single-char replacements (length 1, skipped).
-  // Non-concealed chunks with length > 1 are exact substrings of content in order.
-  let contentPos = 0
-  for (const chunk of chunks) {
-    if (chunk.text.length <= 1) continue
+  const sourceRanges = context.sourceRanges ?? getSequentialSourceRanges(chunks)
+  const result: TextChunk[] = []
+  let linkIndex = 0
 
-    const idx = content.indexOf(chunk.text, contentPos)
-    if (idx < 0) continue
-
-    for (const range of ranges) {
-      if (idx < range.end && idx + chunk.text.length > range.start) {
-        chunk.link = { url: range.url }
-        break
-      }
+  for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
+    const chunk = chunks[chunkIndex]
+    const sourceRange = sourceRanges[chunkIndex]
+    if (!sourceRange) {
+      result.push(chunk)
+      continue
     }
 
-    contentPos = idx + chunk.text.length
+    while (linkIndex < ranges.length && ranges[linkIndex].end <= sourceRange[0]) linkIndex++
+    const range = ranges[linkIndex]
+    if (!range || range.start >= sourceRange[1]) {
+      result.push(chunk)
+      continue
+    }
+
+    const sourceText = context.content.slice(sourceRange[0], sourceRange[1])
+    if (chunk.text !== sourceText) {
+      result.push({ ...chunk, link: { url: range.url } })
+      continue
+    }
+
+    splitChunkAtLinks(chunk, sourceRange, ranges, linkIndex, result)
   }
 
-  return chunks
+  return result
+}
+
+function collectLinkRanges(content: string, highlights: SimpleHighlight[]): LinkRange[] {
+  const ranges: LinkRange[] = []
+  const explicitDestinations: LinkRange[] = []
+  const labels: SourceRange[] = []
+  const rawRanges: SourceRange[] = []
+
+  for (const [start, end, group] of highlights) {
+    if (group === "markup.link.label") labels.push([start, end])
+    if (RAW_SCOPES.some((scope) => group === scope || group.startsWith(`${scope}.`))) rawRanges.push([start, end])
+    if (!URL_SCOPES.includes(group)) continue
+
+    const url =
+      group === "markup.link.url" ? normalizeMarkdownDestination(content.slice(start, end)) : content.slice(start, end)
+    if (isLinkTargetSupported(url)) explicitDestinations.push({ start, end, url })
+  }
+
+  labels.sort(compareSourceRanges)
+  explicitDestinations.sort((left, right) => left.start - right.start)
+  let labelIndex = 0
+  let latestLabel: SourceRange | undefined
+  for (const destination of explicitDestinations) {
+    while (labelIndex < labels.length && labels[labelIndex][1] <= destination.start) {
+      latestLabel = labels[labelIndex++]
+    }
+    if (latestLabel && content.slice(latestLabel[1], destination.start) === "](") {
+      ranges.push({ start: latestLabel[0], end: latestLabel[1], url: destination.url })
+    }
+    ranges.push(destination)
+    latestLabel = undefined
+  }
+
+  rawRanges.sort(compareSourceRanges)
+  collectBareHttpUrls(content, rawRanges, explicitDestinations, ranges)
+  ranges.sort((left, right) => left.start - right.start || left.end - right.end)
+  return ranges
+}
+
+function normalizeMarkdownDestination(destination: string): string {
+  let normalized = destination.trim()
+  if (normalized.startsWith("<") && normalized.endsWith(">")) normalized = normalized.slice(1, -1)
+  normalized = normalized.replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, "$1")
+  normalized = normalized.replace(/&#(x[\da-f]+|\d+);|&(amp|lt|gt|quot);/gi, (entity, numeric, named) => {
+    if (numeric) {
+      const hexadecimal = numeric[0]?.toLowerCase() === "x"
+      const codePoint = Number.parseInt(hexadecimal ? numeric.slice(1) : numeric, hexadecimal ? 16 : 10)
+      if (codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) return entity
+      return String.fromCodePoint(codePoint)
+    }
+    return { amp: "&", lt: "<", gt: ">", quot: '"' }[String(named).toLowerCase()] ?? entity
+  })
+  try {
+    return encodeURI(normalized).replace(/%25([\da-f]{2})/gi, "%$1")
+  } catch {
+    return ""
+  }
+}
+
+function collectBareHttpUrls(
+  content: string,
+  rawRanges: SourceRange[],
+  explicitDestinations: LinkRange[],
+  ranges: LinkRange[],
+): void {
+  let rawIndex = 0
+  let explicitIndex = 0
+  let index = 0
+
+  while (index < content.length) {
+    const hasScheme = content.startsWith("http://", index) || content.startsWith("https://", index)
+    const hasStartBoundary = index === 0 || !/[\p{L}\p{N}_@]/u.test(previousCodePoint(content, index))
+    if (!hasScheme || !hasStartBoundary) {
+      index++
+      continue
+    }
+
+    while (rawIndex < rawRanges.length && rawRanges[rawIndex][1] <= index) rawIndex++
+    while (explicitIndex < explicitDestinations.length && explicitDestinations[explicitIndex].end <= index)
+      explicitIndex++
+
+    let end = index
+    let hasControl = false
+    const nextRawStart = rawIndex < rawRanges.length ? rawRanges[rawIndex][0] : content.length
+    while (end < content.length && end < nextRawStart && !isUrlBoundary(content.charCodeAt(end), content[end])) {
+      if (content.charCodeAt(end) < 0x20 || content.charCodeAt(end) === 0x7f) hasControl = true
+      end++
+    }
+
+    const insideRaw = rawIndex < rawRanges.length && rawRanges[rawIndex][0] <= index && index < rawRanges[rawIndex][1]
+    const insideExplicit =
+      explicitIndex < explicitDestinations.length &&
+      explicitDestinations[explicitIndex].start <= index &&
+      index < explicitDestinations[explicitIndex].end
+    const trimmedEnd = trimUrlEnd(content, index, end)
+    const url = content.slice(index, trimmedEnd)
+    if (!hasControl && !insideRaw && !insideExplicit && isHttpUrl(url))
+      ranges.push({ start: index, end: trimmedEnd, url })
+    index = Math.max(end, index + 1)
+  }
+}
+
+function isUrlBoundary(code: number, character: string): boolean {
+  return (
+    code === 0x20 ||
+    code === 0x09 ||
+    code === 0x0a ||
+    code === 0x0d ||
+    character === "<" ||
+    character === ">" ||
+    character === '"' ||
+    character === "'"
+  )
+}
+
+function previousCodePoint(content: string, end: number): string {
+  const last = content.charCodeAt(end - 1)
+  const startsSurrogatePair =
+    last >= 0xdc00 &&
+    last <= 0xdfff &&
+    end >= 2 &&
+    content.charCodeAt(end - 2) >= 0xd800 &&
+    content.charCodeAt(end - 2) <= 0xdbff
+  return content.slice(startsSurrogatePair ? end - 2 : end - 1, end)
+}
+
+function trimUrlEnd(content: string, start: number, initialEnd: number): number {
+  let end = initialEnd
+  while (end > start && /[.,;:!?]/.test(content[end - 1])) end--
+
+  for (const [open, close] of [
+    ["(", ")"],
+    ["[", "]"],
+    ["{", "}"],
+  ] as const) {
+    let balance = 0
+    for (let index = start; index < end; index++) {
+      if (content[index] === open) balance++
+      else if (content[index] === close) balance--
+    }
+    while (balance < 0 && content[end - 1] === close) {
+      end--
+      balance++
+    }
+  }
+  return end
+}
+
+function isHttpUrl(url: string): boolean {
+  if (!isLinkTargetSupported(url)) return false
+  try {
+    const parsed = new URL(url)
+    return (parsed.protocol === "http:" || parsed.protocol === "https:") && parsed.hostname.length > 0
+  } catch {
+    return false
+  }
+}
+
+function isSafeLinkTarget(url: string): boolean {
+  return url.length > 0 && !/[\u0000-\u001f\u007f-\u009f]/.test(url)
+}
+
+export function isLinkTargetSupported(url: string): boolean {
+  return isSafeLinkTarget(url) && new TextEncoder().encode(url).length <= MAX_LINK_TARGET_BYTES
+}
+
+export function normalizeMarkdownLinkTarget(destination: string): string {
+  return normalizeMarkdownDestination(destination)
+}
+
+function splitChunkAtLinks(
+  chunk: TextChunk,
+  sourceRange: SourceRange,
+  ranges: LinkRange[],
+  initialRangeIndex: number,
+  result: TextChunk[],
+): void {
+  let offset = sourceRange[0]
+  let rangeIndex = initialRangeIndex
+  while (offset < sourceRange[1]) {
+    while (rangeIndex < ranges.length && ranges[rangeIndex].end <= offset) rangeIndex++
+    const range = ranges[rangeIndex]
+    if (!range || range.start >= sourceRange[1]) {
+      result.push({ ...chunk, text: chunk.text.slice(offset - sourceRange[0]), link: undefined })
+      return
+    }
+    if (offset < range.start) {
+      const end = Math.min(range.start, sourceRange[1])
+      result.push({ ...chunk, text: chunk.text.slice(offset - sourceRange[0], end - sourceRange[0]), link: undefined })
+      offset = end
+      continue
+    }
+    const end = Math.min(range.end, sourceRange[1])
+    result.push({
+      ...chunk,
+      text: chunk.text.slice(offset - sourceRange[0], end - sourceRange[0]),
+      link: { url: range.url },
+    })
+    offset = end
+  }
+}
+
+function getSequentialSourceRanges(chunks: TextChunk[]): SourceRange[] {
+  const ranges: SourceRange[] = []
+  let offset = 0
+  for (const chunk of chunks) {
+    ranges.push([offset, offset + chunk.text.length])
+    offset += chunk.text.length
+  }
+  return ranges
+}
+
+function compareSourceRanges(left: SourceRange, right: SourceRange): number {
+  return left[0] - right[0] || left[1] - right[1]
 }

--- a/packages/core/src/lib/detect-links.ts
+++ b/packages/core/src/lib/detect-links.ts
@@ -4,6 +4,7 @@ import type { SimpleHighlight } from "./tree-sitter/types.js"
 const URL_SCOPES = ["markup.link.url", "string.special.url"]
 const RAW_SCOPES = ["markup.raw", "markup.raw.block"]
 const MAX_LINK_TARGET_BYTES = 512
+const textEncoder = new TextEncoder()
 
 type SourceRange = readonly [start: number, end: number]
 
@@ -20,7 +21,8 @@ export function detectLinks(
   const ranges = collectLinkRanges(context.content, context.highlights)
   if (ranges.length === 0) return chunks
 
-  const sourceRanges = context.sourceRanges ?? getSequentialSourceRanges(chunks)
+  const sourceRanges = context.sourceRanges ?? getExactSequentialSourceRanges(chunks, context.content)
+  if (!sourceRanges) return chunks
   const result: TextChunk[] = []
   let linkIndex = 0
 
@@ -55,16 +57,24 @@ function collectLinkRanges(content: string, highlights: SimpleHighlight[]): Link
   const ranges: LinkRange[] = []
   const explicitDestinations: LinkRange[] = []
   const labels: SourceRange[] = []
-  const rawRanges: SourceRange[] = []
+  const excludedBareRanges: SourceRange[] = []
 
   for (const [start, end, group] of highlights) {
-    if (group === "markup.link.label") labels.push([start, end])
-    if (RAW_SCOPES.some((scope) => group === scope || group.startsWith(`${scope}.`))) rawRanges.push([start, end])
+    if (group === "markup.link.label") {
+      labels.push([start, end])
+      excludedBareRanges.push([start, end])
+    }
+    if (RAW_SCOPES.some((scope) => group === scope || group.startsWith(`${scope}.`))) {
+      excludedBareRanges.push([start, end])
+    }
     if (!URL_SCOPES.includes(group)) continue
 
     const url =
       group === "markup.link.url" ? normalizeMarkdownDestination(content.slice(start, end)) : content.slice(start, end)
-    if (isLinkTargetSupported(url)) explicitDestinations.push({ start, end, url })
+    if (isLinkTargetSupported(url)) {
+      explicitDestinations.push({ start, end, url })
+      excludedBareRanges.push([start, end])
+    }
   }
 
   labels.sort(compareSourceRanges)
@@ -82,8 +92,8 @@ function collectLinkRanges(content: string, highlights: SimpleHighlight[]): Link
     latestLabel = undefined
   }
 
-  rawRanges.sort(compareSourceRanges)
-  collectBareHttpUrls(content, rawRanges, explicitDestinations, ranges)
+  excludedBareRanges.sort(compareSourceRanges)
+  collectBareHttpUrls(content, excludedBareRanges, ranges)
   ranges.sort((left, right) => left.start - right.start || left.end - right.end)
   return ranges
 }
@@ -108,47 +118,53 @@ function normalizeMarkdownDestination(destination: string): string {
   }
 }
 
-function collectBareHttpUrls(
-  content: string,
-  rawRanges: SourceRange[],
-  explicitDestinations: LinkRange[],
-  ranges: LinkRange[],
-): void {
-  let rawIndex = 0
-  let explicitIndex = 0
+function collectBareHttpUrls(content: string, excludedRanges: SourceRange[], ranges: LinkRange[]): void {
+  let excludedIndex = 0
   let index = 0
 
   while (index < content.length) {
-    const hasScheme = content.startsWith("http://", index) || content.startsWith("https://", index)
+    const schemeLength = getHttpSchemeLength(content, index)
     const hasStartBoundary = index === 0 || !/[\p{L}\p{N}_@]/u.test(previousCodePoint(content, index))
-    if (!hasScheme || !hasStartBoundary) {
+    if (schemeLength === 0 || !hasStartBoundary) {
       index++
       continue
     }
 
-    while (rawIndex < rawRanges.length && rawRanges[rawIndex][1] <= index) rawIndex++
-    while (explicitIndex < explicitDestinations.length && explicitDestinations[explicitIndex].end <= index)
-      explicitIndex++
+    while (excludedIndex < excludedRanges.length && excludedRanges[excludedIndex][1] <= index) excludedIndex++
 
-    let end = index
+    let end = index + schemeLength
     let hasControl = false
-    const nextRawStart = rawIndex < rawRanges.length ? rawRanges[rawIndex][0] : content.length
-    while (end < content.length && end < nextRawStart && !isUrlBoundary(content.charCodeAt(end), content[end])) {
+    const nextExcludedStart = excludedIndex < excludedRanges.length ? excludedRanges[excludedIndex][0] : content.length
+    while (end < content.length && end < nextExcludedStart && !isUrlBoundary(content.charCodeAt(end), content[end])) {
       if (content.charCodeAt(end) < 0x20 || content.charCodeAt(end) === 0x7f) hasControl = true
       end++
     }
 
-    const insideRaw = rawIndex < rawRanges.length && rawRanges[rawIndex][0] <= index && index < rawRanges[rawIndex][1]
-    const insideExplicit =
-      explicitIndex < explicitDestinations.length &&
-      explicitDestinations[explicitIndex].start <= index &&
-      index < explicitDestinations[explicitIndex].end
+    const insideExcluded =
+      excludedIndex < excludedRanges.length &&
+      excludedRanges[excludedIndex][0] <= index &&
+      index < excludedRanges[excludedIndex][1]
     const trimmedEnd = trimUrlEnd(content, index, end)
     const url = content.slice(index, trimmedEnd)
-    if (!hasControl && !insideRaw && !insideExplicit && isHttpUrl(url))
-      ranges.push({ start: index, end: trimmedEnd, url })
+    if (!hasControl && !insideExcluded && isHttpUrl(url)) ranges.push({ start: index, end: trimmedEnd, url })
     index = Math.max(end, index + 1)
   }
+}
+
+function getHttpSchemeLength(content: string, start: number): number {
+  if (matchesAsciiCaseInsensitive(content, start, "https://")) return 8
+  if (matchesAsciiCaseInsensitive(content, start, "http://")) return 7
+  return 0
+}
+
+function matchesAsciiCaseInsensitive(content: string, start: number, expected: string): boolean {
+  if (start + expected.length > content.length) return false
+  for (let offset = 0; offset < expected.length; offset++) {
+    const code = content.charCodeAt(start + offset)
+    const lowerCode = code >= 0x41 && code <= 0x5a ? code + 0x20 : code
+    if (lowerCode !== expected.charCodeAt(offset)) return false
+  }
+  return true
 }
 
 function isUrlBoundary(code: number, character: string): boolean {
@@ -159,8 +175,7 @@ function isUrlBoundary(code: number, character: string): boolean {
     code === 0x0d ||
     character === "<" ||
     character === ">" ||
-    character === '"' ||
-    character === "'"
+    character === '"'
   )
 }
 
@@ -177,7 +192,7 @@ function previousCodePoint(content: string, end: number): string {
 
 function trimUrlEnd(content: string, start: number, initialEnd: number): number {
   let end = initialEnd
-  while (end > start && /[.,;:!?]/.test(content[end - 1])) end--
+  while (end > start && /[.,;:!?']/.test(content[end - 1])) end--
 
   for (const [open, close] of [
     ["(", ")"],
@@ -212,7 +227,7 @@ function isSafeLinkTarget(url: string): boolean {
 }
 
 export function isLinkTargetSupported(url: string): boolean {
-  return isSafeLinkTarget(url) && new TextEncoder().encode(url).length <= MAX_LINK_TARGET_BYTES
+  return isSafeLinkTarget(url) && textEncoder.encode(url).length <= MAX_LINK_TARGET_BYTES
 }
 
 export function normalizeMarkdownLinkTarget(destination: string): string {
@@ -251,14 +266,16 @@ function splitChunkAtLinks(
   }
 }
 
-function getSequentialSourceRanges(chunks: TextChunk[]): SourceRange[] {
+function getExactSequentialSourceRanges(chunks: TextChunk[], content: string): SourceRange[] | undefined {
   const ranges: SourceRange[] = []
   let offset = 0
   for (const chunk of chunks) {
     ranges.push([offset, offset + chunk.text.length])
     offset += chunk.text.length
   }
-  return ranges
+  return offset === content.length && chunks.every((chunk, index) => chunk.text === content.slice(...ranges[index]))
+    ? ranges
+    : undefined
 }
 
 function compareSourceRanges(left: SourceRange, right: SourceRange): number {

--- a/packages/core/src/lib/tree-sitter-styled-text.ts
+++ b/packages/core/src/lib/tree-sitter-styled-text.ts
@@ -11,6 +11,7 @@ registerEnvVar({ name: "OTUI_TS_STYLE_WARN", default: false, description: "Enabl
 interface TextChunkOptions {
   enabled?: boolean
   baseHighlight?: string
+  sourceRanges?: Array<[start: number, end: number]>
 }
 
 interface Boundary {
@@ -118,6 +119,7 @@ export function treeSitterToTextChunks(
                 })
               : 0,
           })
+          options?.sourceRanges?.push([currentOffset, boundary.offset])
         }
       } else {
         const insideInjectionContainer = injectionContainerRanges.some(
@@ -198,6 +200,7 @@ export function treeSitterToTextChunks(
               })
             : 0,
         })
+        options?.sourceRanges?.push([currentOffset, boundary.offset])
       }
     } else if (currentOffset < boundary.offset) {
       const text = content.slice(currentOffset, boundary.offset)
@@ -216,6 +219,7 @@ export function treeSitterToTextChunks(
             })
           : 0,
       })
+      options?.sourceRanges?.push([currentOffset, boundary.offset])
     }
 
     if (boundary.type === "start") {
@@ -274,6 +278,7 @@ export function treeSitterToTextChunks(
           })
         : 0,
     })
+    options?.sourceRanges?.push([currentOffset, content.length])
   }
 
   return chunks

--- a/packages/core/src/lib/tree-sitter/assets/markdown_inline/highlights.scm
+++ b/packages/core/src/lib/tree-sitter/assets/markdown_inline/highlights.scm
@@ -28,6 +28,9 @@
   ["[" "(" ")"] @markup.link)
 
 (inline_link
+  ["(" ")"] @markup.link.destination)
+
+(inline_link
   "]" @markup.link.bracket.close)
 
 ; Conceal opening bracket

--- a/packages/core/src/renderables/Code.ts
+++ b/packages/core/src/renderables/Code.ts
@@ -21,6 +21,7 @@ export type OnHighlightCallback = (
 
 export interface ChunkRenderContext extends HighlightContext {
   highlights: SimpleHighlight[]
+  sourceRanges?: ReadonlyArray<readonly [start: number, end: number]>
 }
 
 export type OnChunksCallback = (
@@ -366,16 +367,19 @@ export class CodeRenderable extends TextBufferRenderable {
       }
 
       if (highlights.length > 0 || this._onChunks || this._baseHighlight) {
+        const sourceRanges: Array<[number, number]> = []
         const context: ChunkRenderContext = {
           content,
           filetype,
           syntaxStyle: this._syntaxStyle,
           highlights,
+          sourceRanges,
         }
 
         let chunks = treeSitterToTextChunks(content, highlights, this._syntaxStyle, {
           enabled: this._conceal,
           baseHighlight: this._baseHighlight,
+          sourceRanges,
         })
         // onChunks may rewrite text arbitrarily, so the conceal-only source map would be invalid.
         const renderedLineSources = this._onChunks ? undefined : this.getConcealLinesSourceMap(content, highlights)

--- a/packages/core/src/renderables/Markdown.ts
+++ b/packages/core/src/renderables/Markdown.ts
@@ -6,7 +6,7 @@ import { createTextAttributes } from "../utils.js"
 import type { BorderStyle } from "../lib/border.js"
 import { RGBA, parseColor, type ColorInput } from "../lib/RGBA.js"
 import { Lexer, type MarkedToken, type Token, type Tokens } from "marked"
-import { CodeRenderable, type OnChunksCallback } from "./Code.js"
+import { CodeRenderable, type OnChunksCallback, type OnHighlightCallback } from "./Code.js"
 import { BoxRenderable } from "./Box.js"
 import { StyledText } from "../lib/styled-text.js"
 import { TextRenderable } from "./Text.js"
@@ -21,7 +21,7 @@ import type { TreeSitterClient } from "../lib/tree-sitter/index.js"
 import { infoStringToFiletype } from "../lib/tree-sitter/resolve-ft.js"
 import { parseMarkdownIncremental, type ParseState } from "./markdown-parser.js"
 import type { OptimizedBuffer } from "../buffer.js"
-import { detectLinks } from "../lib/detect-links.js"
+import { detectLinks, isLinkTargetSupported, normalizeMarkdownLinkTarget } from "../lib/detect-links.js"
 
 export type MarkdownTableStyle = "grid" | "columns"
 
@@ -275,10 +275,20 @@ export class MarkdownRenderable extends Renderable {
   _blockStates: BlockState[] = []
   _stableBlockCount = 0
   private _styleDirty: boolean = false
+  private _hyperlinksEnabled: boolean
+  private _capabilitiesListener = (): void => {
+    if (this.isDestroyed) return
+    const hyperlinksEnabled = this.ctx.capabilities?.hyperlinks === true
+    if (hyperlinksEnabled === this._hyperlinksEnabled) return
+    this._hyperlinksEnabled = hyperlinksEnabled
+    this._styleDirty = true
+    this.requestRender()
+  }
   private _linkifyMarkdownChunks: OnChunksCallback = (chunks, context) =>
     detectLinks(chunks, {
       content: context.content,
       highlights: context.highlights,
+      sourceRanges: context.sourceRanges,
     })
 
   protected _contentDefaultOptions = {
@@ -307,7 +317,9 @@ export class MarkdownRenderable extends Renderable {
     this._renderNode = options.renderNode
     this._streaming = options.streaming ?? this._contentDefaultOptions.streaming
     this._internalBlockMode = options.internalBlockMode ?? this._contentDefaultOptions.internalBlockMode
+    this._hyperlinksEnabled = this.ctx.capabilities?.hyperlinks === true
 
+    this.ctx.on("capabilities", this._capabilitiesListener)
     this.updateBlocks()
   }
 
@@ -548,9 +560,11 @@ export class MarkdownRenderable extends Renderable {
           for (const child of token.tokens) {
             this.renderInlineTokenWithStyle(child as MarkedToken, chunks, "markup.link.label", linkHref)
           }
-          chunks.push(this.createChunk(" (", "markup.link", linkHref))
-          chunks.push(this.createChunk(token.href, "markup.link.url", linkHref))
-          chunks.push(this.createChunk(")", "markup.link", linkHref))
+          if (!this._hyperlinksEnabled || !isLinkTargetSupported(token.href)) {
+            chunks.push(this.createChunk(" (", "markup.link", linkHref))
+            chunks.push(this.createChunk(token.href, "markup.link.url", linkHref))
+            chunks.push(this.createChunk(")", "markup.link", linkHref))
+          }
         } else {
           chunks.push(this.createChunk("[", "markup.link", linkHref))
           for (const child of token.tokens) {
@@ -647,6 +661,7 @@ export class MarkdownRenderable extends Renderable {
       streaming: true,
       initialStyledText,
       baseHighlight,
+      onHighlight: this.createMarkdownHighlightCallback(),
       onChunks,
       treeSitterClient: this._treeSitterClient,
       width: "100%",
@@ -984,6 +999,7 @@ export class MarkdownRenderable extends Renderable {
     renderable.drawUnstyledText = initialStyledText !== undefined
     renderable.streaming = true
     renderable.baseHighlight = baseHighlight
+    renderable.onHighlight = this.createMarkdownHighlightCallback()
     renderable.content = content
     renderable.marginBottom = marginBottom
   }
@@ -2131,6 +2147,49 @@ export class MarkdownRenderable extends Renderable {
     this._styleDirty = false
     this.rerenderBlocks()
     this.requestRender()
+  }
+
+  private createMarkdownHighlightCallback(): OnHighlightCallback {
+    return (highlights, context) => {
+      if (!this._hyperlinksEnabled) return highlights
+
+      const delimiters = highlights
+        .filter((highlight) => highlight[2] === "markup.link.destination")
+        .sort((left, right) => left[0] - right[0])
+      if (delimiters.length === 0) return highlights
+
+      const concealed = [...highlights]
+      const closingLabels = new Map<number, number>()
+      for (let index = 0; index < concealed.length; index++) {
+        const highlight = concealed[index]
+        if (highlight[3]?.conceal === " ") closingLabels.set(highlight[1], index)
+      }
+      let delimiterIndex = 0
+      for (const [urlStart, urlEnd, group] of highlights) {
+        if (group !== "markup.link.url") continue
+        const target = normalizeMarkdownLinkTarget(context.content.slice(urlStart, urlEnd))
+        if (!isLinkTargetSupported(target)) continue
+        while (delimiterIndex < delimiters.length && delimiters[delimiterIndex][1] <= urlStart) delimiterIndex++
+
+        const close = delimiters[delimiterIndex]
+        const open = delimiters[delimiterIndex - 1]
+        if (!open || !close || open[0] >= urlStart || close[0] < urlEnd) continue
+
+        concealed.push([open[0], close[1], "conceal.link.destination", { conceal: "" }])
+        const closingLabel = closingLabels.get(open[0])
+        if (closingLabel !== undefined) {
+          const highlight = concealed[closingLabel]
+          concealed[closingLabel] = [highlight[0], highlight[1], highlight[2], { ...highlight[3], conceal: "" }]
+        }
+        delimiterIndex++
+      }
+      return concealed
+    }
+  }
+
+  protected override destroySelf(): void {
+    this.ctx.off("capabilities", this._capabilitiesListener)
+    super.destroySelf()
   }
 
   protected renderSelf(buffer: OptimizedBuffer, deltaTime: number): void {

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -21,6 +21,8 @@ import {
 } from "../../testing.js"
 import { ManualClock } from "../../testing/manual-clock.js"
 import { TextAttributes, type CapturedFrame } from "../../types.js"
+import { getLinkId } from "../../utils.js"
+import { createTerminalCapabilities, setRendererCapabilities } from "../../testing/terminal-capabilities.js"
 
 let renderer: TestRenderer
 let mockMouse: MockMouse
@@ -164,6 +166,20 @@ function findSpanContaining(frame: CapturedFrame, text: string) {
   }
 
   return undefined
+}
+
+function getLinkedSpans(frame: CapturedFrame): Array<{ text: string; url: string }> {
+  const renderLib = (renderer as unknown as { lib: { linkGetUrl: (id: number) => string } }).lib
+  const linked: Array<{ text: string; url: string }> = []
+
+  for (const line of frame.lines) {
+    for (const span of line.spans) {
+      const linkId = getLinkId(span.attributes)
+      if (linkId !== 0) linked.push({ text: span.text, url: renderLib.linkGetUrl(linkId) })
+    }
+  }
+
+  return linked
 }
 
 function getMarginBottom(renderable: { getLayoutNode(): { getMargin(edge: Edge): unknown } }): number {
@@ -1909,6 +1925,93 @@ test("links with conceal=false", async () => {
     Check out [OpenTUI](https://github.com/sst/opentui) for
     more."
   `)
+})
+
+test("real Tree-sitter linkifies bare URLs across wrapping but excludes code", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-bare-links",
+    content:
+      "Visit https://example.com/a((b))/long/path now. `https://inline.example`\n\n```text\nhttps://fenced.example\n```",
+    syntaxStyle,
+    conceal: true,
+    width: 24,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const linked = getLinkedSpans(captureSpans())
+  expect(linked.map((span) => span.text).join("")).toContain("https://example.com/a((b))/long/path")
+  expect(new Set(linked.map((span) => span.url))).toEqual(new Set(["https://example.com/a((b))/long/path"]))
+})
+
+test("real Tree-sitter normalizes angle destinations and preserves entity-concealed labels", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-normalized-link",
+    content: String.raw`[a&amp;b](<https://example.com/a\(b\)> "escaped \"title\"")`,
+    syntaxStyle,
+    conceal: true,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const linked = getLinkedSpans(captureSpans())
+  expect(linked.map((span) => span.text).join("")).toContain("a&b")
+  expect(linked.every((span) => span.url === "https://example.com/a(b)")).toBe(true)
+})
+
+test("Markdown link concealment follows hyperlink capability transitions", async () => {
+  setRendererCapabilities(renderer, { hyperlinks: false })
+  const linkSyntaxStyle = SyntaxStyle.fromStyles({
+    default: { fg: RGBA.fromValues(1, 1, 1, 1) },
+    "markup.link.label": { bold: true },
+  })
+  const md = createMarkdownRenderable({
+    id: "markdown-capability-links",
+    content: String.raw`Read [label](https://example.com/a\(b\) "escaped \"title\"") now`,
+    syntaxStyle: linkSyntaxStyle,
+    conceal: true,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+  expect(captureFrame()).toContain('label (https://example.com/a\\(b\\) "escaped \\"title\\"")')
+
+  const supported = setRendererCapabilities(renderer, { hyperlinks: true })
+  renderer.emit("capabilities", supported)
+  await renderMarkdownRenderable(md)
+  expect(captureFrame()).toContain("Read label now")
+  expect(captureFrame()).not.toContain("https://example.com")
+  const supportedFrame = captureSpans()
+  expect(getLinkedSpans(supportedFrame).some((span) => span.text.includes("label"))).toBe(true)
+  expect(findSpanContaining(supportedFrame, "label")!.attributes & TextAttributes.BOLD).toBeTruthy()
+
+  const unsupported = createTerminalCapabilities({ hyperlinks: false })
+  ;(renderer as unknown as { _capabilities: typeof unsupported })._capabilities = unsupported
+  renderer.emit("capabilities", unsupported)
+  await renderMarkdownRenderable(md)
+  expect(captureFrame()).toContain("https://example.com")
+
+  md.destroyRecursively()
+  expect(renderer.listenerCount("capabilities")).toBe(0)
+})
+
+test("keeps an overlong Markdown destination visible when native links cannot store it", async () => {
+  setRendererCapabilities(renderer, { hyperlinks: true })
+  const destination = `https://example.com/${"a".repeat(512)}`
+  const md = createMarkdownRenderable({
+    id: "markdown-overlong-link",
+    content: `[label](${destination})`,
+    syntaxStyle,
+    conceal: true,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  expect(captureFrame().replace(/\s/g, "")).toContain(destination)
+  expect(getLinkedSpans(captureSpans())).toEqual([])
 })
 
 // Horizontal rule

--- a/packages/core/src/zig/link.zig
+++ b/packages/core/src/zig/link.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 pub const LinkPoolError = error{
     OutOfMemory,
     InvalidId,
+    InvalidUrl,
     WrongGeneration,
     UrlTooLong,
 };
@@ -148,10 +149,30 @@ pub const LinkPool = struct {
         }
     }
 
-    pub fn alloc(self: *LinkPool, url: []const u8) LinkPoolError!IdPayload {
-        if (url.len > self.slot_capacity) {
-            return LinkPoolError.UrlTooLong;
+    fn validateUrl(url: []const u8) LinkPoolError!void {
+        // OSC 8 targets are opaque UTF-8 URI references. Scheme and percent-encoding
+        // policy belongs to callers; this boundary rejects terminal control bytes.
+        if (url.len == 0) return LinkPoolError.InvalidUrl;
+        if (url.len > MAX_URL_LENGTH) return LinkPoolError.UrlTooLong;
+        if (!std.unicode.utf8ValidateSlice(url)) return LinkPoolError.InvalidUrl;
+
+        var index: usize = 0;
+        while (index < url.len) {
+            const byte = url[index];
+            if (byte <= 0x1f or byte == 0x7f) return LinkPoolError.InvalidUrl;
+
+            // UTF-8 encodes the C1 control range U+0080..U+009F as C2 80..9F.
+            if (byte == 0xc2 and index + 1 < url.len and url[index + 1] <= 0x9f) {
+                return LinkPoolError.InvalidUrl;
+            }
+
+            index += std.unicode.utf8ByteSequenceLength(byte) catch return LinkPoolError.InvalidUrl;
         }
+    }
+
+    pub fn alloc(self: *LinkPool, url: []const u8) LinkPoolError!IdPayload {
+        std.debug.assert(self.slot_capacity == MAX_URL_LENGTH);
+        try validateUrl(url);
 
         if (self.lookupOrInvalidate(url)) |live_id| {
             return live_id;

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -1377,24 +1377,17 @@ pub const CliRenderer = struct {
                 const sameAttributes = fgMatch and bgMatch and currentAttributes != null and cell.attributes == currentAttributes.?;
 
                 const linkId = if (hyperlinksEnabled) ansi.TextAttributes.getLinkId(cell.attributes) else 0;
+                const starts_run = !sameAttributes or runStart == -1;
+                const repositions_cursor = runStart == -1;
 
-                if (hyperlinksEnabled and linkId != currentLinkId) {
-                    if (currentLinkId != 0) {
-                        writer.writeAll("\x1b]8;;\x1b\\") catch {};
-                    }
-                    currentLinkId = linkId;
-                    if (currentLinkId != 0) {
-                        const lp = link.initGlobalLinkPool(self.allocator);
-                        if (lp.get(currentLinkId)) |url_bytes| {
-                            writer.print("\x1b]8;id={d};{s}\x1b\\", .{ currentLinkId, url_bytes }) catch {};
-                        } else |_| {
-                            // Link not found, treat as no link
-                            currentLinkId = 0;
-                        }
-                    }
+                if (hyperlinksEnabled and currentLinkId != 0 and
+                    (linkId != currentLinkId or repositions_cursor))
+                {
+                    writer.writeAll("\x1b]8;;\x1b\\") catch {};
+                    currentLinkId = 0;
                 }
 
-                if (!sameAttributes or runStart == -1) {
+                if (starts_run) {
                     if (runLength > 0) {
                         writer.writeAll(ansi.ANSI.reset) catch {};
                     }
@@ -1406,12 +1399,24 @@ pub const CliRenderer = struct {
                     currentBg = cell.bg;
                     currentAttributes = cell.attributes;
 
-                    ansi.ANSI.moveToOutput(writer, x + 1, y + 1 + self.renderOffset) catch {};
+                    if (repositions_cursor) {
+                        ansi.ANSI.moveToOutput(writer, x + 1, y + 1 + self.renderOffset) catch {};
+                    }
 
                     self.emitColor(writer, cell.fg, false);
                     self.emitColor(writer, cell.bg, true);
 
                     ansi.TextAttributes.applyAttributesOutputWriter(writer, cell.attributes) catch {};
+                }
+
+                if (hyperlinksEnabled and linkId != 0 and currentLinkId != linkId) {
+                    currentLinkId = linkId;
+                    const lp = link.initGlobalLinkPool(self.allocator);
+                    if (lp.get(currentLinkId)) |url_bytes| {
+                        writer.print("\x1b]8;id={d};{s}\x1b\\", .{ currentLinkId, url_bytes }) catch {};
+                    } else |_| {
+                        currentLinkId = 0;
+                    }
                 }
 
                 // Handle grapheme characters
@@ -1431,7 +1436,18 @@ pub const CliRenderer = struct {
                             if (capabilities.explicit_cursor_positioning) {
                                 const nextX = x + graphemeWidth;
                                 if (nextX < self.width) {
+                                    if (currentLinkId != 0) {
+                                        writer.writeAll("\x1b]8;;\x1b\\") catch {};
+                                    }
                                     ansi.ANSI.moveToOutput(writer, nextX + 1, y + 1 + self.renderOffset) catch {};
+                                    if (currentLinkId != 0) {
+                                        const lp = link.initGlobalLinkPool(self.allocator);
+                                        if (lp.get(currentLinkId)) |url_bytes| {
+                                            writer.print("\x1b]8;id={d};{s}\x1b\\", .{ currentLinkId, url_bytes }) catch {};
+                                        } else |_| {
+                                            currentLinkId = 0;
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -1455,6 +1471,11 @@ pub const CliRenderer = struct {
                 self.currentRenderBuffer.syncCell(x, y, nextCell.?);
 
                 cellsUpdated += 1;
+            }
+
+            if (hyperlinksEnabled and currentLinkId != 0) {
+                writer.writeAll("\x1b]8;;\x1b\\") catch {};
+                currentLinkId = 0;
             }
         }
 

--- a/packages/core/src/zig/syntax-style.zig
+++ b/packages/core/src/zig/syntax-style.zig
@@ -64,6 +64,10 @@ pub const SyntaxStyle = struct {
 
         self.emitter.emit(.Destroy);
         self.emitter.deinit();
+        var name_iterator = self.name_to_id.keyIterator();
+        while (name_iterator.next()) |name| {
+            global_allocator.free(@constCast(name.*));
+        }
         self.arena.deinit();
         global_allocator.destroy(self.arena);
         self.* = undefined;
@@ -72,16 +76,18 @@ pub const SyntaxStyle = struct {
     fn putStyle(self: *SyntaxStyle, name: []const u8, definition: StyleDefinition) SyntaxStyleError!u32 {
         if (self.name_to_id.get(name)) |existing_id| {
             try self.id_to_style.put(self.allocator, existing_id, definition);
+            self.clearCache();
             return existing_id;
         }
 
         const id = self.next_id;
-        self.next_id += 1;
-
-        const owned_name = self.allocator.dupe(u8, name) catch return SyntaxStyleError.OutOfMemory;
+        const owned_name = self.global_allocator.dupe(u8, name) catch return SyntaxStyleError.OutOfMemory;
+        errdefer self.global_allocator.free(owned_name);
 
         try self.name_to_id.put(self.allocator, owned_name, id);
+        errdefer std.debug.assert(self.name_to_id.remove(owned_name));
         try self.id_to_style.put(self.allocator, id, definition);
+        self.next_id += 1;
 
         return id;
     }
@@ -96,6 +102,13 @@ pub const SyntaxStyle = struct {
 
     pub fn registerStyleDefinition(self: *SyntaxStyle, name: []const u8, definition: StyleDefinition) SyntaxStyleError!u32 {
         return self.putStyle(name, definition);
+    }
+
+    pub fn removeStyle(self: *SyntaxStyle, name: []const u8) void {
+        const removed = self.name_to_id.fetchRemove(name) orelse return;
+        std.debug.assert(self.id_to_style.remove(removed.value));
+        self.global_allocator.free(removed.key);
+        self.clearCache();
     }
 
     pub fn resolveById(self: *const SyntaxStyle, id: u32) ?StyleDefinition {

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -832,7 +832,7 @@ fn checkEnvironmentOverrides(self: *Terminal) void {
         }
     }
 
-    if (!self.caps.hyperlinks and self.term_info.from_xtversion) {
+    if (!self.caps.hyperlinks) {
         if (isHyperlinkTerm(self.getTerminalName())) {
             self.caps.hyperlinks = true;
         }
@@ -1258,7 +1258,9 @@ fn isHyperlinkTerm(value: []const u8) bool {
         std.ascii.indexOfIgnoreCase(value, "kitty") != null or
         std.ascii.indexOfIgnoreCase(value, "wezterm") != null or
         std.ascii.indexOfIgnoreCase(value, "alacritty") != null or
-        std.ascii.indexOfIgnoreCase(value, "iterm") != null;
+        std.ascii.indexOfIgnoreCase(value, "iterm") != null or
+        std.ascii.eqlIgnoreCase(value, "zed") or
+        std.ascii.eqlIgnoreCase(value, "vscode");
 }
 
 pub fn getCapabilities(self: *Terminal) Capabilities {

--- a/packages/core/src/zig/tests/link_test.zig
+++ b/packages/core/src/zig/tests/link_test.zig
@@ -23,6 +23,47 @@ test "LinkPool - alloc and get URL" {
     try std.testing.expectEqualSlices(u8, url, retrieved);
 }
 
+test "LinkPool - rejects unsafe OSC 8 targets" {
+    var pool = LinkPool.init(std.testing.allocator);
+    defer pool.deinit();
+
+    const invalid_targets = [_][]const u8{
+        "",
+        "https://example.com/\x00suffix",
+        "https://example.com/\x07suffix",
+        "https://example.com/\x1bsuffix",
+        "https://example.com/\x7fsuffix",
+        "https://example.com/\xc2\x80suffix",
+        "https://example.com/\xc2\x9fsuffix",
+        "https://example.com/\xffsuffix",
+    };
+
+    for (invalid_targets) |target| {
+        try std.testing.expectError(LinkPoolError.InvalidUrl, pool.alloc(target));
+    }
+
+    var overlong: [link.MAX_URL_LENGTH + 1]u8 = undefined;
+    @memset(&overlong, 'a');
+    try std.testing.expectError(LinkPoolError.UrlTooLong, pool.alloc(&overlong));
+    try std.testing.expectEqual(@as(u64, 0), pool.getTotalSlots());
+}
+
+test "LinkPool - accepts bounded UTF-8 absolute and relative targets" {
+    var pool = LinkPool.init(std.testing.allocator);
+    defer pool.deinit();
+
+    const targets = [_][]const u8{
+        "https://example.com/a?b=c#d",
+        "../docs/readme.md",
+        "https://example.com/caf\xc3\xa9",
+    };
+
+    for (targets) |target| {
+        const id = try pool.alloc(target);
+        try std.testing.expectEqualSlices(u8, target, try pool.get(id));
+    }
+}
+
 test "LinkPool - decref to zero allows slot reuse" {
     var pool = LinkPool.init(std.testing.allocator);
     defer pool.deinit();

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -928,9 +928,45 @@ test "renderer - hyperlink spanning multiple rows uses same id" {
         count += 1;
         pos += found + expected_open.len;
     }
-    // Should appear exactly once: the link stays open across rows without
-    // close/reopen at row boundaries, so terminals treat it as one contiguous link.
-    try std.testing.expectEqual(@as(usize, 1), count);
+    try std.testing.expectEqual(@as(usize, 2), count);
+
+    const second_row_move = std.mem.indexOf(u8, output, "\x1b[2;1H") orelse return error.TestUnexpectedResult;
+    const second_open = std.mem.lastIndexOf(u8, output, expected_open) orelse return error.TestUnexpectedResult;
+    try std.testing.expect(second_row_move < second_open);
+}
+
+test "renderer - closes OSC 8 around wide grapheme cursor correction" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var test_cli_renderer = try TestRenderer.create(std.testing.allocator, 8, 1, pool);
+    defer test_cli_renderer.deinit();
+    const cli_renderer = test_cli_renderer.renderer;
+    cli_renderer.terminal.caps.hyperlinks = true;
+    cli_renderer.terminal.caps.explicit_cursor_positioning = true;
+
+    const link_id = try link_pool.alloc("https://example.com/wide");
+    const attributes = ansi.TextAttributes.setLinkId(0, link_id);
+    const fg = ansi.rgbaFromFloats(1.0, 1.0, 1.0, 1.0);
+    const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
+    try cli_renderer.getNextBuffer().drawText("\xf0\x9f\x91\x8bX", 0, 0, fg, bg, attributes);
+
+    _ = cli_renderer.render(false);
+    const rendered = test_cli_renderer.lastOutput();
+    const correction = std.mem.indexOf(u8, rendered, "\x1b[1;3H") orelse return error.TestUnexpectedResult;
+    const close_before = std.mem.lastIndexOf(u8, rendered[0..correction], "\x1b]8;;\x1b\\") orelse
+        return error.TestUnexpectedResult;
+    const open_after_offset = std.mem.indexOf(u8, rendered[correction..], "\x1b]8;id=") orelse
+        return error.TestUnexpectedResult;
+    const open_after = correction + open_after_offset;
+    const following_text_offset = std.mem.indexOfScalar(u8, rendered[correction..], 'X') orelse
+        return error.TestUnexpectedResult;
+    const following_text = correction + following_text_offset;
+    try std.testing.expect(close_before < correction);
+    try std.testing.expect(correction < open_after);
+    try std.testing.expect(open_after < following_text);
 }
 
 test "renderer - explicit default and indexed tags use ANSI default/indexed output" {

--- a/packages/core/src/zig/tests/syntax-style_test.zig
+++ b/packages/core/src/zig/tests/syntax-style_test.zig
@@ -340,6 +340,39 @@ test "SyntaxStyle - merge caches results" {
     try std.testing.expect(style.getCacheSize() > 0);
 }
 
+test "SyntaxStyle - updating and removing styles invalidates merge cache" {
+    const style = try SyntaxStyle.init(std.testing.allocator);
+    defer style.deinit();
+
+    const id = try style.registerStyle("dynamic", null, null, 0b0001);
+    const ids = [_]u32{id};
+    _ = try style.mergeStyles(&ids);
+    try std.testing.expect(style.getCacheSize() > 0);
+
+    const updated_id = try style.registerStyle("dynamic", null, null, 0b0010);
+    try std.testing.expectEqual(id, updated_id);
+    try std.testing.expectEqual(@as(usize, 0), style.getCacheSize());
+    try std.testing.expectEqual(@as(u32, 0b0010), (try style.mergeStyles(&ids)).attributes);
+
+    style.removeStyle("dynamic");
+    try std.testing.expectEqual(@as(usize, 0), style.getStyleCount());
+    try std.testing.expectEqual(@as(usize, 0), style.getCacheSize());
+}
+
+fn registerStyleWithFailingAllocator(allocator: std.mem.Allocator) !void {
+    const style = try SyntaxStyle.init(allocator);
+    defer style.deinit();
+    _ = try style.registerStyle("allocation-failure", null, null, 1);
+}
+
+test "SyntaxStyle - style insertion is allocation-failure safe" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        registerStyleWithFailingAllocator,
+        .{},
+    );
+}
+
 test "SyntaxStyle - merge different order produces different results" {
     const style = try SyntaxStyle.init(std.testing.allocator);
     defer style.deinit();

--- a/packages/core/src/zig/tests/terminal_test.zig
+++ b/packages/core/src/zig/tests/terminal_test.zig
@@ -389,6 +389,19 @@ test "environment overrides - does not enable hyperlinks for WSL non-xterm terms
     try testing.expect(!term.caps.hyperlinks);
 }
 
+test "environment overrides - TERM_PROGRAM enables hyperlinks for Zed and VS Code" {
+    const programs = [_][]const u8{ "zed", "vscode" };
+    for (programs) |program| {
+        var env = std.process.EnvMap.init(testing.allocator);
+        defer env.deinit();
+        try env.put("TERM", "xterm-256color");
+        try env.put("TERM_PROGRAM", program);
+
+        const term = Terminal.init(.{ .env_map = &env });
+        try testing.expect(term.caps.hyperlinks);
+    }
+}
+
 test "setHostEnvVar detects ansi256 separately from rgb" {
     var env = std.process.EnvMap.init(testing.allocator);
     defer env.deinit();

--- a/packages/core/src/zig/tests/text-buffer_test.zig
+++ b/packages/core/src/zig/tests/text-buffer_test.zig
@@ -1675,6 +1675,108 @@ test "TextBuffer setStyledText - repeated calls with SyntaxStyle (crash reproduc
     try std.testing.expect(arena_growth < max_expected_growth);
 }
 
+test "TextBuffer setStyledText - generated styles are isolated and cleaned up" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var first = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer first.deinit();
+    var second = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer second.deinit();
+
+    const ss = @import("../syntax-style.zig");
+    const style = try ss.SyntaxStyle.init(std.testing.allocator);
+    defer style.deinit();
+    first.setSyntaxStyle(style);
+    second.setSyntaxStyle(style);
+
+    const a = "a";
+    const b = "b";
+    const chunks = [_]text_buffer.StyledChunk{
+        .{ .text_ptr = a.ptr, .text_len = a.len, .fg_ptr = null, .bg_ptr = null, .attributes = 1 },
+        .{ .text_ptr = b.ptr, .text_len = b.len, .fg_ptr = null, .bg_ptr = null, .attributes = 2 },
+    };
+    try first.setStyledText(&chunks);
+    const first_ids = [_]u32{
+        first.getLineHighlights(0)[0].style_id,
+        first.getLineHighlights(0)[1].style_id,
+    };
+    try second.setStyledText(&chunks);
+    try std.testing.expectEqual(@as(usize, 4), style.getStyleCount());
+    try std.testing.expect(first_ids[0] != second.getLineHighlights(0)[0].style_id);
+
+    try first.setStyledText(chunks[0..1]);
+    try std.testing.expectEqual(@as(usize, 3), style.getStyleCount());
+    try std.testing.expectEqual(first_ids[0], first.getLineHighlights(0)[0].style_id);
+
+    first.clear();
+    try std.testing.expectEqual(@as(usize, 3), style.getStyleCount());
+    try std.testing.expect(style.resolveById(first_ids[0]) != null);
+
+    try second.setText("plain");
+    try std.testing.expectEqual(@as(usize, 1), style.getStyleCount());
+
+    try first.setStyledText(&chunks);
+    try std.testing.expectEqual(@as(usize, 2), style.getStyleCount());
+
+    var temporary_directory = std.testing.tmpDir(.{});
+    defer temporary_directory.cleanup();
+    const file = try temporary_directory.dir.createFile("plain.txt", .{});
+    try file.writeAll("loaded");
+    file.close();
+    const file_path = try temporary_directory.dir.realpathAlloc(std.testing.allocator, "plain.txt");
+    defer std.testing.allocator.free(file_path);
+    try first.loadFile(file_path);
+    try std.testing.expectEqual(@as(usize, 0), style.getStyleCount());
+
+    try first.setStyledText(&chunks);
+    first.setSyntaxStyle(null);
+    try std.testing.expectEqual(@as(usize, 0), style.getStyleCount());
+
+    var third = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    third.setSyntaxStyle(style);
+    try third.setStyledText(&chunks);
+    try std.testing.expectEqual(@as(usize, 2), style.getStyleCount());
+    third.deinit();
+    try std.testing.expectEqual(@as(usize, 0), style.getStyleCount());
+}
+
+test "TextBuffer setStyledText - growth allocation failure preserves owned buffer" {
+    var failing_allocator = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    const allocator = failing_allocator.allocator();
+    const pool = gp.initGlobalPool(allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+
+    const small = "small";
+    const small_chunks = [_]text_buffer.StyledChunk{
+        .{ .text_ptr = small.ptr, .text_len = small.len, .fg_ptr = null, .bg_ptr = null, .attributes = 0 },
+    };
+    try tb.setStyledText(&small_chunks);
+
+    const large = "this replacement requires a larger persistent styled buffer";
+    const large_chunks = [_]text_buffer.StyledChunk{
+        .{ .text_ptr = large.ptr, .text_len = large.len, .fg_ptr = null, .bg_ptr = null, .attributes = 0 },
+    };
+    failing_allocator.fail_index = failing_allocator.alloc_index;
+    try std.testing.expectError(error.OutOfMemory, tb.setStyledText(&large_chunks));
+    try std.testing.expect(failing_allocator.has_induced_failure);
+
+    var preserved: [small.len]u8 = undefined;
+    const preserved_len = tb.getTextRange(0, small.len, &preserved);
+    try std.testing.expectEqual(small.len, preserved_len);
+    try std.testing.expectEqualStrings(small, preserved[0..preserved_len]);
+
+    failing_allocator.fail_index = std.math.maxInt(usize);
+    try tb.setStyledText(&small_chunks);
+}
+
 test "addHighlightByCharRange - single line highlight should not extend to EOL" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/core/src/zig/text-buffer.zig
+++ b/packages/core/src/zig/text-buffer.zig
@@ -91,6 +91,7 @@ pub const UnifiedTextBuffer = struct {
     styled_text_mem_id: ?u8,
     styled_buffer: ?[]u8,
     styled_capacity: usize,
+    styled_chunk_style_count: usize,
 
     tab_width: u8,
 
@@ -225,6 +226,7 @@ pub const UnifiedTextBuffer = struct {
             .styled_text_mem_id = null,
             .styled_buffer = null,
             .styled_capacity = 0,
+            .styled_chunk_style_count = 0,
             .tab_width = 2,
         };
 
@@ -236,6 +238,7 @@ pub const UnifiedTextBuffer = struct {
         defer global_allocator.destroy(self);
 
         if (self.syntax_style) |style| {
+            self.clearStyledChunkStyles();
             (@constCast(style)).offDestroy(@ptrCast(self), onSyntaxStyleDestroyed);
         }
 
@@ -353,12 +356,17 @@ pub const UnifiedTextBuffer = struct {
     /// Preserves highlights, memory buffers, and arena allocations.
     /// Use this for frequent text updates where undo/redo history should be preserved.
     pub fn clear(self: *Self) void {
+        self.clearContent();
+    }
+
+    fn clearContent(self: *Self) void {
         self.clearLinkRefs();
         self._rope.clear();
         self.markAllViewsDirty();
     }
 
     pub fn reset(self: *Self) void {
+        self.clearStyledChunkStyles();
         self.clearLinkRefs();
 
         // Free highlight/span arrays (they use global_allocator, not arena)
@@ -413,6 +421,7 @@ pub const UnifiedTextBuffer = struct {
     fn onSyntaxStyleDestroyed(ctx_ptr: *anyopaque) void {
         const self = @as(*Self, @ptrCast(@alignCast(ctx_ptr)));
         self.syntax_style = null;
+        self.styled_chunk_style_count = 0;
     }
 
     pub fn setSyntaxStyle(self: *Self, syntax_style: ?*const SyntaxStyle) void {
@@ -422,6 +431,7 @@ pub const UnifiedTextBuffer = struct {
             (@constCast(style)).onDestroy(@ptrCast(self), onSyntaxStyleDestroyed) catch return;
         }
         if (self.syntax_style) |prev| {
+            self.clearStyledChunkStyles();
             (@constCast(prev)).offDestroy(@ptrCast(self), onSyntaxStyleDestroyed);
         }
         self.syntax_style = syntax_style;
@@ -445,9 +455,34 @@ pub const UnifiedTextBuffer = struct {
         }
     }
 
+    fn clearStyledChunkStyles(self: *Self) void {
+        self.removeStyledChunkStylesFrom(0);
+    }
+
+    fn removeStyledChunkStylesFrom(self: *Self, start: usize) void {
+        if (start >= self.styled_chunk_style_count) return;
+        const style = self.syntax_style orelse {
+            self.styled_chunk_style_count = 0;
+            return;
+        };
+
+        var index = start;
+        while (index < self.styled_chunk_style_count) : (index += 1) {
+            var name_buffer: [96]u8 = undefined;
+            const name = styledChunkStyleName(self, index, &name_buffer);
+            (@constCast(style)).removeStyle(name);
+        }
+        self.styled_chunk_style_count = start;
+    }
+
+    fn styledChunkStyleName(self: *const Self, index: usize, buffer: *[96]u8) []const u8 {
+        return std.fmt.bufPrint(buffer, "chunk-{x}-{d}", .{ @intFromPtr(self), index }) catch unreachable;
+    }
+
     /// Set the text content using SIMD-optimized line break detection
     pub fn setText(self: *Self, text: []const u8) TextBufferError!void {
         self.clearInternalHighlights();
+        self.clearStyledChunkStyles();
         self.clear();
         const mem_id = try self.mem_registry.register(text, false);
         try self.setTextInternal(mem_id, text);
@@ -457,6 +492,7 @@ pub const UnifiedTextBuffer = struct {
     pub fn setTextFromMemId(self: *Self, mem_id: u8) TextBufferError!void {
         const text = self.mem_registry.get(mem_id) orelse return TextBufferError.InvalidMemId;
         self.clearInternalHighlights();
+        self.clearStyledChunkStyles();
         self.clear();
         try self.setTextInternal(mem_id, text);
     }
@@ -1082,6 +1118,7 @@ pub const UnifiedTextBuffer = struct {
         chunks: []const StyledChunk,
     ) TextBufferError!void {
         if (chunks.len == 0) {
+            self.clearStyledChunkStyles();
             self.clear();
             self.clearAllHighlights();
             return;
@@ -1090,41 +1127,44 @@ pub const UnifiedTextBuffer = struct {
         // Calculate total text length
         var total_len: usize = 0;
         for (chunks) |chunk| {
-            total_len += chunk.text_len;
+            total_len = std.math.add(usize, total_len, chunk.text_len) catch return TextBufferError.OutOfMemory;
+            if (total_len > std.math.maxInt(u32)) return TextBufferError.OutOfMemory;
         }
 
         if (total_len == 0) {
-            self.clear();
+            self.clearStyledChunkStyles();
+            self.clearContent();
             self.clearAllHighlights();
             return;
         }
 
-        self.clear();
+        var replacement_buffer: ?[]u8 = null;
+        defer if (replacement_buffer) |buffer| self.global_allocator.free(buffer);
+        if (total_len > self.styled_capacity) {
+            replacement_buffer = self.global_allocator.alloc(u8, total_len) catch return TextBufferError.OutOfMemory;
+            copyStyledChunkText(replacement_buffer.?, chunks);
+        }
+
+        self.clearContent();
         self.clearAllHighlights();
 
         _ = self.arena.reset(.retain_capacity);
 
         self._rope = UnifiedRope.init(self.allocator) catch return TextBufferError.OutOfMemory;
 
-        if (total_len > self.styled_capacity) {
+        if (replacement_buffer) |new_buffer| {
             if (self.styled_buffer) |old_buf| {
                 self.global_allocator.free(old_buf);
             }
-            const new_buf = self.global_allocator.alloc(u8, total_len) catch return TextBufferError.OutOfMemory;
-            self.styled_buffer = new_buf;
+            self.styled_buffer = new_buffer;
             self.styled_capacity = total_len;
+            replacement_buffer = null;
+        } else {
+            const buffer = self.styled_buffer.?[0..total_len];
+            copyStyledChunkText(buffer, chunks);
         }
 
         const full_text = self.styled_buffer.?[0..total_len];
-
-        var offset: usize = 0;
-        for (chunks) |chunk| {
-            if (chunk.text_len > 0) {
-                const chunk_text = chunk.text_ptr[0..chunk.text_len];
-                @memcpy(full_text[offset .. offset + chunk.text_len], chunk_text);
-                offset += chunk.text_len;
-            }
-        }
 
         if (self.styled_text_mem_id) |mem_id| {
             try self.mem_registry.replace(mem_id, full_text, false);
@@ -1134,8 +1174,14 @@ pub const UnifiedTextBuffer = struct {
         }
 
         try self.setTextInternal(self.styled_text_mem_id.?, full_text);
+        self.removeStyledChunkStylesFrom(chunks.len);
 
         if (self.syntax_style) |style| {
+            errdefer {
+                self.clearStyledChunkStyles();
+                self.clearAllHighlights();
+                self.clearLinkRefs();
+            }
             var seen_link_ids: std.AutoHashMapUnmanaged(u32, void) = .{};
             defer seen_link_ids.deinit(self.global_allocator);
 
@@ -1147,11 +1193,11 @@ pub const UnifiedTextBuffer = struct {
                 const chunk_text = chunk.text_ptr[0..chunk.text_len];
                 const chunk_len = self.measureText(chunk_text);
 
-                if (chunk_len > 0) {
-                    const fg = if (chunk.fg_ptr) |fgPtr| utils.ptrToRGBA(fgPtr) else null;
-                    const bg = if (chunk.bg_ptr) |bgPtr| utils.ptrToRGBA(bgPtr) else null;
+                const fg = if (chunk.fg_ptr) |fgPtr| utils.ptrToRGBA(fgPtr) else null;
+                const bg = if (chunk.bg_ptr) |bgPtr| utils.ptrToRGBA(bgPtr) else null;
 
-                    var attributes = chunk.attributes;
+                var attributes = chunk.attributes;
+                if (chunk_len > 0) {
                     if (chunk.link_ptr) |link_ptr| {
                         if (chunk.link_len > 0) {
                             const tracker = self.getLinkTracker();
@@ -1167,21 +1213,35 @@ pub const UnifiedTextBuffer = struct {
                             }
                         }
                     }
-
-                    var style_name_buf: [64]u8 = undefined;
-                    const style_name = std.fmt.bufPrint(&style_name_buf, "chunk{d}", .{i}) catch continue;
-                    const style_id = (@constCast(style)).registerStyleDefinition(style_name, .{
-                        .fg = fg,
-                        .bg = bg,
-                        .attributes = attributes,
-                    }) catch continue;
-
-                    self.addHighlightByCharRangeInternal(char_pos, char_pos + chunk_len, style_id, 1, 0, true) catch {};
                 }
 
-                char_pos += chunk_len;
+                var style_name_buf: [96]u8 = undefined;
+                const style_name = styledChunkStyleName(self, i, &style_name_buf);
+                const style_id = (@constCast(style)).registerStyleDefinition(style_name, .{
+                    .fg = fg,
+                    .bg = bg,
+                    .attributes = attributes,
+                }) catch return TextBufferError.OutOfMemory;
+                self.styled_chunk_style_count = @max(self.styled_chunk_style_count, i + 1);
+
+                if (chunk_len > 0) {
+                    const char_end = std.math.add(u32, char_pos, chunk_len) catch return TextBufferError.OutOfMemory;
+                    self.addHighlightByCharRangeInternal(char_pos, char_end, style_id, 1, 0, true) catch {};
+                    char_pos = char_end;
+                }
             }
         }
+    }
+
+    fn copyStyledChunkText(buffer: []u8, chunks: []const StyledChunk) void {
+        var offset: usize = 0;
+        for (chunks) |chunk| {
+            if (chunk.text_len == 0) continue;
+            const chunk_text = chunk.text_ptr[0..chunk.text_len];
+            @memcpy(buffer[offset .. offset + chunk.text_len], chunk_text);
+            offset += chunk.text_len;
+        }
+        std.debug.assert(offset == buffer.len);
     }
 
     /// Load text from a file path (relative to cwd)
@@ -1198,6 +1258,8 @@ pub const UnifiedTextBuffer = struct {
 
         const file_size = file.getEndPos() catch return TextBufferError.OutOfMemory;
 
+        self.clearInternalHighlights();
+        self.clearStyledChunkStyles();
         self.clear();
 
         const content = self.allocator.alloc(u8, file_size) catch return TextBufferError.OutOfMemory;


### PR DESCRIPTION
Preserve source ranges through Tree-sitter rendering so bare HTTP URLs and Markdown labels receive correct link metadata across concealment and wrapping.

Conceal Markdown destinations only when OSC 8 is supported, retain visible fallbacks for unsupported or overlong targets, and exclude code spans.

Validate OSC 8 targets at the native boundary, isolate generated chunk styles per buffer, and keep hyperlink state correct across cursor movement.

Closes #869
Closes #1196