### PR TITLE
fix(core): bound CSI ?997 re-query with a cooldown damper (stacked on #1213)

### DIFF
--- a/packages/core/src/renderer-theme-mode.ts
+++ b/packages/core/src/renderer-theme-mode.ts
@@ -44,7 +44,6 @@ export class RendererThemeMode {
   private static readonly QUERY_TIMEOUT_MS = 250
 
   private _themeMode: ThemeMode | null = null
-  private themeQueryPending = true
   private themeOscForeground: string | null = null
   private themeOscBackground: string | null = null
   private themeRefreshTimeoutId: TimerHandle | null = null
@@ -89,7 +88,6 @@ export class RendererThemeMode {
 
     this.clock.clearTimeout(this.themeRefreshTimeoutId)
     this.themeRefreshTimeoutId = null
-    this.themeQueryPending = false
   }
 
   public dispose(): void {
@@ -130,10 +128,19 @@ export class RendererThemeMode {
       return { handled: false, changedMode: null }
     }
 
-    if (!this.themeQueryPending) {
-      return { handled: true, changedMode: null }
-    }
-
+    // Apply the inferred mode once both foreground and background replies have
+    // arrived, even if the 250ms query timeout already fired. A terminal that
+    // answers OSC 10/11 slower than QUERY_TIMEOUT_MS — common under WezTerm,
+    // where a color-scheme change can take ~1s to settle in the OSC 11 reply —
+    // would otherwise have its late answer silently dropped, leaving the mode
+    // stuck on the old value. requestThemeOscColors resets fg/bg to null at
+    // the start of each query, so stale values from a prior query cannot leak
+    // in here.
+    //
+    // Note this means unsolicited OSC 10/11 replies can mutate the theme mode
+    // at any time (fg/bg persist after a completed query). After suspend(),
+    // inertness relies on the stdin data listener being detached — not on an
+    // internal pending flag.
     if (!this.themeOscForeground || !this.themeOscBackground) {
       return { handled: true, changedMode: null }
     }
@@ -156,23 +163,22 @@ export class RendererThemeMode {
 
   private completeThemeQuery(): void {
     this.clearThemeRefreshTimeout()
-    this.themeQueryPending = false
   }
 
   private requestThemeOscColors(): void {
     // Ignore repeated ?997 notifications while the current OSC refresh is
-    // still in flight.
+    // still in flight: under tmux on macOS the OSC 10/11 round-trip itself
+    // provokes another ?997, so starting a new query per notification would
+    // recreate the feedback loop from #975.
     if (this.themeRefreshTimeoutId !== null) {
       return
     }
 
-    this.themeQueryPending = true
     this.themeOscForeground = null
     this.themeOscBackground = null
 
     this.host.queryThemeColors()
 
-    this.clearThemeRefreshTimeout()
     this.themeRefreshTimeoutId = this.clock.setTimeout(() => {
       this.completeThemeQuery()
     }, RendererThemeMode.QUERY_TIMEOUT_MS)

--- a/packages/core/src/renderer-theme-mode.ts
+++ b/packages/core/src/renderer-theme-mode.ts
@@ -42,11 +42,16 @@ type ThemeWaiter = {
 
 export class RendererThemeMode {
   private static readonly QUERY_TIMEOUT_MS = 250
+  private static readonly FOLLOW_UP_COOLDOWN_MS = 5000
+  private static readonly PROVOKED_WINDOW_MS = 1000
 
   private _themeMode: ThemeMode | null = null
   private themeOscForeground: string | null = null
   private themeOscBackground: string | null = null
   private themeRefreshTimeoutId: TimerHandle | null = null
+  private requeryPending = false
+  private lastFollowUpQueryAt = Number.NEGATIVE_INFINITY
+  private lastQueryActivityAt = Number.NEGATIVE_INFINITY
   private waiters = new Set<ThemeWaiter>()
 
   constructor(
@@ -88,6 +93,7 @@ export class RendererThemeMode {
 
     this.clock.clearTimeout(this.themeRefreshTimeoutId)
     this.themeRefreshTimeoutId = null
+    this.requeryPending = false
   }
 
   public dispose(): void {
@@ -163,24 +169,70 @@ export class RendererThemeMode {
 
   private completeThemeQuery(): void {
     this.clearThemeRefreshTimeout()
+    this.lastQueryActivityAt = this.clock.now()
+    this.consumePendingRequery()
   }
 
   private requestThemeOscColors(): void {
-    // Ignore repeated ?997 notifications while the current OSC refresh is
-    // still in flight: under tmux on macOS the OSC 10/11 round-trip itself
-    // provokes another ?997, so starting a new query per notification would
-    // recreate the feedback loop from #975.
+    // A ?997 while a query is in flight must not start another query
+    // immediately — under tmux on macOS the OSC 10/11 round-trip itself
+    // provokes the next ?997, and querying per notification recreates the
+    // feedback loop from #975. Remember it instead (single slot) so the
+    // current query can be followed by at most one cooldown-gated re-query.
     if (this.themeRefreshTimeoutId !== null) {
+      this.requeryPending = true
       return
+    }
+
+    // A ?997 arriving shortly after the previous query's activity while idle
+    // is likely provoked by that query's own round-trip (fast-reply variant
+    // of #975: the reply completes the query before the provoked ?997
+    // lands). Route it through the same cooldown gate instead of treating it
+    // as fresh.
+    if (this.clock.now() - this.lastQueryActivityAt < RendererThemeMode.PROVOKED_WINDOW_MS) {
+      this.requeryPending = true
+      this.consumePendingRequery()
+      return
+    }
+
+    this.beginThemeQuery(false)
+  }
+
+  private consumePendingRequery(): void {
+    if (!this.requeryPending) {
+      return
+    }
+
+    this.requeryPending = false
+
+    // At most one follow-up query per cooldown regardless of how many
+    // notifications arrived: this is what breaks the self-sustaining
+    // query→provoked-?997→re-query cycle of #975 while still honoring one
+    // genuine notification that landed mid-flight.
+    if (this.clock.now() - this.lastFollowUpQueryAt < RendererThemeMode.FOLLOW_UP_COOLDOWN_MS) {
+      return
+    }
+
+    this.beginThemeQuery(true)
+  }
+
+  private beginThemeQuery(isFollowUp: boolean): void {
+    const now = this.clock.now()
+    this.lastQueryActivityAt = now
+    if (isFollowUp) {
+      this.lastFollowUpQueryAt = now
     }
 
     this.themeOscForeground = null
     this.themeOscBackground = null
+    this.requeryPending = false
 
     this.host.queryThemeColors()
 
     this.themeRefreshTimeoutId = this.clock.setTimeout(() => {
-      this.completeThemeQuery()
+      this.clearThemeRefreshTimeout()
+      this.lastQueryActivityAt = this.clock.now()
+      this.consumePendingRequery()
     }, RendererThemeMode.QUERY_TIMEOUT_MS)
   }
 

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -2054,6 +2054,136 @@ test("late OSC 11 reply arriving after the query timeout still applies the theme
   renderer.destroy()
 })
 
+test("tmux #975 simulation: query-provoked ?997 must not sustain a query loop", async () => {
+  const { renderer, queryThemeColorsCalls, clock } = await createThemeQueryRenderer()
+
+  // #975 shape: the OSC 10/11 round-trip itself provokes the next ?997.
+  // The terminal never answers (slow path); each query provokes a
+  // notification 50ms later.
+  // @ts-expect-error - mocking for test
+  renderer.lib.queryThemeColors = () => {
+    queryThemeColorsCalls.count += 1
+    clock.setTimeout(() => renderer.stdin.emit("data", Buffer.from("\x1b[?997;1n")), 50)
+  }
+
+  renderer.stdin.emit("data", Buffer.from("\x1b[?997;1n"))
+
+  for (let t = 0; t < 10_000; t += 10) {
+    clock.advance(10)
+    await flushMicrotasks()
+  }
+
+  expect(queryThemeColorsCalls.count).toBeLessThanOrEqual(2)
+
+  renderer.destroy()
+})
+
+test("query-provoked ?997 after a fast reply must not sustain a query loop", async () => {
+  const { renderer, queryThemeColorsCalls, clock } = await createThemeQueryRenderer()
+
+  // Fast-reply variant of #975: the terminal answers OSC 10/11 within 10ms
+  // (query completes early), and the round-trip still provokes a ?997 50ms
+  // after each query — arriving while no query is in flight.
+  // @ts-expect-error - mocking for test
+  renderer.lib.queryThemeColors = () => {
+    queryThemeColorsCalls.count += 1
+    clock.setTimeout(() => {
+      renderer.stdin.emit("data", Buffer.from("\x1b]10;#ffffff\x07"))
+      renderer.stdin.emit("data", Buffer.from("\x1b]11;#000000\x07"))
+    }, 10)
+    clock.setTimeout(() => renderer.stdin.emit("data", Buffer.from("\x1b[?997;1n")), 50)
+  }
+
+  renderer.stdin.emit("data", Buffer.from("\x1b[?997;1n"))
+
+  for (let t = 0; t < 10_000; t += 10) {
+    clock.advance(10)
+    await flushMicrotasks()
+  }
+
+  expect(queryThemeColorsCalls.count).toBeLessThanOrEqual(2)
+
+  renderer.destroy()
+})
+
+test("?997 during an in-flight query with a fast pre-settle reply still triggers the follow-up", async () => {
+  const { renderer, queryThemeColorsCalls, clock } = await createThemeQueryRenderer()
+
+  // Settle-lag race: a second ?997 arrives while the first query is in
+  // flight, then the terminal answers the first query quickly with
+  // pre-settle (stale) colors. The follow-up must run via early
+  // consumption — not only from the 250ms timeout, which the fast reply
+  // cancels.
+  renderer.stdin.emit("data", Buffer.from("\x1b[?997;1n"))
+  advanceClock(clock, 100)
+  expect(queryThemeColorsCalls.count).toBe(1)
+
+  renderer.stdin.emit("data", Buffer.from("\x1b[?997;2n"))
+  advanceClock(clock, 10)
+
+  // Stale full reply completes query #1 before its timeout.
+  renderer.stdin.emit("data", Buffer.from("\x1b]10;#ffffff\x07"))
+  renderer.stdin.emit("data", Buffer.from("\x1b]11;#000000\x07"))
+  await flushMicrotasks()
+  expect(renderer.themeMode).toBe("dark")
+  expect(queryThemeColorsCalls.count).toBe(2)
+
+  // The settled colors answer the follow-up query.
+  advanceClock(clock, 50)
+  renderer.stdin.emit("data", Buffer.from("\x1b]10;#000000\x07"))
+  renderer.stdin.emit("data", Buffer.from("\x1b]11;#ffffff\x07"))
+  await flushMicrotasks()
+  expect(renderer.themeMode).toBe("light")
+
+  renderer.destroy()
+})
+
+test("?997 during an in-flight query triggers exactly one follow-up after the timeout", async () => {
+  const { renderer, queryThemeColorsCalls, clock } = await createThemeQueryRenderer()
+
+  renderer.stdin.emit("data", Buffer.from("\x1b[?997;1n"))
+  advanceClock(clock, 100)
+  expect(queryThemeColorsCalls.count).toBe(1)
+
+  renderer.stdin.emit("data", Buffer.from("\x1b[?997;2n"))
+  advanceClock(clock, 149)
+  expect(queryThemeColorsCalls.count).toBe(1)
+
+  advanceClock(clock, 1)
+  await flushMicrotasks()
+  expect(queryThemeColorsCalls.count).toBe(2)
+
+  // With no further notifications, the follow-up window times out without
+  // spawning another query.
+  advanceClock(clock, 250)
+  advanceClock(clock, 250)
+  await flushMicrotasks()
+  expect(queryThemeColorsCalls.count).toBe(2)
+
+  renderer.destroy()
+})
+
+test("a genuine theme change after the follow-up cooldown starts a fresh query", async () => {
+  const { renderer, queryThemeColorsCalls, clock } = await createThemeQueryRenderer()
+
+  renderer.stdin.emit("data", Buffer.from("\x1b[?997;1n"))
+  advanceClock(clock, 100)
+  renderer.stdin.emit("data", Buffer.from("\x1b[?997;2n"))
+  advanceClock(clock, 150)
+  await flushMicrotasks()
+  expect(queryThemeColorsCalls.count).toBe(2)
+  advanceClock(clock, 250)
+  await flushMicrotasks()
+
+  // A real theme change long after all query activity must never be gated.
+  advanceClock(clock, 10_000)
+  renderer.stdin.emit("data", Buffer.from("\x1b[?997;2n"))
+  advanceClock(clock, 10)
+  expect(queryThemeColorsCalls.count).toBe(3)
+
+  renderer.destroy()
+})
+
 test("pixel resolution response should not trigger keypress", async () => {
   const keypresses: KeyEvent[] = []
   currentRenderer.keyInput.on("keypress", (event) => {

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -2019,6 +2019,41 @@ test("waitForThemeMode resolves with current theme mode when renderer is destroy
   await expect(themeModePromise).resolves.toBeNull()
 })
 
+test("late OSC 11 reply arriving after the query timeout still applies the theme mode", async () => {
+  const { renderer, queryThemeColorsCalls, clock } = await createThemeQueryRenderer()
+  const themeModes: string[] = []
+  renderer.on("theme_mode", (mode) => {
+    themeModes.push(mode)
+  })
+
+  // Establish an initial dark mode.
+  renderer.stdin.emit("data", Buffer.from("\x1b]10;#ffffff\x07"))
+  renderer.stdin.emit("data", Buffer.from("\x1b]11;#000000\x07"))
+  advanceClock(clock)
+  expect(renderer.themeMode).toBe("dark")
+
+  // Terminal reports a theme change. opentui re-queries OSC 10/11.
+  renderer.stdin.emit("data", Buffer.from("\x1b[?997;2n"))
+  advanceClock(clock, 249)
+  expect(queryThemeColorsCalls.count).toBe(1)
+
+  // Let the 250ms query timeout fire with no reply yet. Waiters stop waiting,
+  // but a delayed reply must still be honored rather than silently dropped.
+  advanceClock(clock, 1)
+  await flushMicrotasks()
+  expect(renderer.themeMode).toBe("dark")
+
+  // The terminal finally answers with a light background after the timeout.
+  renderer.stdin.emit("data", Buffer.from("\x1b]10;#000000\x07"))
+  renderer.stdin.emit("data", Buffer.from("\x1b]11;#ffffff\x07"))
+  advanceClock(clock)
+
+  expect(renderer.themeMode).toBe("light")
+  expect(themeModes).toEqual(["dark", "light"])
+
+  renderer.destroy()
+})
+
 test("pixel resolution response should not trigger keypress", async () => {
   const keypresses: KeyEvent[] = []
   currentRenderer.keyInput.on("keypress", (event) => {


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #1213.** The first commit here is #1213's Bug-A fix (honor late OSC replies); until #1213 merges, this diff includes it. Please review only the second commit.

Follows up on the review feedback in #1213: the original bounded re-query reintroduced the #975 feedback loop and missed its own target case. This PR replaces the #976 silent in-flight drop with a follow-up query behind a real loop damper, per the suggested path forward.

## Problem

The #976 fix silently drops any `?997` notification arriving while an OSC 10/11 query is in flight. A terminal whose colors are still settling when it notifies gets stuck on the pre-transition mode until some later event. But naively re-querying per dropped notification re-opens #975, where the OSC round-trip itself provokes the next `?997`.

## Design

- A `?997` during an in-flight query sets a single-slot `requeryPending` flag instead of being dropped.
- The pending follow-up is consumed on **both** completion paths — the 250ms timeout **and** early completion via a full OSC reply — so a terminal that answers quickly with pre-settle colors no longer strands the deferred notification (the settle-lag race called out in review).
- **Cooldown**: at most one follow-up query per 5s (`FOLLOW_UP_COOLDOWN_MS`) regardless of how many notifications arrive. In the #975 shape (each query provokes the next `?997`), queries settle at 2 instead of looping at one per 250ms.
- **Provoked window**: an idle `?997` arriving within 1s (`PROVOKED_WINDOW_MS`) of the last query activity is treated as a follow-up candidate under the same cooldown. This closes the fast-reply bypass: a terminal that answers within the 250ms window completes the query *before* its provoked `?997` lands, so that notification would otherwise count as "fresh" and sustain the loop around the in-flight guard.
- Genuine notifications outside the provoked window always start a fresh query immediately, never gated.

## Tests

All modeled with `ManualClock` in `renderer.input.test.ts`:

1. **tmux #975 simulation** (adapted from the reviewer's test in the #1213 review — thank you): each `queryThemeColors` provokes a `?997` 50ms later, terminal never answers → queries stay ≤ 2 over 10s of virtual time.
2. **Fast-reply #975 variant**: terminal answers in 10ms and the provoked `?997` lands at 50ms while idle → still ≤ 2.
3. **Settle-lag early consumption**: `?997` #2 in-flight + fast pre-settle reply → follow-up runs immediately via early completion, settled colors applied.
4. **Single-follow-up bound**: in-flight `?997` produces exactly one follow-up; further notifications within cooldown produce none.
5. **Genuine change after cooldown** → fresh query fires immediately.

All 102 tests in `renderer.input.test.ts` pass; tests 2–4 fail on the Bug-A-only base (#1213), confirming they exercise this change.