### PR TITLE
fix(core): identity-based child management, resolves duplicate-id culling corruption

### DIFF
--- a/packages/core/dev/keypress-debug-renderer.ts
+++ b/packages/core/dev/keypress-debug-renderer.ts
@@ -56,7 +56,7 @@ function addEvent(eventType: string, event: object) {
   if (children.length > 50) {
     const oldest = children[0]
     if (oldest) {
-      scrollBox.remove(oldest.id)
+      scrollBox.remove(oldest)
       oldest.destroyRecursively()
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     "bench:native": "cd src/zig && zig build bench -Dbench-optimize=ReleaseFast --",
     "bench:layout": "bun src/benchmark/layout-benchmark.ts",
     "bench:box-draw": "bun src/benchmark/box-draw-benchmark.ts",
+    "bench:render-traversal": "bun src/benchmark/render-traversal-benchmark.ts",
     "bench:text-table": "bun src/benchmark/text-table-benchmark.ts",
     "bench:ts": "bun src/benchmark/native-span-feed-benchmark.ts --suite=quick --json=src/benchmark/latest-quick-bench-run.json && bun src/benchmark/native-span-feed-benchmark.ts --suite=default --json=src/benchmark/latest-default-bench-run.json && bun src/benchmark/native-span-feed-benchmark.ts --suite=large --json=src/benchmark/latest-large-bench-run.json && bun src/benchmark/native-span-feed-benchmark.ts --suite=all --json=src/benchmark/latest-all-bench-run.json && bun src/benchmark/native-span-feed-async-benchmark.ts --json=src/benchmark/latest-async-bench-run.json",
     "publish": "bun scripts/publish.ts",

--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -197,6 +197,10 @@ export abstract class BaseRenderable extends EventEmitter {
   }
 }
 
+function hasLayoutNode(child: BaseRenderable): child is BaseRenderable & { getLayoutNode(): YogaNode } {
+  return "getLayoutNode" in child && typeof child.getLayoutNode === "function"
+}
+
 interface LayoutGenerationContext extends RenderContext {
   __otuiLayoutGeneration?: number
   __otuiRenderListRevision?: number
@@ -1334,15 +1338,15 @@ export abstract class Renderable extends BaseRenderable {
   }
 
   public remove(child: BaseRenderable): void {
-    const childWithLayout = child as BaseRenderable & {
-      getLayoutNode?: () => YogaNode
-      onRemove?: () => void
+    if (!(child instanceof BaseRenderable)) {
+      throw new Error("remove expects a renderable child object")
     }
-    if (typeof childWithLayout.getLayoutNode !== "function") {
+
+    if (!hasLayoutNode(child)) {
       return
     }
 
-    const index = this._childrenInLayoutOrder.indexOf(child as Renderable)
+    const index = this._childrenInLayoutOrder.findIndex((candidate) => candidate === child)
     if (index === -1) {
       return
     }
@@ -1351,18 +1355,25 @@ export abstract class Renderable extends BaseRenderable {
       this.propagateLiveCount(-child._liveCount)
     }
 
-    this.yogaNode.removeChild(childWithLayout.getLayoutNode())
+    this.yogaNode.removeChild(child.getLayoutNode())
     this._childrenInLayoutOrder.splice(index, 1)
 
-    const zIndexIndex = this._childrenInZIndexOrder.indexOf(child as Renderable)
+    const zIndexIndex = this._childrenInZIndexOrder.findIndex((candidate) => candidate === child)
     if (zIndexIndex !== -1) {
       this._childrenInZIndexOrder.splice(zIndexIndex, 1)
     }
 
-    this._shouldUpdateBefore.delete(child as Renderable)
+    for (const candidate of this._shouldUpdateBefore) {
+      if (candidate === child) {
+        this._shouldUpdateBefore.delete(candidate)
+        break
+      }
+    }
     this.requestRender()
 
-    childWithLayout.onRemove?.()
+    if (child instanceof Renderable) {
+      child.onRemove()
+    }
     child.parent = null
     if (child instanceof Renderable) {
       this._ctx.unregisterLifecyclePass(child)

--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -150,8 +150,7 @@ export abstract class BaseRenderable extends EventEmitter {
   }
 
   public abstract add(obj: BaseRenderable | unknown, index?: number): number
-  public abstract remove(id: string): void
-  public abstract removeChild(child: BaseRenderable): void
+  public abstract remove(child: BaseRenderable): void
   public abstract insertBefore(obj: BaseRenderable | unknown, anchor: BaseRenderable | unknown): void
   public abstract getChildren(): BaseRenderable[]
   public abstract getChildrenCount(): number
@@ -1191,7 +1190,7 @@ export abstract class Renderable extends BaseRenderable {
 
   private replaceParent(obj: Renderable) {
     if (obj.parent) {
-      obj.parent.removeChild(obj)
+      obj.parent.remove(obj)
     }
     obj.parent = this
   }
@@ -1334,16 +1333,7 @@ export abstract class Renderable extends BaseRenderable {
     return this._childrenInLayoutOrder.find((child) => child.id === id)
   }
 
-  public remove(id: string): void {
-    if (!id) {
-      return
-    }
-
-    const child = this.getRenderable(id)
-    if (child) this.removeChild(child)
-  }
-
-  public removeChild(child: BaseRenderable): void {
+  public remove(child: BaseRenderable): void {
     const childWithLayout = child as BaseRenderable & {
       getLayoutNode?: () => YogaNode
       onRemove?: () => void
@@ -1566,7 +1556,7 @@ export abstract class Renderable extends BaseRenderable {
     this.emit(RenderableEvents.DESTROYED)
 
     if (this.parent) {
-      this.parent.removeChild(this)
+      this.parent.remove(this)
     }
 
     if (this.frameBuffer) {
@@ -1575,7 +1565,7 @@ export abstract class Renderable extends BaseRenderable {
     }
 
     for (const child of [...this._childrenInLayoutOrder]) {
-      this.removeChild(child)
+      this.remove(child)
     }
 
     this._childrenInLayoutOrder = []

--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -197,10 +197,6 @@ export abstract class BaseRenderable extends EventEmitter {
   }
 }
 
-function hasLayoutNode(child: BaseRenderable): child is BaseRenderable & { getLayoutNode(): YogaNode } {
-  return "getLayoutNode" in child && typeof child.getLayoutNode === "function"
-}
-
 interface LayoutGenerationContext extends RenderContext {
   __otuiLayoutGeneration?: number
   __otuiRenderListRevision?: number
@@ -324,14 +320,6 @@ export abstract class Renderable extends BaseRenderable {
     if (this.buffered) {
       this.createFrameBuffer()
     }
-  }
-
-  public override get id() {
-    return this._id
-  }
-
-  public override set id(value: string) {
-    super.id = value
   }
 
   public get focusable(): boolean {
@@ -1342,42 +1330,37 @@ export abstract class Renderable extends BaseRenderable {
       throw new Error("remove expects a renderable child object")
     }
 
-    if (!hasLayoutNode(child)) {
-      return
-    }
-
-    const index = this._childrenInLayoutOrder.findIndex((candidate) => candidate === child)
+    // Membership in _childrenInLayoutOrder proves child is a Renderable with a
+    // layout node; anything else (text nodes, children of other parents,
+    // already-detached renderables) is a caller bug worth surfacing in dev.
+    const index = this._childrenInLayoutOrder.indexOf(child as Renderable)
     if (index === -1) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(`Renderable with id ${child.id} is not a child of ${this.id}, skipping remove`)
+      }
       return
     }
 
-    if (child instanceof Renderable && child._liveCount > 0) {
-      this.propagateLiveCount(-child._liveCount)
+    const renderable = this._childrenInLayoutOrder[index]
+
+    if (renderable._liveCount > 0) {
+      this.propagateLiveCount(-renderable._liveCount)
     }
 
-    this.yogaNode.removeChild(child.getLayoutNode())
+    this.yogaNode.removeChild(renderable.getLayoutNode())
     this._childrenInLayoutOrder.splice(index, 1)
 
-    const zIndexIndex = this._childrenInZIndexOrder.findIndex((candidate) => candidate === child)
+    const zIndexIndex = this._childrenInZIndexOrder.indexOf(renderable)
     if (zIndexIndex !== -1) {
       this._childrenInZIndexOrder.splice(zIndexIndex, 1)
     }
 
-    for (const candidate of this._shouldUpdateBefore) {
-      if (candidate === child) {
-        this._shouldUpdateBefore.delete(candidate)
-        break
-      }
-    }
+    this._shouldUpdateBefore.delete(renderable)
     this.requestRender()
 
-    if (child instanceof Renderable) {
-      child.onRemove()
-    }
-    child.parent = null
-    if (child instanceof Renderable) {
-      this._ctx.unregisterLifecyclePass(child)
-    }
+    renderable.onRemove()
+    renderable.parent = null
+    this._ctx.unregisterLifecyclePass(renderable)
 
     this.childrenPrimarySortDirty = true
     bumpRenderListRevision(this._ctx)

--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -151,6 +151,7 @@ export abstract class BaseRenderable extends EventEmitter {
 
   public abstract add(obj: BaseRenderable | unknown, index?: number): number
   public abstract remove(id: string): void
+  public abstract removeChild(child: BaseRenderable): void
   public abstract insertBefore(obj: BaseRenderable | unknown, anchor: BaseRenderable | unknown): void
   public abstract getChildren(): BaseRenderable[]
   public abstract getChildrenCount(): number
@@ -266,7 +267,6 @@ export abstract class Renderable extends BaseRenderable {
   protected _opacity: number = 1.0
   private _flexShrink: number = 1
 
-  private renderableMapById: Map<string, Renderable> = new Map()
   protected _childrenInLayoutOrder: Renderable[] = []
   protected _childrenInZIndexOrder: Renderable[] = []
   private needsZIndexSort: boolean = false
@@ -328,10 +328,6 @@ export abstract class Renderable extends BaseRenderable {
   }
 
   public override set id(value: string) {
-    if (this.parent) {
-      this.parent.renderableMapById.delete(this.id)
-      this.parent.renderableMapById.set(value, this)
-    }
     super.id = value
   }
 
@@ -1195,7 +1191,7 @@ export abstract class Renderable extends BaseRenderable {
 
   private replaceParent(obj: Renderable) {
     if (obj.parent) {
-      obj.parent.remove(obj.id)
+      obj.parent.removeChild(obj)
     }
     obj.parent = this
   }
@@ -1229,7 +1225,6 @@ export abstract class Renderable extends BaseRenderable {
     } else {
       this.replaceParent(renderable)
       this.needsZIndexSort = true
-      this.renderableMapById.set(renderable.id, renderable)
       this._childrenInZIndexOrder.push(renderable)
 
       if (typeof renderable.onLifecyclePass === "function") {
@@ -1287,14 +1282,14 @@ export abstract class Renderable extends BaseRenderable {
       return -1
     }
 
-    if (!this.renderableMapById.has(anchor.id)) {
+    if (this._childrenInLayoutOrder.indexOf(anchor) === -1) {
       if (process.env.NODE_ENV !== "production") {
         console.warn(`Anchor with id ${anchor.id} does not exist within the parent ${this.id}, skipping insertBefore`)
       }
       return -1
     }
 
-    if (renderable === anchor || renderable.id === anchor.id) {
+    if (renderable === anchor) {
       if (process.env.NODE_ENV !== "production") {
         console.warn(`Anchor is the same as the node ${renderable.id} being inserted, skipping insertBefore`)
       }
@@ -1307,7 +1302,6 @@ export abstract class Renderable extends BaseRenderable {
     } else {
       this.replaceParent(renderable)
       this.needsZIndexSort = true
-      this.renderableMapById.set(renderable.id, renderable)
       this._childrenInZIndexOrder.push(renderable)
 
       if (typeof renderable.onLifecyclePass === "function") {
@@ -1337,7 +1331,7 @@ export abstract class Renderable extends BaseRenderable {
 
   // TODO: that naming is meh
   public getRenderable(id: string): Renderable | undefined {
-    return this.renderableMapById.get(id)
+    return this._childrenInLayoutOrder.find((child) => child.id === id)
   }
 
   public remove(id: string): void {
@@ -1345,36 +1339,47 @@ export abstract class Renderable extends BaseRenderable {
       return
     }
 
-    if (this.renderableMapById.has(id)) {
-      const obj = this.renderableMapById.get(id)
-      if (obj) {
-        if (obj._liveCount > 0) {
-          this.propagateLiveCount(-obj._liveCount)
-        }
+    const child = this.getRenderable(id)
+    if (child) this.removeChild(child)
+  }
 
-        const childLayoutNode = obj.getLayoutNode()
-        this.yogaNode.removeChild(childLayoutNode)
-        this.requestRender()
-
-        obj.onRemove()
-        obj.parent = null
-        this._ctx.unregisterLifecyclePass(obj)
-        this.renderableMapById.delete(id)
-
-        const index = this._childrenInLayoutOrder.findIndex((obj) => obj.id === id)
-        if (index !== -1) {
-          this._childrenInLayoutOrder.splice(index, 1)
-        }
-
-        const zIndexIndex = this._childrenInZIndexOrder.findIndex((obj) => obj.id === id)
-        if (zIndexIndex !== -1) {
-          this._childrenInZIndexOrder.splice(zIndexIndex, 1)
-        }
-
-        this.childrenPrimarySortDirty = true
-        bumpRenderListRevision(this._ctx)
-      }
+  public removeChild(child: BaseRenderable): void {
+    const childWithLayout = child as BaseRenderable & {
+      getLayoutNode?: () => YogaNode
+      onRemove?: () => void
     }
+    if (typeof childWithLayout.getLayoutNode !== "function") {
+      return
+    }
+
+    const index = this._childrenInLayoutOrder.indexOf(child as Renderable)
+    if (index === -1) {
+      return
+    }
+
+    if (child instanceof Renderable && child._liveCount > 0) {
+      this.propagateLiveCount(-child._liveCount)
+    }
+
+    this.yogaNode.removeChild(childWithLayout.getLayoutNode())
+    this._childrenInLayoutOrder.splice(index, 1)
+
+    const zIndexIndex = this._childrenInZIndexOrder.indexOf(child as Renderable)
+    if (zIndexIndex !== -1) {
+      this._childrenInZIndexOrder.splice(zIndexIndex, 1)
+    }
+
+    this._shouldUpdateBefore.delete(child as Renderable)
+    this.requestRender()
+
+    childWithLayout.onRemove?.()
+    child.parent = null
+    if (child instanceof Renderable) {
+      this._ctx.unregisterLifecyclePass(child)
+    }
+
+    this.childrenPrimarySortDirty = true
+    bumpRenderListRevision(this._ctx)
   }
 
   protected onRemove(): void {
@@ -1561,7 +1566,7 @@ export abstract class Renderable extends BaseRenderable {
     this.emit(RenderableEvents.DESTROYED)
 
     if (this.parent) {
-      this.parent.remove(this.id)
+      this.parent.removeChild(this)
     }
 
     if (this.frameBuffer) {
@@ -1569,12 +1574,13 @@ export abstract class Renderable extends BaseRenderable {
       this.frameBuffer = null
     }
 
-    for (const child of this._childrenInLayoutOrder) {
-      this.remove(child.id)
+    for (const child of [...this._childrenInLayoutOrder]) {
+      this.removeChild(child)
     }
 
     this._childrenInLayoutOrder = []
-    this.renderableMapById.clear()
+    this._childrenInZIndexOrder = []
+    this._shouldUpdateBefore.clear()
     Renderable.renderablesByNumber.delete(this.num)
 
     this.blur()

--- a/packages/core/src/benchmark/render-traversal-benchmark.ts
+++ b/packages/core/src/benchmark/render-traversal-benchmark.ts
@@ -46,6 +46,7 @@ type ScenarioResult = {
   minMs: number
   maxMs: number
   stdDevMs: number
+  rmePercent: number
   approxUsPerRenderable: number
 }
 
@@ -56,6 +57,7 @@ type TimingStats = {
   minMs: number
   maxMs: number
   stdDevMs: number
+  rmePercent: number
 }
 
 type TreeStats = {
@@ -181,7 +183,10 @@ try {
     writeLine(outputEnabled, `Running ${scenario.name}...`)
     const result = await runScenario(scenario, ctx, iterations, warmupIterations)
     results.push(result)
-    writeLine(outputEnabled, `  avg=${result.avgMs.toFixed(4)}ms p95=${result.p95Ms.toFixed(4)}ms`)
+    writeLine(
+      outputEnabled,
+      `  avg=${result.avgMs.toFixed(4)}ms p95=${result.p95Ms.toFixed(4)}ms rme=${result.rmePercent.toFixed(2)}%`,
+    )
   }
 } finally {
   renderer.destroy()
@@ -195,6 +200,7 @@ if (outputEnabled) {
       layoutOnlyBoxes: result.layoutOnlyBoxesPerIteration,
       avgMs: result.avgMs,
       p95Ms: result.p95Ms,
+      "rme%": result.rmePercent,
       usPerRenderable: result.approxUsPerRenderable,
     })),
   )
@@ -343,6 +349,10 @@ function createScenarios(): ScenarioDefinition[] {
         }
       },
     },
+    createCullingScalingScenario(100),
+    createCullingScalingScenario(1000),
+    createCullingScalingScenario(5000),
+    createCullingScalingScenario(10000),
     {
       name: "scrollbar_stack",
       description: "Visible scrollbars and slider tracks with arrows",
@@ -456,6 +466,82 @@ function createScenarios(): ScenarioDefinition[] {
       },
     },
   ]
+}
+
+// Frame-time scaling with total child count under viewport culling, at a
+// constant visible count (~viewport height). This is the per-frame
+// O(total children) layout-refresh path in Renderable.updateLayout for
+// _hasVisibleChildFilter parents: before culling can read screen positions,
+// every child gets one updateFromLayout (FFI getComputedLayout) per frame,
+// so steady-state frame time grows with hidden children. Watch
+// approxUsPerRenderable across the scaling scenarios: roughly constant means
+// the per-frame cost is linear in total children; if the refresh path ever
+// becomes O(visible), it should drop as childCount grows.
+function createCullingScalingScenario(childCount: number): ScenarioDefinition {
+  return {
+    name: `scrollbox_culling_scaling_${childCount}`,
+    description: `Scrolling viewport-culled scrollbox with ${childCount} rows, constant visible count`,
+    setup: async (ctx) => {
+      clearRoot(ctx.renderer)
+      resetBuffers(ctx.renderer)
+
+      let renderables = 0
+      let layoutOnlyBoxes = 0
+
+      const root = new BoxRenderable(ctx.renderer, {
+        id: `bench-culling-scaling-root-${childCount}`,
+        width: "100%",
+        height: "100%",
+        border: false,
+        backgroundColor: COLORS.transparent,
+      })
+      renderables += 1
+      layoutOnlyBoxes += 1
+      ctx.renderer.root.add(root)
+
+      const scrollBox = new ScrollBoxRenderable(ctx.renderer, {
+        id: `bench-culling-scaling-scrollbox-${childCount}`,
+        width: "100%",
+        height: "100%",
+        viewportCulling: true,
+      })
+      renderables += 1
+      layoutOnlyBoxes += 1
+      root.add(scrollBox)
+
+      for (let i = 0; i < childCount; i += 1) {
+        const row = new BoxRenderable(ctx.renderer, {
+          id: `bench-culling-scaling-row-${i}`,
+          width: "100%",
+          height: 1,
+          flexShrink: 0,
+          border: false,
+          backgroundColor: i % 2 === 0 ? COLORS.panel : COLORS.element,
+        })
+        renderables += 1
+        scrollBox.add(row)
+      }
+
+      await ctx.renderOnce()
+      scrollBox.scrollTo(Math.floor(childCount / 2))
+      await ctx.renderOnce()
+
+      return {
+        renderablesPerIteration: renderables,
+        layoutOnlyBoxesPerIteration: layoutOnlyBoxes,
+        runIteration: async (iteration) => {
+          // Alternate 1-row scrolls: every frame is a real translate change
+          // (the steady-state streaming/scrolling workload) while the visible
+          // count stays constant and the position returns home every 2 frames.
+          scrollBox.scrollBy(iteration % 2 === 0 ? 1 : -1)
+          await ctx.renderOnce()
+        },
+        teardown: () => {
+          root.destroyRecursively()
+        },
+      }
+    },
+  }
 }
 
 async function buildOpencodeLayoutTree(ctx: BenchmarkContext, options: LayoutTreeOptions): Promise<LayoutTreeState> {
@@ -731,6 +817,7 @@ async function runScenario(
       minMs: round(stats.minMs, 4),
       maxMs: round(stats.maxMs, 4),
       stdDevMs: round(stats.stdDevMs, 4),
+      rmePercent: round(stats.rmePercent, 2),
       approxUsPerRenderable:
         runtime.renderablesPerIteration > 0 ? round((stats.avgMs * 1000) / runtime.renderablesPerIteration, 3) : 0,
     }
@@ -765,6 +852,7 @@ function calculateStats(samples: number[]): TimingStats {
       minMs: 0,
       maxMs: 0,
       stdDevMs: 0,
+      rmePercent: 0,
     }
   }
 
@@ -792,7 +880,35 @@ function calculateStats(samples: number[]): TimingStats {
     minMs,
     maxMs,
     stdDevMs: Math.sqrt(variance),
+    rmePercent: relativeMarginOfError(samples, avgMs),
   }
+}
+
+// 95% confidence relative margin of error via Student-t, matching the
+// convention in layout-benchmark.ts.
+function relativeMarginOfError(samples: readonly number[], average: number): number {
+  if (samples.length <= 1 || average === 0) {
+    return 0
+  }
+
+  let variance = 0
+  for (const value of samples) {
+    const diff = value - average
+    variance += diff * diff
+  }
+  variance /= samples.length - 1
+
+  const sem = Math.sqrt(variance) / Math.sqrt(samples.length)
+  return Math.abs((sem * tCritical95(samples.length - 1) * 100) / average)
+}
+
+function tCritical95(degreesOfFreedom: number): number {
+  const table = [12.706, 4.303, 3.182, 2.776, 2.571, 2.447, 2.365, 2.306, 2.262, 2.228]
+  if (degreesOfFreedom <= 0) {
+    return 0
+  }
+
+  return table[degreesOfFreedom - 1] ?? 1.96
 }
 
 function round(value: number, places: number): number {

--- a/packages/core/src/plugins/core-slot.ts
+++ b/packages/core/src/plugins/core-slot.ts
@@ -461,7 +461,7 @@ export class SlotRenderable<
 
   private _detachNodeFromMount(node: BaseRenderable): void {
     if (node.parent === this) {
-      this.remove(node.id)
+      this.removeChild(node)
     }
   }
 
@@ -555,7 +555,7 @@ export class SlotRenderable<
     for (const node of this._mountedNodes) {
       if (!desiredNodeSet.has(node)) {
         if (node.parent === this) {
-          this.remove(node.id)
+          this.removeChild(node)
         }
       }
     }
@@ -569,7 +569,7 @@ export class SlotRenderable<
       }
 
       const childAtIndex = this.getChildren()[index]
-      if (childAtIndex?.id !== node.id) {
+      if (childAtIndex !== node) {
         this.add(node, index)
       }
     }

--- a/packages/core/src/plugins/core-slot.ts
+++ b/packages/core/src/plugins/core-slot.ts
@@ -461,7 +461,7 @@ export class SlotRenderable<
 
   private _detachNodeFromMount(node: BaseRenderable): void {
     if (node.parent === this) {
-      this.removeChild(node)
+      this.remove(node)
     }
   }
 
@@ -555,7 +555,7 @@ export class SlotRenderable<
     for (const node of this._mountedNodes) {
       if (!desiredNodeSet.has(node)) {
         if (node.parent === this) {
-          this.removeChild(node)
+          this.remove(node)
         }
       }
     }

--- a/packages/core/src/renderables/Diff.test.ts
+++ b/packages/core/src/renderables/Diff.test.ts
@@ -2956,7 +2956,7 @@ test("DiffRenderable - split view with word wrapping: changing diff content shou
 
   // Clean up
   parentContainer1.destroyRecursively()
-  renderer.root.remove("parent-container-1")
+  renderer.root.remove(parentContainer1)
   await renderOnce()
 
   // PART 2: BUGGY PATH

--- a/packages/core/src/renderables/Diff.test.ts
+++ b/packages/core/src/renderables/Diff.test.ts
@@ -2954,9 +2954,8 @@ test("DiffRenderable - split view with word wrapping: changing diff content shou
 
   const correctFrame = captureFrame()
 
-  // Clean up
+  // Clean up (destroyRecursively already detaches from the parent)
   parentContainer1.destroyRecursively()
-  renderer.root.remove(parentContainer1)
   await renderOnce()
 
   // PART 2: BUGGY PATH

--- a/packages/core/src/renderables/Diff.ts
+++ b/packages/core/src/renderables/Diff.ts
@@ -311,11 +311,11 @@ export class DiffRenderable extends Renderable {
     this.flexDirection = "column"
 
     if (this.leftSide && this.leftSideAdded) {
-      super.removeChild(this.leftSide)
+      super.remove(this.leftSide)
       this.leftSideAdded = false
     }
     if (this.rightSide && this.rightSideAdded) {
-      super.removeChild(this.rightSide)
+      super.remove(this.rightSide)
       this.rightSideAdded = false
     }
 
@@ -488,13 +488,13 @@ export class DiffRenderable extends Renderable {
     if (this.errorTextRenderable) {
       const errorTextIndex = this.getChildren().indexOf(this.errorTextRenderable)
       if (errorTextIndex !== -1) {
-        super.removeChild(this.errorTextRenderable)
+        super.remove(this.errorTextRenderable)
       }
     }
     if (this.errorCodeRenderable) {
       const errorCodeIndex = this.getChildren().indexOf(this.errorCodeRenderable)
       if (errorCodeIndex !== -1) {
-        super.removeChild(this.errorCodeRenderable)
+        super.remove(this.errorCodeRenderable)
       }
     }
 
@@ -579,7 +579,7 @@ export class DiffRenderable extends Renderable {
     this.createOrUpdateSide("left", codeRenderable, lineColors, lineSigns, lineNumbers, new Set<number>(), "100%")
 
     if (this.rightSide && this.rightSideAdded) {
-      super.removeChild(this.rightSide)
+      super.remove(this.rightSide)
       this.rightSideAdded = false
     }
   }
@@ -592,13 +592,13 @@ export class DiffRenderable extends Renderable {
     if (this.errorTextRenderable) {
       const errorTextIndex = this.getChildren().indexOf(this.errorTextRenderable)
       if (errorTextIndex !== -1) {
-        super.removeChild(this.errorTextRenderable)
+        super.remove(this.errorTextRenderable)
       }
     }
     if (this.errorCodeRenderable) {
       const errorCodeIndex = this.getChildren().indexOf(this.errorCodeRenderable)
       if (errorCodeIndex !== -1) {
-        super.removeChild(this.errorCodeRenderable)
+        super.remove(this.errorCodeRenderable)
       }
     }
 

--- a/packages/core/src/renderables/Diff.ts
+++ b/packages/core/src/renderables/Diff.ts
@@ -311,11 +311,11 @@ export class DiffRenderable extends Renderable {
     this.flexDirection = "column"
 
     if (this.leftSide && this.leftSideAdded) {
-      super.remove(this.leftSide.id)
+      super.removeChild(this.leftSide)
       this.leftSideAdded = false
     }
     if (this.rightSide && this.rightSideAdded) {
-      super.remove(this.rightSide.id)
+      super.removeChild(this.rightSide)
       this.rightSideAdded = false
     }
 
@@ -488,13 +488,13 @@ export class DiffRenderable extends Renderable {
     if (this.errorTextRenderable) {
       const errorTextIndex = this.getChildren().indexOf(this.errorTextRenderable)
       if (errorTextIndex !== -1) {
-        super.remove(this.errorTextRenderable.id)
+        super.removeChild(this.errorTextRenderable)
       }
     }
     if (this.errorCodeRenderable) {
       const errorCodeIndex = this.getChildren().indexOf(this.errorCodeRenderable)
       if (errorCodeIndex !== -1) {
-        super.remove(this.errorCodeRenderable.id)
+        super.removeChild(this.errorCodeRenderable)
       }
     }
 
@@ -579,7 +579,7 @@ export class DiffRenderable extends Renderable {
     this.createOrUpdateSide("left", codeRenderable, lineColors, lineSigns, lineNumbers, new Set<number>(), "100%")
 
     if (this.rightSide && this.rightSideAdded) {
-      super.remove(this.rightSide.id)
+      super.removeChild(this.rightSide)
       this.rightSideAdded = false
     }
   }
@@ -592,13 +592,13 @@ export class DiffRenderable extends Renderable {
     if (this.errorTextRenderable) {
       const errorTextIndex = this.getChildren().indexOf(this.errorTextRenderable)
       if (errorTextIndex !== -1) {
-        super.remove(this.errorTextRenderable.id)
+        super.removeChild(this.errorTextRenderable)
       }
     }
     if (this.errorCodeRenderable) {
       const errorCodeIndex = this.getChildren().indexOf(this.errorCodeRenderable)
       if (errorCodeIndex !== -1) {
-        super.remove(this.errorCodeRenderable.id)
+        super.removeChild(this.errorCodeRenderable)
       }
     }
 

--- a/packages/core/src/renderables/LineNumberRenderable.ts
+++ b/packages/core/src/renderables/LineNumberRenderable.ts
@@ -432,11 +432,11 @@ export class LineNumberRenderable extends Renderable {
     if (this.target) {
       // Remove event listener from old target
       this.target.off("line-info-change", this.handleLineInfoChange)
-      super.remove(this.target.id)
+      super.removeChild(this.target)
     }
 
     if (this.gutter) {
-      super.remove(this.gutter.id)
+      super.removeChild(this.gutter)
       this.gutter = null
     }
 
@@ -488,10 +488,11 @@ export class LineNumberRenderable extends Renderable {
       return
     }
 
-    if (this.gutter && id === this.gutter.id) {
+    const child = this.getRenderable(id)
+    if (this.gutter && child === this.gutter) {
       throw new Error("LineNumberRenderable: Cannot remove gutter directly.")
     }
-    if (this.target && id === this.target.id) {
+    if (this.target && child === this.target) {
       throw new Error("LineNumberRenderable: Cannot remove target directly. Use clearTarget() instead.")
     }
     super.remove(id)
@@ -514,11 +515,11 @@ export class LineNumberRenderable extends Renderable {
   public clearTarget(): void {
     if (this.target) {
       this.target.off("line-info-change", this.handleLineInfoChange)
-      super.remove(this.target.id)
+      super.removeChild(this.target)
       this.target = null
     }
     if (this.gutter) {
-      super.remove(this.gutter.id)
+      super.removeChild(this.gutter)
       this.gutter = null
     }
   }

--- a/packages/core/src/renderables/LineNumberRenderable.ts
+++ b/packages/core/src/renderables/LineNumberRenderable.ts
@@ -1,4 +1,4 @@
-import { Renderable, type RenderableOptions } from "../Renderable.js"
+import { Renderable, type BaseRenderable, type RenderableOptions } from "../Renderable.js"
 import { OptimizedBuffer } from "../buffer.js"
 import type { RenderContext, LineInfoProvider } from "../types.js"
 import { RGBA, parseColor } from "../lib/RGBA.js"
@@ -432,11 +432,11 @@ export class LineNumberRenderable extends Renderable {
     if (this.target) {
       // Remove event listener from old target
       this.target.off("line-info-change", this.handleLineInfoChange)
-      super.removeChild(this.target)
+      super.remove(this.target)
     }
 
     if (this.gutter) {
-      super.removeChild(this.gutter)
+      super.remove(this.gutter)
       this.gutter = null
     }
 
@@ -482,20 +482,19 @@ export class LineNumberRenderable extends Renderable {
   }
 
   // Override remove to prevent removing gutter/target directly
-  public override remove(id: string): void {
+  public override remove(child: BaseRenderable): void {
     if (this._isDestroying) {
-      super.remove(id)
+      super.remove(child)
       return
     }
 
-    const child = this.getRenderable(id)
     if (this.gutter && child === this.gutter) {
       throw new Error("LineNumberRenderable: Cannot remove gutter directly.")
     }
     if (this.target && child === this.target) {
       throw new Error("LineNumberRenderable: Cannot remove target directly. Use clearTarget() instead.")
     }
-    super.remove(id)
+    super.remove(child)
   }
 
   // Override destroyRecursively to properly clean up internal components
@@ -515,11 +514,11 @@ export class LineNumberRenderable extends Renderable {
   public clearTarget(): void {
     if (this.target) {
       this.target.off("line-info-change", this.handleLineInfoChange)
-      super.removeChild(this.target)
+      super.remove(this.target)
       this.target = null
     }
     if (this.gutter) {
-      super.removeChild(this.gutter)
+      super.remove(this.gutter)
       this.gutter = null
     }
   }

--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -1,7 +1,7 @@
 import { type KeyEvent } from "../lib/index.js"
 import { getObjectsInViewport } from "../lib/objects-in-viewport.js"
 import { LinearScrollAccel, MacOSScrollAccel, type ScrollAcceleration } from "../lib/scroll-acceleration.js"
-import type { Renderable, RenderableOptions } from "../Renderable.js"
+import type { BaseRenderable, Renderable, RenderableOptions } from "../Renderable.js"
 import type { MouseEvent } from "../renderer.js"
 import type { RenderContext } from "../types.js"
 import { BoxRenderable, type BoxOptions } from "./Box.js"
@@ -521,6 +521,10 @@ export class ScrollBoxRenderable extends BoxRenderable {
 
   public remove(id: string): void {
     this.content.remove(id)
+  }
+
+  public removeChild(child: BaseRenderable): void {
+    this.content.removeChild(child)
   }
 
   public getChildren(): Renderable[] {

--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -519,16 +519,16 @@ export class ScrollBoxRenderable extends BoxRenderable {
     return this.content.insertBefore(obj, anchor)
   }
 
-  public remove(id: string): void {
-    this.content.remove(id)
-  }
-
-  public removeChild(child: BaseRenderable): void {
-    this.content.removeChild(child)
+  public remove(child: BaseRenderable): void {
+    this.content.remove(child)
   }
 
   public getChildren(): Renderable[] {
     return this.content.getChildren()
+  }
+
+  public getRenderable(id: string): Renderable | undefined {
+    return this.content.getRenderable(id)
   }
 
   protected onMouseEvent(event: MouseEvent): void {

--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -520,6 +520,14 @@ export class ScrollBoxRenderable extends BoxRenderable {
   }
 
   public remove(child: BaseRenderable): void {
+    // Internal parts (wrapper, scrollbars) are direct children of the root,
+    // not of content. Route by actual parentage so destroy() and explicit
+    // removals of internals detach them instead of silently no-oping through
+    // the content delegation.
+    if (child.parent === this) {
+      super.remove(child)
+      return
+    }
     this.content.remove(child)
   }
 

--- a/packages/core/src/renderables/Text.test.ts
+++ b/packages/core/src/renderables/Text.test.ts
@@ -761,7 +761,7 @@ describe("TextRenderable Selection", () => {
       await renderOnce()
       expect(text.plainText).toBe("Hello Cruel World")
 
-      text.remove(node2.id)
+      text.remove(node2)
 
       await renderOnce()
 
@@ -782,7 +782,7 @@ describe("TextRenderable Selection", () => {
       await renderOnce()
       expect(text.plainText).toBe("Test")
 
-      text.remove(node.id)
+      text.remove(node)
 
       await renderOnce()
       expect(text.plainText).toBe("")
@@ -958,7 +958,7 @@ describe("TextRenderable Selection", () => {
       await renderOnce()
       expect(text.plainText).toBe("Initial A B C D")
 
-      text.remove(nodeB.id)
+      text.remove(nodeB)
 
       await renderOnce()
       expect(text.plainText).toBe("Initial A C D")
@@ -2399,7 +2399,7 @@ describe("TextRenderable Selection", () => {
       const charFrame = captureFrame()
 
       // Remove the char text and add word text
-      currentRenderer.root.remove(charText.id)
+      currentRenderer.root.remove(charText)
       await renderOnce()
 
       await createTextRenderable(currentRenderer, {

--- a/packages/core/src/renderables/Text.ts
+++ b/packages/core/src/renderables/Text.ts
@@ -100,12 +100,8 @@ export class TextRenderable extends TextBufferRenderable {
     return this.rootTextNode.add(obj, index)
   }
 
-  public remove(id: string): void {
-    this.rootTextNode.remove(id)
-  }
-
-  public removeChild(child: BaseRenderable): void {
-    this.rootTextNode.removeChild(child)
+  public remove(child: BaseRenderable): void {
+    this.rootTextNode.remove(child)
   }
 
   public insertBefore(obj: BaseRenderable | any, anchor?: TextNodeRenderable): number {

--- a/packages/core/src/renderables/Text.ts
+++ b/packages/core/src/renderables/Text.ts
@@ -104,6 +104,10 @@ export class TextRenderable extends TextBufferRenderable {
     this.rootTextNode.remove(id)
   }
 
+  public removeChild(child: BaseRenderable): void {
+    this.rootTextNode.removeChild(child)
+  }
+
   public insertBefore(obj: BaseRenderable | any, anchor?: TextNodeRenderable): number {
     this.rootTextNode.insertBefore(obj, anchor)
     return this.rootTextNode.children.indexOf(obj)

--- a/packages/core/src/renderables/TextNode.test.ts
+++ b/packages/core/src/renderables/TextNode.test.ts
@@ -302,6 +302,15 @@ describe("TextNodeRenderable", () => {
 
       expect(() => node.remove(child)).not.toThrow()
     })
+
+    it("should reject string ids at runtime", () => {
+      const node = new TextNodeRenderable({})
+      const child = new TextNodeRenderable({ id: "child" })
+      node.add(child)
+
+      expect(() => (node as any).remove("child")).toThrow("remove expects a TextNodeRenderable child object")
+      expect(node.children[0]).toBe(child)
+    })
   })
 
   describe("clear Method", () => {

--- a/packages/core/src/renderables/TextNode.test.ts
+++ b/packages/core/src/renderables/TextNode.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test"
+import { describe, expect, it, spyOn } from "bun:test"
 import { TextNodeRenderable, isTextNodeRenderable } from "./TextNode.js"
 import { RGBA } from "../lib/RGBA.js"
 import { StyledText, red, bold, t } from "../lib/styled-text.js"
@@ -296,11 +296,31 @@ describe("TextNodeRenderable", () => {
       expect(first.parent).toBeNull()
     })
 
-    it("should ignore a child not contained by the node", () => {
+    it("should warn in dev instead of throwing for a child not contained by the node", () => {
       const node = new TextNodeRenderable({})
       const child = new TextNodeRenderable({})
 
-      expect(() => node.remove(child)).not.toThrow()
+      const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+      try {
+        expect(() => node.remove(child)).not.toThrow()
+        expect(warnSpy).toHaveBeenCalledTimes(1)
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    it("should not warn when removing an actual child", () => {
+      const node = new TextNodeRenderable({})
+      const child = new TextNodeRenderable({})
+      node.add(child)
+
+      const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+      try {
+        node.remove(child)
+        expect(warnSpy).not.toHaveBeenCalled()
+      } finally {
+        warnSpy.mockRestore()
+      }
     })
 
     it("should reject string ids at runtime", () => {

--- a/packages/core/src/renderables/TextNode.test.ts
+++ b/packages/core/src/renderables/TextNode.test.ts
@@ -264,7 +264,7 @@ describe("TextNodeRenderable", () => {
       node.add(child)
       node.add("Last")
 
-      node.remove(child.id)
+      node.remove(child)
 
       expect(node.children).toEqual(["First", "Last"])
       expect(child.parent).toBeNull()
@@ -280,7 +280,7 @@ describe("TextNodeRenderable", () => {
 
       expect(node.getRenderable("duplicate")).toBe(first)
 
-      node.removeChild(second)
+      node.remove(second)
 
       expect(node.children).toHaveLength(1)
       expect(node.children[0]).toBe(first)
@@ -288,18 +288,19 @@ describe("TextNodeRenderable", () => {
       expect(second.parent).toBeNull()
       expect(node.getRenderable("duplicate")).toBe(first)
 
-      node.remove("duplicate")
+      const found = node.getRenderable("duplicate")
+      expect(found).toBe(first)
+      if (found) node.remove(found)
 
       expect(node.children).toHaveLength(0)
       expect(first.parent).toBeNull()
     })
 
-    it("should throw error when child not found in remove", () => {
+    it("should ignore a child not contained by the node", () => {
       const node = new TextNodeRenderable({})
+      const child = new TextNodeRenderable({})
 
-      expect(() => {
-        node.remove("nonexistent-id")
-      }).toThrow("Child not found in children")
+      expect(() => node.remove(child)).not.toThrow()
     })
   })
 

--- a/packages/core/src/renderables/TextNode.test.ts
+++ b/packages/core/src/renderables/TextNode.test.ts
@@ -270,6 +270,30 @@ describe("TextNodeRenderable", () => {
       expect(child.parent).toBeNull()
     })
 
+    it("should remove duplicate-id children by first public match or exact object", () => {
+      const node = new TextNodeRenderable({})
+      const first = new TextNodeRenderable({ id: "duplicate" })
+      const second = new TextNodeRenderable({ id: "duplicate" })
+
+      node.add(first)
+      node.add(second)
+
+      expect(node.getRenderable("duplicate")).toBe(first)
+
+      node.removeChild(second)
+
+      expect(node.children).toHaveLength(1)
+      expect(node.children[0]).toBe(first)
+      expect(first.parent).toBe(node)
+      expect(second.parent).toBeNull()
+      expect(node.getRenderable("duplicate")).toBe(first)
+
+      node.remove("duplicate")
+
+      expect(node.children).toHaveLength(0)
+      expect(first.parent).toBeNull()
+    })
+
     it("should throw error when child not found in remove", () => {
       const node = new TextNodeRenderable({})
 

--- a/packages/core/src/renderables/TextNode.ts
+++ b/packages/core/src/renderables/TextNode.ts
@@ -196,7 +196,9 @@ export class TextNodeRenderable extends BaseRenderable {
   }
 
   public remove(child: BaseRenderable): void {
-    if (!isTextNodeRenderable(child)) return
+    if (!isTextNodeRenderable(child)) {
+      throw new Error("remove expects a TextNodeRenderable child object")
+    }
 
     const childIndex = this._children.indexOf(child)
     if (childIndex === -1) return

--- a/packages/core/src/renderables/TextNode.ts
+++ b/packages/core/src/renderables/TextNode.ts
@@ -201,7 +201,12 @@ export class TextNodeRenderable extends BaseRenderable {
     }
 
     const childIndex = this._children.indexOf(child)
-    if (childIndex === -1) return
+    if (childIndex === -1) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(`TextNodeRenderable with id ${child.id} is not a child of ${this.id}, skipping remove`)
+      }
+      return
+    }
 
     this._children.splice(childIndex, 1)
     child.parent = null

--- a/packages/core/src/renderables/TextNode.ts
+++ b/packages/core/src/renderables/TextNode.ts
@@ -55,6 +55,21 @@ export class TextNodeRenderable extends BaseRenderable {
   }
 
   public set children(children: (string | TextNodeRenderable)[]) {
+    for (const child of this._children) {
+      if (isTextNodeRenderable(child) && child.parent === this) {
+        child.parent = null
+      }
+    }
+
+    for (const child of children) {
+      if (isTextNodeRenderable(child)) {
+        if (child.parent && child.parent !== this) {
+          child.parent.removeChild(child)
+        }
+        child.parent = this
+      }
+    }
+
     this._children = children
     this.requestRender()
   }
@@ -79,15 +94,8 @@ export class TextNodeRenderable extends BaseRenderable {
     }
 
     if (isTextNodeRenderable(obj)) {
-      if (index !== undefined) {
-        this._children.splice(index, 0, obj)
-        obj.parent = this
-        this.requestRender()
-        return index
-      }
-
-      const insertIndex = this._children.length
-      this._children.push(obj)
+      const insertIndex = this.prepareChildInsert(obj, index)
+      this._children.splice(insertIndex, 0, obj)
       obj.parent = this
       this.requestRender()
       return insertIndex
@@ -112,11 +120,42 @@ export class TextNodeRenderable extends BaseRenderable {
     throw new Error("TextNodeRenderable only accepts strings, TextNodeRenderable instances, or StyledText instances")
   }
 
+  private prepareChildInsert(child: TextNodeRenderable, index?: number): number {
+    let insertIndex = index ?? this._children.length
+
+    if (child.parent && child.parent !== this) {
+      child.parent.removeChild(child)
+    } else if (child.parent === this) {
+      const currentIndex = this._children.indexOf(child)
+      if (currentIndex !== -1) {
+        this._children.splice(currentIndex, 1)
+        if (currentIndex < insertIndex) insertIndex -= 1
+      }
+    }
+
+    return Math.max(0, Math.min(insertIndex, this._children.length))
+  }
+
   public replace(obj: TextNodeRenderable | string, index: number) {
-    this._children[index] = obj
-    if (typeof obj !== "string") {
+    const existing = this._children[index]
+    if (isTextNodeRenderable(existing) && existing.parent === this) {
+      existing.parent = null
+    }
+
+    if (isTextNodeRenderable(obj)) {
+      if (obj.parent && obj.parent !== this) {
+        obj.parent.removeChild(obj)
+      } else if (obj.parent === this) {
+        const currentIndex = this._children.indexOf(obj)
+        if (currentIndex !== -1 && currentIndex !== index) {
+          this._children.splice(currentIndex, 1)
+          if (currentIndex < index) index -= 1
+        }
+      }
       obj.parent = this
     }
+
+    this._children[index] = obj
     this.requestRender()
   }
 
@@ -133,12 +172,18 @@ export class TextNodeRenderable extends BaseRenderable {
       throw new Error("Anchor node not found in children")
     }
 
+    if (child === anchorNode) {
+      return this
+    }
+
+    if (isTextNodeRenderable(child)) {
+      this.add(child, anchorIndex)
+      return this
+    }
+
     if (typeof child === "string") {
       this._children.splice(anchorIndex, 0, child)
-    } else if (isTextNodeRenderable(child)) {
-      this._children.splice(anchorIndex, 0, child)
-      child.parent = this
-    } else if (child instanceof StyledText) {
+    } else if (isStyledText(child)) {
       const textNodes = styledTextToTextNodes(child)
       this._children.splice(anchorIndex, 0, ...textNodes)
       textNodes.forEach((node) => (node.parent = this))
@@ -151,20 +196,32 @@ export class TextNodeRenderable extends BaseRenderable {
   }
 
   public remove(id: string): this {
-    const childIndex = this.getRenderableIndex(id)
-    if (childIndex === -1) {
+    const child = this.getRenderable(id)
+    if (!child) {
       throw new Error("Child not found in children")
     }
 
-    const child = this._children[childIndex] as TextNodeRenderable
+    this.removeChild(child)
+    return this
+  }
+
+  public removeChild(child: BaseRenderable): void {
+    if (!isTextNodeRenderable(child)) return
+
+    const childIndex = this._children.indexOf(child)
+    if (childIndex === -1) return
 
     this._children.splice(childIndex, 1)
     child.parent = null
     this.requestRender()
-    return this
   }
 
   public clear(): void {
+    for (const child of this._children) {
+      if (isTextNodeRenderable(child) && child.parent === this) {
+        child.parent = null
+      }
+    }
     this._children = []
     this.requestRender()
   }

--- a/packages/core/src/renderables/TextNode.ts
+++ b/packages/core/src/renderables/TextNode.ts
@@ -64,7 +64,7 @@ export class TextNodeRenderable extends BaseRenderable {
     for (const child of children) {
       if (isTextNodeRenderable(child)) {
         if (child.parent && child.parent !== this) {
-          child.parent.removeChild(child)
+          child.parent.remove(child)
         }
         child.parent = this
       }
@@ -124,7 +124,7 @@ export class TextNodeRenderable extends BaseRenderable {
     let insertIndex = index ?? this._children.length
 
     if (child.parent && child.parent !== this) {
-      child.parent.removeChild(child)
+      child.parent.remove(child)
     } else if (child.parent === this) {
       const currentIndex = this._children.indexOf(child)
       if (currentIndex !== -1) {
@@ -144,7 +144,7 @@ export class TextNodeRenderable extends BaseRenderable {
 
     if (isTextNodeRenderable(obj)) {
       if (obj.parent && obj.parent !== this) {
-        obj.parent.removeChild(obj)
+        obj.parent.remove(obj)
       } else if (obj.parent === this) {
         const currentIndex = this._children.indexOf(obj)
         if (currentIndex !== -1 && currentIndex !== index) {
@@ -195,17 +195,7 @@ export class TextNodeRenderable extends BaseRenderable {
     return this
   }
 
-  public remove(id: string): this {
-    const child = this.getRenderable(id)
-    if (!child) {
-      throw new Error("Child not found in children")
-    }
-
-    this.removeChild(child)
-    return this
-  }
-
-  public removeChild(child: BaseRenderable): void {
+  public remove(child: BaseRenderable): void {
     if (!isTextNodeRenderable(child)) return
 
     const childIndex = this._children.indexOf(child)

--- a/packages/core/src/renderables/composition/vnode.ts
+++ b/packages/core/src/renderables/composition/vnode.ts
@@ -151,20 +151,8 @@ export function wrapWithDelegates<T extends InstanceType<RenderableConstructor>>
 ): T {
   if (!delegateMap || Object.keys(delegateMap).length === 0) return instance
 
-  const descendantCache = new Map<string, Renderable | undefined>()
-
   const getDescendant = (id: string): Renderable | undefined => {
-    if (descendantCache.has(id)) {
-      const cached = descendantCache.get(id)
-      if (cached !== undefined) {
-        return cached
-      }
-    }
-    const descendant = (instance as Renderable).findDescendantById(id)
-    if (descendant) {
-      descendantCache.set(id, descendant)
-    }
-    return descendant
+    return (instance as Renderable).findDescendantById(id)
   }
 
   const proxy = new Proxy(instance as any, {

--- a/packages/core/src/tests/renderable.test.ts
+++ b/packages/core/src/tests/renderable.test.ts
@@ -22,10 +22,7 @@ export class TestBaseRenderable extends BaseRenderable {
   add(obj: BaseRenderable | unknown, index?: number): number {
     throw new Error("Method not implemented.")
   }
-  remove(id: string): void {
-    throw new Error("Method not implemented.")
-  }
-  removeChild(child: BaseRenderable): void {
+  remove(child: BaseRenderable): void {
     throw new Error("Method not implemented.")
   }
   insertBefore(obj: BaseRenderable | unknown, anchor: BaseRenderable | unknown): void {
@@ -279,13 +276,13 @@ describe("Renderable - Child Management", () => {
     expect(index2).toBe(1)
     expect(parent.getChildrenCount()).toBe(2)
 
-    parent.remove("child1")
+    parent.remove(child1)
     expect(parent.getChildrenCount()).toBe(1)
     expect(parent.getRenderable("child1")).toBeUndefined()
     expect(parent.getRenderable("child2")).toBe(child2)
   })
 
-  test("public id lookup and removal use first matching duplicate child", () => {
+  test("public id lookup returns first matching duplicate child", () => {
     const parent = new TestRenderable(testRenderer, { id: "parent" })
     const first = new TestRenderable(testRenderer, { id: "duplicate" })
     const second = new TestRenderable(testRenderer, { id: "duplicate" })
@@ -298,7 +295,9 @@ describe("Renderable - Child Management", () => {
     expect(parent.getRenderable("duplicate")).toBe(first)
     expect(parent.findDescendantById("duplicate")).toBe(first)
 
-    parent.remove("duplicate")
+    const found = parent.getRenderable("duplicate")
+    expect(found).toBe(first)
+    if (found) parent.remove(found)
 
     const children = parent.getChildren()
     expect(children).toHaveLength(2)
@@ -309,7 +308,7 @@ describe("Renderable - Child Management", () => {
     expect(parent.getRenderable("duplicate")).toBe(second)
   })
 
-  test("object removal detaches the exact duplicate-id child", () => {
+  test("remove detaches the exact duplicate-id child", () => {
     const parent = new TestRenderable(testRenderer, { id: "parent" })
     const first = new TestRenderable(testRenderer, { id: "duplicate" })
     const second = new TestRenderable(testRenderer, { id: "duplicate" })
@@ -319,7 +318,7 @@ describe("Renderable - Child Management", () => {
     parent.add(second)
     parent.add(tail)
 
-    parent.removeChild(second)
+    parent.remove(second)
 
     const children = parent.getChildren()
     expect(children).toHaveLength(2)
@@ -1656,7 +1655,7 @@ describe("Renderable - Complex Layout Update Scenarios", () => {
     expect(child1InitialY).toBe(0)
     expect(child2InitialY).toBe(30)
 
-    parent.remove(child1.id)
+    parent.remove(child1)
     await renderOnce()
 
     expect(child2.y).toBe(0)

--- a/packages/core/src/tests/renderable.test.ts
+++ b/packages/core/src/tests/renderable.test.ts
@@ -338,6 +338,82 @@ describe("Renderable - Child Management", () => {
     expect(parent.getChildren()[0]).toBe(child)
   })
 
+  test("remove warns in dev when the object was never a child", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const child = new TestRenderable(testRenderer, { id: "child" })
+    const stranger = new TestRenderable(testRenderer, { id: "stranger" })
+    parent.add(child)
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      expect(() => parent.remove(stranger)).not.toThrow()
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(parent.getChildren()).toEqual([child])
+      expect(stranger.parent).toBeNull()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test("remove warns in dev and does not detach a child that belongs to another parent", () => {
+    const parentA = new TestRenderable(testRenderer, { id: "parent-a" })
+    const parentB = new TestRenderable(testRenderer, { id: "parent-b" })
+    const child = new TestRenderable(testRenderer, { id: "child" })
+    parentA.add(child)
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      parentB.remove(child)
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(child.parent).toBe(parentA)
+      expect(parentA.getChildren()).toEqual([child])
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test("remove warns in dev when passed a text node instead of a layout child", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const textNode = new TextNodeRenderable({ id: "text-node" })
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      expect(() => parent.remove(textNode)).not.toThrow()
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test("remove stays silent for actual children", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const child = new TestRenderable(testRenderer, { id: "child" })
+    parent.add(child)
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      parent.remove(child)
+      expect(warnSpy).not.toHaveBeenCalled()
+      expect(child.parent).toBeNull()
+      expect(parent.getChildrenCount()).toBe(0)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test("changing a child's id keeps parent lookups working", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const child = new TestRenderable(testRenderer, { id: "old-id" })
+    parent.add(child)
+
+    child.id = "new-id"
+
+    expect(child.id).toBe("new-id")
+    expect(parent.getRenderable("new-id")).toBe(child)
+    expect(parent.getRenderable("old-id")).toBeUndefined()
+    expect(parent.findDescendantById("new-id")).toBe(child)
+  })
+
   test("insertBefore accepts an anchor with the same public id", () => {
     const parent = new TestRenderable(testRenderer, { id: "parent" })
     const first = new TestRenderable(testRenderer, { id: "duplicate" })

--- a/packages/core/src/tests/renderable.test.ts
+++ b/packages/core/src/tests/renderable.test.ts
@@ -25,6 +25,9 @@ export class TestBaseRenderable extends BaseRenderable {
   remove(id: string): void {
     throw new Error("Method not implemented.")
   }
+  removeChild(child: BaseRenderable): void {
+    throw new Error("Method not implemented.")
+  }
   insertBefore(obj: BaseRenderable | unknown, anchor: BaseRenderable | unknown): void {
     throw new Error("Method not implemented.")
   }
@@ -280,6 +283,111 @@ describe("Renderable - Child Management", () => {
     expect(parent.getChildrenCount()).toBe(1)
     expect(parent.getRenderable("child1")).toBeUndefined()
     expect(parent.getRenderable("child2")).toBe(child2)
+  })
+
+  test("public id lookup and removal use first matching duplicate child", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const first = new TestRenderable(testRenderer, { id: "duplicate" })
+    const second = new TestRenderable(testRenderer, { id: "duplicate" })
+    const tail = new TestRenderable(testRenderer, { id: "tail" })
+
+    parent.add(first)
+    parent.add(second)
+    parent.add(tail)
+
+    expect(parent.getRenderable("duplicate")).toBe(first)
+    expect(parent.findDescendantById("duplicate")).toBe(first)
+
+    parent.remove("duplicate")
+
+    const children = parent.getChildren()
+    expect(children).toHaveLength(2)
+    expect(children[0]).toBe(second)
+    expect(children[1]).toBe(tail)
+    expect(first.parent).toBeNull()
+    expect(second.parent).toBe(parent)
+    expect(parent.getRenderable("duplicate")).toBe(second)
+  })
+
+  test("object removal detaches the exact duplicate-id child", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const first = new TestRenderable(testRenderer, { id: "duplicate" })
+    const second = new TestRenderable(testRenderer, { id: "duplicate" })
+    const tail = new TestRenderable(testRenderer, { id: "tail" })
+
+    parent.add(first)
+    parent.add(second)
+    parent.add(tail)
+
+    parent.removeChild(second)
+
+    const children = parent.getChildren()
+    expect(children).toHaveLength(2)
+    expect(children[0]).toBe(first)
+    expect(children[1]).toBe(tail)
+    expect(first.parent).toBe(parent)
+    expect(second.parent).toBeNull()
+    expect(parent.getRenderable("duplicate")).toBe(first)
+  })
+
+  test("insertBefore accepts an anchor with the same public id", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const first = new TestRenderable(testRenderer, { id: "duplicate" })
+    const second = new TestRenderable(testRenderer, { id: "duplicate" })
+    const tail = new TestRenderable(testRenderer, { id: "tail" })
+
+    parent.add(first)
+    parent.add(tail)
+    parent.insertBefore(second, first)
+
+    const children = parent.getChildren()
+    expect(children).toHaveLength(3)
+    expect(children[0]).toBe(second)
+    expect(children[1]).toBe(first)
+    expect(children[2]).toBe(tail)
+    expect(first.parent).toBe(parent)
+    expect(second.parent).toBe(parent)
+  })
+
+  test("reparenting moves the exact duplicate-id child", () => {
+    const oldParent = new TestRenderable(testRenderer, { id: "old-parent" })
+    const newParent = new TestRenderable(testRenderer, { id: "new-parent" })
+    const first = new TestRenderable(testRenderer, { id: "duplicate" })
+    const second = new TestRenderable(testRenderer, { id: "duplicate" })
+
+    oldParent.add(first)
+    oldParent.add(second)
+    newParent.add(second)
+
+    const oldChildren = oldParent.getChildren()
+    const newChildren = newParent.getChildren()
+    expect(oldChildren).toHaveLength(1)
+    expect(newChildren).toHaveLength(1)
+    expect(oldChildren[0]).toBe(first)
+    expect(newChildren[0]).toBe(second)
+    expect(first.parent).toBe(oldParent)
+    expect(second.parent).toBe(newParent)
+  })
+
+  test("destroying a duplicate-id child removes that exact child", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const first = new TestRenderable(testRenderer, { id: "duplicate" })
+    const second = new TestRenderable(testRenderer, { id: "duplicate" })
+    const tail = new TestRenderable(testRenderer, { id: "tail" })
+
+    parent.add(first)
+    parent.add(second)
+    parent.add(tail)
+
+    second.destroy()
+
+    const children = parent.getChildren()
+    expect(children).toHaveLength(2)
+    expect(children[0]).toBe(first)
+    expect(children[1]).toBe(tail)
+    expect(first.parent).toBe(parent)
+    expect(second.parent).toBeNull()
+    expect(second.isDestroyed).toBe(true)
   })
 
   test("renderBefore position changes update hit-grid coordinates in the same frame", async () => {

--- a/packages/core/src/tests/renderable.test.ts
+++ b/packages/core/src/tests/renderable.test.ts
@@ -261,6 +261,74 @@ describe("Renderable", () => {
   })
 })
 
+describe("Renderable - layout read caching invariants", () => {
+  // Behavioral contracts for any layout-read caching or batching scheme
+  // (the render-list reuse keyed on the context layout generation today, a
+  // native render tree with shared layout buffers tomorrow): every mutation
+  // that can change computed layout must be visible on the next frame, even
+  // when it bypasses the Renderable setters, and ancestor movement must
+  // cascade to descendant screen positions without a relayout.
+
+  test("direct yoga-node style mutation bypassing all setters is picked up next frame", async () => {
+    const box = new TestRenderable(testRenderer, { id: "yoga-bypass", width: 10, height: 2 })
+    testRenderer.root.add(box)
+    await renderOnce()
+    expect(box.width).toBe(10)
+
+    box.getLayoutNode().setWidth(30)
+    await renderOnce()
+
+    expect(box.width).toBe(30)
+  })
+
+  test("out-of-band subtree calculateLayout does not freeze later layout reads", async () => {
+    const parent = new TestRenderable(testRenderer, { id: "oob-parent", width: 40, height: 6 })
+    const child = new TestRenderable(testRenderer, { id: "oob-child", width: 10, height: 2 })
+    parent.add(child)
+    testRenderer.root.add(parent)
+    await renderOnce()
+    expect(child.width).toBe(10)
+
+    // Mutate and lay out the subtree directly through yoga, bypassing the
+    // renderer's root calculateLayout entirely.
+    child.getLayoutNode().setWidth(25)
+    parent.getLayoutNode().calculateLayout(undefined, undefined)
+    await renderOnce()
+
+    expect(child.width).toBe(25)
+  })
+
+  test("grandchild screen position follows a translate-only ancestor move", async () => {
+    const parent = new TestRenderable(testRenderer, {
+      id: "cascade-parent",
+      position: "absolute",
+      left: 2,
+      top: 2,
+      width: 30,
+      height: 10,
+    })
+    const child = new TestRenderable(testRenderer, { id: "cascade-child", width: 20, height: 6 })
+    const grandchild = new TestRenderable(testRenderer, { id: "cascade-grandchild", width: 10, height: 2 })
+
+    child.add(grandchild)
+    parent.add(child)
+    testRenderer.root.add(parent)
+    await renderOnce()
+
+    const beforeX = grandchild.screenX
+    const beforeY = grandchild.screenY
+
+    // Translate does not touch yoga: no relayout happens, only ancestor
+    // screen positions move. Every descendant must follow on the next frame.
+    parent.translateX = 7
+    parent.translateY = 5
+    await renderOnce()
+
+    expect(grandchild.screenX).toBe(beforeX + 7)
+    expect(grandchild.screenY).toBe(beforeY + 5)
+  })
+})
+
 describe("Renderable - Child Management", () => {
   test("can add and remove children", () => {
     const parent = new TestRenderable(testRenderer, { id: "parent" })

--- a/packages/core/src/tests/renderable.test.ts
+++ b/packages/core/src/tests/renderable.test.ts
@@ -329,6 +329,15 @@ describe("Renderable - Child Management", () => {
     expect(parent.getRenderable("duplicate")).toBe(first)
   })
 
+  test("remove rejects string ids at runtime", () => {
+    const parent = new TestRenderable(testRenderer, { id: "parent" })
+    const child = new TestRenderable(testRenderer, { id: "child" })
+    parent.add(child)
+
+    expect(() => (parent as any).remove("child")).toThrow("remove expects a renderable child object")
+    expect(parent.getChildren()[0]).toBe(child)
+  })
+
   test("insertBefore accepts an anchor with the same public id", () => {
     const parent = new TestRenderable(testRenderer, { id: "parent" })
     const first = new TestRenderable(testRenderer, { id: "duplicate" })

--- a/packages/core/src/tests/renderer.control.test.ts
+++ b/packages/core/src/tests/renderer.control.test.ts
@@ -363,7 +363,7 @@ test("mouse input is suspended when renderer is suspended", async () => {
   await mockMouse.click(0, 0)
   expect(mouseEventReceived).toBe(true)
 
-  renderer.root.remove(testRenderable.id)
+  renderer.root.remove(testRenderable)
 })
 
 test("paste input is suspended when renderer is suspended", () => {

--- a/packages/core/src/tests/renderer.focus-restore.test.ts
+++ b/packages/core/src/tests/renderer.focus-restore.test.ts
@@ -211,7 +211,7 @@ describe("focus restore - terminal mode re-enable on focus-in", () => {
     await mockMouse.click(5, 5)
     expect(mouseEventCount).toBeGreaterThan(countBefore)
 
-    renderer.root.remove(target.id)
+    renderer.root.remove(target)
   })
 
   test("keyboard input works after focus restore cycle", async () => {

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -130,6 +130,49 @@ describe("ScrollBoxRenderable - child delegation", () => {
   })
 })
 
+describe("ScrollBoxRenderable - culled content layout freshness", () => {
+  test("rows revealed after off-screen relayouts render at fresh positions", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "reveal-scrollbox",
+      width: 30,
+      height: 6,
+      viewportCulling: true,
+    })
+    testRenderer.root.add(scrollbox)
+
+    const rows: BoxRenderable[] = []
+    for (let i = 0; i < 40; i++) {
+      const row = new BoxRenderable(testRenderer, { id: `reveal-row-${i}`, height: 1, flexShrink: 0 })
+      row.add(new TextRenderable(testRenderer, { content: `row-${i}` }))
+      scrollbox.add(row)
+      rows.push(row)
+    }
+    await renderOnce()
+
+    scrollbox.scrollTo(scrollbox.scrollHeight)
+    await renderOnce()
+
+    // While the top rows are culled (their subtrees skipped by traversal),
+    // relayout several times so any staleness in skipped subtrees would have
+    // multiple chances to accumulate before the rows are revealed again.
+    for (const rowHeight of [2, 3, 2]) {
+      rows[0].height = rowHeight
+      await renderOnce()
+    }
+
+    scrollbox.scrollTo(0)
+    await renderOnce()
+
+    // row-0 is now 2 tall, so the following rows must have shifted down and
+    // their text subtrees must render at fresh absolute positions.
+    const lines = captureCharFrame().split("\n")
+    expect(lines[0]).toContain("row-0")
+    expect(lines[2]).toContain("row-1")
+    expect(lines[3]).toContain("row-2")
+    expect(lines[4]).toContain("row-3")
+  })
+})
+
 describe("ScrollBoxRenderable - clipping", () => {
   test("clips nested scrollbox content to inner viewport (see issue #388)", async () => {
     const root = new BoxRenderable(testRenderer, {

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, beforeEach, afterEach, describe } from "bun:test"
+import { test, expect, beforeEach, afterEach, describe, spyOn } from "bun:test"
 import { createTestRenderer, type TestRenderer, type MockMouse, MockTreeSitterClient } from "../testing.js"
 import { ScrollBoxRenderable } from "../renderables/ScrollBox.js"
 import { BoxRenderable } from "../renderables/Box.js"
@@ -89,6 +89,44 @@ describe("ScrollBoxRenderable - child delegation", () => {
     expect(children[0].id).toBe("child1")
     expect(children[1].id).toBe("child3")
     expect(children[2].id).toBe("child2")
+  })
+
+  test("destroyRecursively fully detaches internal parts without warnings", () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, { id: "scrollbox" })
+    const child = new BoxRenderable(testRenderer, { id: "child" })
+    scrollbox.add(child)
+
+    const wrapper = scrollbox.wrapper
+    const verticalScrollBar = scrollbox.verticalScrollBar
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      scrollbox.destroyRecursively()
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+
+    expect(wrapper.isDestroyed).toBe(true)
+    expect(wrapper.parent).toBeNull()
+    expect(verticalScrollBar.isDestroyed).toBe(true)
+    expect(verticalScrollBar.parent).toBeNull()
+    expect(child.isDestroyed).toBe(true)
+    expect(child.parent).toBeNull()
+  })
+
+  test("removing an internal part by reference detaches it from its real parent", () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, { id: "scrollbox" })
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      scrollbox.remove(scrollbox.verticalScrollBar)
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+
+    expect(scrollbox.verticalScrollBar.parent).toBeNull()
   })
 })
 

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -70,7 +70,7 @@ describe("ScrollBoxRenderable - child delegation", () => {
     scrollbox.add(child)
     expect(scrollbox.getChildren().length).toBe(1)
 
-    scrollbox.remove(child.id)
+    scrollbox.remove(child)
     expect(scrollbox.getChildren().length).toBe(0)
   })
 
@@ -1363,7 +1363,8 @@ console.log(processor.reduce((acc, val) => acc + val, 0))`
     // Force a size recalculation that programmatically clamps scrollTop to 0.
     // This must not be treated as a user returning to sticky position.
     for (let i = 0; i < 28; i++) {
-      scrollBox.remove(`line-${i}`)
+      const line = scrollBox.getRenderable(`line-${i}`)
+      if (line) scrollBox.remove(line)
     }
     await renderOnce()
 

--- a/packages/core/src/zig/renderer-output.zig
+++ b/packages/core/src/zig/renderer-output.zig
@@ -168,6 +168,7 @@ pub const OutputBackend = union(enum) {
 pub const BufferedBackend = struct {
     const BufferId = enum { A, B };
 
+    allocator: Allocator,
     output: BufferedOutput,
     ownedStdoutOutput: ?*StdoutOutput = null,
     ownedMemoryOutput: ?*MemoryOutput = null,
@@ -201,6 +202,7 @@ pub const BufferedBackend = struct {
         errdefer allocator.free(b_buf);
 
         return BufferedBackend{
+            .allocator = allocator,
             .output = output,
             .outputA = a_buf,
             .outputB = b_buf,
@@ -329,16 +331,16 @@ pub const BufferedBackend = struct {
             &self.outputLenA
         else
             &self.outputLenB;
-        const buffer = if (self.activeBuffer == .A)
-            self.outputA
-        else
-            self.outputB;
+        const required = bufferLen.* + data.len;
 
-        if (bufferLen.* + data.len > buffer.len) {
-            return error.BufferFull;
+        const buffer = if (self.activeBuffer == .A) &self.outputA else &self.outputB;
+
+        if (required > buffer.*.len) {
+            const capacity = @max(required, buffer.*.len * 2);
+            buffer.* = self.allocator.realloc(buffer.*, capacity) catch return error.BufferFull;
         }
 
-        @memcpy(buffer[bufferLen.*..][0..data.len], data);
+        @memcpy(buffer.*[bufferLen.*..][0..data.len], data);
         bufferLen.* += data.len;
         return data.len;
     }

--- a/packages/core/src/zig/renderer-output.zig
+++ b/packages/core/src/zig/renderer-output.zig
@@ -153,9 +153,9 @@ pub const OutputBackend = union(enum) {
         }
     }
 
-    pub fn deinit(self: *OutputBackend, allocator: Allocator) void {
+    pub fn deinit(self: *OutputBackend) void {
         switch (self.*) {
-            inline else => |*b| b.deinit(allocator),
+            inline else => |*b| b.deinit(),
         }
     }
 };
@@ -167,6 +167,12 @@ pub const OutputBackend = union(enum) {
 /// has isolated output storage.
 pub const BufferedBackend = struct {
     const BufferId = enum { A, B };
+
+    /// Number of consecutive frames that fit in the default buffer before an
+    /// oversized buffer is shrunk back to OUTPUT_BUFFER_SIZE. Keeps a workload
+    /// of sustained large frames from realloc-churning while still returning
+    /// spike memory once frames are consistently small again.
+    const SHRINK_AFTER_SMALL_FRAMES = 64;
 
     allocator: Allocator,
     output: BufferedOutput,
@@ -180,6 +186,11 @@ pub const BufferedBackend = struct {
     activeBuffer: BufferId = .A,
     lastCommittedBuffer: BufferId = .A,
     hasCommittedFrame: bool = false,
+    /// Set when frame bytes were dropped because a buffer could not grow.
+    /// endFrame consumes it and reports the frame as failed so the renderer
+    /// forces a full repaint instead of trusting the committed cell diff.
+    frameWriteFailed: bool = false,
+    smallFrameStreak: u32 = 0,
 
     useThread: bool = false,
     renderThread: ?std.Thread = null,
@@ -229,7 +240,10 @@ pub const BufferedBackend = struct {
         return backend;
     }
 
-    pub fn deinit(self: *BufferedBackend, allocator: Allocator) void {
+    /// Frees with the allocator captured at create time. The buffers may have
+    /// been realloc-grown by frame writes, so freeing them with any other
+    /// allocator would be undefined behavior.
+    pub fn deinit(self: *BufferedBackend) void {
         if (self.renderThread) |thread| {
             self.renderMutex.lock();
             while (self.renderInProgress) {
@@ -247,15 +261,15 @@ pub const BufferedBackend = struct {
             self.renderThread = null;
         }
 
-        allocator.free(self.outputA);
-        allocator.free(self.outputB);
+        self.allocator.free(self.outputA);
+        self.allocator.free(self.outputB);
         if (self.ownedStdoutOutput) |stdoutOutput| {
-            allocator.destroy(stdoutOutput);
+            self.allocator.destroy(stdoutOutput);
             self.ownedStdoutOutput = null;
         }
         if (self.ownedMemoryOutput) |memoryOutput| {
             memoryOutput.deinit();
-            allocator.destroy(memoryOutput);
+            self.allocator.destroy(memoryOutput);
             self.ownedMemoryOutput = null;
         }
     }
@@ -337,7 +351,10 @@ pub const BufferedBackend = struct {
 
         if (required > buffer.*.len) {
             const capacity = @max(required, buffer.*.len * 2);
-            buffer.* = self.allocator.realloc(buffer.*, capacity) catch return error.BufferFull;
+            buffer.* = self.allocator.realloc(buffer.*, capacity) catch {
+                self.frameWriteFailed = true;
+                return error.BufferFull;
+            };
         }
 
         @memcpy(buffer.*[bufferLen.*..][0..data.len], data);
@@ -352,6 +369,8 @@ pub const BufferedBackend = struct {
     }
 
     pub fn beginFrame(self: *BufferedBackend) void {
+        self.frameWriteFailed = false;
+        self.maybeShrinkActiveBuffer();
         if (self.activeBuffer == .A) {
             self.outputLenA = 0;
         } else {
@@ -359,8 +378,40 @@ pub const BufferedBackend = struct {
         }
     }
 
+    /// Give spike memory back once frames have been consistently small again.
+    /// Runs at frame start when the active buffer is exclusively owned by the
+    /// producer: in threaded mode the render thread only ever reads the buffer
+    /// handed off at the previous endFrame, which is the other one.
+    fn maybeShrinkActiveBuffer(self: *BufferedBackend) void {
+        if (self.smallFrameStreak < SHRINK_AFTER_SMALL_FRAMES) return;
+        const buffer = if (self.activeBuffer == .A) &self.outputA else &self.outputB;
+        if (buffer.*.len <= OUTPUT_BUFFER_SIZE) return;
+        buffer.* = self.allocator.realloc(buffer.*, OUTPUT_BUFFER_SIZE) catch return;
+    }
+
+    fn updateSmallFrameStreak(self: *BufferedBackend, frame_len: usize) void {
+        if (frame_len <= OUTPUT_BUFFER_SIZE) {
+            self.smallFrameStreak +|= 1;
+        } else {
+            self.smallFrameStreak = 0;
+        }
+    }
+
     pub fn endFrame(self: *BufferedBackend) WriteStatus {
         const frame_len = if (self.activeBuffer == .A) self.outputLenA else self.outputLenB;
+
+        if (self.frameWriteFailed) {
+            // Frame bytes were dropped mid-frame. Flushing the truncated ANSI
+            // stream could leave the terminal inside an escape sequence, so
+            // drop the partial frame entirely and report failure; the renderer
+            // reacts by forcing a full repaint on the next frame.
+            self.frameWriteFailed = false;
+            self.smallFrameStreak = 0;
+            return .failed;
+        }
+
+        self.updateSmallFrameStreak(frame_len);
+
         if (self.useThread and frame_len == 0) {
             self.lastCommittedBuffer = self.activeBuffer;
             self.hasCommittedFrame = true;
@@ -520,7 +571,7 @@ pub const FeedBackend = struct {
         return FeedBackend{ .feed = feed };
     }
 
-    pub fn deinit(_: *FeedBackend, _: Allocator) void {
+    pub fn deinit(_: *FeedBackend) void {
         // Feed memory is owned by the TypeScript side. Nothing to free here.
     }
 

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -289,7 +289,7 @@ pub const CliRenderer = struct {
             .buffered => |buffered_output| .{ .buffered = try BufferedBackend.create(allocator, buffered_output) },
             .feed => |feed_ptr| .{ .feed = FeedBackend.create(feed_ptr) },
         };
-        errdefer backend.deinit(allocator);
+        errdefer backend.deinit();
 
         self.* = .{
             .width = width,
@@ -359,7 +359,7 @@ pub const CliRenderer = struct {
         // without replaying the stale last-frame buffer on top of the
         // freshly-restored terminal.
         self.performShutdownSequence();
-        self.backend.deinit(self.allocator);
+        self.backend.deinit();
         self.terminal.deinit();
 
         self.currentRenderBuffer.deinit();

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -17,6 +17,20 @@ const RGBA = text_buffer.RGBA;
 const TestMemoryOutput = test_renderer_mod.TestMemoryOutput;
 const TestRenderer = test_renderer_mod.TestRenderer;
 
+const CountingOutput = struct {
+    writes: u32 = 0,
+
+    fn bufferedOutput(self: *CountingOutput) @import("../renderer-output.zig").BufferedOutput {
+        return .{ .ctx = self, .write_fn = write, .thread_safe = true };
+    }
+
+    fn write(ctx: *anyopaque, data: []const u8) void {
+        const self: *CountingOutput = @ptrCast(@alignCast(ctx));
+        _ = data;
+        self.writes += 1;
+    }
+};
+
 const SlowThreadSafeOutput = struct {
     delay_ns: u64,
     writes: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
@@ -832,6 +846,9 @@ test "renderer - grows frame output instead of committing cells whose ANSI was d
         const output = test_cli_renderer.lastOutput();
         const current = cli_renderer.getCurrentBuffer();
 
+        // Guard that this test actually exercises the growth path: the frame
+        // must not fit in the default output buffer.
+        try std.testing.expect(output.len > renderer.OUTPUT_BUFFER_SIZE);
         try std.testing.expect(current.get(width - 24, height - 1).?.char == 'F');
         try std.testing.expect(std.mem.indexOf(u8, output, "EARLY_SCROLL_CHANGED") != null);
         try std.testing.expect(std.mem.indexOf(u8, output, "FULL_TOOL_RESULT_MARKER") != null);
@@ -2472,7 +2489,7 @@ test "threaded buffered destroy: no stale write after shutdown ANSI" {
 test "threaded buffered backend skips instead of blocking behind output" {
     var output = SlowThreadSafeOutput{ .delay_ns = 200 * std.time.ns_per_ms };
     var backend = try renderer.BufferedBackend.create(std.testing.allocator, output.bufferedOutput());
-    defer backend.deinit(std.testing.allocator);
+    defer backend.deinit();
     backend.setUseThread(true);
 
     backend.beginFrame();
@@ -2496,4 +2513,92 @@ test "threaded buffered backend skips instead of blocking behind output" {
     backend.setUseThread(false);
     try std.testing.expectEqual(@as(u32, 2), output.writes.load(.monotonic));
     try std.testing.expectEqualStrings("next graphics frame", output.payloads[1][0..output.lengths[1]]);
+}
+
+test "buffered backend reports a failed frame when growth allocation fails" {
+    const rout = @import("../renderer-output.zig");
+    // Initial create performs exactly two allocations (buffer A and B). The
+    // growth realloc is the next allocation/resize, which must fail.
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{
+        .fail_index = 2,
+        .resize_fail_index = 0,
+    });
+    var out = CountingOutput{};
+    var backend = try renderer.BufferedBackend.create(failing.allocator(), out.bufferedOutput());
+    defer backend.deinit();
+
+    backend.beginFrame();
+    var w = backend.writer();
+    const chunk = [_]u8{'x'} ** 4096;
+    var write_failed = false;
+    var written: usize = 0;
+    while (written <= renderer.OUTPUT_BUFFER_SIZE) : (written += chunk.len) {
+        w.writeAll(&chunk) catch {
+            write_failed = true;
+            break;
+        };
+    }
+    try std.testing.expect(write_failed);
+
+    // A frame whose bytes were dropped must be reported as failed so the
+    // renderer can force a full repaint, and the truncated ANSI stream must
+    // not reach the terminal.
+    try std.testing.expectEqual(rout.WriteStatus.failed, backend.endFrame());
+    try std.testing.expectEqual(@as(u32, 0), out.writes);
+
+    // The failure is per-frame: a following frame that fits reports ok.
+    backend.beginFrame();
+    try backend.writer().writeAll("recovered");
+    try std.testing.expectEqual(rout.WriteStatus.ok, backend.endFrame());
+    try std.testing.expect(out.writes >= 1);
+}
+
+test "buffered backend releases oversized frame buffers after the spike passes" {
+    var gpa = std.heap.GeneralPurposeAllocator(.{ .enable_memory_limit = true }){};
+    defer std.debug.assert(gpa.deinit() == .ok);
+    var out = CountingOutput{};
+
+    var backend = try renderer.BufferedBackend.create(gpa.allocator(), out.bufferedOutput());
+    defer backend.deinit();
+
+    // One pathological frame that grows the active buffer to ~4x the default.
+    backend.beginFrame();
+    var w = backend.writer();
+    const chunk = [_]u8{'x'} ** 4096;
+    var written: usize = 0;
+    while (written < 4 * renderer.OUTPUT_BUFFER_SIZE) : (written += chunk.len) {
+        try w.writeAll(&chunk);
+    }
+    _ = backend.endFrame();
+    try std.testing.expect(gpa.total_requested_bytes > 3 * renderer.OUTPUT_BUFFER_SIZE);
+
+    // A long run of ordinary frames afterwards must release the spike memory
+    // instead of pinning it for the lifetime of the renderer.
+    var i: usize = 0;
+    while (i < 200) : (i += 1) {
+        backend.beginFrame();
+        try backend.writer().writeAll("small frame");
+        _ = backend.endFrame();
+    }
+
+    try std.testing.expect(gpa.total_requested_bytes <= 3 * renderer.OUTPUT_BUFFER_SIZE);
+}
+
+test "buffered backend frees grown buffers cleanly on deinit" {
+    // Regression guard for the alloc/free pairing: buffers grown by frame
+    // writes must be freed by the same allocator that grew them. deinit no
+    // longer takes an allocator parameter, so a mismatch is unrepresentable;
+    // std.testing.allocator verifies there is no leak and no invalid free.
+    var out = CountingOutput{};
+    var backend = try renderer.BufferedBackend.create(std.testing.allocator, out.bufferedOutput());
+    defer backend.deinit();
+
+    backend.beginFrame();
+    var w = backend.writer();
+    const chunk = [_]u8{'x'} ** 4096;
+    var written: usize = 0;
+    while (written < 2 * renderer.OUTPUT_BUFFER_SIZE) : (written += chunk.len) {
+        try w.writeAll(&chunk);
+    }
+    try std.testing.expectEqual(@import("../renderer-output.zig").WriteStatus.ok, backend.endFrame());
 }

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -793,6 +793,51 @@ test "renderer - unchanged grapheme should not churn IDs across frames" {
     try std.testing.expect(std.mem.indexOf(u8, second_output, "👋") == null);
 }
 
+test "renderer - grows frame output instead of committing cells whose ANSI was dropped" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+
+    const width: u32 = 1000;
+    const height: u32 = 160;
+    for ([_]bool{ false, true }) |threaded| {
+        var test_cli_renderer = if (threaded)
+            try TestRenderer.createThreadSafe(std.testing.allocator, width, height, pool)
+        else
+            try TestRenderer.create(std.testing.allocator, width, height, pool);
+        defer test_cli_renderer.deinit();
+        const cli_renderer = test_cli_renderer.renderer;
+        if (threaded) cli_renderer.setUseThread(true);
+        const next = cli_renderer.getNextBuffer();
+        const bg = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0);
+
+        for (0..height) |y| {
+            for (0..width) |x| {
+                const value: u8 = @intCast((x + y * width) % 255);
+                const fg = ansi.rgbColor(value, 255 - value, value / 2, 255);
+                next.set(@intCast(x), @intCast(y), .{ .char = 'X', .fg = fg, .bg = bg, .attributes = 0 });
+            }
+        }
+        try next.drawText("EARLY_SCROLL_CHANGED", 0, 0, ansi.rgbaFromFloats(1, 1, 1, 1), bg, 0);
+        try next.drawText(
+            "FULL_TOOL_RESULT_MARKER",
+            width - 24,
+            height - 1,
+            ansi.rgbaFromFloats(1, 1, 1, 1),
+            bg,
+            0,
+        );
+
+        _ = cli_renderer.render(false);
+        if (threaded) cli_renderer.setUseThread(false);
+        const output = test_cli_renderer.lastOutput();
+        const current = cli_renderer.getCurrentBuffer();
+
+        try std.testing.expect(current.get(width - 24, height - 1).?.char == 'F');
+        try std.testing.expect(std.mem.indexOf(u8, output, "EARLY_SCROLL_CHANGED") != null);
+        try std.testing.expect(std.mem.indexOf(u8, output, "FULL_TOOL_RESULT_MARKER") != null);
+    }
+}
+
 test "renderer - hyperlinks enabled with OSC 8 output" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/examples/src/console-demo.ts
+++ b/packages/examples/src/console-demo.ts
@@ -318,27 +318,29 @@ export function destroy(renderer: CliRenderer): void {
   renderer.clearFrameCallbacks()
 
   if (titleText) {
-    renderer.root.remove("console_demo_title")
+    renderer.root.remove(titleText)
     titleText = null
   }
 
   if (instructionsText) {
-    renderer.root.remove("console_demo_instructions")
+    renderer.root.remove(instructionsText)
     instructionsText = null
   }
 
   if (statusText) {
-    renderer.root.remove("console_demo_status")
+    renderer.root.remove(statusText)
     statusText = null
   }
 
   for (const button of consoleButtons) {
-    renderer.root.remove(button.id)
+    renderer.root.remove(button)
   }
   consoleButtons = []
 
-  renderer.root.remove("decor1")
-  renderer.root.remove("decor2")
+  for (const id of ["decor1", "decor2"]) {
+    const decor = renderer.root.getRenderable(id)
+    if (decor) renderer.root.remove(decor)
+  }
 
   buttonCounters = {
     log: 0,

--- a/packages/examples/src/draggable-three-demo.ts
+++ b/packages/examples/src/draggable-three-demo.ts
@@ -243,7 +243,8 @@ export function destroy(renderer: CliRenderer): void {
   }
 
   if (parentContainer) {
-    renderer.root.remove("draggable-three-container")
+    const draggableThreeContainer = renderer.root.getRenderable("draggable-three-container")
+    if (draggableThreeContainer) renderer.root.remove(draggableThreeContainer)
     parentContainer = null
   }
 }

--- a/packages/examples/src/focus-restore-demo.ts
+++ b/packages/examples/src/focus-restore-demo.ts
@@ -64,7 +64,7 @@ function addLogLine(renderer: CliRenderer, text: string, color: RGBA) {
 
   // Remove old renderables
   for (const r of logRenderables) {
-    logBox.remove(r.id)
+    logBox.remove(r)
     r.destroy()
   }
   logRenderables.length = 0
@@ -281,12 +281,12 @@ export function destroy(renderer: CliRenderer): void {
 
   // Clean up renderables
   if (mouseArea) {
-    renderer.root.remove(mouseArea.id)
+    renderer.root.remove(mouseArea)
     mouseArea.destroy()
     mouseArea = null
   }
   if (container) {
-    renderer.root.remove(container.id)
+    renderer.root.remove(container)
     container.destroyRecursively()
     container = null
   }

--- a/packages/examples/src/fonts.ts
+++ b/packages/examples/src/fonts.ts
@@ -223,10 +223,12 @@ export function destroy(rendererInstance: CliRenderer): void {
     renderer.keyInput.off("keypress", handleKeyPress)
   }
 
-  rendererInstance.root.remove("ascii-demo")
+  const asciiDemo = rendererInstance.root.getRenderable("ascii-demo")
+  if (asciiDemo) rendererInstance.root.remove(asciiDemo)
 
   if (parentContainer) {
-    rendererInstance.root.remove("fonts-container")
+    const fontsContainer = rendererInstance.root.getRenderable("fonts-container")
+    if (fontsContainer) rendererInstance.root.remove(fontsContainer)
     parentContainer = null
   }
 

--- a/packages/examples/src/fractal-shader-demo.ts
+++ b/packages/examples/src/fractal-shader-demo.ts
@@ -242,7 +242,8 @@ export function destroy(renderer: CliRenderer): void {
   renderer.clearFrameCallbacks()
 
   if (parentContainer) {
-    renderer.root.remove("fractal-container")
+    const fractalContainer = renderer.root.getRenderable("fractal-container")
+    if (fractalContainer) renderer.root.remove(fractalContainer)
     parentContainer = null
   }
 

--- a/packages/examples/src/framebuffer-demo.ts
+++ b/packages/examples/src/framebuffer-demo.ts
@@ -635,20 +635,25 @@ export function destroy(renderer: CliRenderer): void {
   renderer.clearFrameCallbacks()
 
   if (parentContainer) {
-    renderer.root.remove("framebuffer-container")
+    renderer.root.remove(parentContainer)
     parentContainer = null
   }
 
-  renderer.root.remove("pattern")
-  renderer.root.remove("moving-box")
-  renderer.root.remove("overlay")
-  renderer.root.remove("ball")
-  renderer.root.remove("resizable-box")
-  renderer.root.remove("large-source")
-  renderer.root.remove("crop-demo-1")
-  renderer.root.remove("crop-demo-2")
-  renderer.root.remove("crop-demo-3")
-  renderer.root.remove("emoji-demo")
+  for (const id of [
+    "pattern",
+    "moving-box",
+    "overlay",
+    "ball",
+    "resizable-box",
+    "large-source",
+    "crop-demo-1",
+    "crop-demo-2",
+    "crop-demo-3",
+    "emoji-demo",
+  ]) {
+    const child = renderer.root.getRenderable(id)
+    if (child) renderer.root.remove(child)
+  }
 
   boxX = 10
   boxY = 10

--- a/packages/examples/src/full-unicode-demo.ts
+++ b/packages/examples/src/full-unicode-demo.ts
@@ -231,7 +231,8 @@ export function destroy(renderer: CliRenderer): void {
     renderer.keyInput.off("keypress", demoState.keyHandler)
   }
   renderer.clearPostProcessFns()
-  renderer.root.remove("full-unicode-root")
+  const root = renderer.root.getRenderable("full-unicode-root")
+  if (root) renderer.root.remove(root)
   demoState = null
 }
 

--- a/packages/examples/src/golden-star-demo.ts
+++ b/packages/examples/src/golden-star-demo.ts
@@ -923,9 +923,10 @@ export async function run(renderer: CliRenderer): Promise<void> {
 
 export function destroy(renderer: CliRenderer): void {
   renderer.clearFrameCallbacks()
-  renderer.root.remove("golden-star-main")
-  renderer.root.remove("overlay")
-  renderer.root.remove("gradientBand")
+  for (const id of ["golden-star-main", "overlay", "gradientBand"]) {
+    const child = renderer.root.getRenderable(id)
+    if (child) renderer.root.remove(child)
+  }
 }
 
 if (import.meta.main) {

--- a/packages/examples/src/grayscale-buffer-demo.ts
+++ b/packages/examples/src/grayscale-buffer-demo.ts
@@ -232,7 +232,8 @@ export function destroy(renderer: CliRenderer): void {
     keyListener = null
   }
 
-  renderer.root.remove("grayscale-demo")
+  const grayscaleDemo = renderer.root.getRenderable("grayscale-demo")
+  if (grayscaleDemo) renderer.root.remove(grayscaleDemo)
   framebuffer = null
   leftBuffer = null
   rightBuffer = null

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -1352,7 +1352,7 @@ class ExampleSelector {
     }
 
     if (this.notImplementedText) {
-      this.renderer.root.remove(this.notImplementedText.id)
+      this.renderer.root.remove(this.notImplementedText)
       this.notImplementedText = null
     }
 

--- a/packages/examples/src/input-demo.ts
+++ b/packages/examples/src/input-demo.ts
@@ -348,13 +348,14 @@ export function destroy(rendererInstance: CliRenderer): void {
 
   inputElements.forEach((input) => {
     if (input) {
-      rendererInstance.root.remove(input.id)
+      rendererInstance.root.remove(input)
       input.destroy()
     }
   })
   inputElements.length = 0
 
-  rendererInstance.root.remove("parent-container")
+  const parentContainer = rendererInstance.root.getRenderable("parent-container")
+  if (parentContainer) rendererInstance.root.remove(parentContainer)
 
   nameInput = null
   emailInput = null

--- a/packages/examples/src/input-select-layout-demo.ts
+++ b/packages/examples/src/input-select-layout-demo.ts
@@ -387,10 +387,10 @@ export function destroy(rendererInstance: CliRenderer): void {
   if (textInput) textInput.destroy()
 
   // Clean up elements directly from root
-  if (headerBox) rendererInstance.root.remove(headerBox.id)
-  if (selectContainerBox) rendererInstance.root.remove(selectContainerBox.id)
-  if (inputContainerBox) rendererInstance.root.remove(inputContainerBox.id)
-  if (footerBox) rendererInstance.root.remove(footerBox.id)
+  if (headerBox) rendererInstance.root.remove(headerBox)
+  if (selectContainerBox) rendererInstance.root.remove(selectContainerBox)
+  if (inputContainerBox) rendererInstance.root.remove(inputContainerBox)
+  if (footerBox) rendererInstance.root.remove(footerBox)
 
   // Clean up all elements
   header = null

--- a/packages/examples/src/keypress-debug-demo.ts
+++ b/packages/examples/src/keypress-debug-demo.ts
@@ -729,7 +729,7 @@ export function destroy(renderer: CliRenderer): void {
   }
 
   if (mainContainer) {
-    renderer.root.remove(mainContainer.id)
+    renderer.root.remove(mainContainer)
     mainContainer.destroyRecursively()
     mainContainer = null
   }

--- a/packages/examples/src/lights-phong-demo.ts
+++ b/packages/examples/src/lights-phong-demo.ts
@@ -274,8 +274,10 @@ export async function run(renderer: CliRenderer): Promise<void> {
 export function destroy(renderer: CliRenderer): void {
   if (demoState) {
     demoState.cleanup()
-    renderer.root.remove("phong-main")
-    renderer.root.remove("phong-container")
+    for (const id of ["phong-main", "phong-container"]) {
+      const child = renderer.root.getRenderable(id)
+      if (child) renderer.root.remove(child)
+    }
     demoState = null
   }
 }

--- a/packages/examples/src/link-demo.ts
+++ b/packages/examples/src/link-demo.ts
@@ -201,11 +201,12 @@ function createCard(
 
 export function destroy(renderer: CliRenderer): void {
   for (const box of draggableBoxes) {
-    renderer.root.remove(box.id)
+    renderer.root.remove(box)
   }
   draggableBoxes = []
   dragModeEnabled = false
-  renderer.root.remove("main-container")
+  const mainContainer = renderer.root.getRenderable("main-container")
+  if (mainContainer) renderer.root.remove(mainContainer)
   renderer.setCursorPosition(0, 0, false)
 }
 

--- a/packages/examples/src/live-state-demo.ts
+++ b/packages/examples/src/live-state-demo.ts
@@ -140,7 +140,7 @@ function removeDemoRenderable(renderer: CliRenderer): void {
     return
   }
 
-  renderer.root.getRenderable("live-demo-main-group")?.remove(demoRenderable.id)
+  renderer.root.getRenderable("live-demo-main-group")?.remove(demoRenderable)
   demoRenderable = null
   updateStatusText("Removed demo renderable")
 }

--- a/packages/examples/src/native-audio-demo.ts
+++ b/packages/examples/src/native-audio-demo.ts
@@ -1459,7 +1459,8 @@ export function destroy(renderer: CliRenderer): void {
 
   renderer.removePostProcessFn(fftBackgroundPostProcess)
 
-  renderer.root.remove("native-audio-demo-root")
+  const rootRenderable = renderer.root.getRenderable("native-audio-demo-root")
+  if (rootRenderable) renderer.root.remove(rootRenderable)
   root = null
   titleText = null
   statusText = null

--- a/packages/examples/src/nested-zindex-demo.ts
+++ b/packages/examples/src/nested-zindex-demo.ts
@@ -340,8 +340,10 @@ export function destroy(renderer: CliRenderer): void {
     globalKeyboardHandler = null
   }
 
-  renderer.root.remove("main-title")
-  renderer.root.remove("parent-container")
+  for (const id of ["main-title", "parent-container"]) {
+    const child = renderer.root.getRenderable(id)
+    if (child) renderer.root.remove(child)
+  }
 
   renderer.clearFrameCallbacks()
   renderer.setCursorPosition(0, 0, false)

--- a/packages/examples/src/notification-demo.ts
+++ b/packages/examples/src/notification-demo.ts
@@ -440,7 +440,7 @@ export function destroy(rendererInstance: CliRenderer): void {
     capabilityHandler = null
   }
   if (root) {
-    rendererInstance.root.remove(root.id)
+    rendererInstance.root.remove(root)
     root.destroyRecursively()
   }
 

--- a/packages/examples/src/opacity-example.ts
+++ b/packages/examples/src/opacity-example.ts
@@ -213,11 +213,11 @@ export function destroy(rendererInstance: CliRenderer): void {
   }
   rendererInstance.keyInput.off("keypress", handleKeyPress)
   if (header) {
-    rendererInstance.root.remove("opacity-demo-header")
+    rendererInstance.root.remove(header)
     header = null
   }
   if (container) {
-    rendererInstance.root.remove("opacity-demo-container")
+    rendererInstance.root.remove(container)
     container = null
   }
   boxes = []

--- a/packages/examples/src/opentui-demo.ts
+++ b/packages/examples/src/opentui-demo.ts
@@ -192,7 +192,8 @@ export function run(renderer: CliRenderer): void {
       // Remove any wheel pixels that are no longer part of the wheel
       for (const pixelId of activeWheelPixels) {
         if (!newWheelPixels.has(pixelId)) {
-          tabGroup.remove(pixelId)
+          const pixel = tabGroup.getRenderable(pixelId)
+          if (pixel) tabGroup.remove(pixel)
           activeWheelPixels.delete(pixelId)
         }
       }
@@ -204,7 +205,8 @@ export function run(renderer: CliRenderer): void {
     },
     hide: () => {
       for (const pixelId of activeWheelPixels) {
-        renderer.root.remove(pixelId)
+        const pixel = renderer.root.getRenderable(pixelId)
+        if (pixel) renderer.root.remove(pixel)
       }
       activeWheelPixels.clear()
     },
@@ -1040,7 +1042,7 @@ export function destroy(renderer: CliRenderer): void {
   }
 
   if (globalTabController) {
-    renderer.root.remove(globalTabController.id)
+    renderer.root.remove(globalTabController)
     globalTabController = null
   }
 

--- a/packages/examples/src/physx-planck-2d-demo.ts
+++ b/packages/examples/src/physx-planck-2d-demo.ts
@@ -96,8 +96,10 @@ function cleanupPendingDemoState(renderer: CliRenderer, state: PendingDemoState)
   }
 
   if (!renderer.isDestroyed) {
-    renderer.root.remove("planck-main")
-    renderer.root.remove("planck-container")
+    for (const id of ["planck-main", "planck-container"]) {
+      const child = renderer.root.getRenderable(id)
+      if (child) renderer.root.remove(child)
+    }
   }
 
   if (pendingDemoState === state) {
@@ -127,8 +129,10 @@ function cleanupDemoState(renderer: CliRenderer, state: DemoState): void {
   state.engine.destroy()
 
   if (!renderer.isDestroyed) {
-    renderer.root.remove("planck-main")
-    renderer.root.remove("planck-container")
+    for (const id of ["planck-main", "planck-container"]) {
+      const child = renderer.root.getRenderable(id)
+      if (child) renderer.root.remove(child)
+    }
   }
 }
 

--- a/packages/examples/src/physx-rapier-2d-demo.ts
+++ b/packages/examples/src/physx-rapier-2d-demo.ts
@@ -112,8 +112,10 @@ function cleanupPendingDemoState(renderer: CliRenderer, state: PendingDemoState)
   }
 
   if (!renderer.isDestroyed) {
-    renderer.root.remove("rapier-main")
-    renderer.root.remove("rapier-container")
+    for (const id of ["rapier-main", "rapier-container"]) {
+      const child = renderer.root.getRenderable(id)
+      if (child) renderer.root.remove(child)
+    }
   }
 
   if (pendingDemoState === state) {
@@ -143,8 +145,10 @@ function cleanupDemoState(renderer: CliRenderer, state: DemoState): void {
   state.engine.destroy()
 
   if (!renderer.isDestroyed) {
-    renderer.root.remove("rapier-main")
-    renderer.root.remove("rapier-container")
+    for (const id of ["rapier-main", "rapier-container"]) {
+      const child = renderer.root.getRenderable(id)
+      if (child) renderer.root.remove(child)
+    }
   }
 }
 

--- a/packages/examples/src/relative-positioning-demo.ts
+++ b/packages/examples/src/relative-positioning-demo.ts
@@ -306,7 +306,8 @@ export function destroy(renderer: CliRenderer): void {
     globalKeyboardHandler = null
   }
 
-  renderer.root.remove("root-container")
+  const rootContainer = renderer.root.getRenderable("root-container")
+  if (rootContainer) renderer.root.remove(rootContainer)
 
   renderer.clearFrameCallbacks()
   renderer.setCursorPosition(0, 0, false)

--- a/packages/examples/src/scroll-example.ts
+++ b/packages/examples/src/scroll-example.ts
@@ -195,7 +195,7 @@ export function run(rendererInstance: CliRenderer): void {
 
 export function destroy(rendererInstance: CliRenderer): void {
   if (mainContainer) {
-    rendererInstance.root.remove(mainContainer.id)
+    rendererInstance.root.remove(mainContainer)
     mainContainer.destroyRecursively()
     mainContainer = null
   }

--- a/packages/examples/src/scrollbox-mouse-test.ts
+++ b/packages/examples/src/scrollbox-mouse-test.ts
@@ -94,7 +94,7 @@ export function run(renderer: CliRenderer): void {
 
 export function destroy(renderer: CliRenderer): void {
   renderer.root.getChildren().forEach((child) => {
-    renderer.root.remove(child.id)
+    renderer.root.remove(child)
     child.destroyRecursively()
   })
   scrollBox = null

--- a/packages/examples/src/scrollbox-overlay-hit-test.ts
+++ b/packages/examples/src/scrollbox-overlay-hit-test.ts
@@ -182,7 +182,7 @@ export function destroy(renderer: CliRenderer): void {
   }
 
   renderer.root.getChildren().forEach((child) => {
-    renderer.root.remove(child.id)
+    renderer.root.remove(child)
     child.destroyRecursively()
   })
 

--- a/packages/examples/src/select-demo.ts
+++ b/packages/examples/src/select-demo.ts
@@ -214,12 +214,13 @@ export function destroy(rendererInstance: CliRenderer): void {
   }
 
   if (selectElement) {
-    rendererInstance.root.remove(selectElement.id)
+    rendererInstance.root.remove(selectElement)
     selectElement.destroy()
     selectElement = null
   }
 
-  rendererInstance.root.remove("parent-container")
+  const parentContainer = rendererInstance.root.getRenderable("parent-container")
+  if (parentContainer) rendererInstance.root.remove(parentContainer)
 
   keyLegendDisplay = null
   statusDisplay = null

--- a/packages/examples/src/shader-cube-demo.ts
+++ b/packages/examples/src/shader-cube-demo.ts
@@ -996,8 +996,10 @@ export function destroy(renderer: CliRenderer): void {
   demoState.engine.destroy()
   renderer.clearPostProcessFns()
 
-  renderer.root.remove("shader-cube-main")
-  renderer.root.remove("shader-cube-container")
+  for (const id of ["shader-cube-main", "shader-cube-container"]) {
+    const child = renderer.root.getRenderable(id)
+    if (child) renderer.root.remove(child)
+  }
 
   demoState = null
 }

--- a/packages/examples/src/simple-layout-example.ts
+++ b/packages/examples/src/simple-layout-example.ts
@@ -552,11 +552,11 @@ export function destroy(rendererInstance: CliRenderer): void {
     renderer.off("resize", handleResize)
   }
 
-  if (header) rendererInstance.root.remove(header.id)
-  if (contentArea) rendererInstance.root.remove(contentArea.id)
-  if (footer) rendererInstance.root.remove(footer.id)
-  if (moveableElement) rendererInstance.root.remove(moveableElement.id)
-  if (absolutePositionedBox) rendererInstance.root.remove(absolutePositionedBox.id)
+  if (header) rendererInstance.root.remove(header)
+  if (contentArea) rendererInstance.root.remove(contentArea)
+  if (footer) rendererInstance.root.remove(footer)
+  if (moveableElement) rendererInstance.root.remove(moveableElement)
+  if (absolutePositionedBox) rendererInstance.root.remove(absolutePositionedBox)
 
   header = null
   headerText = null

--- a/packages/examples/src/split-mode-demo.ts
+++ b/packages/examples/src/split-mode-demo.ts
@@ -1256,7 +1256,7 @@ class SplitFooterDemo {
     this.renderer.off(CliRenderEvents.THEME_MODE, this.handleThemeMode)
     this.renderer.off(CliRenderEvents.DESTROY, this.handleRendererDestroy)
 
-    this.renderer.root.remove(this.shell.id)
+    this.renderer.root.remove(this.shell)
 
     if (!this.renderer.isDestroyed) {
       this.renderer.externalOutputMode = "passthrough"

--- a/packages/examples/src/sprite-animation-demo.ts
+++ b/packages/examples/src/sprite-animation-demo.ts
@@ -415,8 +415,10 @@ export function destroy(renderer: CliRenderer): void {
     demoState.explosionManager.disposeAll()
     demoState.engine.destroy()
 
-    renderer.root.remove("main")
-    renderer.root.remove("sprite-animation-container")
+    for (const id of ["main", "sprite-animation-container"]) {
+      const child = renderer.root.getRenderable(id)
+      if (child) renderer.root.remove(child)
+    }
     renderer.clearFrameCallbacks()
 
     demoState = null

--- a/packages/examples/src/sprite-particle-generator-demo.ts
+++ b/packages/examples/src/sprite-particle-generator-demo.ts
@@ -443,13 +443,14 @@ export function destroy(renderer: CliRenderer): void {
   }
 
   if (framebufferRenderableRef) {
-    renderer.root.remove(framebufferRenderableRef.id)
+    renderer.root.remove(framebufferRenderableRef)
     framebufferRenderableRef = null
   }
   framebuffer = null
 
   if (parentContainer) {
-    renderer.root.remove("particle-container")
+    const particleContainer = renderer.root.getRenderable("particle-container")
+    if (particleContainer) renderer.root.remove(particleContainer)
     parentContainer = null
   }
 

--- a/packages/examples/src/static-sprite-demo.ts
+++ b/packages/examples/src/static-sprite-demo.ts
@@ -159,10 +159,12 @@ export function destroy(renderer: CliRenderer): void {
     resizeHandler = null
   }
 
-  renderer.root.remove("main")
+  const main = renderer.root.getRenderable("main")
+  if (main) renderer.root.remove(main)
 
   if (parentContainer) {
-    renderer.root.remove("static-sprite-container")
+    const staticSpriteContainer = renderer.root.getRenderable("static-sprite-container")
+    if (staticSpriteContainer) renderer.root.remove(staticSpriteContainer)
     parentContainer = null
   }
 

--- a/packages/examples/src/sticky-scroll-example.ts
+++ b/packages/examples/src/sticky-scroll-example.ts
@@ -37,7 +37,7 @@ function clearAllItems() {
   // Remove all children from scroll box
   const children = scrollBox.getChildren()
   for (const child of children) {
-    scrollBox.remove(child.id)
+    scrollBox.remove(child)
     child.destroyRecursively()
   }
 
@@ -283,7 +283,7 @@ export function run(rendererInstance: CliRenderer): void {
 
 export function destroy(rendererInstance: CliRenderer): void {
   if (mainContainer) {
-    rendererInstance.root.remove(mainContainer.id)
+    rendererInstance.root.remove(mainContainer)
     mainContainer.destroyRecursively()
     mainContainer = null
   }

--- a/packages/examples/src/styled-text-demo.ts
+++ b/packages/examples/src/styled-text-demo.ts
@@ -260,7 +260,8 @@ export function destroy(rendererInstance: CliRenderer): void {
   }
 
   if (parentContainer) {
-    rendererInstance.root.remove("styled-text-container")
+    const styledTextContainer = rendererInstance.root.getRenderable("styled-text-container")
+    if (styledTextContainer) rendererInstance.root.remove(styledTextContainer)
     parentContainer = null
   }
 

--- a/packages/examples/src/tab-select-demo.ts
+++ b/packages/examples/src/tab-select-demo.ts
@@ -193,13 +193,14 @@ export function destroy(rendererInstance: CliRenderer): void {
   }
 
   if (tabSelect) {
-    rendererInstance.root.remove(tabSelect.id)
+    rendererInstance.root.remove(tabSelect)
     tabSelect.destroy()
     tabSelect = null
   }
 
   if (parentContainer) {
-    rendererInstance.root.remove("tab-select-container")
+    const tabSelectContainer = rendererInstance.root.getRenderable("tab-select-container")
+    if (tabSelectContainer) rendererInstance.root.remove(tabSelectContainer)
     parentContainer = null
   }
 

--- a/packages/examples/src/terminal.ts
+++ b/packages/examples/src/terminal.ts
@@ -465,7 +465,8 @@ export function destroy(renderer: CliRenderer): void {
   }
 
   if (scrollBox) {
-    renderer.root.remove("main-container")
+    const mainContainer = renderer.root.getRenderable("main-container")
+    if (mainContainer) renderer.root.remove(mainContainer)
     scrollBox = null
   }
 

--- a/packages/examples/src/texture-loading-demo.ts
+++ b/packages/examples/src/texture-loading-demo.ts
@@ -242,7 +242,8 @@ export function destroy(renderer: CliRenderer): void {
   }
 
   if (parentContainer) {
-    renderer.root.remove("texture-loading-container")
+    const textureLoadingContainer = renderer.root.getRenderable("texture-loading-container")
+    if (textureLoadingContainer) renderer.root.remove(textureLoadingContainer)
     parentContainer = null
   }
 }

--- a/packages/examples/src/timeline-example.ts
+++ b/packages/examples/src/timeline-example.ts
@@ -619,7 +619,8 @@ class TimelineExample {
   }
 
   public destroy(): void {
-    this.renderer.root.remove("timeline-container")
+    const timelineContainer = this.renderer.root.getRenderable("timeline-container")
+    if (timelineContainer) this.renderer.root.remove(timelineContainer)
   }
 }
 

--- a/packages/examples/src/transparency-demo.ts
+++ b/packages/examples/src/transparency-demo.ts
@@ -381,11 +381,12 @@ export function destroy(renderer: CliRenderer): void {
   }
 
   for (const box of draggableBoxes) {
-    renderer.root.remove(box.id)
+    renderer.root.remove(box)
   }
   draggableBoxes = []
 
-  renderer.root.remove("parent-container")
+  const parentContainer = renderer.root.getRenderable("parent-container")
+  if (parentContainer) renderer.root.remove(parentContainer)
   renderer.setCursorPosition(0, 0, false)
 }
 

--- a/packages/examples/src/wide-grapheme-overlay-demo.ts
+++ b/packages/examples/src/wide-grapheme-overlay-demo.ts
@@ -257,7 +257,7 @@ export function destroy(renderer: CliRenderer): void {
   renderer.clearFrameCallbacks()
 
   for (const box of draggableBoxes) {
-    renderer.root.remove(box.id)
+    renderer.root.remove(box)
   }
   draggableBoxes = []
   nextZIndex = 101
@@ -265,7 +265,8 @@ export function destroy(renderer: CliRenderer): void {
   scrim = null
   headerDisplay = null
 
-  renderer.root.remove("wg-overlay-root")
+  const root = renderer.root.getRenderable("wg-overlay-root")
+  if (root) renderer.root.remove(root)
   renderer.setCursorPosition(0, 0, false)
 }
 

--- a/packages/react/src/reconciler/host-config.ts
+++ b/packages/react/src/reconciler/host-config.ts
@@ -70,7 +70,7 @@ export const hostConfig: HostConfig<
 
   // Remove a child from a parent
   removeChild(parent: Instance, child: Instance) {
-    parent.remove(child.id)
+    parent.removeChild(child)
   },
 
   // Insert a child before another child
@@ -85,7 +85,7 @@ export const hostConfig: HostConfig<
 
   // Remove a child from container
   removeChildFromContainer(parent: Container, child: Instance) {
-    parent.remove(child.id)
+    parent.removeChild(child)
   },
 
   // Prepare for commit
@@ -194,7 +194,7 @@ export const hostConfig: HostConfig<
   clearContainer(container: Container) {
     // Remove all children
     const children = container.getChildren()
-    children.forEach((child) => container.remove(child.id))
+    children.forEach((child) => container.removeChild(child))
   },
 
   // Misc

--- a/packages/react/src/reconciler/host-config.ts
+++ b/packages/react/src/reconciler/host-config.ts
@@ -70,7 +70,7 @@ export const hostConfig: HostConfig<
 
   // Remove a child from a parent
   removeChild(parent: Instance, child: Instance) {
-    parent.removeChild(child)
+    parent.remove(child)
   },
 
   // Insert a child before another child
@@ -85,7 +85,7 @@ export const hostConfig: HostConfig<
 
   // Remove a child from container
   removeChildFromContainer(parent: Container, child: Instance) {
-    parent.removeChild(child)
+    parent.remove(child)
   },
 
   // Prepare for commit
@@ -194,7 +194,7 @@ export const hostConfig: HostConfig<
   clearContainer(container: Container) {
     // Remove all children
     const children = container.getChildren()
-    children.forEach((child) => container.removeChild(child))
+    children.forEach((child) => container.remove(child))
   },
 
   // Misc

--- a/packages/react/src/reconciler/host-config.ts
+++ b/packages/react/src/reconciler/host-config.ts
@@ -68,8 +68,12 @@ export const hostConfig: HostConfig<
     parent.add(child)
   },
 
-  // Remove a child from a parent
+  // Remove a child from a parent. During coordinated teardown (for example
+  // renderer.destroy() triggering root.unmount() via onDestroy) the renderable
+  // tree may already be destroyed when React commits its deletion effects, so
+  // an already-detached child is expected and must not be re-removed.
   removeChild(parent: Instance, child: Instance) {
+    if (!child.parent) return
     parent.remove(child)
   },
 
@@ -83,8 +87,10 @@ export const hostConfig: HostConfig<
     parent.insertBefore(child, beforeChild)
   },
 
-  // Remove a child from container
+  // Remove a child from container. Skips children that were already detached
+  // by renderer teardown; see removeChild.
   removeChildFromContainer(parent: Container, child: Instance) {
+    if (!child.parent) return
     parent.remove(child)
   },
 

--- a/packages/react/tests/layout.test.tsx
+++ b/packages/react/tests/layout.test.tsx
@@ -101,6 +101,42 @@ describe("React Renderer | Layout Tests", () => {
     })
   })
 
+  describe("Duplicate IDs", () => {
+    it("removes the exact duplicate-id child during keyed list reconciliation", async () => {
+      let setItems!: (items: number[]) => void
+
+      function TestComponent() {
+        const [items, updateItems] = useState([0, 1, 2])
+        setItems = updateItems
+
+        return (
+          <box id="container">
+            {items.map((item) => (
+              <box key={item} id="duplicate" height={1} flexShrink={0} />
+            ))}
+          </box>
+        )
+      }
+
+      testSetup = await testRender(<TestComponent />, { width: 20, height: 5 })
+      await testSetup.renderOnce()
+
+      const container = testSetup.renderer.root.findDescendantById("container")!
+      const initialChildren = container.getChildren()
+      const removedChild = initialChildren[1]!
+
+      act(() => setItems([0, 2]))
+      await testSetup.renderOnce()
+
+      const children = container.getChildren()
+      expect(children).toHaveLength(2)
+      expect(children[0]).toBe(initialChildren[0])
+      expect(children[1]).toBe(initialChildren[2])
+      expect(removedChild.parent).toBeNull()
+      expect(children.every((child) => child.id === "duplicate" && child.parent === container)).toBe(true)
+    })
+  })
+
   describe("Select Rendering", () => {
     it("should restore the selection indicator when the prop resets", async () => {
       let resetIndicator: () => void

--- a/packages/react/tests/slot.test.tsx
+++ b/packages/react/tests/slot.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import { createTestRenderer, type TestRendererOptions } from "@opentui/core/testing"
 import { createContext, useContext, useEffect, useMemo, useState } from "react"
 import { act, type ReactNode } from "react"
@@ -106,6 +106,36 @@ describe("React Slot System", () => {
     const frame = testSetup.captureCharFrame()
 
     expect(frame).toContain("fallback-only")
+  })
+
+  it("coordinated teardown does not re-remove nodes the renderer already destroyed", async () => {
+    // renderer.destroy() destroys the renderable tree and then triggers
+    // root.unmount() via onDestroy. React's deletion effects run against
+    // already-detached nodes; the host config must treat that as a no-op
+    // instead of asking the container to remove non-children.
+    const { setup } = await setupSlotTest(
+      (registry) => {
+        const AppSlot = Slot<AppSlots, typeof hostContext>
+        return (
+          <AppSlot registry={registry} name="statusbar" user="sam">
+            <text>fallback-only</text>
+          </AppSlot>
+        )
+      },
+      { width: 50, height: 6 },
+    )
+    testSetup = setup
+    await testSetup.renderOnce()
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      act(() => {
+        testSetup.renderer.destroy()
+      })
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   it("appends plugin output after fallback content by default", async () => {

--- a/packages/solid/src/elements/extras.ts
+++ b/packages/solid/src/elements/extras.ts
@@ -36,7 +36,7 @@ export function Portal(props: { mount?: DomNode; ref?: (el: {}) => void; childre
       insert(renderRoot, content)
       el.add(container)
       props.ref && (props as any).ref(container)
-      onCleanup(() => el.remove(container.id))
+      onCleanup(() => el.removeChild(container))
     },
     undefined,
     { render: true },

--- a/packages/solid/src/elements/extras.ts
+++ b/packages/solid/src/elements/extras.ts
@@ -36,7 +36,7 @@ export function Portal(props: { mount?: DomNode; ref?: (el: {}) => void; childre
       insert(renderRoot, content)
       el.add(container)
       props.ref && (props as any).ref(container)
-      onCleanup(() => el.removeChild(container))
+      onCleanup(() => el.remove(container))
     },
     undefined,
     { render: true },

--- a/packages/solid/src/elements/slot.ts
+++ b/packages/solid/src/elements/slot.ts
@@ -32,6 +32,8 @@ class SlotBaseRenderable extends BaseRenderable {
 
   public remove(id: string): void {}
 
+  public removeChild(child: BaseRenderable): void {}
+
   public insertBefore(obj: BaseRenderable | unknown, anchor: BaseRenderable | unknown): void {
     throw new Error("Can't add children on an Slot renderable")
   }

--- a/packages/solid/src/elements/slot.ts
+++ b/packages/solid/src/elements/slot.ts
@@ -30,9 +30,7 @@ class SlotBaseRenderable extends BaseRenderable {
     return []
   }
 
-  public remove(id: string): void {}
-
-  public removeChild(child: BaseRenderable): void {}
+  public remove(child: BaseRenderable): void {}
 
   public insertBefore(obj: BaseRenderable | unknown, anchor: BaseRenderable | unknown): void {
     throw new Error("Can't add children on an Slot renderable")

--- a/packages/solid/src/reconciler.ts
+++ b/packages/solid/src/reconciler.ts
@@ -100,7 +100,7 @@ function _insertNode(parent: DomNode, node: DomNode, anchor?: DomNode): void {
 
   const children = getNodeChildren(parent)
 
-  const anchorIndex = children.findIndex((el) => el.id === anchor.id)
+  const anchorIndex = children.indexOf(anchor)
   if (anchorIndex === -1) {
     log("[INSERT]", "Could not find anchor", logId(parent), logId(anchor), "[children]", ...children.map((c) => c.id))
   }
@@ -126,7 +126,7 @@ function _removeNode(parent: DomNode, node: DomNode): void {
     node = slotChild
   }
 
-  parent.remove(node.id)
+  parent.removeChild(node)
 
   slotParent?.didRemoveSlotChild(parent, node)
 

--- a/packages/solid/src/reconciler.ts
+++ b/packages/solid/src/reconciler.ts
@@ -126,7 +126,7 @@ function _removeNode(parent: DomNode, node: DomNode): void {
     node = slotChild
   }
 
-  parent.removeChild(node)
+  parent.remove(node)
 
   slotParent?.didRemoveSlotChild(parent, node)
 

--- a/packages/solid/src/scrollback.ts
+++ b/packages/solid/src/scrollback.ts
@@ -115,7 +115,7 @@ function measureSnapshotHeight(renderContext: ScrollbackRenderContext["renderCon
     return Math.max(1, Math.trunc(root.getLayoutNode().getComputedLayout().height))
   } finally {
     if (root.parent === measureRoot) {
-      measureRoot.removeChild(root)
+      measureRoot.remove(root)
     }
     measureRoot.destroyRecursively()
   }

--- a/packages/solid/src/scrollback.ts
+++ b/packages/solid/src/scrollback.ts
@@ -115,7 +115,7 @@ function measureSnapshotHeight(renderContext: ScrollbackRenderContext["renderCon
     return Math.max(1, Math.trunc(root.getLayoutNode().getComputedLayout().height))
   } finally {
     if (root.parent === measureRoot) {
-      measureRoot.remove(root.id)
+      measureRoot.removeChild(root)
     }
     measureRoot.destroyRecursively()
   }

--- a/packages/solid/tests/scrollbox-duplicate-id-culling.test.tsx
+++ b/packages/solid/tests/scrollbox-duplicate-id-culling.test.tsx
@@ -1,0 +1,68 @@
+import { afterEach, expect, test } from "bun:test"
+import type { Renderable, ScrollBoxRenderable } from "@opentui/core"
+import { createSignal, For } from "solid-js"
+import { testRender } from "../index.js"
+
+const setups: Array<Awaited<ReturnType<typeof testRender>>> = []
+afterEach(() => setups.splice(0).forEach((setup) => setup.renderer.destroy()))
+
+test("removing a multi-file tool block does not orphan a duplicate-id child in scrollbox ordering", async () => {
+  const [files, setFiles] = createSignal(Array.from({ length: 7 }, (_, index) => ({ index })))
+  let scroll: ScrollBoxRenderable | undefined
+  const setup = await testRender(
+    () => (
+      <box width={40} height={12}>
+        <scrollbox ref={(value) => (scroll = value)} viewportCulling={true} flexGrow={1}>
+          <box height={20} flexShrink={0}>
+            <text>before</text>
+          </box>
+          <For each={files()}>
+            {(file) => (
+              <box id="tool-block-part" height={10 + file.index} flexShrink={0}>
+                <text>file {file.index}</text>
+              </box>
+            )}
+          </For>
+          <For each={Array.from({ length: 30 }, (_, index) => index)}>
+            {(index) => (
+              <box id={`tail-${index}`} height={10} flexShrink={0}>
+                <text>tail {index}</text>
+              </box>
+            )}
+          </For>
+        </scrollbox>
+      </box>
+    ),
+    { width: 40, height: 12 },
+  )
+  setups.push(setup)
+  await setup.renderOnce()
+
+  scroll!.scrollTo(scroll!.scrollHeight)
+  await setup.renderOnce()
+
+  setFiles([])
+  await setup.renderOnce()
+
+  scroll!.scrollBy(-100)
+  await setup.renderOnce()
+
+  const duplicateChildren = scroll!.getChildren().filter((child) => child.id === "tool-block-part")
+  const content = scroll!.content as unknown as {
+    getChildrenSortedByPrimaryAxis(): Renderable[]
+  }
+  const sortedChildren = content.getChildrenSortedByPrimaryAxis()
+  const sortedMonotonically = sortedChildren.every(
+    (child, index) => index === 0 || child.screenY >= sortedChildren[index - 1]!.screenY,
+  )
+
+  expect({
+    remainingDuplicateChildren: duplicateChildren.length,
+    parentlessDuplicateChildren: duplicateChildren.filter((child) => !child.parent).length,
+    sortedMonotonically,
+  }).toEqual({
+    remainingDuplicateChildren: 0,
+    parentlessDuplicateChildren: 0,
+    sortedMonotonically: true,
+  })
+})

--- a/packages/solid/tests/scrollbox-duplicate-id-culling.test.tsx
+++ b/packages/solid/tests/scrollbox-duplicate-id-culling.test.tsx
@@ -51,7 +51,7 @@ test("removing a multi-file tool block does not orphan a duplicate-id child in s
   const content = scroll!.content as unknown as {
     getChildrenSortedByPrimaryAxis(): Renderable[]
   }
-  const sortedChildren = content.getChildrenSortedByPrimaryAxis()
+  const sortedChildren = content.getChildrenSortedByPrimaryAxis().filter((child) => typeof child.screenY === "number")
   const sortedMonotonically = sortedChildren.every(
     (child, index) => index === 0 || child.screenY >= sortedChildren[index - 1]!.screenY,
   )

--- a/packages/solid/tests/slot-reconciler-move.test.ts
+++ b/packages/solid/tests/slot-reconciler-move.test.ts
@@ -151,7 +151,7 @@ describe("slot placeholder moves", () => {
 
       expect(slot.parent).toBe(parentB)
 
-      parentB.remove(childB.id)
+      parentB.remove(childB)
       slot.didRemoveSlotChild(parentB, childB)
 
       expect(slot.parent).toBe(parentA)

--- a/packages/web/src/content/docs/components/tab-select.mdx
+++ b/packages/web/src/content/docs/components/tab-select.mdx
@@ -158,7 +158,7 @@ contentArea.add(currentPanel)
 tabs.on("itemSelected", (index, option) => {
   // Remove current panel
   if (currentPanel) {
-    contentArea.remove(currentPanel.id)
+    contentArea.remove(currentPanel)
   }
   // Add new panel based on selection
   switch (option.name) {

--- a/packages/web/src/content/docs/core-concepts/renderables.mdx
+++ b/packages/web/src/content/docs/core-concepts/renderables.mdx
@@ -69,8 +69,8 @@ container.add(body)
 
 renderer.root.add(container)
 
-// Later, remove a child
-container.remove("body")
+// Later, remove a child by reference
+container.remove(body)
 ```
 
 ## Finding Renderables
@@ -80,6 +80,10 @@ Navigate the tree to find specific renderables:
 ```typescript
 // Get a direct child by ID
 const title = container.getRenderable("title")
+
+// Remove by ID lookup when needed
+const body = container.getRenderable("body")
+if (body) container.remove(body)
 
 // Recursively search all descendants
 const deepChild = container.findDescendantById("nested-input")


### PR DESCRIPTION
## Breaking

- `remove(id: string)` → `remove(child: BaseRenderable)` across all renderables;
  strings throw at runtime. Look up via `getRenderable(id)` /
  `findDescendantById(id)` when needed (docs updated).

## Core

- All internal child bookkeeping uses object identity; `renderableMapById` removed,
  ids remain as a pure query API (first match wins on duplicates)
- `remove` warns in dev when the object is not a child; ScrollBox routes internal
  parts (wrapper, scrollbars) by parentage so `destroy()` fully detaches them
- TextNode reparenting hygiene in `add`/`replace`/`insertBefore`/`children`
- `destroy()` no longer skips children (live-array iteration bug) and clears
  z-index/pending-update state

## Renderer (zig)

- Frame output buffers grow on demand instead of dropping ANSI mid-frame while
  still committing cells (the source of "stale cells never repainted")
- Failed growth reports `.failed` → forced full repaint; partial frames are not
  flushed; buffers shrink back after 64 small frames; `deinit` frees with the
  owning allocator

## Frameworks

- react/solid reconcilers pass child references; react host config tolerates
  teardown overlap (unmount during `renderer.destroy()`)