### PR TITLE
fix(core): respect useKittyKeyboard: null to disable kitty keyboard protocol

### DIFF
--- a/packages/core/src/lib/stdin-parser.test.ts
+++ b/packages/core/src/lib/stdin-parser.test.ts
@@ -1219,6 +1219,46 @@ describe("StdinParser", () => {
   })
 
   describe("protocol context", () => {
+    test("updating Kitty context synchronizes complete key decoding", () => {
+      const parser = createParser({
+        useKittyKeyboard: false,
+        protocolContext: { kittyKeyboardEnabled: false },
+      })
+
+      try {
+        parser.push(Buffer.from("\x1b[97u"))
+        expect(snap(parser)).toEqual([k("", { raw: "\x1b[97u" })])
+
+        parser.updateProtocolContext({ kittyKeyboardEnabled: true })
+        parser.push(Buffer.from("\x1b[97u"))
+        expect(snap(parser)).toEqual([k("a", { raw: "\x1b[97u" })])
+
+        parser.updateProtocolContext({ kittyKeyboardEnabled: false })
+        parser.push(Buffer.from("\x1b[97u"))
+        expect(snap(parser)).toEqual([k("", { raw: "\x1b[97u" })])
+      } finally {
+        parser.destroy()
+      }
+    })
+
+    test("disabling Kitty context flushes a timed-out partial key", () => {
+      const { parser, clock } = createTimedParser({
+        protocolContext: { kittyKeyboardEnabled: true },
+      })
+
+      try {
+        parser.push(Buffer.from("\x1b[97;2"))
+        expect(snap(parser)).toEqual([])
+        clock.advance(TEST_TIMEOUT_MS)
+        expect(snap(parser)).toEqual([])
+
+        parser.updateProtocolContext({ kittyKeyboardEnabled: false })
+        expect(snap(parser)).toEqual([resp("unknown", "\x1b[97;2")])
+      } finally {
+        parser.destroy()
+      }
+    })
+
     test("partial explicit-width CPR stays pending after timeout when probe is active", () => {
       const { parser, clock } = createTimedParser({
         protocolContext: { explicitWidthCprActive: true },

--- a/packages/core/src/lib/stdin-parser.ts
+++ b/packages/core/src/lib/stdin-parser.ts
@@ -570,7 +570,7 @@ export class StdinParser {
   private readonly maxPendingBytes: number
   private readonly armTimeouts: boolean
   private readonly onTimeoutFlush: (() => void) | null
-  private readonly useKittyKeyboard: boolean
+  private useKittyKeyboard: boolean
   private readonly mouseParser = new MouseParser()
   private readonly clock: Clock
   private protocolContext: StdinParserProtocolContext
@@ -618,6 +618,9 @@ export class StdinParser {
 
   public updateProtocolContext(patch: Partial<StdinParserProtocolContext>): void {
     this.ensureAlive()
+    if (patch.kittyKeyboardEnabled !== undefined) {
+      this.useKittyKeyboard = patch.kittyKeyboardEnabled
+    }
     this.protocolContext = { ...this.protocolContext, ...patch }
     this.reconcileDeferredStateWithProtocolContext()
     this.reconcileTimeoutState()

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1054,7 +1054,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     if (process.platform === "linux") config.useThread = false
     lib.setUseThread(rendererPtr, config.useThread)
 
-    const kittyConfig = config.useKittyKeyboard ?? {}
+    // Only undefined falls back to the defaults: null explicitly disables the protocol
+    const kittyConfig = config.useKittyKeyboard === undefined ? {} : config.useKittyKeyboard
     const kittyFlags = buildKittyKeyboardFlags(kittyConfig)
     lib.setKittyKeyboardFlags(rendererPtr, kittyFlags)
 

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -811,6 +811,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private enableMouseMovement: boolean = false
   private _useMouse: boolean = true
+  private _useKittyKeyboard: boolean = true
   private autoFocus: boolean = true
   private _screenMode: ScreenMode = "alternate-screen"
   private _footerHeight: number = DEFAULT_FOOTER_HEIGHT
@@ -1173,6 +1174,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     process.on("beforeExit", this.exitHandler)
 
     const useKittyForParsing = kittyConfig !== null
+    this._useKittyKeyboard = useKittyForParsing
     this._keyHandler = new InternalKeyHandler()
     this._keyHandler.on("keypress", (event) => {
       // Use the shared matcher here too. Kitty can report a non-Latin
@@ -1843,12 +1845,15 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   public get useKittyKeyboard(): boolean {
-    return this.lib.getKittyKeyboardFlags(this.rendererPtr) > 0
+    return this._useKittyKeyboard
   }
 
   public set useKittyKeyboard(use: boolean) {
-    const flags = use ? KITTY_FLAG_DISAMBIGUATE | KITTY_FLAG_ALTERNATE_KEYS : 0
-    this.lib.setKittyKeyboardFlags(this.rendererPtr, flags)
+    if (use) {
+      this.enableKittyKeyboard(KITTY_FLAG_DISAMBIGUATE | KITTY_FLAG_ALTERNATE_KEYS)
+    } else {
+      this.disableKittyKeyboard()
+    }
   }
 
   public createScrollbackSurface(options: ScrollbackSurfaceOptions = {}): ScrollbackSurface {
@@ -3068,11 +3073,13 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   public enableKittyKeyboard(flags: number = 0b00011): void {
     this.lib.enableKittyKeyboard(this.rendererPtr, flags)
+    this._useKittyKeyboard = true
     this.updateStdinParserProtocolContext({ kittyKeyboardEnabled: true })
   }
 
   public disableKittyKeyboard(): void {
     this.lib.disableKittyKeyboard(this.rendererPtr)
+    this._useKittyKeyboard = false
     this.updateStdinParserProtocolContext({ kittyKeyboardEnabled: false }, true)
   }
 

--- a/packages/core/src/tests/renderer.kitty-flags.test.ts
+++ b/packages/core/src/tests/renderer.kitty-flags.test.ts
@@ -195,9 +195,8 @@ test("optional flags default to false", () => {
   expect(flags & KITTY_FLAG_REPORT_TEXT).toBeFalsy()
 })
 
-// NOTE: These tests are not running the kitty activation sequences,
-// only verifying that the configuration is applied correctly
-// (renderer.useKittyKeyboard reads the flags back from the native renderer).
+// These tests only verify the public configuration state. Terminal activation,
+// parsing, and lifecycle behavior are covered by renderer.kitty-lifecycle.test.ts.
 describe("useKittyKeyboard configuration", () => {
   test("useKittyKeyboard: null disables the kitty keyboard protocol", async () => {
     const { renderer } = await createTestRenderer({
@@ -205,8 +204,11 @@ describe("useKittyKeyboard configuration", () => {
       exitOnCtrlC: false,
     })
 
-    expect(renderer.useKittyKeyboard).toBe(false)
-    renderer.destroy()
+    try {
+      expect(renderer.useKittyKeyboard).toBe(false)
+    } finally {
+      renderer.destroy()
+    }
   })
 
   test("useKittyKeyboard omitted enables the protocol with defaults", async () => {
@@ -214,8 +216,11 @@ describe("useKittyKeyboard configuration", () => {
       exitOnCtrlC: false,
     })
 
-    expect(renderer.useKittyKeyboard).toBe(true)
-    renderer.destroy()
+    try {
+      expect(renderer.useKittyKeyboard).toBe(true)
+    } finally {
+      renderer.destroy()
+    }
   })
 
   test("useKittyKeyboard options object enables the protocol", async () => {
@@ -224,7 +229,10 @@ describe("useKittyKeyboard configuration", () => {
       exitOnCtrlC: false,
     })
 
-    expect(renderer.useKittyKeyboard).toBe(true)
-    renderer.destroy()
+    try {
+      expect(renderer.useKittyKeyboard).toBe(true)
+    } finally {
+      renderer.destroy()
+    }
   })
 })

--- a/packages/core/src/tests/renderer.kitty-flags.test.ts
+++ b/packages/core/src/tests/renderer.kitty-flags.test.ts
@@ -1,5 +1,6 @@
-import { test, expect } from "bun:test"
+import { test, expect, describe } from "bun:test"
 import { buildKittyKeyboardFlags } from "../renderer.js"
+import { createTestRenderer } from "../testing/test-renderer.js"
 
 // Kitty Keyboard Protocol progressive enhancement flags
 // See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/#progressive-enhancement
@@ -192,4 +193,38 @@ test("optional flags default to false", () => {
   expect(flags & KITTY_FLAG_EVENT_TYPES).toBeFalsy()
   expect(flags & KITTY_FLAG_ALL_KEYS_AS_ESCAPES).toBeFalsy()
   expect(flags & KITTY_FLAG_REPORT_TEXT).toBeFalsy()
+})
+
+// NOTE: These tests are not running the kitty activation sequences,
+// only verifying that the configuration is applied correctly
+// (renderer.useKittyKeyboard reads the flags back from the native renderer).
+describe("useKittyKeyboard configuration", () => {
+  test("useKittyKeyboard: null disables the kitty keyboard protocol", async () => {
+    const { renderer } = await createTestRenderer({
+      useKittyKeyboard: null,
+      exitOnCtrlC: false,
+    })
+
+    expect(renderer.useKittyKeyboard).toBe(false)
+    renderer.destroy()
+  })
+
+  test("useKittyKeyboard omitted enables the protocol with defaults", async () => {
+    const { renderer } = await createTestRenderer({
+      exitOnCtrlC: false,
+    })
+
+    expect(renderer.useKittyKeyboard).toBe(true)
+    renderer.destroy()
+  })
+
+  test("useKittyKeyboard options object enables the protocol", async () => {
+    const { renderer } = await createTestRenderer({
+      useKittyKeyboard: { events: true },
+      exitOnCtrlC: false,
+    })
+
+    expect(renderer.useKittyKeyboard).toBe(true)
+    renderer.destroy()
+  })
 })

--- a/packages/core/src/tests/renderer.kitty-lifecycle.test.ts
+++ b/packages/core/src/tests/renderer.kitty-lifecycle.test.ts
@@ -6,19 +6,37 @@ import type { NativeSpanFeed } from "../NativeSpanFeed.js"
 import { CliRenderer, type KittyKeyboardOptions } from "../renderer.js"
 import { createTestStdin, TestWriteStream } from "../testing/test-streams.js"
 
+const KITTY_GRAPHICS_QUERY = "\x1b_Gi=31337,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\\x1b[c"
+
 class CollectingWriteStream extends TestWriteStream {
   private readonly writes: Buffer[] = []
+  private deferCallbacks = false
+  private pendingCallbacks: Array<() => void> = []
 
   override _write(chunk: unknown, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
     const bytes = chunk instanceof Uint8Array ? Buffer.from(chunk) : Buffer.from(String(chunk))
     this.writes.push(bytes)
-    callback()
+    if (this.deferCallbacks) {
+      this.pendingCallbacks.push(() => callback())
+    } else {
+      callback()
+    }
   }
 
   public take(): string {
     const output = Buffer.concat(this.writes).toString("latin1")
     this.writes.length = 0
     return output
+  }
+
+  public deferWriteCallbacks(): void {
+    this.deferCallbacks = true
+  }
+
+  public releaseWriteCallbacks(): void {
+    this.deferCallbacks = false
+    const callbacks = this.pendingCallbacks.splice(0)
+    for (const callback of callbacks) callback()
   }
 }
 
@@ -27,6 +45,7 @@ interface KittyRendererHarness {
   stdin: NodeJS.ReadStream
   stdout: CollectingWriteStream
   feed: NativeSpanFeed
+  initialOutput: string
 }
 
 async function createKittyRenderer(
@@ -57,8 +76,8 @@ async function createKittyRenderer(
       await renderer.setupTerminal()
     }
     await feed.idle()
-    stdout.take()
-    return { renderer, stdin, stdout, feed }
+    const initialOutput = stdout.take()
+    return { renderer, stdin, stdout, feed, initialOutput }
   } catch (error) {
     try {
       renderer.destroy()
@@ -93,23 +112,83 @@ function occursBefore(output: string, first: string, second: string): boolean {
   return firstIndex >= 0 && secondIndex > firstIndex
 }
 
+function countOccurrences(output: string, sequence: string): number {
+  return output.split(sequence).length - 1
+}
+
+test("useKittyKeyboard: null masks inherited Kitty input before capability detection", async () => {
+  const harness = await createKittyRenderer()
+
+  try {
+    const keys: Array<{ name: string; source: string }> = []
+    harness.renderer.keyInput.on("keypress", (key) => {
+      keys.push({ name: key.name, source: key.source })
+    })
+    harness.stdin.emit("data", Buffer.from("\x1b[97u"))
+
+    expect({
+      startupPushes: countOccurrences(harness.initialOutput, "\x1b[>0u"),
+      keys,
+    }).toEqual({
+      startupPushes: 1,
+      keys: [{ name: "", source: "raw" }],
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
 test("useKittyKeyboard: null masks an inherited Kitty mode for the renderer lifetime", async () => {
   const harness = await createKittyRenderer()
 
   try {
     const activationOutput = await reportInheritedKittyMode(harness)
-    expect(activationOutput).toContain("\x1b[>0u")
-    expect(activationOutput).not.toContain("\x1b[<u")
 
-    let inputSource: string | undefined
-    harness.renderer.keyInput.once("keypress", (key) => {
-      inputSource = key.source
+    const keys: Array<{ name: string; source: string }> = []
+    harness.renderer.keyInput.on("keypress", (key) => {
+      keys.push({ name: key.name, source: key.source })
     })
     harness.stdin.emit("data", Buffer.from("\x1b[97u"))
-    expect(inputSource).not.toBe("kitty")
 
     const shutdownOutput = await destroyKittyRenderer(harness)
-    expect(shutdownOutput).toContain("\x1b[<u")
+    expect({
+      startupPushes: countOccurrences(harness.initialOutput, "\x1b[>0u"),
+      activationPushes: countOccurrences(activationOutput, "\x1b[>0u"),
+      activationPops: countOccurrences(activationOutput, "\x1b[<u"),
+      keys,
+      shutdownPops: countOccurrences(shutdownOutput, "\x1b[<u"),
+    }).toEqual({
+      startupPushes: 1,
+      activationPushes: 0,
+      activationPops: 0,
+      keys: [{ name: "", source: "raw" }],
+      shutdownPops: 1,
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("a focus cycle restores the owned zero-flag Kitty entry without growing the stack", async () => {
+  const harness = await createKittyRenderer()
+
+  try {
+    harness.stdin.emit("data", Buffer.from("\x1b[O"))
+    harness.stdin.emit("data", Buffer.from("\x1b[I"))
+    await harness.feed.idle()
+    const focusOutput = harness.stdout.take()
+
+    expect({
+      poppedEntries: countOccurrences(focusOutput, "\x1b[<u"),
+      pushedEntries: countOccurrences(focusOutput, "\x1b[>0u"),
+      popBeforePush: occursBefore(focusOutput, "\x1b[<u", "\x1b[>0u"),
+      enabled: harness.renderer.useKittyKeyboard,
+    }).toEqual({
+      poppedEntries: 1,
+      pushedEntries: 1,
+      popBeforePush: true,
+      enabled: false,
+    })
   } finally {
     await destroyKittyRenderer(harness)
   }
@@ -134,15 +213,135 @@ test("a zero-flag options object masks inherited flags without disabling Kitty p
     harness.stdin.emit("data", Buffer.from("\x1b[97u"))
 
     expect({
-      pushedZero: activationOutput.includes("\x1b[>0u"),
-      disabledFallback: activationOutput.includes("\x1b[>4;0m"),
+      startupPushes: countOccurrences(harness.initialOutput, "\x1b[>0u"),
+      startupEnabledFallback: harness.initialOutput.includes("\x1b[>4;1m"),
+      activationPushes: countOccurrences(activationOutput, "\x1b[>0u"),
+      disabledFallback: harness.initialOutput.includes("\x1b[>4;0m") || activationOutput.includes("\x1b[>4;0m"),
+      enabled: harness.renderer.useKittyKeyboard,
       inputSource,
     }).toEqual({
-      pushedZero: true,
+      startupPushes: 1,
+      startupEnabledFallback: true,
+      activationPushes: 0,
       disabledFallback: false,
+      enabled: true,
       inputSource: "kitty",
     })
   } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("useKittyKeyboard setter enables terminal state and parsing", async () => {
+  const harness = await createKittyRenderer()
+
+  try {
+    await reportInheritedKittyMode(harness)
+
+    harness.renderer.useKittyKeyboard = true
+    await harness.feed.idle()
+    const enableOutput = harness.stdout.take()
+
+    const keys: Array<{ name: string; source: string }> = []
+    harness.renderer.keyInput.on("keypress", (key) => {
+      keys.push({ name: key.name, source: key.source })
+    })
+    harness.stdin.emit("data", Buffer.from("\x1b[97u"))
+
+    expect({
+      poppedEntries: countOccurrences(enableOutput, "\x1b[<u"),
+      pushedEntries: countOccurrences(enableOutput, "\x1b[>5u"),
+      replacedPreviousMode: occursBefore(enableOutput, "\x1b[<u", "\x1b[>5u"),
+      disabledFallback: countOccurrences(enableOutput, "\x1b[>4;0m"),
+      enabled: harness.renderer.useKittyKeyboard,
+      keys,
+    }).toEqual({
+      poppedEntries: 1,
+      pushedEntries: 1,
+      replacedPreviousMode: true,
+      disabledFallback: 1,
+      enabled: true,
+      keys: [{ name: "a", source: "kitty" }],
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("useKittyKeyboard setter disables terminal state and parsing", async () => {
+  const harness = await createKittyRenderer({ events: true })
+
+  try {
+    await reportInheritedKittyMode(harness)
+
+    harness.renderer.useKittyKeyboard = false
+    await harness.feed.idle()
+    const disableOutput = harness.stdout.take()
+
+    const keys: Array<{ name: string; source: string }> = []
+    harness.renderer.keyInput.on("keypress", (key) => {
+      keys.push({ name: key.name, source: key.source })
+    })
+    harness.stdin.emit("data", Buffer.from("\x1b[97u"))
+
+    expect({
+      poppedEntries: countOccurrences(disableOutput, "\x1b[<u"),
+      pushedEntries: countOccurrences(disableOutput, "\x1b[>0u"),
+      replacedPreviousMode: occursBefore(disableOutput, "\x1b[<u", "\x1b[>0u"),
+      enabledFallback: countOccurrences(disableOutput, "\x1b[>4;1m"),
+      enabled: harness.renderer.useKittyKeyboard,
+      keys,
+    }).toEqual({
+      poppedEntries: 1,
+      pushedEntries: 1,
+      replacedPreviousMode: true,
+      enabledFallback: 1,
+      enabled: false,
+      keys: [{ name: "", source: "raw" }],
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("Kitty lifecycle output remains pending until an asynchronous Writable callback completes", async () => {
+  const harness = await createKittyRenderer({ events: true })
+
+  try {
+    await reportInheritedKittyMode(harness)
+    harness.stdout.deferWriteCallbacks()
+
+    harness.renderer.disableKittyKeyboard()
+    const idlePromise = harness.feed.idle()
+    let idleResolved = false
+    void idlePromise.then(() => {
+      idleResolved = true
+    })
+    await Promise.resolve()
+
+    expect({
+      backpressured: harness.feed.isBackpressured(),
+      idleResolved,
+    }).toEqual({
+      backpressured: true,
+      idleResolved: false,
+    })
+
+    harness.stdout.releaseWriteCallbacks()
+    await idlePromise
+    const disableOutput = harness.stdout.take()
+
+    expect({
+      poppedEntries: countOccurrences(disableOutput, "\x1b[<u"),
+      pushedEntries: countOccurrences(disableOutput, "\x1b[>0u"),
+      enabledFallback: countOccurrences(disableOutput, "\x1b[>4;1m"),
+    }).toEqual({
+      poppedEntries: 1,
+      pushedEntries: 1,
+      enabledFallback: 1,
+    })
+  } finally {
+    harness.stdout.releaseWriteCallbacks()
     await destroyKittyRenderer(harness)
   }
 })
@@ -262,6 +461,42 @@ test("disableKittyKeyboard synchronizes terminal state, parsing, getter, fallbac
   }
 })
 
+test("disableKittyKeyboard masks inherited Kitty input before capability detection", async () => {
+  const harness = await createKittyRenderer({ events: true })
+
+  try {
+    harness.renderer.disableKittyKeyboard()
+    await harness.feed.idle()
+    const disableOutput = harness.stdout.take()
+
+    const keys: Array<{ name: string; source: string }> = []
+    harness.renderer.keyInput.on("keypress", (key) => {
+      keys.push({ name: key.name, source: key.source })
+    })
+    harness.stdin.emit("data", Buffer.from("\x1b[97u"))
+
+    expect({
+      startupEnabledFallback: countOccurrences(harness.initialOutput, "\x1b[>4;1m"),
+      startupKittyPushes: countOccurrences(harness.initialOutput, "\x1b[>7u"),
+      disablePops: countOccurrences(disableOutput, "\x1b[<u"),
+      disablePushes: countOccurrences(disableOutput, "\x1b[>0u"),
+      disabledFallback: disableOutput.includes("\x1b[>4;0m"),
+      enabled: harness.renderer.useKittyKeyboard,
+      keys,
+    }).toEqual({
+      startupEnabledFallback: 1,
+      startupKittyPushes: 0,
+      disablePops: 0,
+      disablePushes: 1,
+      disabledFallback: false,
+      enabled: false,
+      keys: [{ name: "", source: "raw" }],
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
 test("disableKittyKeyboard before setup defers terminal writes until setup", async () => {
   const harness = await createKittyRenderer({ events: true }, false)
 
@@ -273,17 +508,19 @@ test("disableKittyKeyboard before setup defers terminal writes until setup", asy
 
     await harness.renderer.setupTerminal()
     await harness.feed.idle()
-    harness.stdout.take()
+    const setupOutput = harness.stdout.take()
     const activationOutput = await reportInheritedKittyMode(harness)
 
     expect({
       outputBeforeSetup,
       enabledBeforeSetup,
-      activationPushedZero: activationOutput.includes("\x1b[>0u"),
+      setupPushes: countOccurrences(setupOutput, "\x1b[>0u"),
+      activationPushes: countOccurrences(activationOutput, "\x1b[>0u"),
     }).toEqual({
       outputBeforeSetup: "",
       enabledBeforeSetup: false,
-      activationPushedZero: true,
+      setupPushes: 1,
+      activationPushes: 0,
     })
   } finally {
     await destroyKittyRenderer(harness)
@@ -324,6 +561,80 @@ test("disableKittyKeyboard while suspended defers terminal writes until resume",
   }
 })
 
+test("capability handling does not reactivate Kitty after an input handler suspends the renderer", async () => {
+  const harness = await createKittyRenderer()
+
+  try {
+    harness.renderer.prependInputHandler((sequence) => {
+      if (sequence !== "\x1b[?1u") return false
+      harness.renderer.suspend()
+      return false
+    })
+
+    harness.stdin.emit("data", Buffer.from("\x1b[?1u"))
+    await harness.feed.idle()
+    const suspendOutput = harness.stdout.take()
+
+    harness.renderer.resume()
+    await harness.feed.idle()
+    const resumeOutput = harness.stdout.take()
+
+    expect({
+      capabilityDetected: harness.renderer.capabilities?.kitty_keyboard,
+      suspendPops: countOccurrences(suspendOutput, "\x1b[<u"),
+      suspendPushes: countOccurrences(suspendOutput, "\x1b[>0u"),
+      suspendFallbackEnables: countOccurrences(suspendOutput, "\x1b[>4;1m"),
+      suspendGraphicsQueries: countOccurrences(suspendOutput, KITTY_GRAPHICS_QUERY),
+      resumePushes: countOccurrences(resumeOutput, "\x1b[>0u"),
+      resumeFallbackEnables: countOccurrences(resumeOutput, "\x1b[>4;1m"),
+      resumeGraphicsQueries: countOccurrences(resumeOutput, KITTY_GRAPHICS_QUERY),
+    }).toEqual({
+      capabilityDetected: true,
+      suspendPops: 1,
+      suspendPushes: 0,
+      suspendFallbackEnables: 0,
+      suspendGraphicsQueries: 0,
+      resumePushes: 1,
+      resumeFallbackEnables: 1,
+      resumeGraphicsQueries: 1,
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("resume before a capability response preserves pending queries until the response arrives", async () => {
+  const harness = await createKittyRenderer()
+
+  try {
+    harness.renderer.suspend()
+    await harness.feed.idle()
+    harness.stdout.take()
+
+    harness.renderer.resume()
+    await harness.feed.idle()
+    const resumeOutput = harness.stdout.take()
+
+    const capabilityOutput = await reportInheritedKittyMode(harness)
+
+    expect({
+      resumePushes: countOccurrences(resumeOutput, "\x1b[>0u"),
+      resumeGraphicsQueries: countOccurrences(resumeOutput, KITTY_GRAPHICS_QUERY),
+      capabilityDetected: harness.renderer.capabilities?.kitty_keyboard,
+      capabilityPushes: countOccurrences(capabilityOutput, "\x1b[>0u"),
+      capabilityGraphicsQueries: countOccurrences(capabilityOutput, KITTY_GRAPHICS_QUERY),
+    }).toEqual({
+      resumePushes: 1,
+      resumeGraphicsQueries: 0,
+      capabilityDetected: true,
+      capabilityPushes: 0,
+      capabilityGraphicsQueries: 1,
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
 test("enableKittyKeyboard preserves modifyOtherKeys when Kitty support was not detected", async () => {
   const harness = await createKittyRenderer()
 
@@ -337,11 +648,13 @@ test("enableKittyKeyboard preserves modifyOtherKeys when Kitty support was not d
     const enableOutput = harness.stdout.take()
 
     expect({
-      attemptedKittyPush: enableOutput.includes("\x1b[>7u"),
-      disabledFallback: enableOutput.includes("\x1b[>4;0m"),
+      startupEnabledFallback: countOccurrences(harness.initialOutput, "\x1b[>4;1m"),
+      attemptedKittyPushes: countOccurrences(enableOutput, "\x1b[>7u"),
+      disabledFallback: countOccurrences(enableOutput, "\x1b[>4;0m"),
     }).toEqual({
-      attemptedKittyPush: true,
-      disabledFallback: false,
+      startupEnabledFallback: 1,
+      attemptedKittyPushes: 1,
+      disabledFallback: 0,
     })
   } finally {
     await destroyKittyRenderer(harness)
@@ -357,7 +670,14 @@ test("enableKittyKeyboard with zero flags preserves the modifyOtherKeys fallback
     harness.renderer.enableKittyKeyboard(0)
     await harness.feed.idle()
 
-    expect(harness.stdout.take()).not.toContain("\x1b[>4;0m")
+    const enableOutput = harness.stdout.take()
+    expect({
+      startupEnabledFallback: countOccurrences(harness.initialOutput, "\x1b[>4;1m"),
+      disabledFallback: countOccurrences(enableOutput, "\x1b[>4;0m"),
+    }).toEqual({
+      startupEnabledFallback: 1,
+      disabledFallback: 0,
+    })
   } finally {
     await destroyKittyRenderer(harness)
   }
@@ -379,7 +699,7 @@ test("runtime Kitty changes before setup are deferred until setup", async () => 
 
     await harness.renderer.setupTerminal()
     await harness.feed.idle()
-    harness.stdout.take()
+    const setupOutput = harness.stdout.take()
     const activationOutput = await reportInheritedKittyMode(harness)
 
     expect({
@@ -387,15 +707,17 @@ test("runtime Kitty changes before setup are deferred until setup", async () => 
       enabledAfterEnable,
       disableOutput,
       enabledAfterDisable,
-      activationPushedZero: activationOutput.includes("\x1b[>0u"),
-      activationKeptFallback: !activationOutput.includes("\x1b[>4;0m"),
+      setupPushes: countOccurrences(setupOutput, "\x1b[>0u"),
+      activationPushes: countOccurrences(activationOutput, "\x1b[>0u"),
+      keptFallback: !setupOutput.includes("\x1b[>4;0m") && !activationOutput.includes("\x1b[>4;0m"),
     }).toEqual({
       enableOutput: "",
       enabledAfterEnable: true,
       disableOutput: "",
       enabledAfterDisable: false,
-      activationPushedZero: true,
-      activationKeptFallback: true,
+      setupPushes: 1,
+      activationPushes: 0,
+      keptFallback: true,
     })
   } finally {
     await destroyKittyRenderer(harness)
@@ -471,12 +793,29 @@ test("repeated enableKittyKeyboard preserves fallback without detected support",
 
     harness.renderer.enableKittyKeyboard(7)
     await harness.feed.idle()
-    harness.stdout.take()
+    const firstEnableOutput = harness.stdout.take()
 
     harness.renderer.enableKittyKeyboard(7)
     await harness.feed.idle()
 
-    expect(harness.stdout.take()).not.toContain("\x1b[>4;0m")
+    const repeatedEnableOutput = harness.stdout.take()
+    expect({
+      startupEnabledFallback: countOccurrences(harness.initialOutput, "\x1b[>4;1m"),
+      firstEnablePops: countOccurrences(firstEnableOutput, "\x1b[<u"),
+      firstEnablePushes: countOccurrences(firstEnableOutput, "\x1b[>7u"),
+      firstEnableDisabledFallback: countOccurrences(firstEnableOutput, "\x1b[>4;0m"),
+      pushedEntries: countOccurrences(repeatedEnableOutput, "\x1b[>7u"),
+      poppedEntries: countOccurrences(repeatedEnableOutput, "\x1b[<u"),
+      disabledFallback: countOccurrences(repeatedEnableOutput, "\x1b[>4;0m"),
+    }).toEqual({
+      startupEnabledFallback: 1,
+      firstEnablePops: 1,
+      firstEnablePushes: 1,
+      firstEnableDisabledFallback: 0,
+      pushedEntries: 0,
+      poppedEntries: 0,
+      disabledFallback: 0,
+    })
   } finally {
     await destroyKittyRenderer(harness)
   }

--- a/packages/core/src/tests/renderer.kitty-lifecycle.test.ts
+++ b/packages/core/src/tests/renderer.kitty-lifecycle.test.ts
@@ -1,0 +1,483 @@
+import { Buffer } from "node:buffer"
+
+import { expect, test } from "bun:test"
+
+import type { NativeSpanFeed } from "../NativeSpanFeed.js"
+import { CliRenderer, type KittyKeyboardOptions } from "../renderer.js"
+import { createTestStdin, TestWriteStream } from "../testing/test-streams.js"
+
+class CollectingWriteStream extends TestWriteStream {
+  private readonly writes: Buffer[] = []
+
+  override _write(chunk: unknown, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    const bytes = chunk instanceof Uint8Array ? Buffer.from(chunk) : Buffer.from(String(chunk))
+    this.writes.push(bytes)
+    callback()
+  }
+
+  public take(): string {
+    const output = Buffer.concat(this.writes).toString("latin1")
+    this.writes.length = 0
+    return output
+  }
+}
+
+interface KittyRendererHarness {
+  renderer: CliRenderer
+  stdin: NodeJS.ReadStream
+  stdout: CollectingWriteStream
+  feed: NativeSpanFeed
+}
+
+async function createKittyRenderer(
+  useKittyKeyboard: KittyKeyboardOptions | null = null,
+  setupTerminal = true,
+): Promise<KittyRendererHarness> {
+  const stdin = createTestStdin()
+  const stdout = new CollectingWriteStream(80, 24)
+  const renderer = new CliRenderer(stdin, stdout as CollectingWriteStream & NodeJS.WriteStream, 80, 24, {
+    useKittyKeyboard,
+    useMouse: false,
+    useThread: false,
+    screenMode: "main-screen",
+    consoleMode: "disabled",
+    clearOnShutdown: false,
+    exitOnCtrlC: false,
+    exitSignals: [],
+    remote: true,
+  })
+  const feed = (renderer as unknown as { _feed: NativeSpanFeed | null })._feed
+  if (!feed) {
+    renderer.destroy()
+    throw new Error("Expected a feed-backed renderer")
+  }
+
+  try {
+    if (setupTerminal) {
+      await renderer.setupTerminal()
+    }
+    await feed.idle()
+    stdout.take()
+    return { renderer, stdin, stdout, feed }
+  } catch (error) {
+    try {
+      renderer.destroy()
+    } catch {}
+    try {
+      await feed.idle()
+    } catch {}
+    throw error
+  }
+}
+
+async function reportInheritedKittyMode(harness: KittyRendererHarness): Promise<string> {
+  harness.stdin.emit("data", Buffer.from("\x1b[?1u"))
+  await harness.feed.idle()
+  return harness.stdout.take()
+}
+
+async function destroyKittyRenderer(harness: KittyRendererHarness): Promise<string> {
+  try {
+    if (!harness.renderer.isDestroyed) {
+      harness.renderer.destroy()
+    }
+  } finally {
+    await harness.feed.idle()
+  }
+  return harness.stdout.take()
+}
+
+function occursBefore(output: string, first: string, second: string): boolean {
+  const firstIndex = output.indexOf(first)
+  const secondIndex = output.indexOf(second)
+  return firstIndex >= 0 && secondIndex > firstIndex
+}
+
+test("useKittyKeyboard: null masks an inherited Kitty mode for the renderer lifetime", async () => {
+  const harness = await createKittyRenderer()
+
+  try {
+    const activationOutput = await reportInheritedKittyMode(harness)
+    expect(activationOutput).toContain("\x1b[>0u")
+    expect(activationOutput).not.toContain("\x1b[<u")
+
+    let inputSource: string | undefined
+    harness.renderer.keyInput.once("keypress", (key) => {
+      inputSource = key.source
+    })
+    harness.stdin.emit("data", Buffer.from("\x1b[97u"))
+    expect(inputSource).not.toBe("kitty")
+
+    const shutdownOutput = await destroyKittyRenderer(harness)
+    expect(shutdownOutput).toContain("\x1b[<u")
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("a zero-flag options object masks inherited flags without disabling Kitty parsing", async () => {
+  const harness = await createKittyRenderer({
+    disambiguate: false,
+    alternateKeys: false,
+    events: false,
+    allKeysAsEscapes: false,
+    reportText: false,
+  })
+
+  try {
+    const activationOutput = await reportInheritedKittyMode(harness)
+
+    let inputSource: string | undefined
+    harness.renderer.keyInput.once("keypress", (key) => {
+      inputSource = key.source
+    })
+    harness.stdin.emit("data", Buffer.from("\x1b[97u"))
+
+    expect({
+      pushedZero: activationOutput.includes("\x1b[>0u"),
+      disabledFallback: activationOutput.includes("\x1b[>4;0m"),
+      inputSource,
+    }).toEqual({
+      pushedZero: true,
+      disabledFallback: false,
+      inputSource: "kitty",
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("enableKittyKeyboard after null synchronizes terminal state, parsing, getter, and resume", async () => {
+  const harness = await createKittyRenderer()
+
+  try {
+    await reportInheritedKittyMode(harness)
+
+    harness.renderer.enableKittyKeyboard(7)
+    await harness.feed.idle()
+    const enableOutput = harness.stdout.take()
+    const enabledAfterEnable = harness.renderer.useKittyKeyboard
+
+    const keys: Array<{ name: string; source: string }> = []
+    harness.renderer.keyInput.on("keypress", (key) => {
+      keys.push({ name: key.name, source: key.source })
+    })
+    harness.stdin.emit("data", Buffer.from("\x1b[97u"))
+
+    harness.renderer.suspend()
+    await harness.feed.idle()
+    const suspendOutput = harness.stdout.take()
+
+    harness.renderer.resume()
+    await harness.feed.idle()
+    const resumeOutput = harness.stdout.take()
+    harness.stdin.emit("data", Buffer.from("\x1b[98u"))
+
+    expect({
+      enableReplacedPreviousMode: occursBefore(enableOutput, "\x1b[<u", "\x1b[>7u"),
+      fallbackDisabled: enableOutput.includes("\x1b[>4;0m"),
+      enabledAfterEnable,
+      suspendPoppedMode: suspendOutput.includes("\x1b[<u"),
+      resumeRestoredMode: resumeOutput.includes("\x1b[>7u"),
+      enabledAfterResume: harness.renderer.useKittyKeyboard,
+      keys,
+    }).toEqual({
+      enableReplacedPreviousMode: true,
+      fallbackDisabled: true,
+      enabledAfterEnable: true,
+      suspendPoppedMode: true,
+      resumeRestoredMode: true,
+      enabledAfterResume: true,
+      keys: [
+        { name: "a", source: "kitty" },
+        { name: "b", source: "kitty" },
+      ],
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("disableKittyKeyboard synchronizes terminal state, parsing, getter, fallback, and resume", async () => {
+  const harness = await createKittyRenderer({ events: true })
+
+  try {
+    await reportInheritedKittyMode(harness)
+
+    harness.renderer.disableKittyKeyboard()
+    await harness.feed.idle()
+    const disableOutput = harness.stdout.take()
+    const enabledAfterDisable = harness.renderer.useKittyKeyboard
+
+    const keys: Array<{ name: string; source: string }> = []
+    harness.renderer.keyInput.on("keypress", (key) => {
+      keys.push({ name: key.name, source: key.source })
+    })
+    harness.stdin.emit("data", Buffer.from("\x1b[97u"))
+    const kittySourceBeforeSuspend = keys.at(-1)?.source
+    harness.stdin.emit("data", Buffer.from("x"))
+    const rawNameBeforeSuspend = keys.at(-1)?.name
+
+    harness.renderer.suspend()
+    await harness.feed.idle()
+    const suspendOutput = harness.stdout.take()
+
+    harness.renderer.resume()
+    await harness.feed.idle()
+    const resumeOutput = harness.stdout.take()
+    harness.stdin.emit("data", Buffer.from("\x1b[98u"))
+    const kittySourceAfterResume = keys.at(-1)?.source
+    harness.stdin.emit("data", Buffer.from("y"))
+    const rawNameAfterResume = keys.at(-1)?.name
+
+    expect({
+      disableReplacedPreviousMode: occursBefore(disableOutput, "\x1b[<u", "\x1b[>0u"),
+      fallbackEnabled: disableOutput.includes("\x1b[>4;1m"),
+      enabledAfterDisable,
+      suspendPoppedMode: suspendOutput.includes("\x1b[<u"),
+      resumeRestoredMode: resumeOutput.includes("\x1b[>0u"),
+      resumeFallbackEnabled: resumeOutput.includes("\x1b[>4;1m"),
+      resumeDidNotDisableFallback: !resumeOutput.includes("\x1b[>4;0m"),
+      enabledAfterResume: harness.renderer.useKittyKeyboard,
+      kittySourceBeforeSuspend,
+      rawNameBeforeSuspend,
+      kittySourceAfterResume,
+      rawNameAfterResume,
+    }).toEqual({
+      disableReplacedPreviousMode: true,
+      fallbackEnabled: true,
+      enabledAfterDisable: false,
+      suspendPoppedMode: true,
+      resumeRestoredMode: true,
+      resumeFallbackEnabled: true,
+      resumeDidNotDisableFallback: true,
+      enabledAfterResume: false,
+      kittySourceBeforeSuspend: "raw",
+      rawNameBeforeSuspend: "x",
+      kittySourceAfterResume: "raw",
+      rawNameAfterResume: "y",
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("disableKittyKeyboard before setup defers terminal writes until setup", async () => {
+  const harness = await createKittyRenderer({ events: true }, false)
+
+  try {
+    harness.renderer.disableKittyKeyboard()
+    await harness.feed.idle()
+    const outputBeforeSetup = harness.stdout.take()
+    const enabledBeforeSetup = harness.renderer.useKittyKeyboard
+
+    await harness.renderer.setupTerminal()
+    await harness.feed.idle()
+    harness.stdout.take()
+    const activationOutput = await reportInheritedKittyMode(harness)
+
+    expect({
+      outputBeforeSetup,
+      enabledBeforeSetup,
+      activationPushedZero: activationOutput.includes("\x1b[>0u"),
+    }).toEqual({
+      outputBeforeSetup: "",
+      enabledBeforeSetup: false,
+      activationPushedZero: true,
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("disableKittyKeyboard while suspended defers terminal writes until resume", async () => {
+  const harness = await createKittyRenderer({ events: true })
+
+  try {
+    await reportInheritedKittyMode(harness)
+    harness.renderer.suspend()
+    await harness.feed.idle()
+    harness.stdout.take()
+
+    harness.renderer.disableKittyKeyboard()
+    await harness.feed.idle()
+    const outputWhileSuspended = harness.stdout.take()
+    const enabledWhileSuspended = harness.renderer.useKittyKeyboard
+
+    harness.renderer.resume()
+    await harness.feed.idle()
+    const resumeOutput = harness.stdout.take()
+
+    expect({
+      outputWhileSuspended,
+      enabledWhileSuspended,
+      resumePushedZero: resumeOutput.includes("\x1b[>0u"),
+      resumeEnabledFallback: resumeOutput.includes("\x1b[>4;1m"),
+    }).toEqual({
+      outputWhileSuspended: "",
+      enabledWhileSuspended: false,
+      resumePushedZero: true,
+      resumeEnabledFallback: true,
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("enableKittyKeyboard preserves modifyOtherKeys when Kitty support was not detected", async () => {
+  const harness = await createKittyRenderer()
+
+  try {
+    harness.stdin.emit("data", Buffer.from("\x1b[c"))
+    await harness.feed.idle()
+    harness.stdout.take()
+
+    harness.renderer.enableKittyKeyboard(7)
+    await harness.feed.idle()
+    const enableOutput = harness.stdout.take()
+
+    expect({
+      attemptedKittyPush: enableOutput.includes("\x1b[>7u"),
+      disabledFallback: enableOutput.includes("\x1b[>4;0m"),
+    }).toEqual({
+      attemptedKittyPush: true,
+      disabledFallback: false,
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("enableKittyKeyboard with zero flags preserves the modifyOtherKeys fallback", async () => {
+  const harness = await createKittyRenderer()
+
+  try {
+    await reportInheritedKittyMode(harness)
+
+    harness.renderer.enableKittyKeyboard(0)
+    await harness.feed.idle()
+
+    expect(harness.stdout.take()).not.toContain("\x1b[>4;0m")
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("runtime Kitty changes before setup are deferred until setup", async () => {
+  const harness = await createKittyRenderer(null, false)
+
+  try {
+    harness.renderer.enableKittyKeyboard(7)
+    await harness.feed.idle()
+    const enableOutput = harness.stdout.take()
+    const enabledAfterEnable = harness.renderer.useKittyKeyboard
+
+    harness.renderer.disableKittyKeyboard()
+    await harness.feed.idle()
+    const disableOutput = harness.stdout.take()
+    const enabledAfterDisable = harness.renderer.useKittyKeyboard
+
+    await harness.renderer.setupTerminal()
+    await harness.feed.idle()
+    harness.stdout.take()
+    const activationOutput = await reportInheritedKittyMode(harness)
+
+    expect({
+      enableOutput,
+      enabledAfterEnable,
+      disableOutput,
+      enabledAfterDisable,
+      activationPushedZero: activationOutput.includes("\x1b[>0u"),
+      activationKeptFallback: !activationOutput.includes("\x1b[>4;0m"),
+    }).toEqual({
+      enableOutput: "",
+      enabledAfterEnable: true,
+      disableOutput: "",
+      enabledAfterDisable: false,
+      activationPushedZero: true,
+      activationKeptFallback: true,
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("runtime Kitty changes while suspended are deferred until resume", async () => {
+  const harness = await createKittyRenderer()
+
+  try {
+    await reportInheritedKittyMode(harness)
+    harness.renderer.suspend()
+    await harness.feed.idle()
+    harness.stdout.take()
+
+    harness.renderer.enableKittyKeyboard(7)
+    await harness.feed.idle()
+    const positiveEnableOutput = harness.stdout.take()
+
+    harness.renderer.enableKittyKeyboard(0)
+    await harness.feed.idle()
+    const zeroEnableOutput = harness.stdout.take()
+
+    harness.renderer.resume()
+    await harness.feed.idle()
+    const resumeOutput = harness.stdout.take()
+
+    expect({
+      positiveEnableOutput,
+      zeroEnableOutput,
+      resumePushedZero: resumeOutput.includes("\x1b[>0u"),
+      resumeEnabledFallback: resumeOutput.includes("\x1b[>4;1m"),
+    }).toEqual({
+      positiveEnableOutput: "",
+      zeroEnableOutput: "",
+      resumePushedZero: true,
+      resumeEnabledFallback: true,
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("changing enabled Kitty flags to zero restores modifyOtherKeys", async () => {
+  const harness = await createKittyRenderer({ events: true })
+
+  try {
+    await reportInheritedKittyMode(harness)
+
+    harness.renderer.enableKittyKeyboard(0)
+    await harness.feed.idle()
+    const enableOutput = harness.stdout.take()
+
+    expect({
+      replacedPreviousMode: occursBefore(enableOutput, "\x1b[<u", "\x1b[>0u"),
+      restoredFallback: enableOutput.includes("\x1b[>4;1m"),
+    }).toEqual({
+      replacedPreviousMode: true,
+      restoredFallback: true,
+    })
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})
+
+test("repeated enableKittyKeyboard preserves fallback without detected support", async () => {
+  const harness = await createKittyRenderer()
+
+  try {
+    harness.stdin.emit("data", Buffer.from("\x1b[c"))
+    await harness.feed.idle()
+    harness.stdout.take()
+
+    harness.renderer.enableKittyKeyboard(7)
+    await harness.feed.idle()
+    harness.stdout.take()
+
+    harness.renderer.enableKittyKeyboard(7)
+    await harness.feed.idle()
+
+    expect(harness.stdout.take()).not.toContain("\x1b[>4;0m")
+  } finally {
+    await destroyKittyRenderer(harness)
+  }
+})

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -415,7 +415,7 @@ pub const CliRenderer = struct {
 
         self.terminal.setCursorPosition(1, 1, false);
         // Zero flags still need an owned stack entry to mask an inherited mode.
-        self.terminal.enableDetectedFeatures(writer, true) catch {};
+        self.terminal.applyDetectedFeatures(writer, true) catch {};
 
         self.backend.writeOut(stream.getWritten());
     }
@@ -1931,13 +1931,11 @@ pub const CliRenderer = struct {
     pub fn disableKittyKeyboard(self: *CliRenderer) void {
         var stream = std.io.fixedBufferStream(&self.writeOutBuf);
         self.terminal.setKittyKeyboardFlags(0);
-        if (self.terminal.state.kitty_keyboard) {
-            self.terminal.setKittyKeyboard(
-                stream.writer(),
-                self.terminalSetup and !self.terminalSuspended,
-                0,
-            ) catch {};
-        }
+        self.terminal.setKittyKeyboard(
+            stream.writer(),
+            self.terminalSetup and !self.terminalSuspended,
+            0,
+        ) catch {};
         if (self.terminalSetup and !self.terminalSuspended and !self.terminal.state.modify_other_keys) {
             self.terminal.setModifyOtherKeys(stream.writer(), true) catch {};
         }
@@ -1955,12 +1953,10 @@ pub const CliRenderer = struct {
 
     pub fn processCapabilityResponse(self: *CliRenderer, response: []const u8) void {
         self.terminal.processCapabilityResponse(response);
+        if (!self.terminalSetup or self.terminalSuspended) return;
+
         var stream = std.io.fixedBufferStream(&self.writeOutBuf);
-        _ = self.terminal.sendPendingQueries(stream.writer()) catch |err| blk: {
-            logger.warn("Failed to send pending queries: {}", .{err});
-            break :blk false;
-        };
-        self.terminal.enableDetectedFeatures(stream.writer(), true) catch {};
+        self.terminal.applyDetectedFeatures(stream.writer(), true) catch {};
         self.writeOut(stream.getWritten());
     }
 

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -120,6 +120,7 @@ pub const CliRenderer = struct {
     terminal: Terminal,
     useAlternateScreen: bool = true,
     terminalSetup: bool = false,
+    terminalSuspended: bool = false,
     clearOnShutdown: bool = true,
 
     splitScrollback: split_scrollback.SplitScrollback = .{},
@@ -385,6 +386,7 @@ pub const CliRenderer = struct {
     pub fn setupTerminal(self: *CliRenderer, useAlternateScreen: bool) void {
         self.useAlternateScreen = useAlternateScreen;
         self.terminalSetup = true;
+        self.terminalSuspended = false;
 
         // Build capability query into a stack buffer, then emit via backend.
         // Buffer sized to accommodate all capability-query sequences with margin.
@@ -412,8 +414,8 @@ pub const CliRenderer = struct {
         }
 
         self.terminal.setCursorPosition(1, 1, false);
-        const useKitty = self.terminal.opts.kitty_keyboard_flags > 0;
-        self.terminal.enableDetectedFeatures(writer, useKitty) catch {};
+        // Zero flags still need an owned stack entry to mask an inherited mode.
+        self.terminal.enableDetectedFeatures(writer, true) catch {};
 
         self.backend.writeOut(stream.getWritten());
     }
@@ -421,10 +423,12 @@ pub const CliRenderer = struct {
     pub fn suspendRenderer(self: *CliRenderer) void {
         if (!self.terminalSetup) return;
         self.performShutdownSequence();
+        self.terminalSuspended = true;
     }
 
     pub fn resumeRenderer(self: *CliRenderer) void {
         if (!self.terminalSetup) return;
+        self.terminalSuspended = false;
         self.setupTerminalWithoutDetection(self.useAlternateScreen, self.renderOffset == 0);
     }
 
@@ -1910,14 +1914,33 @@ pub const CliRenderer = struct {
     }
 
     pub fn enableKittyKeyboard(self: *CliRenderer, flags: u8) void {
+        self.terminal.setKittyKeyboardFlags(flags);
+        if (!self.terminalSetup or self.terminalSuspended) return;
+
         var stream = std.io.fixedBufferStream(&self.writeOutBuf);
+        if (flags > 0 and self.terminal.caps.kitty_keyboard and self.terminal.state.modify_other_keys) {
+            self.terminal.setModifyOtherKeys(stream.writer(), false) catch {};
+        }
         self.terminal.setKittyKeyboard(stream.writer(), true, flags) catch {};
+        if (flags == 0 and self.terminalSetup and !self.terminalSuspended and !self.terminal.state.modify_other_keys) {
+            self.terminal.setModifyOtherKeys(stream.writer(), true) catch {};
+        }
         self.writeOut(stream.getWritten());
     }
 
     pub fn disableKittyKeyboard(self: *CliRenderer) void {
         var stream = std.io.fixedBufferStream(&self.writeOutBuf);
-        self.terminal.setKittyKeyboard(stream.writer(), false, 0) catch {};
+        self.terminal.setKittyKeyboardFlags(0);
+        if (self.terminal.state.kitty_keyboard) {
+            self.terminal.setKittyKeyboard(
+                stream.writer(),
+                self.terminalSetup and !self.terminalSuspended,
+                0,
+            ) catch {};
+        }
+        if (self.terminalSetup and !self.terminalSuspended and !self.terminal.state.modify_other_keys) {
+            self.terminal.setModifyOtherKeys(stream.writer(), true) catch {};
+        }
         self.writeOut(stream.getWritten());
     }
 
@@ -1937,8 +1960,7 @@ pub const CliRenderer = struct {
             logger.warn("Failed to send pending queries: {}", .{err});
             break :blk false;
         };
-        const useKitty = self.terminal.opts.kitty_keyboard_flags > 0;
-        self.terminal.enableDetectedFeatures(stream.writer(), useKitty) catch {};
+        self.terminal.enableDetectedFeatures(stream.writer(), true) catch {};
         self.writeOut(stream.getWritten());
     }
 

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -152,6 +152,7 @@ skip_graphics_query: bool = false,
 skip_explicit_width_query: bool = false,
 graphics_query_pending: bool = false,
 capability_queries_pending: bool = false,
+capability_response_pending: bool = false,
 startup_cursor_query_pending: bool = false,
 startup_cursor_query_captured: bool = false,
 
@@ -285,6 +286,7 @@ pub fn queryTerminalSend(self: *Terminal, tty: anytype) !void {
     self.checkEnvironmentOverrides();
     self.graphics_query_pending = !self.skip_graphics_query;
     self.capability_queries_pending = false;
+    self.capability_response_pending = false;
     self.startup_cursor_query_pending = true;
     self.startup_cursor_query_captured = false;
 
@@ -359,6 +361,19 @@ pub fn sendPendingQueries(self: *Terminal, tty: anytype) !bool {
     return sent;
 }
 
+pub fn applyDetectedFeatures(self: *Terminal, tty: anytype, use_kitty_keyboard: bool) !void {
+    if (self.capability_response_pending) {
+        var queries_applied = true;
+        _ = self.sendPendingQueries(tty) catch |err| blk: {
+            logger.warn("Failed to send pending queries: {}", .{err});
+            queries_applied = false;
+            break :blk false;
+        };
+        if (queries_applied) self.capability_response_pending = false;
+    }
+    try self.enableDetectedFeatures(tty, use_kitty_keyboard);
+}
+
 pub fn enableDetectedFeatures(self: *Terminal, tty: anytype, use_kitty_keyboard: bool) !void {
     if (builtin.os.tag == .windows) {
         // Windows-specific defaults for ConPTY
@@ -373,7 +388,7 @@ pub fn enableDetectedFeatures(self: *Terminal, tty: anytype, use_kitty_keyboard:
         try self.setModifyOtherKeys(tty, true);
     }
 
-    if (self.caps.kitty_keyboard and use_kitty_keyboard) {
+    if (use_kitty_keyboard and (self.caps.kitty_keyboard or self.opts.kitty_keyboard_flags == 0)) {
         // Keep modifyOtherKeys as the fallback when the owned Kitty entry has no enhancements.
         if (self.opts.kitty_keyboard_flags > 0 and self.state.modify_other_keys) {
             try self.setModifyOtherKeys(tty, false);
@@ -1056,6 +1071,7 @@ pub fn restoreTerminalModes(self: *Terminal, tty: anytype) !void {
 ///
 /// Parsing these is not complete yet
 pub fn processCapabilityResponse(self: *Terminal, response: []const u8) void {
+    self.capability_response_pending = true;
     self.parseOsc99NotificationQuery(response);
     self.parseItermCapabilities(response);
     self.parseXtgettcapMs(response);

--- a/packages/core/src/zig/terminal.zig
+++ b/packages/core/src/zig/terminal.zig
@@ -374,7 +374,8 @@ pub fn enableDetectedFeatures(self: *Terminal, tty: anytype, use_kitty_keyboard:
     }
 
     if (self.caps.kitty_keyboard and use_kitty_keyboard) {
-        if (self.state.modify_other_keys) {
+        // Keep modifyOtherKeys as the fallback when the owned Kitty entry has no enhancements.
+        if (self.opts.kitty_keyboard_flags > 0 and self.state.modify_other_keys) {
             try self.setModifyOtherKeys(tty, false);
         }
         try self.setKittyKeyboard(tty, true, self.opts.kitty_keyboard_flags);
@@ -955,6 +956,11 @@ pub fn setFocusTracking(self: *Terminal, tty: anytype, enable: bool) !void {
 
 pub fn setKittyKeyboard(self: *Terminal, tty: anytype, enable: bool, flags: u8) !void {
     if (enable) {
+        if (self.state.kitty_keyboard and self.state.kitty_keyboard_flags != flags) {
+            try tty.writeAll(ansi.ANSI.csiUPop);
+            self.state.kitty_keyboard = false;
+            self.state.kitty_keyboard_flags = 0;
+        }
         if (!self.state.kitty_keyboard) {
             try tty.print(ansi.ANSI.csiUPush, .{flags});
             self.state.kitty_keyboard = true;

--- a/packages/core/src/zig/tests/terminal_test.zig
+++ b/packages/core/src/zig/tests/terminal_test.zig
@@ -677,6 +677,44 @@ test "sendPendingQueries - skips graphics when skip_graphics_query is set" {
     try testing.expect(std.mem.indexOf(u8, output, "Gi=31337") == null);
 }
 
+test "applyDetectedFeatures - sends pending queries before enabling modes" {
+    var term = Terminal.init(.{ .kitty_keyboard_flags = 0, .remote_mode = .remote });
+    term.graphics_query_pending = true;
+    term.processCapabilityResponse("\x1b[?1u");
+
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.applyDetectedFeatures(&writer, true);
+
+    const output = writer.getWritten();
+    const graphics_query = std.mem.indexOf(u8, output, ansi.ANSI.kittyGraphicsQuery).?;
+    const kitty_mode = std.mem.indexOf(u8, output, "\x1b[>0u").?;
+
+    try testing.expect(graphics_query < kitty_mode);
+    try testing.expect(!term.graphics_query_pending);
+    try testing.expect(!term.capability_response_pending);
+    try testing.expect(term.state.modify_other_keys);
+    try testing.expect(term.state.kitty_keyboard);
+    try testing.expectEqual(@as(u8, 0), term.state.kitty_keyboard_flags);
+}
+
+test "applyDetectedFeatures - preserves pending queries until a response is processed" {
+    var term = Terminal.init(.{ .kitty_keyboard_flags = 0, .remote_mode = .remote });
+    term.graphics_query_pending = true;
+
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.applyDetectedFeatures(&writer, true);
+
+    try testing.expect(std.mem.indexOf(u8, writer.getWritten(), ansi.ANSI.kittyGraphicsQuery) == null);
+    try testing.expect(term.graphics_query_pending);
+    try testing.expect(term.state.modify_other_keys);
+    try testing.expect(term.state.kitty_keyboard);
+    try testing.expectEqual(@as(u8, 0), term.state.kitty_keyboard_flags);
+}
+
 test "isXtversionTmux - detects tmux from xtversion" {
     var term = Terminal.init(.{});
 
@@ -1386,6 +1424,67 @@ test "enableDetectedFeatures - sends initial theme queries" {
     try testing.expect(std.mem.indexOf(u8, output, "\x1b]11;?\x07") != null);
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[?996n") == null);
     try testing.expect(term.state.theme_queries_sent);
+}
+
+test "enableDetectedFeatures - zero Kitty flags own one stack entry before detection" {
+    var term = Terminal.init(.{ .kitty_keyboard_flags = 0, .remote_mode = .remote });
+    try testing.expect(!term.caps.kitty_keyboard);
+
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.enableDetectedFeatures(&writer, true);
+
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, writer.getWritten(), ansi.ANSI.modifyOtherKeysSet));
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, writer.getWritten(), "\x1b[>0u"));
+    try testing.expect(term.state.modify_other_keys);
+    try testing.expect(term.state.kitty_keyboard);
+    try testing.expectEqual(@as(u8, 0), term.state.kitty_keyboard_flags);
+
+    writer.reset();
+    try term.enableDetectedFeatures(&writer, true);
+
+    try testing.expectEqual(@as(usize, 0), std.mem.count(u8, writer.getWritten(), "\x1b[>0u"));
+    try testing.expectEqual(@as(usize, 0), std.mem.count(u8, writer.getWritten(), ansi.ANSI.csiUPop));
+}
+
+test "setKittyKeyboard - replaces changed flags without growing the stack" {
+    var term = Terminal.init(.{});
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.setKittyKeyboard(&writer, true, 7);
+    try testing.expectEqualStrings("\x1b[>7u", writer.getWritten());
+
+    writer.reset();
+    try term.setKittyKeyboard(&writer, true, 5);
+    try testing.expectEqualStrings("\x1b[<u\x1b[>5u", writer.getWritten());
+    try testing.expect(term.state.kitty_keyboard);
+    try testing.expectEqual(@as(u8, 5), term.state.kitty_keyboard_flags);
+
+    writer.reset();
+    try term.setKittyKeyboard(&writer, true, 5);
+    try testing.expectEqual(@as(usize, 0), writer.getWritten().len);
+
+    try term.setKittyKeyboard(&writer, false, 0);
+    try testing.expectEqualStrings(ansi.ANSI.csiUPop, writer.getWritten());
+    try testing.expect(!term.state.kitty_keyboard);
+    try testing.expectEqual(@as(u8, 0), term.state.kitty_keyboard_flags);
+}
+
+test "restoreTerminalModes - replaces a zero-flag Kitty entry" {
+    var term = Terminal.init(.{});
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try term.setKittyKeyboard(&writer, true, 0);
+    writer.reset();
+
+    try term.restoreTerminalModes(&writer);
+
+    try testing.expectEqualStrings("\x1b[<u\x1b[>0u", writer.getWritten());
+    try testing.expect(term.state.kitty_keyboard);
+    try testing.expectEqual(@as(u8, 0), term.state.kitty_keyboard_flags);
 }
 
 test "setMouseMode - enable without movement keeps click/drag only" {


### PR DESCRIPTION
`config.useKittyKeyboard ?? {}` coerced `null` to `{}`, enabling the default flags (disambiguate + alternateKeys) instead of disabling the protocol as the type comment and docs state. `buildKittyKeyboardFlags` already handled `null`; it just never received it, and `useKittyForParsing` could never be `false`.

Fix preserves `null` (only `undefined` falls back to `{}`), so `null` now yields flags 0 and disables kitty stdin parsing.

Added config-level regression tests to `renderer.kitty-flags.test.ts` asserting the public `renderer.useKittyKeyboard` getter through `createTestRenderer` for `null` (disabled), omitted (defaults on), and `{ events: true }` — the `null` case failed before the fix.