### PR TITLE
fix: request modifyOtherKeys level 2 to support more key combos under tmux.

### DIFF
--- a/packages/core/src/lib/parse.keypress-kitty.test.ts
+++ b/packages/core/src/lib/parse.keypress-kitty.test.ts
@@ -38,6 +38,27 @@ test("parseKeypress - Kitty keyboard ctrl+a", () => {
   expect(result.meta).toBe(false)
 })
 
+test("parseKeypress - Kitty keyboard uppercase primary codepoint normalizes to lowercase name", () => {
+  // tmux (and plain xterm) can put the *shifted* codepoint (65 = 'A') as the
+  // primary field rather than the base one. The name must still normalize to
+  // lowercase so `ctrl+shift+a` bindings match (issue #1184). Shift comes from
+  // the modifier mask. See parse.keypress-kitty.ts.
+  const options: ParseKeypressOptions = { useKittyKeyboard: true }
+
+  // Ctrl+Shift+A as tmux csi-u: \x1b[65;6u (mod 6 => shift+ctrl, primary 65='A')
+  const ctrlShiftA = parseKeypress("\x1b[65;6u", options)!
+  expect(ctrlShiftA.name).toBe("a")
+  expect(ctrlShiftA.shift).toBe(true)
+  expect(ctrlShiftA.ctrl).toBe(true)
+  expect(ctrlShiftA.meta).toBe(false)
+
+  // Shift+Z with uppercase primary: \x1b[90;2u
+  const shiftZ = parseKeypress("\x1b[90;2u", options)!
+  expect(shiftZ.name).toBe("z")
+  expect(shiftZ.shift).toBe(true)
+  expect(shiftZ.ctrl).toBe(false)
+})
+
 test("parseKeypress - Kitty keyboard alt+a", () => {
   const options: ParseKeypressOptions = { useKittyKeyboard: true }
   const result = parseKeypress("\x1b[97;3u", options)!

--- a/packages/core/src/lib/parse.keypress-kitty.ts
+++ b/packages/core/src/lib/parse.keypress-kitty.ts
@@ -373,7 +373,12 @@ export function parseKittyKeyboard(sequence: string): ParsedKey | null {
   } else {
     // It's a Unicode character
     if (codepoint > 0 && codepoint <= 0x10ffff) {
-      const char = String.fromCodePoint(codepoint)
+      // Normalize uppercase letters to lowercase so `name` reflects the
+      // physical key (the shift flag is derived from the modifier mask below).
+      // Terminals differ on whether they encode the shifted (65='A') or base
+      // (97='a') codepoint here, so this keeps `ctrl+shift+a` matching either way.
+      const normalizedCodepoint = codepoint >= 65 && codepoint <= 90 ? codepoint + 32 : codepoint
+      const char = String.fromCodePoint(normalizedCodepoint)
       key.name = char === " " ? "space" : char
 
       // Keep the raw Unicode codepoint from Kitty so higher-level matching can

--- a/packages/core/src/lib/parse.keypress.test.ts
+++ b/packages/core/src/lib/parse.keypress.test.ts
@@ -1645,6 +1645,36 @@ test("parseKeypress - modifyOtherKeys digits", () => {
   expect(shiftOne.source).toBe("raw")
 })
 
+test("parseKeypress - modifyOtherKeys uppercase letters normalize to lowercase name + shift", () => {
+  // Under modifyOtherKeys level 2 (which tmux/xterm request), shifted letters
+  // arrive as the uppercase codepoint (65 = 'A'). The name must be normalized to
+  // lowercase with shift reported separately, otherwise `ctrl+shift+a` bindings
+  // (issue #1184) never match. See parse.keypress.ts.
+
+  // Ctrl+Shift+A: CSI 27;6;65~ (modifier 6 = shift bit 1 + ctrl bit 4)
+  const ctrlShiftA = parseKeypress("\x1b[27;6;65~")!
+  expect(ctrlShiftA.name).toBe("a")
+  expect(ctrlShiftA.shift).toBe(true)
+  expect(ctrlShiftA.ctrl).toBe(true)
+  expect(ctrlShiftA.meta).toBe(false)
+  expect(ctrlShiftA.option).toBe(false)
+  expect(ctrlShiftA.sequence).toBe("a")
+  expect(ctrlShiftA.raw).toBe("\x1b[27;6;65~")
+
+  // Shift+Z: CSI 27;2;90~ (modifier 2 = shift bit 1)
+  const shiftZ = parseKeypress("\x1b[27;2;90~")!
+  expect(shiftZ.name).toBe("z")
+  expect(shiftZ.shift).toBe(true)
+  expect(shiftZ.ctrl).toBe(false)
+
+  // A terminal that instead sends the base (lowercase) codepoint 97 = 'a' must
+  // continue to yield the same name, so the binding matches either encoding.
+  const ctrlShiftALower = parseKeypress("\x1b[27;6;97~")!
+  expect(ctrlShiftALower.name).toBe("a")
+  expect(ctrlShiftALower.ctrl).toBe(true)
+  expect(ctrlShiftALower.shift).toBe(true)
+})
+
 test("parseKeypress - modifyOtherKeys modified enter keys", () => {
   // Terminals with modifyOtherKeys mode enabled send special escape sequences for modified keys
   // Format: CSI 27 ; modifier ; code ~ where code 13 is enter/return

--- a/packages/core/src/lib/parse.keypress.ts
+++ b/packages/core/src/lib/parse.keypress.ts
@@ -344,6 +344,15 @@ export const parseKeypress = (s: Buffer | string = "", options: ParseKeypressOpt
       key.name = "space"
     } else if (charCode === 127 || charCode === 8) {
       key.name = "backspace"
+    } else if (charCode >= 65 && charCode <= 90) {
+      // Uppercase letter: normalize the name to lowercase and report the
+      // capitalization via the shift flag, matching the raw single-char path.
+      // Terminals differ on whether they send the shifted (65='A') or base
+      // (97='a') codepoint here, so this keeps `ctrl+shift+a` matching either way.
+      const char = String.fromCharCode(charCode + 32)
+      key.name = char
+      key.sequence = char
+      key.shift = true
     } else {
       // For other character codes, use the character itself
       const char = String.fromCharCode(charCode)

--- a/packages/core/src/zig/ansi.zig
+++ b/packages/core/src/zig/ansi.zig
@@ -391,7 +391,7 @@ pub const ANSI = struct {
     pub const csiUPop = "\x1b[<u";
 
     // modifyOtherKeys mode
-    pub const modifyOtherKeysSet = "\x1b[>4;1m";
+    pub const modifyOtherKeysSet = "\x1b[>4;2m";
     pub const modifyOtherKeysReset = "\x1b[>4;0m";
 
     // Movement and erase

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -1003,7 +1003,7 @@ pub fn setColorSchemeUpdates(self: *Terminal, tty: anytype, enable: bool) !void 
 ///   ?1004h  - Focus event tracking (sends \x1b[I / \x1b[O)
 ///   ?2004h  - Bracketed paste mode (wraps pasted text in markers)
 ///   Kitty keyboard protocol (CSI > flags u) - progressive enhancement
-///   modifyOtherKeys (CSI > 4 ; 1 m) - xterm key modification
+///   modifyOtherKeys (CSI > 4 ; 2 m) - xterm key modification
 pub fn restoreTerminalModes(self: *Terminal, tty: anytype) !void {
     // Re-enable mouse tracking modes if active
     if (self.state.mouse) {


### PR DESCRIPTION
This is fix for the issue described here: https://github.com/anomalyco/opentui/issues/1184

Tmux does not implement the kitty keyboard protocol, so opentui falls back to modifyOtherKeys. Level 1 (CSI > 4 ; 1 m) does not encode standard control characters like Ctrl-J (0x0a), so tmux delivers a raw byte indistinguishable from a newline. Level 2 (CSI > 4 ; 2 m) encodes these as CSI-u sequences (e.g. \x1b[106;5u), which the parser already decodes correctly — the fix is solely in what level we request.