### PR TITLE
fix(core): TabSelect underline overruns tab background, make char configurable

### DIFF
--- a/packages/core/src/renderables/TabSelect.test.ts
+++ b/packages/core/src/renderables/TabSelect.test.ts
@@ -36,6 +36,7 @@ function createKeyEvent(input: {
 let currentRenderer: TestRenderer
 let currentMockInput: MockInput
 let renderOnce: () => Promise<void>
+let captureCharFrame: () => string
 let currentClock: ManualClock
 
 const sampleOptions: TabSelectOption[] = [
@@ -63,6 +64,7 @@ beforeEach(async () => {
     renderer: currentRenderer,
     mockInput: currentMockInput,
     renderOnce,
+    captureCharFrame,
   } = await createTestRenderer({
     clock: currentClock,
   }))
@@ -233,6 +235,35 @@ describe("TabSelectRenderable", () => {
       // N should wrap to start
       currentMockInput.pressKey("n")
       expect(tabSelect.getSelectedIndex()).toBe(0)
+    })
+  })
+
+  describe("Underline", () => {
+    test("should render the default underline character under the selected tab", async () => {
+      const { tabSelect } = await createTabSelectRenderable(currentRenderer, {
+        width: 100,
+        options: sampleOptions,
+      })
+
+      const underlineRow = captureCharFrame().split("\n")[1]
+      expect(underlineRow.startsWith("▂".repeat(tabSelect.tabWidth))).toBe(true)
+    })
+
+    test("should render a custom underline character", async () => {
+      const { tabSelect } = await createTabSelectRenderable(currentRenderer, {
+        width: 100,
+        options: sampleOptions,
+        underlineChar: "▃",
+      })
+
+      let underlineRow = captureCharFrame().split("\n")[1]
+      expect(underlineRow.startsWith("▃".repeat(tabSelect.tabWidth))).toBe(true)
+
+      tabSelect.underlineChar = "─"
+      await renderOnce()
+
+      underlineRow = captureCharFrame().split("\n")[1]
+      expect(underlineRow.startsWith("─".repeat(tabSelect.tabWidth))).toBe(true)
     })
   })
 })

--- a/packages/core/src/renderables/TabSelect.ts
+++ b/packages/core/src/renderables/TabSelect.ts
@@ -47,6 +47,7 @@ export interface TabSelectRenderableOptions extends Omit<RenderableOptions<TabSe
   showScrollArrows?: boolean
   showDescription?: boolean
   showUnderline?: boolean
+  underlineChar?: string
   wrapSelection?: boolean
   keyBindings?: TabSelectKeyBinding[]
   keyAliasMap?: KeyAliasMap
@@ -90,6 +91,7 @@ export class TabSelectRenderable extends Renderable {
   private _showScrollArrows: boolean
   private _showDescription: boolean
   private _showUnderline: boolean
+  private _underlineChar: string
   private _wrapSelection: boolean
   private _keyBindingsMap: Map<string, TabSelectAction>
   private _keyAliasMap: KeyAliasMap
@@ -108,6 +110,11 @@ export class TabSelectRenderable extends Renderable {
     this._tabWidth = options.tabWidth || 20
     this._showDescription = options.showDescription ?? true
     this._showUnderline = options.showUnderline ?? true
+    // U+2582 (Block Elements) is designed to fill the cell edge-to-edge and is
+    // sprite-rendered by most terminals. The previous U+25AC (Geometric Shapes) is
+    // missing from many monospace fonts, so a proportional fallback glyph (~1em ink
+    // vs ~0.6em cell) bleeds past the tab's background
+    this._underlineChar = options.underlineChar || "▂"
     this._showScrollArrows = options.showScrollArrows ?? true
     this._wrapSelection = options.wrapSelection ?? false
 
@@ -172,7 +179,7 @@ export class TabSelectRenderable extends Renderable {
       if (isSelected && this._showUnderline && contentHeight >= 2) {
         const underlineY = contentY + 1
         const underlineBg = isSelected ? this._selectedBackgroundColor : bgColor
-        this.frameBuffer.drawText("▬".repeat(actualTabWidth), tabX, underlineY, nameColor, underlineBg)
+        this.frameBuffer.drawText(this._underlineChar.repeat(actualTabWidth), tabX, underlineY, nameColor, underlineBg)
       }
     }
 
@@ -396,6 +403,17 @@ export class TabSelectRenderable extends Renderable {
       this._showUnderline = show
       const newHeight = this.calculateDynamicHeight()
       this.height = newHeight
+      this.requestRender()
+    }
+  }
+
+  public get underlineChar(): string {
+    return this._underlineChar
+  }
+
+  public set underlineChar(char: string) {
+    if (this._underlineChar !== char) {
+      this._underlineChar = char
       this.requestRender()
     }
   }


### PR DESCRIPTION
TLDR:

- introduce a new prop to customize TabSelect underline
- Replace the default value with one that has better compatibility and potentially (haven't verified this) better perf depending on the terminal renderer

Before:

<img width="1302" height="334" alt="@posva-Ghostty‒ tacobook ❐ 0 ● 8 nvim-2026-07-06-15 16 06@2x" src="https://github.com/user-attachments/assets/bbb7bdd5-049d-4501-aa31-d0c6160f4e66" />

After:

<img width="1280" height="304" alt="@posva-Ghostty‒ tacobook ❐ 0 ● 8 nvim-2026-07-06-15 18 07@2x" src="https://github.com/user-attachments/assets/37768641-d2ba-4993-8208-6e2486f764d4" />

---

## Problem

The selected tab's underline in `TabSelectRenderable` is drawn as a repeated `▬` (U+25AC BLACK RECTANGLE). The frame-buffer cell math is correct (U+25AC is East Asian Width Neutral → 1 cell), but the bar visibly overruns the tab's `selectedBackgroundColor` box on the right in many terminal setups.

Root cause: U+25AC is a Geometric Shapes *text symbol*, not a cell-graphics character, and **many monospace fonts don't include it at all** (JetBrains Mono — Ghostty's default — has no glyph for it). The terminal then substitutes a fallback font, and nearly every common fallback (Apple Symbols, Arial, Times, CJK families…) draws it with ~0.83–1.0 em of ink while the terminal cell is only ~0.6 em. Terminals force the glyph *advance* to one cell but don't clip glyph *ink*, so the bar bleeds past the tab edge. Terminal glyph synthesis doesn't help either: Ghostty/Kitty/WezTerm sprite-render Box Drawing, Block Elements, and Legacy Computing, but only a handful of Geometric Shapes (corner triangles) — U+25AC always goes through the font path.

## Fix

- Default the underline to `▂` (U+2582 LOWER ONE QUARTER BLOCK). Block Elements are designed to fill the cell edge-to-edge (measured exactly 600/600 units in JetBrains Mono), and modern terminals sprite-render the whole block pixel-perfectly regardless of font.
- Add an `underlineChar` option (+ getter/setter) so consumers can pick `▃`, `🬭`, `─`, etc. Framework wrappers (react/solid/vue) pick the prop up automatically via `TabSelectRenderableOptions`.

