### PR TITLE
fix(core): suppress JediTerm spurious cursor keys and clear fake shift modifier

### DIFF
--- a/packages/core/src/lib/stdin-parser.test.ts
+++ b/packages/core/src/lib/stdin-parser.test.ts
@@ -745,6 +745,136 @@ describe("StdinParser", () => {
     })
   })
 
+  describe("JediTerm scroll workaround", () => {
+    const jediOpts: StdinParserOptions = { jediTermScrollWorkaround: true }
+
+    test("swallows cursor up after SGR scroll up", () => {
+      const input = "\x1b[<64;10;5M\x1b[A"
+      const p = createParser(jediOpts)
+      try {
+        p.push(Buffer.from(input))
+        const s = snap(p)
+        expect(s).toHaveLength(1)
+        expect(s[0]).toEqual(sgr("\x1b[<64;10;5M", "scroll", 9, 4, { scroll: { direction: "up", delta: 1 } }))
+      } finally {
+        p.destroy()
+      }
+    })
+
+    test("swallows cursor down after SGR scroll down", () => {
+      const input = "\x1b[<65;10;5M\x1b[B"
+      const p = createParser(jediOpts)
+      try {
+        p.push(Buffer.from(input))
+        const s = snap(p)
+        expect(s).toHaveLength(1)
+        expect(s[0]).toEqual(sgr("\x1b[<65;10;5M", "scroll", 9, 4, { button: 1, scroll: { direction: "down", delta: 1 } }))
+      } finally {
+        p.destroy()
+      }
+    })
+
+    test("swallows multiple consecutive cursor keys after a single SGR scroll", () => {
+      const input = "\x1b[<64;10;5M\x1b[A\x1b[A\x1b[A\x1b[A"
+      const p = createParser(jediOpts)
+      try {
+        p.push(Buffer.from(input))
+        const s = snap(p)
+        expect(s).toHaveLength(1)
+        expect(s[0]!.type).toBe("mouse")
+      } finally {
+        p.destroy()
+      }
+    })
+
+    test("swallows cursor keys between multiple SGR scroll events", () => {
+      const input = "\x1b[<64;10;5M\x1b[A\x1b[<64;10;5M\x1b[A\x1b[A"
+      const p = createParser(jediOpts)
+      try {
+        p.push(Buffer.from(input))
+        const s = snap(p)
+        expect(s).toHaveLength(2)
+        for (const event of s) {
+          expect(event.type).toBe("mouse")
+        }
+      } finally {
+        p.destroy()
+      }
+    })
+
+    test("does NOT convert cursor keys without workaround enabled", () => {
+      const input = "\x1b[<64;10;5M\x1b[A"
+      const p = createParser()
+      try {
+        p.push(Buffer.from(input))
+        const s = snap(p)
+        expect(s).toHaveLength(2)
+        expect(s[0]).toEqual(sgr("\x1b[<64;10;5M", "scroll", 9, 4, { scroll: { direction: "up", delta: 1 } }))
+        expect(s[1]).toEqual(k("up", { raw: "\x1b[A" }))
+      } finally {
+        p.destroy()
+      }
+    })
+
+    test("does NOT swallow cursor keys after the time window expires", () => {
+      const clock = new ManualClock()
+      const p = new StdinParser({ jediTermScrollWorkaround: true, armTimeouts: false, clock })
+      try {
+        p.push(Buffer.from("\x1b[<64;10;5M"))
+        const afterScroll = snap(p)
+        expect(afterScroll).toHaveLength(1)
+        expect(afterScroll[0]!.type).toBe("mouse")
+
+        clock.advance(30)
+        p.push(Buffer.from("\x1b[A"))
+        const s = snap(p)
+        expect(s).toHaveLength(1)
+        expect(s[0]).toEqual(k("up", { raw: "\x1b[A" }))
+      } finally {
+        p.destroy()
+      }
+    })
+
+    test("clears pending flag when non-cursor CSI key arrives", () => {
+      // SGR scroll → CSI key that is NOT A/B (e.g., Home = \x1b[H) → cursor key
+      const p = createParser(jediOpts)
+      try {
+        p.push(Buffer.from("\x1b[<64;10;5M"))
+        const afterScroll = snap(p)
+        expect(afterScroll).toHaveLength(1)
+
+        // Push Home key — should reset the JediTerm flag
+        p.push(Buffer.from("\x1b[H"))
+        const afterHome = snap(p)
+        expect(afterHome).toHaveLength(1)
+        expect(afterHome[0]!.type).toBe("key")
+
+        // Now ArrowUp should be a normal key, not a scroll
+        p.push(Buffer.from("\x1b[A"))
+        const afterArrow = snap(p)
+        expect(afterArrow).toHaveLength(1)
+        expect(afterArrow[0]).toEqual(k("up", { raw: "\x1b[A" }))
+      } finally {
+        p.destroy()
+      }
+    })
+
+    test("clears spurious shift modifier from JediTerm scroll events", () => {
+      // JediTerm uses 68 for scroll up, which has the shift bit (4) set
+      const p = createParser(jediOpts)
+      try {
+        p.push(Buffer.from("\x1b[<68;10;5M"))
+        const s = snap(p)
+        expect(s).toHaveLength(1)
+        const mouse = s[0] as MouseSnap
+        expect(mouse.event.type).toBe("scroll")
+        expect(mouse.event.modifiers.shift).toBe(false)
+      } finally {
+        p.destroy()
+      }
+    })
+  })
+
   describe("UTF-8 handling", () => {
     table([
       ["2-byte (é)", "\u00e9", [k("\u00e9")]],

--- a/packages/core/src/lib/stdin-parser.ts
+++ b/packages/core/src/lib/stdin-parser.ts
@@ -56,6 +56,7 @@ export interface StdinParserOptions {
   useKittyKeyboard?: boolean
   protocolContext?: Partial<StdinParserProtocolContext>
   clock?: Clock
+  jediTermScrollWorkaround?: boolean
 }
 
 // State machine tags for the byte scanner. Each tag represents which protocol
@@ -585,6 +586,12 @@ export class StdinParser {
   // True only immediately after a timeout flush emits a lone ESC key. The next
   // `[` may begin a delayed `[<...M/m` mouse continuation recovery path.
   private justFlushedEsc = false
+  // JetBrains JediTerm sends spurious cursor keys (^[[A / ^[[B) immediately
+  // after SGR scroll events, sometimes split across stdin writes. Track the
+  // expiry time (20ms window) so cursor keys arriving in subsequent push()
+  // calls are still swallowed.
+  private jediTermScrollWorkaround: boolean
+  private jediTermScrollExpiry = 0
   private state: ParserState = { tag: "ground" }
   // Scan position within pending.view() during scanPending().
   private cursor = 0
@@ -601,6 +608,7 @@ export class StdinParser {
     this.armTimeouts = options.armTimeouts ?? true
     this.onTimeoutFlush = options.onTimeoutFlush ?? null
     this.useKittyKeyboard = options.useKittyKeyboard ?? true
+    this.jediTermScrollWorkaround = options.jediTermScrollWorkaround ?? false
     this.clock = options.clock ?? SYSTEM_CLOCK
     this.protocolContext = {
       ...DEFAULT_PROTOCOL_CONTEXT,
@@ -1184,6 +1192,26 @@ export class StdinParser {
               continue
             }
 
+            // JetBrains JediTerm workaround: JediTerm sends spurious ^[[A / ^[[B
+            // cursor keys after every SGR scroll event. Swallow them so they
+            // don't reach the keymap as ArrowUp/Down. The real SGR scroll
+            // events already carry correct scroll information.
+            if (
+              this.jediTermScrollWorkaround &&
+              this.clock.now() < this.jediTermScrollExpiry &&
+              (byte === 0x41 || byte === 0x42)
+            ) {
+              // JediTerm sends cursor keys alongside every SGR scroll
+              // event. The real SGR events already carry correct scroll
+              // information — just swallow the redundant cursor keys
+              // so they don't reach the keymap as ArrowUp/Down.
+              this.state = { tag: "ground" }
+              this.consumePrefix(end)
+              continue
+            }
+
+            this.jediTermScrollExpiry = 0
+
             this.emitKeyOrResponse("csi", decodeUtf8(rawBytes))
             this.state = { tag: "ground" }
             this.consumePrefix(end)
@@ -1232,6 +1260,7 @@ export class StdinParser {
             if (isMouseSgrSequence(rawBytes)) {
               this.emitMouse(rawBytes, "sgr")
             } else {
+    this.jediTermScrollExpiry = 0
               this.emitKeyOrResponse("csi", decodeUtf8(rawBytes))
             }
             this.state = { tag: "ground" }
@@ -1799,12 +1828,29 @@ export class StdinParser {
       return
     }
 
-    this.events.push({
-      type: "mouse",
-      raw: decodeLatin1(rawBytes),
-      encoding,
-      event,
-    })
+    this.jediTermScrollExpiry = 0
+
+    if (this.jediTermScrollWorkaround && event.type === "scroll") {
+      // JediTerm uses non-standard scroll button codes (68=up, 69=down)
+      // that have the shift bit (4) spuriously set. Clear it so ScrollBox
+      // doesn't convert vertical scroll into horizontal scroll.
+      const modifiers = { ...event.modifiers, shift: false }
+      this.jediTermScrollExpiry = this.clock.now() + 20
+
+      this.events.push({
+        type: "mouse",
+        raw: decodeLatin1(rawBytes),
+        encoding,
+        event: { ...event, modifiers },
+      })
+    } else {
+      this.events.push({
+        type: "mouse",
+        raw: decodeLatin1(rawBytes),
+        encoding,
+        event,
+      })
+    }
   }
 
   // Handles single bytes in the 0x80–0xFF range that aren't valid UTF-8
@@ -1998,6 +2044,7 @@ export class StdinParser {
     this.pendingSinceMs = null
     this.forceFlush = false
     this.justFlushedEsc = false
+    this.jediTermScrollExpiry = 0
     this.state = { tag: "ground" }
     this.cursor = 0
     this.unitStart = 0

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1187,6 +1187,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.addExitListeners()
 
     const stdinParserMaxBufferBytes = config.stdinParserMaxBufferBytes ?? DEFAULT_STDIN_PARSER_MAX_BUFFER_BYTES
+    const isJedi = process.env.TERMINAL_EMULATOR === "JetBrains-JediTerm"
     this.stdinParser = new StdinParser({
       timeoutMs: 20,
       maxPendingBytes: stdinParserMaxBufferBytes,
@@ -1195,6 +1196,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
         this.drainStdinParser()
       },
       useKittyKeyboard: useKittyForParsing,
+      jediTermScrollWorkaround: isJedi,
       protocolContext: {
         kittyKeyboardEnabled: useKittyForParsing,
         privateCapabilityRepliesActive: false,


### PR DESCRIPTION
### Problem

In JetBrains IDE terminals backed by JediTerm, mouse wheel scrolling can produce extra cursor key sequences in addition to the real SGR mouse scroll event.

This can be reproduced with a minimal terminal test:

```sh
printf '\e[?1049h\e[?1000h\e[?1002h\e[?1006h' && echo "Scroll the mouse wheel. Do not press any keys." && sleep 10 && printf '\e[?1049l'
```

When running this in macOS Terminal, scrolling the mouse wheel only reports SGR mouse scroll sequences, using the standard button codes `64` (scroll up) and `65` (scroll down).
<img width="581" height="143" alt="image" src="https://github.com/user-attachments/assets/6a9c194a-8695-4103-af0d-23ccad846e44" />

When running the same test in PyCharm's terminal, scrolling the mouse wheel reports button codes `68` and `69` instead, and also emits cursor key sequences such as `[[A` / `[[B`, even though no keyboard keys were pressed.
<img width="627" height="175" alt="image" src="https://github.com/user-attachments/assets/6d425e20-35d2-4a4b-9865-d92b2c9d9aa5" />

In opentui-based applications such as opencode, the real scroll event is parsed correctly, but the extra cursor key event is also delivered to the key handling path. This causes the mouse wheel to affect input history instead of only scrolling the output/chat history.

In the PyCharm/JediTerm reproduction above, normal wheel scrolling reports button codes `68` / `69`. In xterm mouse encoding, those correspond to `64` / `65` plus the Shift modifier bit, even though no physical Shift key was pressed.

Since `ScrollBox` treats shift-scroll as horizontal scrolling, this fake Shift modifier can prevent normal vertical scrolling from working as expected.

### Fix

This behavior appears to originate from JetBrains/JediTerm rather than opentui itself. However, adding a narrowly scoped fallback in opentui makes applications like opencode behave correctly in affected JetBrains IDE versions.

The workaround is gated to TERMINAL_EMULATOR=JetBrains-JediTerm, so it should remain safe even if future JetBrains releases fix the underlying behavior.

This adds a JediTerm-specific workaround in `StdinParser`, enabled only when:

```ts
process.env.TERMINAL_EMULATOR === "JetBrains-JediTerm"
```

The workaround:

* emits the real SGR scroll event normally
* briefly suppresses immediately-following `ArrowUp` / `ArrowDown` cursor sequences
* clears the spurious shift modifier on JediTerm scroll events

The workaround is intentionally gated to JediTerm so behavior in other terminals remains unchanged.

I also verified the fix by applying the parser/renderer changes on top of the `@opentui/core@0.3.4` version currently used by opencode. That setup fixes the PyCharm/JediTerm scrolling issue in opencode.

I was not able to run opencode directly against opentui `main`, because opencode currently depends on `@opentui/*@0.3.4`, while opentui `main` expects newer native Yoga FFI symbols such as `yogaConfigCreate`. This appears to be a TS/native binary version mismatch and is unrelated to the stdin parser workaround itself.

### Tests

Added parser tests covering:

* scroll-up followed by spurious `ArrowUp`
* scroll-down followed by spurious `ArrowDown`
* multiple redundant cursor keys after one scroll event
* cursor keys between multiple scroll events
* behavior when the workaround is disabled
* behavior after the suppression window expires
* clearing the fake shift modifier on JediTerm scroll events

### Related opencode issues

* https://github.com/anomalyco/opencode/issues/11992
* https://github.com/anomalyco/opencode/issues/16572
* https://github.com/anomalyco/opencode/issues/19283