### PR TITLE
core: add common Chinese punctuation to wrap break characters

### DIFF
--- a/packages/core/src/zig/tests/edit-buffer_test.zig
+++ b/packages/core/src/zig/tests/edit-buffer_test.zig
@@ -371,6 +371,126 @@ test "EditBuffer - word boundary respects CJK punctuation before ASCII" {
     try std.testing.expectEqual(@as(u32, 0), prev_cursor2.col);
 }
 
+test "EditBuffer - word boundary with General Punctuation" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    try eb.setText("你好“世”界");
+
+    const eol = eb.getEOL();
+
+    // According to the Unicode EastAsianWidth list, the General Punctuation Block contains
+    // many East Asian Ambiguous characters, which are treated as fullwidth in East Asian
+    // context.
+    //
+    // The double quotes here are defined as ambiguous, so they may be counted as 1 column
+    // or 2 columns depending on the implementation.
+    //
+    // Although the current implementation in this library treats them as halfwidth (making
+    // the total column count 10), it could be 12 if the implementation changes in
+    // the future.
+    try std.testing.expect(eol.col == 10 or eol.col == 12);
+
+    const boundary_left_quote: u32 = if (eol.col == 10) 5 else 6;
+    const boundary_right_quote: u32 = eol.col - 2;
+
+    try eb.setCursor(0, 0);
+    const next_cursor = eb.getNextWordBoundary();
+    try std.testing.expectEqual(boundary_left_quote, next_cursor.col);
+
+    try eb.setCursor(next_cursor.row, next_cursor.col);
+    const next_cursor2 = eb.getNextWordBoundary();
+    try std.testing.expectEqual(boundary_right_quote, next_cursor2.col);
+
+    try eb.setCursor(0, eol.col);
+    const prev_cursor = eb.getPrevWordBoundary();
+    try std.testing.expectEqual(boundary_right_quote, prev_cursor.col);
+
+    try eb.setCursor(prev_cursor.row, prev_cursor.col);
+    const prev_cursor2 = eb.getPrevWordBoundary();
+    try std.testing.expectEqual(boundary_left_quote, prev_cursor2.col);
+
+    try eb.setCursor(prev_cursor2.row, prev_cursor2.col);
+    const prev_cursor3 = eb.getPrevWordBoundary();
+    try std.testing.expectEqual(@as(u32, 0), prev_cursor3.col);
+}
+
+test "EditBuffer - word boundary with CJK Symbols and Punctuation" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    try eb.setText("你好【世】界");
+
+    const eol = eb.getEOL();
+    try std.testing.expectEqual(@as(u32, 12), eol.col);
+
+    const boundary_left_bracket: u32 = 6;
+    const boundary_right_bracket: u32 = 10;
+
+    try eb.setCursor(0, 0);
+    const next_cursor = eb.getNextWordBoundary();
+    try std.testing.expectEqual(boundary_left_bracket, next_cursor.col);
+
+    try eb.setCursor(next_cursor.row, next_cursor.col);
+    const next_cursor2 = eb.getNextWordBoundary();
+    try std.testing.expectEqual(boundary_right_bracket, next_cursor2.col);
+
+    try eb.setCursor(0, eol.col);
+    const prev_cursor = eb.getPrevWordBoundary();
+    try std.testing.expectEqual(boundary_right_bracket, prev_cursor.col);
+
+    try eb.setCursor(prev_cursor.row, prev_cursor.col);
+    const prev_cursor2 = eb.getPrevWordBoundary();
+    try std.testing.expectEqual(boundary_left_bracket, prev_cursor2.col);
+
+    try eb.setCursor(prev_cursor2.row, prev_cursor2.col);
+    const prev_cursor3 = eb.getPrevWordBoundary();
+    try std.testing.expectEqual(@as(u32, 0), prev_cursor3.col);
+}
+
+test "EditBuffer - word boundary with fullwidth punctuation" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    try eb.setText("你好：世界");
+
+    const eol = eb.getEOL();
+    try std.testing.expectEqual(@as(u32, 10), eol.col);
+
+    const boundary_colon: u32 = 6;
+
+    try eb.setCursor(0, 0);
+    const next_cursor = eb.getNextWordBoundary();
+    try std.testing.expectEqual(boundary_colon, next_cursor.col);
+
+    try eb.setCursor(next_cursor.row, next_cursor.col);
+    const next_cursor2 = eb.getNextWordBoundary();
+    try std.testing.expectEqual(eol.col, next_cursor2.col);
+
+    try eb.setCursor(0, eol.col);
+    const prev_cursor = eb.getPrevWordBoundary();
+    try std.testing.expectEqual(boundary_colon, prev_cursor.col);
+
+    try eb.setCursor(prev_cursor.row, prev_cursor.col);
+    const prev_cursor2 = eb.getPrevWordBoundary();
+    try std.testing.expectEqual(@as(u32, 0), prev_cursor2.col);
+}
+
 test "EditBuffer - word boundary with compat ideograph and ASCII" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/core/src/zig/tests/utf8_test.zig
+++ b/packages/core/src/zig/tests/utf8_test.zig
@@ -1212,6 +1212,105 @@ test "wrap breaks: CJK punctuation before ASCII" {
     try testing.expectEqual(@as(u16, 3), result.breaks.items[0].char_offset);
 }
 
+test "wrap breaks: general punctuation" {
+    const inputs = [_]struct {
+        text: []const u8,
+        expected_bytes: []const u32,
+        expected_chars: []const u32,
+    }{
+        // ==========================================
+        // General Punctuation Block (0x2000...)
+        // ==========================================
+        .{ .text = "你好‘世界’", .expected_bytes = &[_]u32{ 6, 15 }, .expected_chars = &[_]u32{ 2, 5 } }, // 0x2018, 0x2019
+        .{ .text = "你好“世界”", .expected_bytes = &[_]u32{ 6, 15 }, .expected_chars = &[_]u32{ 2, 5 } }, // 0x201C, 0x201D
+    };
+
+    var result = utf8.WrapBreakResult.init(testing.allocator);
+    defer result.deinit();
+
+    for (inputs) |case| {
+        result.reset(); 
+        try utf8.findWrapBreaks(case.text, &result, .unicode);
+
+        try testing.expectEqual(case.expected_bytes.len, result.breaks.items.len);
+        for (case.expected_bytes, 0..) |expected_byte, i| {
+            try testing.expectEqual(expected_byte, result.breaks.items[i].byte_offset);
+            try testing.expectEqual(case.expected_chars[i], result.breaks.items[i].char_offset);
+        }
+    }
+}
+
+test "wrap breaks: cjk symbols and punctuation" {
+    const inputs = [_]struct {
+        text: []const u8,
+        expected_bytes: []const u32,
+        expected_chars: []const u32,
+    }{
+        // ==========================================
+        // CJK Symbols and Punctuation Block (0x3000...)
+        // ==========================================
+        .{ .text = "你好、世界", .expected_bytes = &[_]u32{6}, .expected_chars = &[_]u32{2} },          // 0x3001
+        .{ .text = "你好。世界", .expected_bytes = &[_]u32{6}, .expected_chars = &[_]u32{2} },          // 0x3002
+        .{ .text = "你好〈世界〉", .expected_bytes = &[_]u32{ 6, 15 }, .expected_chars = &[_]u32{ 2, 5 } }, // 0x3008, 0x3009
+        .{ .text = "你好《世界》", .expected_bytes = &[_]u32{ 6, 15 }, .expected_chars = &[_]u32{ 2, 5 } }, // 0x300A, 0x300B
+        .{ .text = "你好「世界」", .expected_bytes = &[_]u32{ 6, 15 }, .expected_chars = &[_]u32{ 2, 5 } }, // 0x300C, 0x300D
+        .{ .text = "你好『世界』", .expected_bytes = &[_]u32{ 6, 15 }, .expected_chars = &[_]u32{ 2, 5 } }, // 0x300E, 0x300F
+        .{ .text = "你好【世界】", .expected_bytes = &[_]u32{ 6, 15 }, .expected_chars = &[_]u32{ 2, 5 } }, // 0x3010, 0x3011
+        .{ .text = "你好〔世界〕", .expected_bytes = &[_]u32{ 6, 15 }, .expected_chars = &[_]u32{ 2, 5 } }, // 0x3014, 0x3015
+        .{ .text = "你好〖世界〗", .expected_bytes = &[_]u32{ 6, 15 }, .expected_chars = &[_]u32{ 2, 5 } }, // 0x3016, 0x3017
+    };
+
+    var result = utf8.WrapBreakResult.init(testing.allocator);
+    defer result.deinit();
+
+    for (inputs) |case| {
+        result.reset(); 
+        try utf8.findWrapBreaks(case.text, &result, .unicode);
+
+        try testing.expectEqual(case.expected_bytes.len, result.breaks.items.len);
+        for (case.expected_bytes, 0..) |expected_byte, i| {
+            try testing.expectEqual(expected_byte, result.breaks.items[i].byte_offset);
+            try testing.expectEqual(case.expected_chars[i], result.breaks.items[i].char_offset);
+        }
+    }
+}
+
+test "wrap breaks: halfwidth and fullwidth forms" {
+    const inputs = [_]struct {
+        text: []const u8,
+        expected_bytes: []const u32,
+        expected_chars: []const u32,
+    }{
+        // ==========================================
+        // Halfwidth and Fullwidth Forms Block (0xFF00...)
+        // ==========================================
+        .{ .text = "你好！世界", .expected_bytes = &[_]u32{6}, .expected_chars = &[_]u32{2} },          // 0xFF01
+        .{ .text = "你好（世界）", .expected_bytes = &[_]u32{ 6, 15 }, .expected_chars = &[_]u32{ 2, 5 } }, // 0xFF08, 0xFF09
+        .{ .text = "你好，世界", .expected_bytes = &[_]u32{6}, .expected_chars = &[_]u32{2} },          // 0xFF0C
+        .{ .text = "你好．世界", .expected_bytes = &[_]u32{6}, .expected_chars = &[_]u32{2} },          // 0xFF0E
+        .{ .text = "你好：世界", .expected_bytes = &[_]u32{6}, .expected_chars = &[_]u32{2} },          // 0xFF1A
+        .{ .text = "你好；世界", .expected_bytes = &[_]u32{6}, .expected_chars = &[_]u32{2} },          // 0xFF1B
+        .{ .text = "你好？世界", .expected_bytes = &[_]u32{6}, .expected_chars = &[_]u32{2} },          // 0xFF1F
+        .{ .text = "你好［世界］", .expected_bytes = &[_]u32{ 6, 15 }, .expected_chars = &[_]u32{ 2, 5 } }, // 0xFF3B, 0xFF3D
+        .{ .text = "你好｛世界｝", .expected_bytes = &[_]u32{ 6, 15 }, .expected_chars = &[_]u32{ 2, 5 } }, // 0xFF5B, 0xFF5D
+        .{ .text = "你好｜世界", .expected_bytes = &[_]u32{6}, .expected_chars = &[_]u32{2} },          // 0xFF5C
+    };
+
+    var result = utf8.WrapBreakResult.init(testing.allocator);
+    defer result.deinit();
+
+    for (inputs) |case| {
+        result.reset(); 
+        try utf8.findWrapBreaks(case.text, &result, .unicode);
+
+        try testing.expectEqual(case.expected_bytes.len, result.breaks.items.len);
+        for (case.expected_bytes, 0..) |expected_byte, i| {
+            try testing.expectEqual(expected_byte, result.breaks.items[i].byte_offset);
+            try testing.expectEqual(case.expected_chars[i], result.breaks.items[i].char_offset);
+        }
+    }
+}
+
 test "wrap breaks: compat ideograph to ASCII script transition" {
     const input = "丽abc";
 

--- a/packages/core/src/zig/utf8.zig
+++ b/packages/core/src/zig/utf8.zig
@@ -185,12 +185,45 @@ inline fn isUnicodeWrapBreak(cp: u21) bool {
         0x200B, // ZERO WIDTH SPACE
         0x00AD, // SOFT HYPHEN
         0x2010, // HYPHEN
-        0x3001, // IDEOGRAPHIC COMMA
-        0x3002, // IDEOGRAPHIC FULL STOP
-        0xFF01, // FULLWIDTH EXCLAMATION MARK
-        0xFF0C, // FULLWIDTH COMMA
-        0xFF1A, // FULLWIDTH COLON
-        0xFF1F, // FULLWIDTH QUESTION MARK
+
+        // --- General Punctuation ---
+        0x2018, // '‘'      // LEFT SINGLE QUOTATION MARK
+        0x2019, // '’'      // RIGHT SINGLE QUOTATION MARK
+        0x201C, // '“'      // LEFT DOUBLE QUOTATION MARK
+        0x201D, // '”'      // RIGHT DOUBLE QUOTATION MARK
+
+        // --- CJK Symbols and Punctuation ---
+        0x3001, // '、'     // IDEOGRAPHIC COMMA
+        0x3002, // '。'     // IDEOGRAPHIC FULL STOP
+        0x3008, // '〈'     // LEFT ANGLE BRACKET
+        0x3009, // '〉'     // RIGHT ANGLE BRACKET
+        0x300A, // '《'     // LEFT DOUBLE ANGLE BRACKET
+        0x300B, // '》'     // RIGHT DOUBLE ANGLE BRACKET
+        0x300C, // '「'     // LEFT CORNER BRACKET
+        0x300D, // '」'     // RIGHT CORNER BRACKET
+        0x300E, // '『'     // LEFT WHITE CORNER BRACKET
+        0x300F, // '』'     // RIGHT WHITE CORNER BRACKET
+        0x3010, // '【'     // LEFT BLACK LENTICULAR BRACKET
+        0x3011, // '】'     // RIGHT BLACK LENTICULAR BRACKET
+        0x3014, // '〔'     // LEFT TORTOISE SHELL BRACKET
+        0x3015, // '〕'     // RIGHT TORTOISE SHELL BRACKET
+        0x3016, // '〖'     // LEFT WHITE LENTICULAR BRACKET
+        0x3017, // '〗'     // RIGHT WHITE LENTICULAR BRACKET
+
+        // --- Halfwidth and Fullwidth Forms ---
+        0xFF01, // '！'     // FULLWIDTH EXCLAMATION MARK
+        0xFF08, // '（'     // FULLWIDTH LEFT PARENTHESIS
+        0xFF09, // '）'     // FULLWIDTH RIGHT PARENTHESIS
+        0xFF0C, // '，'     // FULLWIDTH COMMA
+        0xFF0E, // '．'     // FULLWIDTH FULL STOP
+        0xFF1A, // '：'     // FULLWIDTH COLON
+        0xFF1B, // '；'     // FULLWIDTH SEMICOLON
+        0xFF1F, // '？'     // FULLWIDTH QUESTION MARK
+        0xFF3B, // '［'     // FULLWIDTH LEFT SQUARE BRACKET
+        0xFF3D, // '］'     // FULLWIDTH RIGHT SQUARE BRACKET
+        0xFF5B, // '｛'     // FULLWIDTH LEFT CURLY BRACKET
+        0xFF5C, // '｜'     // FULLWIDTH VERTICAL LINE
+        0xFF5D, // '｝'     // FULLWIDTH RIGHT CURLY BRACKET
         => true,
         else => false,
     };


### PR DESCRIPTION
The wrap break list only covered 6 CJK punctuation codepoints (、。！，：？), missing brackets, quotes, and other marks commonly used in Chinese text. These are natural word boundaries but were not recognized as wrap break points.

Add 27 codepoints across three Unicode blocks:
- General Punctuation: U+2018–U+2019, U+201C–U+201D (curly quotes)
- CJK Symbols and Punctuation: U+3008–U+3011, U+3014–U+3017 (angle, corner, lenticular, tortoise shell brackets)
- Halfwidth and Fullwidth Forms: U+FF08–U+FF09, U+FF0E, U+FF1B, U+FF3B, U+FF3D, U+FF5B–U+FF5D (fullwidth brackets, period, semicolon, vertical bar)

Add tests covering all new codepoints in utf8_test.zig, and word boundary navigation tests in edit-buffer_test.zig.