### PR TITLE
fix(three): prevent division by zero in createGradient when size <= 1

### DIFF
--- a/packages/three/src/TextureUtils.test.ts
+++ b/packages/three/src/TextureUtils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test"
+import { Color } from "three"
+import { TextureUtils } from "./TextureUtils.js"
+
+describe("TextureUtils.createGradient", () => {
+  it("clamps size 1 up to 2 instead of dividing by zero", () => {
+    // size=1 makes `x / (size - 1)` and `y / (size - 1)` divide by zero,
+    // producing NaN that Uint8ClampedArray silently clamps to 0 - a solid
+    // black pixel instead of the requested gradient.
+    const texture = TextureUtils.createGradient(1, new Color(1, 0, 0), new Color(0, 0, 1), "horizontal")
+    const data = texture.image.data as Uint8ClampedArray
+
+    expect(texture.image.width).toBe(2)
+    expect(texture.image.height).toBe(2)
+    // First column should be the start color (red), not black.
+    expect(data[0]).toBe(255)
+    expect(data[1]).toBe(0)
+    expect(data[2]).toBe(0)
+  })
+
+  it("clamps size 0 up to 2", () => {
+    const texture = TextureUtils.createGradient(0, new Color(1, 0, 0), new Color(0, 0, 1))
+    expect(texture.image.width).toBe(2)
+    expect(texture.image.height).toBe(2)
+  })
+
+  it("clamps negative size up to 2", () => {
+    const texture = TextureUtils.createGradient(-5, new Color(1, 0, 0), new Color(0, 0, 1))
+    expect(texture.image.width).toBe(2)
+    expect(texture.image.height).toBe(2)
+  })
+
+  it("floors a non-integer size", () => {
+    const texture = TextureUtils.createGradient(4.7, new Color(1, 0, 0), new Color(0, 0, 1))
+    expect(texture.image.width).toBe(4)
+    expect(texture.image.height).toBe(4)
+  })
+
+  it("leaves a normal size untouched", () => {
+    const texture = TextureUtils.createGradient(16, new Color(1, 0, 0), new Color(0, 0, 1))
+    expect(texture.image.width).toBe(16)
+    expect(texture.image.height).toBe(16)
+  })
+})

--- a/packages/three/src/TextureUtils.ts
+++ b/packages/three/src/TextureUtils.ts
@@ -97,6 +97,7 @@ export class TextureUtils {
     endColor: Color = new Color(0.0, 0.0, 1.0),
     direction: "horizontal" | "vertical" | "radial" = "vertical",
   ): Texture {
+    size = Math.max(2, Math.floor(size))
     const data = new Uint8ClampedArray(size * size * 4)
 
     for (let y = 0; y < size; y++) {


### PR DESCRIPTION
### Issue for this PR

Closes #1251

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `size = Math.max(2, Math.floor(size))` at the top of `TextureUtils.createGradient()` to prevent division by zero when `size` is 0 or 1. This ensures denominators `(size - 1)` and `(size / 2)` are always at least 1, avoiding `Infinity`/`NaN` in the gradient computation.

### How did you verify your code works?

`Math.max(2, 1)` returns 2, `Math.max(2, 256)` returns 256. The `Math.floor` ensures integer sizes. At size 2, the gradient has a valid denominator of 1.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
