### PR TITLE
clipboard: add tmux transport mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -489,6 +489,22 @@
 
     "@opentui/core": ["@opentui/core@workspace:packages/core"],
 
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Yl3JBLYRrBN+SxXY/gYaqCT/JNrN50K4xO7hYC+/Si8/FgOrBlbRmfJIUNQdZMMLUvOMA+I813+hDw3xfarBzQ=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-kqMVu+LGuHSCxYFkVJtmuyLLLTMztILSNnlx1eSpHHUiDV4PMc+zkxwRIXO+o0TFTW3gNUKleKUkggriYje7Vw=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-PpE1nCHRkxEvSYyZFMToPHjQoVh50A7+BbgetlTX/5ImXzo6iSO83a+7M/1WgZnNu+uZJf5GZKAAcLoRrvQl3Q=="],
+
+    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-rmFMtiCm8I0fESB834sTN/ewoI+QDSber588ZO+i08JR6mbv7hkiKW2H/MhiAY1GxGK4nXApleBMyGVOlVDvgQ=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-/CxFxFv+ffMof2nYQrpgEfNkWKkKxYUSfwdt2RdDN5fZRhcxjE949743rV0Oovw5Az63qxPgbyfcZVNVO2HVNg=="],
+
+    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-WO8RjhqKyqW/7P0xHdEVT8JGfU2MO7RlK0kdkNnRSnAEVwsTNd2ibhmKDPLGpo/DKaLuA00CsnrNiLGZZiQJKQ=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.5.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-AgeTjZbdMxSiuBjyLvcug91qd1Ds6Dlg5z4lCInqL7mPQicDEnKZs5lF2FAaktcU7RPi2wLybbQ/vM0NbpXYmw=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-VttbQHVoZQ5uW5IcQeUHPEx/WFQ2mMflukhhbBjpNSdZOPdzmmC4QGFPQznJVwuzXTnjQ2Nll4AY0ROJ/Q3nkw=="],
+
     "@opentui/examples": ["@opentui/examples@workspace:packages/examples"],
 
     "@opentui/keymap": ["@opentui/keymap@workspace:packages/keymap"],

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -105,6 +105,15 @@ registerEnvVar({
   default: false,
 })
 
+registerEnvVar({
+  name: "OPENTUI_TMUX_CLIPBOARD_MODE",
+  description: "tmux OSC 52 transport: passthrough, raw, or off.",
+  type: "string",
+  default: "passthrough",
+})
+
+export type TmuxClipboardMode = "passthrough" | "raw" | "off"
+
 export interface CliRendererConfig {
   // Read input from this stream. Defaults to process.stdin. Any `Readable`
   // works; capabilities like `setRawMode` are duck-typed and used when present.
@@ -144,6 +153,10 @@ export interface CliRendererConfig {
 
   // Forward these env var names to native terminal detection.
   forwardEnvKeys?: string[]
+
+  // Choose the OSC 52 transport when rendering inside tmux. Defaults to
+  // "passthrough", which preserves historical OpenTUI behavior.
+  tmuxClipboardMode?: TmuxClipboardMode
 
   // Wait this long before handling resize events. Defaults to 100 ms.
   debounceDelay?: number
@@ -548,6 +561,7 @@ const DEFAULT_FORWARDED_ENV_KEYS = [
   "OPENTUI_FORCE_EXPLICIT_WIDTH",
   "OPENTUI_NOTIFICATION_PROTOCOL",
   "OPENTUI_NOTIFICATIONS",
+  "OPENTUI_TMUX_CLIPBOARD_MODE",
   "WT_SESSION",
   "STY",
   "WSL_DISTRO_NAME",
@@ -626,6 +640,11 @@ export function buildKittyKeyboardFlags(config: KittyKeyboardOptions | null | un
   }
 
   return flags
+}
+
+function normalizeTmuxClipboardMode(mode: TmuxClipboardMode): TmuxClipboardMode {
+  if (mode === "passthrough" || mode === "raw" || mode === "off") return mode
+  throw new Error(`tmuxClipboardMode must be "passthrough", "raw", or "off", got ${JSON.stringify(mode)}`)
 }
 
 export class MouseEvent {
@@ -1034,6 +1053,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   ) {
     super()
 
+    const tmuxClipboardMode =
+      config.tmuxClipboardMode === undefined ? undefined : normalizeTmuxClipboardMode(config.tmuxClipboardMode)
+
     this.stdin = stdin
     this.stdout = stdout
     this._usesProcessStdout = stdout === process.stdout
@@ -1143,6 +1165,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       const value = process.env[key]
       if (value === undefined) continue
       this.lib.setTerminalEnvVar(this.rendererPtr, key, value)
+    }
+    if (tmuxClipboardMode !== undefined) {
+      this.lib.setTerminalEnvVar(this.rendererPtr, "OPENTUI_TMUX_CLIPBOARD_MODE", tmuxClipboardMode)
     }
 
     this.exitOnCtrlC = config.exitOnCtrlC === undefined ? true : config.exitOnCtrlC

--- a/packages/core/src/tests/renderer.tmux-clipboard-mode.test.ts
+++ b/packages/core/src/tests/renderer.tmux-clipboard-mode.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { createCliRenderer } from "../renderer.js"
+import { resolveRenderLib } from "../zig.js"
+
+test("invalid tmuxClipboardMode is rejected before native allocation", async () => {
+  const lib = resolveRenderLib()
+  const before = lib.getAllocatorStats()
+
+  await expect(
+    createCliRenderer({
+      bufferedOutput: "memory",
+      tmuxClipboardMode: "invalid" as any,
+    }),
+  ).rejects.toThrow('tmuxClipboardMode must be "passthrough", "raw", or "off"')
+
+  const after = lib.getAllocatorStats()
+  expect(after.activeAllocations).toBe(before.activeAllocations)
+})

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -74,6 +74,12 @@ pub const Osc52Support = enum(u8) {
     unsupported,
 };
 
+const TmuxClipboardMode = enum {
+    passthrough,
+    raw,
+    off,
+};
+
 const NOTIFICATION_QUERY_ID = "opentui-notifications";
 pub const SCREEN_PASSTHROUGH_CHUNK_SIZE = 252;
 pub const CLIPBOARD_PAYLOAD_SIZE_MAX = std.math.maxInt(u32);
@@ -1579,6 +1585,11 @@ pub fn clipboardSequenceSize(self: *Terminal, payload_len: usize) !usize {
     const sequence_len = try std.math.add(usize, encoded_len, OSC52_FRAMING_SIZE);
 
     if (self.isInTmux()) {
+        switch (self.tmuxClipboardMode()) {
+            .raw => return sequence_len,
+            .off => return error.NotSupported,
+            .passthrough => {},
+        }
         const wrapped_len = try std.math.add(usize, sequence_len, 2);
         return std.math.add(usize, wrapped_len, ansi.ANSI.tmuxDcsStart.len + ansi.ANSI.tmuxDcsEnd.len);
     }
@@ -1602,10 +1613,16 @@ pub fn writeClipboard(self: *Terminal, tty: anytype, target: ClipboardTarget, te
     _ = try self.clipboardSequenceSize(text_utf8.len);
 
     if (self.isInTmux()) {
-        try tty.writeAll(ansi.ANSI.tmuxDcsStart);
-        try writeClipboardSequence(tty, target, text_utf8, true);
-        try tty.writeAll(ansi.ANSI.tmuxDcsEnd);
-        return;
+        switch (self.tmuxClipboardMode()) {
+            .raw => {},
+            .off => return error.NotSupported,
+            .passthrough => {
+                try tty.writeAll(ansi.ANSI.tmuxDcsStart);
+                try writeClipboardSequence(tty, target, text_utf8, true);
+                try tty.writeAll(ansi.ANSI.tmuxDcsEnd);
+                return;
+            },
+        }
     }
 
     if (self.isInScreen()) {
@@ -1694,11 +1711,28 @@ fn writeClipboardBytes(writer: anytype, bytes: []const u8, escape: bool) !void {
     }
 }
 
+fn tmuxClipboardMode(self: *Terminal) TmuxClipboardMode {
+    var env_map_storage: ?std.process.EnvMap = null;
+    const env_map: ?*const std.process.EnvMap = self.opts.env_map orelse blk: {
+        env_map_storage = std.process.getEnvMap(std.heap.page_allocator) catch null;
+        break :blk if (env_map_storage) |*map| map else null;
+    };
+    defer if (env_map_storage) |*map| map.deinit();
+
+    if (env_map) |map| {
+        if (map.get("OPENTUI_TMUX_CLIPBOARD_MODE")) |value| {
+            if (std.mem.eql(u8, value, "raw")) return .raw;
+            if (std.mem.eql(u8, value, "off")) return .off;
+        }
+    }
+    return .passthrough;
+}
+
 /// Check if we can write to the clipboard (TTY and OSC 52 supported)
 fn canWriteClipboard(self: *Terminal) bool {
     // In a real TTY environment, we'd check isTTY here
     // Missing or inconclusive capability responses must not block optimistic emission.
-    return self.osc52_support != .unsupported;
+    return self.osc52_support != .unsupported and !(self.isInTmux() and self.tmuxClipboardMode() == .off);
 }
 
 /// Parse xtversion response string and extract terminal name and version

--- a/packages/core/src/zig/tests/terminal_test.zig
+++ b/packages/core/src/zig/tests/terminal_test.zig
@@ -1464,6 +1464,45 @@ test "writeClipboard - wraps in DCS passthrough for tmux" {
     try testing.expect(std.mem.indexOf(u8, output, "\x1b\x1b") != null);
 }
 
+test "writeClipboard - writes raw OSC52 in tmux raw clipboard mode" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var env = std.process.EnvMap.init(testing.allocator);
+    defer env.deinit();
+    try env.put("TMUX", "/tmp/tmux-1000/default,12345,0");
+    try env.put("OPENTUI_TMUX_CLIPBOARD_MODE", "raw");
+
+    var term = Terminal.init(.{ .env_map = &env });
+    term.caps.osc52 = true;
+
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.writeClipboard(&writer, .clipboard, "test");
+
+    try testing.expectEqualStrings("\x1b]52;c;dGVzdA==\x1b\\", writer.getWritten());
+    try testing.expectEqual(try term.clipboardSequenceSize("test".len), writer.getWritten().len);
+}
+
+test "writeClipboard - disables OSC52 in tmux off clipboard mode" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var env = std.process.EnvMap.init(testing.allocator);
+    defer env.deinit();
+    try env.put("TMUX", "/tmp/tmux-1000/default,12345,0");
+    try env.put("OPENTUI_TMUX_CLIPBOARD_MODE", "off");
+
+    var term = Terminal.init(.{ .env_map = &env });
+    term.caps.osc52 = true;
+
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try testing.expectError(error.NotSupported, term.writeClipboard(&writer, .clipboard, "test"));
+    try testing.expectError(error.NotSupported, term.clipboardSequenceSize("test".len));
+    try testing.expectEqual(@as(usize, 0), writer.getWritten().len);
+}
+
 test "writeClipboard - wraps in DCS passthrough for GNU Screen" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 

--- a/packages/web/src/content/docs/core-concepts/renderer.mdx
+++ b/packages/web/src/content/docs/core-concepts/renderer.mdx
@@ -503,6 +503,24 @@ A `true` result means the renderer output path was invoked; it does not prove
 that every output backend accepted the bytes. OSC 52 also does not acknowledge
 terminal acceptance or a clipboard change.
 
+When running inside tmux, OpenTUI uses one OSC 52 transport per clipboard call:
+
+| Mode          | Behavior                                                                                                      |
+| ------------- | ------------------------------------------------------------------------------------------------------------- |
+| `passthrough` | Wrap OSC 52 in tmux DCS passthrough. This is the default and requires `set -g allow-passthrough on` in tmux.  |
+| `raw`         | Emit raw OSC 52 and let tmux handle it. Use this with `set -g set-clipboard on` when passthrough is disabled. |
+| `off`         | Disable OSC 52 clipboard output while inside tmux.                                                            |
+
+Configure the mode on the renderer:
+
+```typescript
+const renderer = await createCliRenderer({
+  tmuxClipboardMode: "raw",
+})
+```
+
+Or set `OPENTUI_TMUX_CLIPBOARD_MODE=raw` before starting the process. OpenTUI does not query tmux options automatically because `set-clipboard`, passthrough, terminal OSC 52 support, and nested sessions are separate pieces of policy.
+
 ### Notifications
 
 Trigger a terminal-mediated desktop notification:

--- a/packages/web/src/content/docs/reference/env-vars.mdx
+++ b/packages/web/src/content/docs/reference/env-vars.mdx
@@ -13,34 +13,35 @@ OpenTUI reads environment variables from `process.env`. Bun loads `.env` automat
 
 ## Variables
 
-| Variable                        | Type      | Default | Description                                                     |
-| ------------------------------- | --------- | ------- | --------------------------------------------------------------- |
-| `OTUI_ASSET_ROOT`               | `string`  | `""`    | Absolute root for relocated OpenTUI runtime assets              |
-| `OTUI_TS_STYLE_WARN`            | `string`  | `false` | Enable warnings for missing syntax styles                       |
-| `OTUI_TREE_SITTER_WORKER_PATH`  | `string`  | `""`    | Path to the Tree-sitter worker                                  |
-| `XDG_CONFIG_HOME`               | `string`  | `""`    | Base directory for user-specific configuration files            |
-| `XDG_DATA_HOME`                 | `string`  | `""`    | Base directory for user-specific data files                     |
-| `OTUI_PALETTE_IDLE_TIMEOUT_MS`  | `number`  | `300`   | Milliseconds of silence after palette queries before fallback   |
-| `OTUI_DEBUG_FFI`                | `boolean` | `false` | Enable debug logging for the FFI bindings                       |
-| `OTUI_SHOW_STATS`               | `boolean` | `false` | Show the debug overlay at startup                               |
-| `OTUI_TRACE_FFI`                | `boolean` | `false` | Enable tracing for the FFI bindings                             |
-| `OPENTUI_FORCE_WCWIDTH`         | presence  | unset   | Use wcwidth for character width calculations                    |
-| `OPENTUI_FORCE_UNICODE`         | presence  | unset   | Force Mode 2026 Unicode support in terminal capabilities        |
-| `OPENTUI_GRAPHICS`              | `string`  | auto    | Control Kitty and Sixel graphics detection                      |
-| `OPENTUI_IMAGE_PROTOCOL`        | `string`  | `auto`  | Default image protocol (`auto`, `kitty`, `sixel`, `blocks`)     |
-| `OPENTUI_FORCE_NOZWJ`           | presence  | unset   | Use no_zwj width method (Unicode without ZWJ joining)           |
-| `OPENTUI_LIBC`                  | `string`  | unset   | Select Linux native libc package (`glibc`, `musl`)              |
-| `OPENTUI_FORCE_EXPLICIT_WIDTH`  | `string`  | -       | Force explicit width detection (`true`/`1` or `false`/`0`)      |
-| `OPENTUI_NOTIFICATION_PROTOCOL` | `string`  | `auto`  | Force notification protocol (`osc9`, `osc777`, `osc99`, `none`) |
-| `OPENTUI_NOTIFICATIONS`         | `boolean` | `true`  | Disable terminal notification detection when false              |
-| `OTUI_USE_CONSOLE`              | `boolean` | `true`  | Enable global `console.*` capture for the built-in overlay      |
-| `SHOW_CONSOLE`                  | `boolean` | `false` | Open the built-in console overlay at startup                    |
-| `OTUI_DUMP_CAPTURES`            | `boolean` | `false` | Dump captured stdout and console caches from the exit handler   |
-| `OTUI_NO_NATIVE_RENDER`         | `boolean` | `false` | Skip the Zig/native frame renderer                              |
-| `OTUI_USE_ALTERNATE_SCREEN`     | `boolean` | unset   | Force alternate-screen or main-screen mode when set             |
-| `OTUI_OVERRIDE_STDOUT`          | `boolean` | unset   | Force stdout capture/passthrough routing when set               |
-| `OTUI_DEBUG`                    | `boolean` | `false` | Capture all raw stdin input for debugging                       |
-| `OTUI_STDIN_LOG`                | `string`  | `""`    | Write the raw stdin byte stream to a file                       |
+| Variable                        | Type      | Default       | Description                                                     |
+| ------------------------------- | --------- | ------------- | --------------------------------------------------------------- |
+| `OTUI_ASSET_ROOT`               | `string`  | `""`          | Absolute root for relocated OpenTUI runtime assets              |
+| `OTUI_TS_STYLE_WARN`            | `string`  | `false`       | Enable warnings for missing syntax styles                       |
+| `OTUI_TREE_SITTER_WORKER_PATH`  | `string`  | `""`          | Path to the Tree-sitter worker                                  |
+| `XDG_CONFIG_HOME`               | `string`  | `""`          | Base directory for user-specific configuration files            |
+| `XDG_DATA_HOME`                 | `string`  | `""`          | Base directory for user-specific data files                     |
+| `OTUI_PALETTE_IDLE_TIMEOUT_MS`  | `number`  | `300`         | Milliseconds of silence after palette queries before fallback   |
+| `OTUI_DEBUG_FFI`                | `boolean` | `false`       | Enable debug logging for the FFI bindings                       |
+| `OTUI_SHOW_STATS`               | `boolean` | `false`       | Show the debug overlay at startup                               |
+| `OTUI_TRACE_FFI`                | `boolean` | `false`       | Enable tracing for the FFI bindings                             |
+| `OPENTUI_FORCE_WCWIDTH`         | presence  | unset         | Use wcwidth for character width calculations                    |
+| `OPENTUI_FORCE_UNICODE`         | presence  | unset         | Force Mode 2026 Unicode support in terminal capabilities        |
+| `OPENTUI_GRAPHICS`              | `string`  | auto          | Control Kitty and Sixel graphics detection                      |
+| `OPENTUI_IMAGE_PROTOCOL`        | `string`  | `auto`        | Default image protocol (`auto`, `kitty`, `sixel`, `blocks`)     |
+| `OPENTUI_FORCE_NOZWJ`           | presence  | unset         | Use no_zwj width method (Unicode without ZWJ joining)           |
+| `OPENTUI_LIBC`                  | `string`  | unset         | Select Linux native libc package (`glibc`, `musl`)              |
+| `OPENTUI_FORCE_EXPLICIT_WIDTH`  | `string`  | -             | Force explicit width detection (`true`/`1` or `false`/`0`)      |
+| `OPENTUI_NOTIFICATION_PROTOCOL` | `string`  | `auto`        | Force notification protocol (`osc9`, `osc777`, `osc99`, `none`) |
+| `OPENTUI_NOTIFICATIONS`         | `boolean` | `true`        | Disable terminal notification detection when false              |
+| `OPENTUI_TMUX_CLIPBOARD_MODE`   | `string`  | `passthrough` | tmux OSC 52 clipboard transport (`passthrough`, `raw`, `off`)   |
+| `OTUI_USE_CONSOLE`              | `boolean` | `true`        | Enable global `console.*` capture for the built-in overlay      |
+| `SHOW_CONSOLE`                  | `boolean` | `false`       | Open the built-in console overlay at startup                    |
+| `OTUI_DUMP_CAPTURES`            | `boolean` | `false`       | Dump captured stdout and console caches from the exit handler   |
+| `OTUI_NO_NATIVE_RENDER`         | `boolean` | `false`       | Skip the Zig/native frame renderer                              |
+| `OTUI_USE_ALTERNATE_SCREEN`     | `boolean` | unset         | Force alternate-screen or main-screen mode when set             |
+| `OTUI_OVERRIDE_STDOUT`          | `boolean` | unset         | Force stdout capture/passthrough routing when set               |
+| `OTUI_DEBUG`                    | `boolean` | `false`       | Capture all raw stdin input for debugging                       |
+| `OTUI_STDIN_LOG`                | `string`  | `""`          | Write the raw stdin byte stream to a file                       |
 
 ## Notes
 
@@ -51,6 +52,7 @@ OpenTUI reads environment variables from `process.env`. Bun loads `.env` automat
 - Linux uses the glibc native package by default. Set `OPENTUI_LIBC=musl` before importing OpenTUI, or define `process.env.OPENTUI_LIBC` as `"musl"` at standalone build time, to use the musl native package. See [Standalone Executables](/docs/reference/standalone-executables).
 - `OPENTUI_NOTIFICATION_PROTOCOL=none` disables notifications. Protocol overrides should only be used when terminal detection cannot identify a supported notification protocol.
 - `OPENTUI_NOTIFICATIONS=0`, `false`, or `off` disables notifications without changing other terminal capability detection.
+- `OPENTUI_TMUX_CLIPBOARD_MODE=raw` emits raw OSC 52 inside tmux for `set -g set-clipboard on`; `passthrough` preserves the default DCS passthrough behavior, and `off` disables OSC 52 while inside tmux.
 - `OTUI_PALETTE_IDLE_TIMEOUT_MS` bounds palette detection when a terminal reports OSC support but does not answer follow-up color queries.
 - Disable global `console.*` capture with `OTUI_USE_CONSOLE=false`. `consoleMode` only changes the overlay surface.
 - `OTUI_USE_ALTERNATE_SCREEN=false` forces `"main-screen"`; `true` forces `"alternate-screen"`. When set, it overrides `screenMode`.


### PR DESCRIPTION
Let users choose how OpenTUI sends OSC 52 through tmux. Setups that disable passthrough can use tmux set-clipboard, and locked-down sessions can disable clipboard output instead of emitting unsupported escapes.