### PR TITLE
chore(github): adopt opencode's contribution templates and PR-standards check

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Report an issue that should be fixed (avoid pasting giant AI generated summaries or your issue may be closed/ignored)
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the bug you encountered
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: input
+    id: opentui-version
+    attributes:
+      label: OpenTUI version
+      description: What version of `@opentui/core` are you using?
+    validations:
+      required: false
+
+  - type: input
+    id: consumer
+    attributes:
+      label: Consumer / framework
+      description: How are you using OpenTUI? (e.g. @opentui/core, @opentui/react, @opentui/solid, opencode)
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshot-or-link
+    attributes:
+      label: Screenshot and/or reproduction
+      description: Attach a screenshot, recording, or minimal reproduction
+      placeholder: Paste link or drag and drop screenshot here
+    validations:
+      required: false
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: what OS are you using?
+      placeholder: e.g., macOS 26.0.1, Ubuntu 22.04, Windows 11
+    validations:
+      required: false
+
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal
+      description: what terminal are you using?
+      placeholder: e.g., iTerm2, Ghostty, Alacritty, Windows Terminal
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,19 @@
+name: 🚀 Feature Request
+description: Suggest an idea, feature, or enhancement
+title: "[FEATURE]:"
+
+body:
+  - type: checkboxes
+    id: verified
+    attributes:
+      label: Feature hasn't been suggested before.
+      options:
+        - label: I have verified this feature I'm about to request hasn't been suggested before.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the enhancement you want to request
+      description: What do you want to change or add? What are the benefits of implementing this? Try to be detailed so we can understand your request better :)
+    validations:
+      required: true

--- a/.github/TEAM_MEMBERS
+++ b/.github/TEAM_MEMBERS
@@ -1,0 +1,6 @@
+kommander
+msmps
+Hona
+simonklee
+Adictya
+fezproof

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+### Issue for this PR
+
+Closes #
+
+### Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / code improvement
+- [ ] Documentation
+
+### What does this PR do?
+
+Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.
+
+**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**
+
+### How did you verify your code works?
+
+### Screenshots / recordings
+
+_If this is a UI change, please include a screenshot or recording._
+
+### Checklist
+
+- [ ] I have tested my changes locally
+- [ ] I have not included unrelated changes in this PR
+
+_If you do not follow this template your PR will be automatically rejected._

--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -1,0 +1,351 @@
+name: pr-standards
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-standards:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check PR standards
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const login = pr.user.login;
+
+            // Skip PRs created before this workflow was adopted (adjust the cutoff as needed)
+            const cutoff = new Date('2026-07-11T00:00:00Z');
+            const prCreated = new Date(pr.created_at);
+            if (prCreated < cutoff) {
+              console.log(`Skipping: PR #${pr.number} was created before cutoff (${prCreated.toISOString()})`);
+              return;
+            }
+
+            // Check if author is a team member or bot
+            if (login.endsWith('[bot]')) return;
+            const { data: file } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: '.github/TEAM_MEMBERS',
+              ref: 'main'
+            });
+            const members = Buffer.from(file.content, 'base64').toString().split('\n').map(l => l.trim()).filter(Boolean);
+            if (members.includes(login)) {
+              console.log(`Skipping: ${login} is a team member`);
+              return;
+            }
+
+            const title = pr.title;
+
+            async function addLabel(label) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: [label]
+              });
+            }
+
+            async function removeLabel(label) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: label
+                });
+              } catch (e) {
+                // Label wasn't present, ignore
+              }
+            }
+
+            async function comment(marker, body) {
+              const markerText = `<!-- pr-standards:${marker} -->`;
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number
+              });
+              
+              const existing = comments.find(c => c.body.includes(markerText));
+              if (existing) return;
+              
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: markerText + '\n' + body
+              });
+            }
+
+            // Step 1: Check title format
+            // Matches: feat:, feat(scope):, feat (scope):, etc.
+            const titlePattern = /^(feat|fix|docs|chore|refactor|test)\s*(\([a-zA-Z0-9-]+\))?\s*:/;
+            const hasValidTitle = titlePattern.test(title);
+
+            if (!hasValidTitle) {
+              await addLabel('needs:title');
+              await comment('title', `Hey! Your PR title \`${title}\` doesn't follow conventional commit format.
+
+            Please update it to start with one of:
+            - \`feat:\` or \`feat(scope):\` new feature
+            - \`fix:\` or \`fix(scope):\` bug fix
+            - \`docs:\` or \`docs(scope):\` documentation changes
+            - \`chore:\` or \`chore(scope):\` maintenance tasks
+            - \`refactor:\` or \`refactor(scope):\` code refactoring
+            - \`test:\` or \`test(scope):\` adding or updating tests
+
+            Where \`scope\` is the package name (e.g., \`app\`, \`desktop\`, \`opencode\`).
+
+            See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#pr-titles) for details.`);
+              return;
+            }
+
+            await removeLabel('needs:title');
+
+            // Step 2: Check for linked issue (skip for docs/refactor/feat PRs)
+            const skipIssueCheck = /^(docs|refactor|feat)\s*(\([a-zA-Z0-9-]+\))?\s*:/.test(title);
+            if (skipIssueCheck) {
+              await removeLabel('needs:issue');
+              console.log('Skipping issue check for docs/refactor/feat PR');
+              return;
+            }
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 1) {
+                      totalCount
+                    }
+                  }
+                }
+              }
+            `;
+
+            const result = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: pr.number
+            });
+
+            const linkedIssues = result.repository.pullRequest.closingIssuesReferences.totalCount;
+
+            if (linkedIssues === 0) {
+              await addLabel('needs:issue');
+              await comment('issue', `Thanks for your contribution!
+
+            This PR doesn't have a linked issue. All PRs must reference an existing issue.
+
+            Please:
+            1. Open an issue describing the bug/feature (if one doesn't exist)
+            2. Add \`Fixes #<number>\` or \`Closes #<number>\` to this PR description
+
+            See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#issue-first-policy) for details.`);
+              return;
+            }
+
+            await removeLabel('needs:issue');
+            console.log('PR meets all standards');
+
+  check-compliance:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check PR template compliance
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const login = pr.user.login;
+
+            // Skip PRs created before this workflow was adopted (adjust the cutoff as needed)
+            const cutoff = new Date('2026-07-11T00:00:00Z');
+            const prCreated = new Date(pr.created_at);
+            if (prCreated < cutoff) {
+              console.log(`Skipping: PR #${pr.number} was created before cutoff (${prCreated.toISOString()})`);
+              return;
+            }
+
+            // Check if author is a team member or bot
+            if (login.endsWith('[bot]')) return;
+            const { data: file } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: '.github/TEAM_MEMBERS',
+              ref: 'main'
+            });
+            const members = Buffer.from(file.content, 'base64').toString().split('\n').map(l => l.trim()).filter(Boolean);
+            if (members.includes(login)) {
+              console.log(`Skipping: ${login} is a team member`);
+              return;
+            }
+
+            const body = pr.body || '';
+            const title = pr.title;
+            const isDocsRefactorOrFeat = /^(docs|refactor|feat)\s*(\([a-zA-Z0-9-]+\))?\s*:/.test(title);
+
+            const issues = [];
+
+            // Check: template sections exist
+            const hasWhatSection = /### What does this PR do\?/.test(body);
+            const hasTypeSection = /### Type of change/.test(body);
+            const hasVerifySection = /### How did you verify your code works\?/.test(body);
+            const hasChecklistSection = /### Checklist/.test(body);
+            const hasIssueSection = /### Issue for this PR/.test(body);
+
+            if (!hasWhatSection || !hasTypeSection || !hasVerifySection || !hasChecklistSection || !hasIssueSection) {
+              issues.push('PR description is missing required template sections. Please use the [PR template](../blob/main/.github/pull_request_template.md).');
+            }
+
+            // Check: "What does this PR do?" has real content (not just placeholder text)
+            if (hasWhatSection) {
+              const whatMatch = body.match(/### What does this PR do\?\s*\n([\s\S]*?)(?=###|$)/);
+              const whatContent = whatMatch ? whatMatch[1].trim() : '';
+              const placeholder = 'Please provide a description of the issue';
+              const onlyPlaceholder = whatContent.includes(placeholder) && whatContent.replace(placeholder, '').replace(/[*\s]/g, '').length < 20;
+              if (!whatContent || onlyPlaceholder) {
+                issues.push('"What does this PR do?" section is empty or only contains placeholder text. Please describe your changes.');
+              }
+            }
+
+            // Check: at least one "Type of change" checkbox is checked
+            if (hasTypeSection) {
+              const typeMatch = body.match(/### Type of change\s*\n([\s\S]*?)(?=###|$)/);
+              const typeContent = typeMatch ? typeMatch[1] : '';
+              const hasCheckedBox = /- \[x\]/i.test(typeContent);
+              if (!hasCheckedBox) {
+                issues.push('No "Type of change" checkbox is checked. Please select at least one.');
+              }
+            }
+
+            // Check: issue reference (skip for docs/refactor/feat)
+            if (!isDocsRefactorOrFeat && hasIssueSection) {
+              const issueMatch = body.match(/### Issue for this PR\s*\n([\s\S]*?)(?=###|$)/);
+              const issueContent = issueMatch ? issueMatch[1].trim() : '';
+              const hasIssueRef = /(closes|fixes|resolves)\s+#\d+/i.test(issueContent) || /#\d+/.test(issueContent);
+              if (!hasIssueRef) {
+                issues.push('No issue referenced. Please add `Closes #<number>` linking to the relevant issue.');
+              }
+            }
+
+            // Check: "How did you verify" has content
+            if (hasVerifySection) {
+              const verifyMatch = body.match(/### How did you verify your code works\?\s*\n([\s\S]*?)(?=###|$)/);
+              const verifyContent = verifyMatch ? verifyMatch[1].trim() : '';
+              if (!verifyContent) {
+                issues.push('"How did you verify your code works?" section is empty. Please explain how you tested.');
+              }
+            }
+
+            // Check: checklist boxes are checked
+            if (hasChecklistSection) {
+              const checklistMatch = body.match(/### Checklist\s*\n([\s\S]*?)(?=###|$)/);
+              const checklistContent = checklistMatch ? checklistMatch[1] : '';
+              const unchecked = (checklistContent.match(/- \[ \]/g) || []).length;
+              const checked = (checklistContent.match(/- \[x\]/gi) || []).length;
+              if (checked < 2) {
+                issues.push('Not all checklist items are checked. Please confirm you have tested locally and have not included unrelated changes.');
+              }
+            }
+
+            // Helper functions
+            async function addLabel(label) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: [label]
+              });
+            }
+
+            async function removeLabel(label) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: label
+                });
+              } catch (e) {}
+            }
+
+            const hasComplianceLabel = pr.labels.some(l => l.name === 'needs:compliance');
+
+            if (issues.length > 0) {
+              // Non-compliant
+              if (!hasComplianceLabel) {
+                await addLabel('needs:compliance');
+              }
+
+              const marker = '<!-- issue-compliance -->';
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number
+              });
+              const existing = comments.find(c => c.body.includes(marker));
+
+              const body_text = `${marker}
+            This PR doesn't fully meet our [contributing guidelines](../blob/main/CONTRIBUTING.md) and [PR template](../blob/main/.github/pull_request_template.md).
+
+            **What needs to be fixed:**
+            ${issues.map(i => `- ${i}`).join('\n')}
+
+            Please edit this PR description to address the above within **2 hours**, or it will be automatically closed.
+
+            If you believe this was flagged incorrectly, please let a maintainer know.`;
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: body_text
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: body_text
+                });
+              }
+
+              console.log(`PR #${pr.number} is non-compliant: ${issues.join(', ')}`);
+            } else if (hasComplianceLabel) {
+              // Was non-compliant, now fixed
+              await removeLabel('needs:compliance');
+
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number
+              });
+              const marker = '<!-- issue-compliance -->';
+              const existing = comments.find(c => c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id
+                });
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: 'Thanks for updating your PR! It now meets our contributing guidelines. :+1:'
+              });
+
+              console.log(`PR #${pr.number} is now compliant, label removed`);
+            } else {
+              console.log(`PR #${pr.number} is compliant`);
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,30 @@
 Bug fixes and feature suggestions are always welcome. For bug fixes, open a PR
 for reviews. Feature suggestions are subject to discussion via issues.
 
+## Pull Requests
+
+Pull requests are checked by an automated `pr-standards` workflow for title
+format, template completeness, and a linked issue.
+
+### PR Titles
+
+PR titles must follow Conventional Commits:
+
+- `feat:` new feature or functionality
+- `fix:` bug fix
+- `docs:` documentation changes
+- `chore:` maintenance / tooling / dependency updates
+- `refactor:` code change without behavior change
+- `test:` adding or updating tests
+
+You can optionally include a package scope, e.g. `fix(core):` or `feat(solid):`.
+
+### Issue First Policy
+
+`fix:` PRs must reference an existing issue. Open an issue describing the bug,
+then add `Closes #<number>` (or `Fixes #<number>`) to the PR description.
+`docs`, `refactor`, and `feat` PRs are exempt from the issue requirement.
+
 ## Code style
 
 Reference existing [AGENTS.md](https://github.com/anomalyco/opentui/blob/main/AGENTS.md) or project conventions if applicable.


### PR DESCRIPTION
### Issue for this PR

Closes #1241

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Ports opencode's contribution scaffolding to opentui so both anomalyco repos
share one contribution flow (#1241): a PR template, issue templates (bug +
feature + config), a `TEAM_MEMBERS` file, and the `pr-standards` workflow that
checks conventional-commit titles, template completeness, and issue-first
linking. `CONTRIBUTING.md` gains **PR Titles** and **Issue First Policy**
sections.

The workflow is adapted to opentui, not copied verbatim:
- reads `TEAM_MEMBERS` from `main` (opentui's default branch), not `dev`
- skips any `[bot]` author instead of the opencode-specific bot login
- links to the `CONTRIBUTING.md` anchors added here
- `TEAM_MEMBERS` seeded from `CODEOWNERS`
- `needs:*` labels are created on first use by the workflow
- the created-before cutoff is set so existing open PRs are not retroactively
  flagged

It uses `pull_request_target` like opencode's, but never checks out or runs PR
code — it only reads repo content and labels/comments via the API, and adds no
secrets.

### How did you verify your code works?

All four YAML files parse cleanly (`Bun.YAML.parse`). The workflow is
opencode's `pr-standards.yml` with only opentui-specific values changed (branch
ref, `[bot]` skip, `CONTRIBUTING.md` links, cutoff date) — no logic changes.
The `CONTRIBUTING.md` anchors (`#pr-titles`, `#issue-first-policy`) match the
links the workflow emits.

### Screenshots / recordings

N/A (repo tooling / templates).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
