### PR TITLE
fix(react): correct inverted autoplay condition in useTimeline

### DIFF
--- a/packages/react/src/hooks/use-timeline.ts
+++ b/packages/react/src/hooks/use-timeline.ts
@@ -5,7 +5,7 @@ export const useTimeline = (options: TimelineOptions = {}) => {
   const timeline = new Timeline(options)
 
   useEffect(() => {
-    if (!options.autoplay) {
+    if (options.autoplay !== false) {
       timeline.play()
     }
 

--- a/packages/react/tests/use-timeline.test.tsx
+++ b/packages/react/tests/use-timeline.test.tsx
@@ -1,0 +1,57 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, mock } from "bun:test"
+import { useTimeline } from "../src/hooks/use-timeline.js"
+import { testRender } from "../src/test-utils.js"
+
+let testSetup: Awaited<ReturnType<typeof testRender>>
+
+function Probe({ autoplay, onTimeline }: { autoplay?: boolean; onTimeline: (t: ReturnType<typeof useTimeline>) => void }) {
+  const timeline = useTimeline(autoplay === undefined ? {} : { autoplay })
+  onTimeline(timeline)
+  return null
+}
+
+describe("useTimeline autoplay", () => {
+  let originalConsoleError: (...args: any[]) => void
+
+  beforeAll(() => {
+    originalConsoleError = console.error
+    console.error = mock(() => {})
+  })
+
+  afterAll(() => {
+    console.error = originalConsoleError
+  })
+
+  afterEach(() => {
+    if (testSetup) {
+      testSetup.renderer.destroy()
+    }
+  })
+
+  it("plays by default when autoplay is not specified", async () => {
+    let timeline: ReturnType<typeof useTimeline> | undefined
+    testSetup = await testRender(<Probe onTimeline={(t) => (timeline = t)} />, { width: 10, height: 5 })
+    await testSetup.renderOnce()
+    expect(timeline!.isPlaying).toBe(true)
+  })
+
+  it("plays when autoplay is explicitly true", async () => {
+    let timeline: ReturnType<typeof useTimeline> | undefined
+    testSetup = await testRender(<Probe autoplay={true} onTimeline={(t) => (timeline = t)} />, {
+      width: 10,
+      height: 5,
+    })
+    await testSetup.renderOnce()
+    expect(timeline!.isPlaying).toBe(true)
+  })
+
+  it("does not play when autoplay is explicitly false", async () => {
+    let timeline: ReturnType<typeof useTimeline> | undefined
+    testSetup = await testRender(<Probe autoplay={false} onTimeline={(t) => (timeline = t)} />, {
+      width: 10,
+      height: 5,
+    })
+    await testSetup.renderOnce()
+    expect(timeline!.isPlaying).toBe(false)
+  })
+})


### PR DESCRIPTION
Bug: TimelineOptions.autoplay defaults to true, but the condition !options.autoplay only plays when autoplay is falsy, so the timeline never starts by default.

Fix: use options.autoplay !== false, matching the correct Solid implementation in packages/solid/src/elements/hooks.ts:148.

Closes #1243
