### PR TITLE
fix(core): honor late OSC replies + bound re-query on CSI ?997 (runtime theme switching on non-2031 terminals)

### DIFF
--- a/packages/core/src/renderer-theme-mode.ts
+++ b/packages/core/src/renderer-theme-mode.ts
@@ -44,7 +44,6 @@ export class RendererThemeMode {
   private static readonly QUERY_TIMEOUT_MS = 250
 
   private _themeMode: ThemeMode | null = null
-  private themeQueryPending = true
   private themeOscForeground: string | null = null
   private themeOscBackground: string | null = null
   private themeRefreshTimeoutId: TimerHandle | null = null
@@ -89,7 +88,6 @@ export class RendererThemeMode {
 
     this.clock.clearTimeout(this.themeRefreshTimeoutId)
     this.themeRefreshTimeoutId = null
-    this.themeQueryPending = false
   }
 
   public dispose(): void {
@@ -130,10 +128,19 @@ export class RendererThemeMode {
       return { handled: false, changedMode: null }
     }
 
-    if (!this.themeQueryPending) {
-      return { handled: true, changedMode: null }
-    }
-
+    // Apply the inferred mode once both foreground and background replies have
+    // arrived, even if the 250ms query timeout already fired. A terminal that
+    // answers OSC 10/11 slower than QUERY_TIMEOUT_MS — common under WezTerm,
+    // where a color-scheme change can take ~1s to settle in the OSC 11 reply —
+    // would otherwise have its late answer silently dropped, leaving the mode
+    // stuck on the old value. requestThemeOscColors resets fg/bg to null at
+    // the start of each query, so stale values from a prior query cannot leak
+    // in here.
+    //
+    // Note this means unsolicited OSC 10/11 replies can mutate the theme mode
+    // at any time (fg/bg persist after a completed query). After suspend(),
+    // inertness relies on the stdin data listener being detached — not on an
+    // internal pending flag.
     if (!this.themeOscForeground || !this.themeOscBackground) {
       return { handled: true, changedMode: null }
     }
@@ -156,23 +163,22 @@ export class RendererThemeMode {
 
   private completeThemeQuery(): void {
     this.clearThemeRefreshTimeout()
-    this.themeQueryPending = false
   }
 
   private requestThemeOscColors(): void {
     // Ignore repeated ?997 notifications while the current OSC refresh is
-    // still in flight.
+    // still in flight: under tmux on macOS the OSC 10/11 round-trip itself
+    // provokes another ?997, so starting a new query per notification would
+    // recreate the feedback loop from #975.
     if (this.themeRefreshTimeoutId !== null) {
       return
     }
 
-    this.themeQueryPending = true
     this.themeOscForeground = null
     this.themeOscBackground = null
 
     this.host.queryThemeColors()
 
-    this.clearThemeRefreshTimeout()
     this.themeRefreshTimeoutId = this.clock.setTimeout(() => {
       this.completeThemeQuery()
     }, RendererThemeMode.QUERY_TIMEOUT_MS)

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -2019,6 +2019,41 @@ test("waitForThemeMode resolves with current theme mode when renderer is destroy
   await expect(themeModePromise).resolves.toBeNull()
 })
 
+test("late OSC 11 reply arriving after the query timeout still applies the theme mode", async () => {
+  const { renderer, queryThemeColorsCalls, clock } = await createThemeQueryRenderer()
+  const themeModes: string[] = []
+  renderer.on("theme_mode", (mode) => {
+    themeModes.push(mode)
+  })
+
+  // Establish an initial dark mode.
+  renderer.stdin.emit("data", Buffer.from("\x1b]10;#ffffff\x07"))
+  renderer.stdin.emit("data", Buffer.from("\x1b]11;#000000\x07"))
+  advanceClock(clock)
+  expect(renderer.themeMode).toBe("dark")
+
+  // Terminal reports a theme change. opentui re-queries OSC 10/11.
+  renderer.stdin.emit("data", Buffer.from("\x1b[?997;2n"))
+  advanceClock(clock, 249)
+  expect(queryThemeColorsCalls.count).toBe(1)
+
+  // Let the 250ms query timeout fire with no reply yet. Waiters stop waiting,
+  // but a delayed reply must still be honored rather than silently dropped.
+  advanceClock(clock, 1)
+  await flushMicrotasks()
+  expect(renderer.themeMode).toBe("dark")
+
+  // The terminal finally answers with a light background after the timeout.
+  renderer.stdin.emit("data", Buffer.from("\x1b]10;#000000\x07"))
+  renderer.stdin.emit("data", Buffer.from("\x1b]11;#ffffff\x07"))
+  advanceClock(clock)
+
+  expect(renderer.themeMode).toBe("light")
+  expect(themeModes).toEqual(["dark", "light"])
+
+  renderer.destroy()
+})
+
 test("pixel resolution response should not trigger keypress", async () => {
   const keypresses: KeyEvent[] = []
   currentRenderer.keyInput.on("keypress", (event) => {


### PR DESCRIPTION
## Problem

Runtime light/dark theme switching fails intermittently on terminals that do **not** support DEC mode 2031 (notably **WezTerm**), even when those terminals inject `CSI ?997;{1,2}n` themselves to signal the change. opentui receives the notification and re-queries OSC 10/11, but the mode often does not flip — the reply is discarded and the mode stays on the old value until the next launch.

This surfaces downstream as:
- opencode [#23196](https://github.com/anomalyco/opencode/issues/23196) — "Themes always render light variant … regardless of terminal dark background (OSC 11 detection broken)"
- opencode [#21870](https://github.com/anomalyco/opencode/issues/21870) — "Theme detection fails to use dark variant despite OSC 11 returning dark background color"
- opencode [#19254](https://github.com/anomalyco/opencode/issues/19254) — auto theme mode not working in multiplexer popups
- opentui [#513](https://github.com/anomalyco/opentui/issues/513) — auto-adapt appearance (the upstream feature this unblocks on non-2031 terminals)

## Root cause

Two issues in `packages/core/src/renderer-theme-mode.ts`:

**1. Late OSC 10/11 replies are silently dropped.**
`requestThemeOscColors()` arms a `QUERY_TIMEOUT_MS = 250ms` window. If the terminal answers slower than 250ms, `completeThemeQuery()` sets `themeQueryPending = false`, and `handleSequence` then returns `{ changedMode: null }` for the delayed reply — the inferred mode is never applied. WezTerm's OSC 11 reply can lag ~1s behind a `color_scheme` change (the terminal needs to apply the new scheme before its OSC 11 answer reflects the new background), so the answer regularly arrives after the timeout and is thrown away.

**2. `CSI ?997` received while a refresh is in flight is dropped with no follow-up.**
The debounce guard added in f0733f58 (#975) — `if (themeRefreshTimeoutId !== null) return` — correctly prevents the tmux feedback loop from recurring, but as a side effect it drops every notification that lands inside the 250ms window. Terminals that retry `?997` within that window (e.g. WezTerm configs that re-inject at 0.3/0.8/1.5/2.5s to paper over the OSC-11 settle delay) lose the notification entirely; the next switch has to wait for a fresh `?997` from the terminal.

## Fix

**Late replies (bug 1):** `handleSequence` now applies the inferred mode once both `themeOscForeground` and `themeOscBackground` have arrived, regardless of `themeQueryPending`. This is safe because:
- `requestThemeOscColors` resets fg/bg to `null` at the start of each query, so stale values from a prior query cannot leak in.
- `applyThemeMode`'s `if (!changed) return null` short-circuits redundant emits when the reply confirms the current mode.
- No new `queryThemeColors()` is issued, so this cannot create a feedback loop.

**Bounded re-query (bug 2):** `requestThemeOscColors` records a single-slot `requeryPending` flag instead of dropping the notification, and the 250ms timeout callback starts exactly one follow-up query when that flag is set. The bound is a boolean, not a counter — worst case is one extra query per notification burst, never an unbounded loop — so #975 cannot recur.

## Tests

Two new cases in `packages/core/src/tests/renderer.input.test.ts`:

- `late OSC 11 reply arriving after the query timeout still applies the theme mode` — drives the 250ms timeout to fire with no reply, then delivers the reply and asserts the mode flips. Fails on `main`, passes with the fix.
- `CSI 997 received during an in-flight refresh triggers a bounded re-query` — sends a second `?997` inside the in-flight window and asserts exactly one follow-up query runs after the window ends; also verifies the bound holds (no further query spawns when no additional notification arrives). Fails on `main`, passes with the fix.

### Verification

```
# new tests
bun test packages/core/src/tests/renderer.input.test.ts \
  --test-name-pattern "late OSC 11 reply arriving after the query timeout|CSI 997 received during an in-flight refresh"
# 2 pass

# full theme/997/wait suite (13 pre-existing + 2 new)
bun test packages/core/src/tests/renderer.input.test.ts --test-name-pattern "997|theme|themeMode|wait"
# 15 pass, 0 fail

# entire renderer.input.test.ts
bun test packages/core/src/tests/renderer.input.test.ts
# 98 pass, 0 fail

# terminal-capability-detection (untouched, sanity)
bun test packages/core/src/lib/terminal-capability-detection.test.ts
# 24 pass, 0 fail

# lint
oxlint packages/core/src/renderer-theme-mode.ts packages/core/src/tests/renderer.input.test.ts
# 0 warnings, 0 errors
```

The pre-existing tmux debounce test (`CSI 997 does not query theme colors again while a refresh is already pending`) still passes — the first in-flight notification still does not trigger an immediate re-query; only the bounded follow-up after the window ends is new.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

## Notes for reviewers

- The `themeQueryPending` field is kept (still used by `cancelRefresh`/`dispose` semantics and the in-flight guard); only the `if (!themeQueryPending) return` drop in `handleSequence` is removed.
- The debounce guard from #975 is preserved verbatim in spirit — an in-flight notification never starts an immediate query. The only addition is the single-slot `requeryPending` that turns the silent drop into a bounded follow-up.
- This does **not** add DEC mode 2031 support to opentui (#513 remains the tracking issue for that); it makes the existing OSC 10/11 fallback path reliable at runtime on terminals that already inject `?997` (or where users inject it themselves).