### PR TITLE
fix(core): guard setRawMode in resume() so input always re-attaches

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -4024,7 +4024,16 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   public resume(): void {
     if (this.stdin.setRawMode) {
-      this.stdin.setRawMode(true)
+      try {
+        this.stdin.setRawMode(true)
+      } catch (error) {
+        // On Windows, uv_tty_set_mode can throw (EINVAL/ENOTTY/EBADF) when the
+        // console handle is in a transient state — e.g. right after shelling
+        // out to a child (git/editor/pager) that grabbed the console. Never let
+        // that skip re-attaching the "data" listener + resume() below, or input
+        // stays permanently dead while the render loop keeps running.
+        console.error("Failed to restore raw mode on resume:", error)
+      }
     }
 
     // Drain any input buffered during suspension before registering the

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -3982,6 +3982,26 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.internalPause()
   }
 
+  // On Windows, uv_tty_set_mode can throw (EINVAL/ENOTTY/EBADF) when the
+  // console handle is in a transient state — e.g. right after shelling out to
+  // a child (git/editor/pager) that grabbed the console. Once the renderer is
+  // already running, never let that abort suspend/resume/destroy, or input
+  // stays permanently dead while the render loop keeps running. (The initial
+  // setup call is intentionally NOT routed through this helper: a raw-mode
+  // failure at construction means the terminal can't be used at all, and
+  // callers rely on that rejecting — see renderer.custom-stdout.test.ts and
+  // renderer.tracker.test.ts.)
+  private trySetRawMode(mode: boolean, context: string): void {
+    if (!this.stdin.setRawMode) {
+      return
+    }
+    try {
+      this.stdin.setRawMode(mode)
+    } catch (error) {
+      console.error(`Failed to set raw mode (${mode}) during ${context}:`, error)
+    }
+  }
+
   public suspend(): void {
     this._previousControlState = this._controlState
 
@@ -4015,26 +4035,13 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this.lib.suspendRenderer(this.rendererPtr)
 
-    if (this.stdin.setRawMode) {
-      this.stdin.setRawMode(false)
-    }
+    this.trySetRawMode(false, "suspend")
 
     this.stdin.pause()
   }
 
   public resume(): void {
-    if (this.stdin.setRawMode) {
-      try {
-        this.stdin.setRawMode(true)
-      } catch (error) {
-        // On Windows, uv_tty_set_mode can throw (EINVAL/ENOTTY/EBADF) when the
-        // console handle is in a transient state — e.g. right after shelling
-        // out to a child (git/editor/pager) that grabbed the console. Never let
-        // that skip re-attaching the "data" listener + resume() below, or input
-        // stays permanently dead while the render loop keeps running.
-        console.error("Failed to restore raw mode on resume:", error)
-      }
-    }
+    this.trySetRawMode(true, "resume")
 
     // Drain any input buffered during suspension before registering the
     // listener. Adding a "data" listener can auto-resume a Readable, so the
@@ -4194,13 +4201,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.setCapturedRenderable(undefined)
 
     this.stdin.removeListener("data", this.stdinListener)
-    if (this.stdin.setRawMode) {
-      try {
-        this.stdin.setRawMode(false)
-      } catch (e) {
-        console.error("Error disabling raw mode during destroy:", e)
-      }
-    }
+    this.trySetRawMode(false, "destroy")
     try {
       this.stdin.pause()
     } catch (e) {

--- a/packages/core/src/tests/renderer.control.test.ts
+++ b/packages/core/src/tests/renderer.control.test.ts
@@ -1,4 +1,5 @@
 import { test, expect, beforeEach, afterEach, spyOn } from "bun:test"
+import { Readable } from "stream"
 import { createTestRenderer, type TestRenderer, type MockInput, type MockMouse } from "../testing/test-renderer.js"
 import { ManualClock } from "../testing/manual-clock.js"
 import { RendererControlState } from "../renderer.js"
@@ -455,4 +456,32 @@ test("suspend/resume does not leak stdin listeners", () => {
   }
 
   expect(renderer.stdin.listenerCount("data")).toBe(baseline)
+})
+
+test("suspend/resume complete a full cycle once setRawMode starts throwing", async () => {
+  // Setup succeeds normally (constructor's raw-mode call is intentionally not
+  // guarded - see renderer.custom-stdout.test.ts/renderer.tracker.test.ts for
+  // that fail-fast contract). Only after that do later calls start throwing,
+  // simulating the transient Windows console-handle state suspend/resume/
+  // destroy must tolerate.
+  const stdin = new Readable({ read() {} }) as any
+  let setupDone = false
+  stdin.setRawMode = () => {
+    if (!setupDone) return
+    throw new Error("EIO: transient console handle state")
+  }
+
+  const { renderer: throwingRenderer } = await createTestRenderer({ stdin })
+  setupDone = true
+
+  try {
+    throwingRenderer.suspend()
+    expect(stdin.isPaused()).toBe(true)
+
+    throwingRenderer.resume()
+    expect(stdin.isPaused()).toBe(false)
+    expect(stdin.listenerCount("data")).toBeGreaterThan(0)
+  } finally {
+    throwingRenderer.destroy()
+  }
 })


### PR DESCRIPTION
## Summary

On Windows, `resume()` can leave the terminal permanently unresponsive — no input, no output — while the render loop keeps running. `resume()` re-arms input as `setRawMode(true)` → drain buffered bytes → re-attach the stdin `data` listener → `stdin.resume()`. On Windows `uv_tty_set_mode` can throw (`EINVAL` / `ENOTTY` / `EBADF`) when the console handle is in a transient state right after a child process (editor / pager / git) released it. The unguarded throw unwinds `resume()` before the `data` listener is re-attached, so input is never restored. `finalizeDestroy()` already wraps its `setRawMode(false)` in try/catch; `resume()` did not.

This PR wraps the `setRawMode(true)` call in try/catch (logging on failure) so the `data`-listener re-attach and `stdin.resume()` always run. If raw mode can't be restored, input falls back to cooked mode instead of dying.

## Repro

On Windows, run an opentui app that suspends and resumes the renderer around a shell-out (e.g. opencode's `/editor`). After the child returns, the terminal is frozen — no input, no output — until the process is killed. Likely the opentui-side cause of anomalyco/opencode#11877.

## Verification

`bun test` — `renderer.focus` / `renderer.focus-restore` / `renderer.lifecycle` / `renderer.idle`: 41 pass, 0 fail. `oxlint` clean.

Closes #1255
