### PR TITLE
fix(core): force full repaint on terminal resize

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -3785,6 +3785,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this._console.resize(this.width, this.height)
     this.root.resize(this.width, this.height)
     this.emit(CliRenderEvents.RESIZE, this.width, this.height)
+    // A terminal resize invalidates the on-screen contents the diff renderer
+    // compares against, so force the next frame to fully repaint. Without this a
+    // grow-back after a shrink leaves stale cells until another resize, matching
+    // every other geometry/mode transition (applyScreenMode, resume, etc.).
+    this.forceFullRepaintRequested = true
     this.requestRender()
   }
 

--- a/packages/core/src/tests/renderer.control.test.ts
+++ b/packages/core/src/tests/renderer.control.test.ts
@@ -144,6 +144,28 @@ test("resume() forces the next alternate-screen render to fully repaint", async 
   await expectStartedResumeForcesNextRender("alternate-screen")
 })
 
+async function expectResizeForcesNextRender(screenMode: "main-screen" | "alternate-screen"): Promise<void> {
+  renderer.destroy()
+  ;({ renderer, mockInput, mockMouse, renderOnce } = await createTestRenderer({ screenMode, width: 80, height: 24 }))
+  ;(renderer as any)._terminalIsSetup = true
+  ;(renderer as any).forceFullRepaintRequested = false
+
+  renderer.resize(120, 40)
+
+  // A terminal resize invalidates what the diff renderer believes is on screen,
+  // so the next frame must fully repaint. Without this, growing back after a
+  // shrink leaves stale cells until another resize (see processResize).
+  expect((renderer as any).forceFullRepaintRequested).toBe(true)
+}
+
+test("resize() forces the next main-screen render to fully repaint", async () => {
+  await expectResizeForcesNextRender("main-screen")
+})
+
+test("resize() forces the next alternate-screen render to fully repaint", async () => {
+  await expectResizeForcesNextRender("alternate-screen")
+})
+
 test("stop() transitions to EXPLICIT_STOPPED and stops rendering", () => {
   renderer.start()
   expect(renderer.isRunning).toBe(true)


### PR DESCRIPTION
### Issue for this PR

Closes #1110

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Shrinking the terminal and growing it back (or shrinking width in
alternate-screen) leaves stale cells on screen — ghost columns/rows — until
you resize again. `processResize` resizes the renderer and requests a render
but never sets `forceFullRepaintRequested`, so the next frame diffs against a
stale buffer and skips cells the terminal still shows as dirty. Every other
screen-invalidating transition (applyScreenMode, resume in #1008/#922,
capability change, buffer reset) already forces a full repaint; resize was the
exception. This implements the fix suggested in #1110 (option 2): force a full
repaint after a resize. TypeScript-only, no native build.

### How did you verify your code works?

Added two regression tests (main-screen and alternate-screen) asserting a
resize sets the full-repaint flag; both fail before the change and pass after.
`bun test packages/core/src/tests/renderer.control.test.ts` → 30 pass;
`oxfmt --check` and `oxlint --deny-warnings` clean. The fix reuses the same
repaint path the existing `resume()` tests already cover. I did not record a
live before/after TUI clip.

### Screenshots / recordings

N/A (internal render path).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
