### PR TITLE
fix(qrcode): iterate codepoints instead of UTF-16 code units in asciiBytes

### DIFF
--- a/packages/qrcode/src/lib/qrcode.encoding.ts
+++ b/packages/qrcode/src/lib/qrcode.encoding.ts
@@ -47,7 +47,11 @@ export function validateBytes(bytes: number[]): number[] {
 
 export function asciiBytes(text: string): number[] {
   const result: number[] = []
-  for (let i = 0; i < text.length; i++) result.push(text.charCodeAt(i))
+  for (const ch of text) {
+    const cp = ch.codePointAt(0)!
+    if (cp > 0x7f) throw new Error(`Character ${JSON.stringify(ch)} is not encodable in ASCII`)
+    result.push(cp)
+  }
   return result
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #1253

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Replaces UTF-16 code unit iteration (`text.length` + `charCodeAt`) with codepoint iteration (`for...of` + `codePointAt`) in `asciiBytes`. Adds ASCII range validation (codepoint ≤ 0x7F) with a descriptive error for non-ASCII input.

This aligns `asciiBytes` with `encodeIso88591` directly below in the same file, which already uses the correct codepoint iteration and range validation pattern.

**Note on reachability:** `asciiBytes`'s only current callers, `QrSegment.makeNumeric` and `QrSegment.makeAlphanumeric`, already regex-validate their input to a strict ASCII subset (`/^[0-9]*$/` and `/^[0-9A-Z $%*+\-./:]*$/`) before calling it, so the surrogate-byte corruption described in #1253 isn't reachable through those two paths today. This PR hardens the exported `asciiBytes` function itself (it's part of the package's public API surface and can be called directly), not a currently-reachable corruption in the QR encoding pipeline.

### How did you verify your code works?

`for...of` iterates by Unicode codepoint (not UTF-16 code unit), correctly handling supplementary-plane characters. The `codepoint > 0x7f` guard follows the same pattern as `encodeIso88591`'s `cp > 0xff` check. Surrogate halves (0xD800-0xDFFF) are no longer possible in the output.

Verified directly: on `main`, `asciiBytes("A😀B")` returns `[65, 55357, 56832, 66]` (surrogate halves as garbage byte values); with this fix it throws `Character "😀" is not encodable in ASCII`.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
