### PR TITLE
fix(ffi): preserve borrowed pointer owners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ Don't use bun-specific APIs. Generated code should work in Bun, Node.js and Deno
 - In portable FFI code, stay within the `node:ffi`/`bun:ffi` type intersection.
 - Avoid backend-specific ABI names in shared definitions: no `usize`, `napi_env`, or `napi_value`. Use explicit widths like `u32`/`u64`.
 - Treat `i64`/`u64` as `bigint`, and native booleans as `0`/`1`.
-- For pointer params, pass `ptr(view)` explicitly and keep shared `Pointer` values as `number | bigint`.
+- For pointer params backed by transient JavaScript memory, pass the `ArrayBuffer` or view directly; the FFI backend borrows it for the duration of the synchronous call. Never pre-resolve such arguments with `ptr()` — a raw address carries no ownership and the runtime may collect the buffer before native code reads it.
+- Use `ptr(view)` only for addresses serialized into structs or retained by native code, and keep the owning buffer alive for as long as native code can read the address. Shared `Pointer` values stay `number | bigint`.
 - For C strings, encode to bytes and pass pointers; do not assume raw JS strings or portable native string return normalization.
 - Create callbacks through the loaded library/platform facade, not `new JSCallback(...)`, and only assume same-thread callback behavior.
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       "name": "@opentui/core",
       "version": "0.4.2",
       "dependencies": {
-        "bun-ffi-structs": "0.2.3",
+        "bun-ffi-structs": "0.2.4",
         "diff": "9.0.0",
         "marked": "17.0.1",
         "string-width": "7.2.0",
@@ -773,7 +773,7 @@
 
     "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
 
-    "bun-ffi-structs": ["bun-ffi-structs@0.2.3", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-pgJiXP+hEgFo9qG51J6ItfY4ocs3vniwNzJ9WhoakB3QB2GdzQxX2EXssentPYlB2hOfJrTjO6iIQkWYzUodpg=="],
+    "bun-ffi-structs": ["bun-ffi-structs@0.2.4", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-AJzsqoVFs1KBbJbWHIYrVZLDC3NhTqqh25awRXqzoLzmBAKr5oqk6+CwuYHAekKx+VBCYVohBoKuRq40dV+TYg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "web-tree-sitter": "0.25.10"
   },
   "dependencies": {
-    "bun-ffi-structs": "0.2.3",
+    "bun-ffi-structs": "0.2.4",
     "diff": "9.0.0",
     "marked": "17.0.1",
     "string-width": "7.2.0",

--- a/packages/core/scripts/test-node.ts
+++ b/packages/core/scripts/test-node.ts
@@ -123,6 +123,7 @@ const emittedAllowlist = [
   ".node-test/src/tests/audio.test.js",
   ".node-test/src/tests/destroy-on-exit.test.js",
   ".node-test/src/tests/destroy-during-render.test.js",
+  ".node-test/src/tests/ffi-borrowed-pointer-callsites.test.js",
   ".node-test/src/tests/hover-cursor.test.js",
   ".node-test/src/tests/native-span-feed-async.test.js",
   ".node-test/src/tests/native-span-feed-close.test.js",

--- a/packages/core/src/platform/ffi.test.ts
+++ b/packages/core/src/platform/ffi.test.ts
@@ -386,26 +386,27 @@ describe("platform/ffi", () => {
     ])
   })
 
-  test("normalizes Node ptr-like arguments from pointers, views, and null", () => {
+  test("preserves Node borrowed pointer arguments and normalizes raw pointers and null", () => {
     const { backend, functionCalls } = createMockNodeBackend()
     const buffer = new ArrayBuffer(16)
     const view = new Uint8Array(buffer, 4, 8)
     const emptyView = new Uint8Array(buffer, 0, 0)
     const library = backend.dlopen("mock", {
       pointers: {
-        args: [FFIType.ptr, FFIType.pointer, FFIType.callback, FFIType.function],
+        args: [FFIType.ptr, FFIType.pointer, FFIType.callback, FFIType.function, FFIType.ptr],
         returns: FFIType.void,
       },
     })
 
-    library.symbols.pointers(view, null, 77 as Pointer, emptyView)
+    library.symbols.pointers(buffer, view, null, 77 as Pointer, emptyView)
 
-    expect(functionCalls).toEqual([
-      {
-        name: "pointers",
-        args: [1004n, 0n, 77n, 0n],
-      },
-    ])
+    expect(functionCalls).toHaveLength(1)
+    expect(functionCalls[0]?.name).toBe("pointers")
+    expect(functionCalls[0]?.args[0]).toBe(buffer)
+    expect(functionCalls[0]?.args[1]).toBe(view)
+    expect(functionCalls[0]?.args[2]).toBe(0n)
+    expect(functionCalls[0]?.args[3]).toBe(77n)
+    expect(functionCalls[0]?.args[4]).toBe(0n)
   })
 
   test("rejects invalid Node ptr-like arguments deterministically", () => {

--- a/packages/core/src/platform/ffi.ts
+++ b/packages/core/src/platform/ffi.ts
@@ -380,7 +380,7 @@ export function createNodeBackend(nodeFfi: NodeFfiBackend): FfiBackend {
       let libraryClosed = false
 
       return {
-        symbols: wrapNodeSymbols(functions, symbols, nodeFfi),
+        symbols: wrapNodeSymbols(functions, symbols),
         createCallback(callback, definition) {
           if (closed) {
             throw new Error(LIBRARY_CLOSED)
@@ -446,18 +446,13 @@ function normalizeNodeDefinitions<Fns extends Record<string, FFIFunction>>(
 function wrapNodeSymbols<Fns extends Record<string, FFIFunction>>(
   functions: Record<string, (...args: any[]) => any>,
   definitions: Fns,
-  nodeFfi: NodeFfiBackend,
 ): { [K in keyof Fns]: (...args: any[]) => any } {
   return Object.fromEntries(
-    Object.entries(functions).map(([name, fn]) => [name, wrapNodeSymbol(fn, definitions[name], nodeFfi)]),
+    Object.entries(functions).map(([name, fn]) => [name, wrapNodeSymbol(fn, definitions[name])]),
   ) as { [K in keyof Fns]: (...args: any[]) => any }
 }
 
-function wrapNodeSymbol(
-  fn: (...args: any[]) => any,
-  definition: FFIFunction,
-  nodeFfi: NodeFfiBackend,
-): (...args: any[]) => any {
+function wrapNodeSymbol(fn: (...args: any[]) => any, definition: FFIFunction): (...args: any[]) => any {
   const pointerArgIndexes = (definition.args ?? []).flatMap((type, index) =>
     isNodePointerArgumentType(type) ? [index] : [],
   )
@@ -470,7 +465,7 @@ function wrapNodeSymbol(
     const normalizedArgs = args.slice()
 
     for (const index of pointerArgIndexes) {
-      normalizedArgs[index] = toNodePointerArgument(nodeFfi, normalizedArgs[index])
+      normalizedArgs[index] = toNodePointerArgument(normalizedArgs[index])
     }
 
     return fn(...normalizedArgs)
@@ -481,7 +476,7 @@ function isNodePointerArgumentType(type: FFITypeOrString): boolean {
   return type === FFIType.ptr || type === FFIType.pointer || type === FFIType.function || type === FFIType.callback
 }
 
-function toNodePointerArgument(nodeFfi: NodeFfiBackend, value: unknown): bigint {
+function toNodePointerArgument(value: unknown): bigint | ArrayBuffer | ArrayBufferView {
   if (value == null) {
     return 0n
   }
@@ -491,11 +486,15 @@ function toNodePointerArgument(nodeFfi: NodeFfiBackend, value: unknown): bigint 
   }
 
   if (ArrayBuffer.isView(value)) {
+    if (!(value.buffer instanceof ArrayBuffer)) {
+      throw new TypeError(NODE_PTR_VALUE)
+    }
+
     if (value.byteLength === 0) {
       return 0n
     }
 
-    return toNodeSourcePointer(nodeFfi, value)
+    return value
   }
 
   if (value instanceof ArrayBuffer) {
@@ -503,7 +502,7 @@ function toNodePointerArgument(nodeFfi: NodeFfiBackend, value: unknown): bigint 
       return 0n
     }
 
-    return toNodeSourcePointer(nodeFfi, value)
+    return value
   }
 
   throw new TypeError(NODE_POINTER_ARGUMENT)

--- a/packages/core/src/tests/ffi-borrowed-pointer-callsites.test.ts
+++ b/packages/core/src/tests/ffi-borrowed-pointer-callsites.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test"
+import { resolveRenderLib } from "../zig.js"
+import { StyledChunkStruct, CursorStyleOptionsStruct } from "../zig-structs.js"
+import { RGBA } from "../lib/RGBA.js"
+import { toArrayBuffer, type Pointer } from "../platform/ffi.js"
+
+// Borrowed-pointer contract for styled text, styled placeholders, and cursor
+// options: packed struct buffers must reach the FFI symbol as object values so
+// the backend can borrow them for the synchronous call. Passing a pre-resolved
+// address instead reintroduces the Node use-after-free from issue #1212.
+
+const lib = resolveRenderLib()
+const symbols = (lib as any).opentui.symbols as Record<string, (...args: any[]) => any>
+
+function withStubbedSymbol(name: string, fn: (calls: any[][]) => void): void {
+  const calls: any[][] = []
+  const original = symbols[name]
+  symbols[name] = (...args: any[]) => {
+    calls.push(args)
+  }
+  try {
+    fn(calls)
+  } finally {
+    symbols[name] = original
+  }
+}
+
+async function forceGc(): Promise<void> {
+  if (typeof Bun !== "undefined") {
+    Bun.gc(true)
+  }
+  ;(globalThis as any).gc?.()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function fieldOffset(struct: { layoutByName: Map<string, { offset: number }> }, name: string): number {
+  const field = struct.layoutByName.get(name)
+  if (!field) {
+    throw new Error(`Missing struct field: ${name}`)
+  }
+  return field.offset
+}
+
+function readPackedColor(packed: ArrayBuffer, offset: number): number[] {
+  // 64-bit StyledChunk/CursorStyleOptions layout; matches the supported
+  // x64/arm64 native targets.
+  const address = new DataView(packed).getBigUint64(offset, true)
+  expect(address).not.toBe(0n)
+  return [...new Uint16Array(toArrayBuffer(address as unknown as Pointer, 0, 8).slice(0))]
+}
+
+describe("borrowed pointer call sites", () => {
+  test("textBufferSetStyledText passes the packed chunk buffer as an object value", () => {
+    withStubbedSymbol("textBufferSetStyledText", (calls) => {
+      const chunks = [
+        { text: "hello", fg: RGBA.fromValues(1, 0, 0, 1) },
+        { text: "world", bg: RGBA.fromValues(0, 0, 1, 1) },
+      ]
+
+      lib.textBufferSetStyledText(0 as any, chunks)
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0]![1]).toBeInstanceOf(ArrayBuffer)
+      expect((calls[0]![1] as ArrayBuffer).byteLength).toBe(StyledChunkStruct.size * chunks.length)
+      expect(calls[0]![2]).toBe(chunks.length)
+    })
+  })
+
+  test("editorViewSetPlaceholderStyledText passes the packed chunk buffer as an object value", () => {
+    withStubbedSymbol("editorViewSetPlaceholderStyledText", (calls) => {
+      lib.editorViewSetPlaceholderStyledText(0 as any, [{ text: "placeholder", fg: RGBA.fromValues(0, 1, 0, 1) }])
+      lib.editorViewSetPlaceholderStyledText(0 as any, [{ text: "" }])
+
+      expect(calls).toHaveLength(2)
+      expect(calls[0]![1]).toBeInstanceOf(ArrayBuffer)
+      expect((calls[0]![1] as ArrayBuffer).byteLength).toBe(StyledChunkStruct.size)
+      expect(calls[1]![1]).toBeNull()
+      expect(calls[1]![2]).toBe(0)
+    })
+  })
+
+  test("setCursorStyleOptions passes the packed options buffer as an object value", () => {
+    withStubbedSymbol("setCursorStyleOptions", (calls) => {
+      lib.setCursorStyleOptions(0 as any, { style: "block", blinking: true, color: RGBA.fromValues(1, 1, 0, 1) })
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0]![1]).toBeInstanceOf(ArrayBuffer)
+      expect((calls[0]![1] as ArrayBuffer).byteLength).toBe(CursorStyleOptionsStruct.size)
+    })
+  })
+})
+
+describe("packed color owner retention", () => {
+  test("styled chunk fg and bg colors stay readable after GC of transient chunks", async () => {
+    const fgOffset = fieldOffset(StyledChunkStruct, "fg")
+    const bgOffset = fieldOffset(StyledChunkStruct, "bg")
+
+    const packTransientChunks = (count: number) => {
+      const chunks = []
+      const expected = []
+      for (let i = 0; i < count; i++) {
+        const fg = RGBA.fromValues((i % 16) / 15, 0, 1, 1)
+        const bg = RGBA.fromValues(0, (i % 16) / 15, 0, 1)
+        chunks.push({ text: `chunk-${i}`, fg, bg })
+        expected.push({ fg: [...fg.buffer], bg: [...bg.buffer] })
+      }
+      // The chunk objects and their RGBA instances are unreachable after this
+      // returns; only the packed buffer may keep the color memory alive.
+      return { packed: StyledChunkStruct.packList(chunks), expected }
+    }
+
+    const count = 16
+    const { packed, expected } = packTransientChunks(count)
+
+    for (let round = 0; round < 20; round++) {
+      const churn = []
+      for (let i = 0; i < 2048; i++) {
+        churn.push(new Uint16Array(4).fill(round))
+      }
+      await forceGc()
+
+      for (let i = 0; i < count; i++) {
+        const base = i * StyledChunkStruct.size
+        expect(readPackedColor(packed, base + fgOffset)).toEqual(expected[i]!.fg)
+        expect(readPackedColor(packed, base + bgOffset)).toEqual(expected[i]!.bg)
+      }
+    }
+  })
+
+  test("cursor style color stays readable after GC of the transient RGBA", async () => {
+    const colorOffset = fieldOffset(CursorStyleOptionsStruct, "color")
+
+    const packTransientColor = () => {
+      const color = RGBA.fromValues(0.5, 0.25, 0.75, 1)
+      return {
+        packed: CursorStyleOptionsStruct.pack({ style: 255, blinking: 255, color, cursor: 255 }),
+        expected: [...color.buffer],
+      }
+    }
+
+    const { packed, expected } = packTransientColor()
+
+    for (let round = 0; round < 20; round++) {
+      const churn = []
+      for (let i = 0; i < 2048; i++) {
+        churn.push(new Uint16Array(4).fill(round))
+      }
+      await forceGc()
+
+      expect(readPackedColor(packed, colorOffset)).toEqual(expected)
+    }
+  })
+})

--- a/packages/core/src/zig-structs.ts
+++ b/packages/core/src/zig-structs.ts
@@ -1,8 +1,11 @@
 import { defineStruct, defineEnum } from "bun-ffi-structs"
-import { ptr, toArrayBuffer, type Pointer } from "./platform/ffi.js"
+import { toArrayBuffer, type Pointer } from "./platform/ffi.js"
 import { RGBA, normalizeColorValue } from "./lib/RGBA.js"
 
-const rgbaPackTransform = (rgba?: RGBA) => (rgba ? ptr(rgba.buffer) : null)
+// Returns the owning Uint16Array so bun-ffi-structs serializes the address and
+// retains the color buffer with the packed struct (requires bun-ffi-structs >= 0.2.4).
+// Returning a raw pointer here would leave the color memory ownerless.
+const rgbaPackTransform = (rgba?: RGBA) => rgba?.buffer ?? null
 const rgbaUnpackTransform = (ptr?: Pointer) =>
   ptr ? RGBA.fromArray(new Uint16Array(toArrayBuffer(ptr, 0, 8))) : undefined
 

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -3189,7 +3189,7 @@ class FFIRenderLib implements RenderLib {
     const cursor = options.cursor != null ? MOUSE_STYLE_TO_ID[options.cursor] : 255
 
     const buffer = CursorStyleOptionsStruct.pack({ style, blinking, color: options.color, cursor })
-    this.opentui.symbols.setCursorStyleOptions(renderer, ptr(buffer))
+    this.opentui.symbols.setCursorStyleOptions(renderer, buffer)
   }
 
   public render(renderer: Pointer, force: boolean): number {
@@ -3780,7 +3780,7 @@ class FFIRenderLib implements RenderLib {
     }
 
     const chunksBuffer = StyledChunkStruct.packList(chunks)
-    this.opentui.symbols.textBufferSetStyledText(buffer, ptr(chunksBuffer), chunks.length)
+    this.opentui.symbols.textBufferSetStyledText(buffer, chunksBuffer, chunks.length)
   }
 
   public textBufferGetLineCount(buffer: Pointer): number {
@@ -5093,7 +5093,7 @@ class FFIRenderLib implements RenderLib {
     }
 
     const chunksBuffer = StyledChunkStruct.packList(nonEmptyChunks)
-    this.opentui.symbols.editorViewSetPlaceholderStyledText(view, ptr(chunksBuffer), nonEmptyChunks.length)
+    this.opentui.symbols.editorViewSetPlaceholderStyledText(view, chunksBuffer, nonEmptyChunks.length)
   }
 
   public editorViewSetTabIndicator(view: EditorViewHandle, indicator: number): void {

--- a/packages/core/tsconfig.node-test.json
+++ b/packages/core/tsconfig.node-test.json
@@ -97,6 +97,7 @@
     "src/tests/destroy-on-exit.fixture.ts",
     "src/tests/destroy-on-exit.test.ts",
     "src/tests/destroy-during-render.test.ts",
+    "src/tests/ffi-borrowed-pointer-callsites.test.ts",
     "src/tests/hover-cursor.test.ts",
     "src/tests/native-span-feed-async.test.ts",
     "src/tests/native-span-feed-close.test.ts",


### PR DESCRIPTION
Pass transient buffers to FFI calls as borrowed objects so Node keeps the JavaScript owner alive for the synchronous
native read. Raw addresses can outlive the object that backs them, which lets GC corrupt styled text and cursor option
data

Fixes #1212 
