### PR TITLE
fix(core): preserve narrow table columns

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "bench:box-draw": "bun src/benchmark/box-draw-benchmark.ts",
     "bench:render-traversal": "bun src/benchmark/render-traversal-benchmark.ts",
     "bench:text-table": "bun src/benchmark/text-table-benchmark.ts",
+    "bench:text-table-width": "bun src/benchmark/text-table-width-benchmark.ts",
     "bench:ts": "bun src/benchmark/native-span-feed-benchmark.ts --suite=quick --json=src/benchmark/latest-quick-bench-run.json && bun src/benchmark/native-span-feed-benchmark.ts --suite=default --json=src/benchmark/latest-default-bench-run.json && bun src/benchmark/native-span-feed-benchmark.ts --suite=large --json=src/benchmark/latest-large-bench-run.json && bun src/benchmark/native-span-feed-benchmark.ts --suite=all --json=src/benchmark/latest-all-bench-run.json && bun src/benchmark/native-span-feed-async-benchmark.ts --json=src/benchmark/latest-async-bench-run.json",
     "publish": "bun scripts/publish.ts",
     "test:dist": "bun scripts/dist-test.ts",

--- a/packages/core/src/benchmark/text-table-width-benchmark.ts
+++ b/packages/core/src/benchmark/text-table-width-benchmark.ts
@@ -1,0 +1,167 @@
+import { allocateProportionalColumnWidths } from "../renderables/text-table-width.js"
+
+interface Scenario {
+  name: string
+  inputs: Input[]
+  iterations: number
+}
+
+interface Input {
+  widths: number[]
+  targetWidth: number
+  minWidth: number
+}
+
+const samples = 9
+const warmups = 2
+let seed = 0x1259
+const propertyInputs = Array.from({ length: 40 }, (_, vectorIdx) => {
+  seed = (seed * 1664525 + 1013904223) >>> 0
+  const minWidth = 1 + (seed % 4)
+  const widths = Array.from({ length: 1 + (vectorIdx % 8) }, () => {
+    seed = (seed * 1664525 + 1013904223) >>> 0
+    return minWidth + (seed % 80)
+  })
+  const minimum = minWidth * widths.length
+  const intrinsic = widths.reduce((sum, width) => sum + width, 0)
+  return Array.from({ length: intrinsic - minimum }, (_, offset) => ({
+    widths,
+    targetWidth: minimum + offset + 1,
+    minWidth,
+  }))
+}).flat()
+const scenarios: Scenario[] = [
+  {
+    name: "reported-5-columns",
+    inputs: [{ widths: [4, 49, 4, 54, 38], targetWidth: 104, minWidth: 1 }],
+    iterations: 1_000_000,
+  },
+  {
+    name: "reviewed-vectors",
+    inputs: [
+      { widths: [91, 9], targetWidth: 37, minWidth: 1 },
+      { widths: [91, 9], targetWidth: 38, minWidth: 1 },
+      { widths: [1000, 100], targetWidth: 401, minWidth: 1 },
+      { widths: [1000, 100], targetWidth: 402, minWidth: 1 },
+      { widths: [7, 7, 7], targetWidth: 13, minWidth: 3 },
+    ],
+    iterations: 1_000_000,
+  },
+  {
+    name: "typical-8-columns",
+    inputs: [{ widths: [6, 42, 9, 75, 4, 28, 13, 61], targetWidth: 120, minWidth: 1 }],
+    iterations: 500_000,
+  },
+  {
+    name: "typical-16-columns",
+    inputs: [
+      {
+        widths: [8, 37, 5, 62, 11, 44, 7, 29, 15, 71, 6, 53, 18, 34, 9, 47],
+        targetWidth: 240,
+        minWidth: 1,
+      },
+    ],
+    iterations: 250_000,
+  },
+  { name: "property-test-corpus", inputs: propertyInputs, iterations: 500_000 },
+  {
+    name: "exact-number-comparison",
+    inputs: [{ widths: [2_516_760, 2_528_584], targetWidth: 58_886, minWidth: 1 }],
+    iterations: 1_000_000,
+  },
+  {
+    name: "exact-bigint-comparison",
+    inputs: [{ widths: [4_000_000_001, 1_000_000_001], targetWidth: 300_001, minWidth: 1 }],
+    iterations: 500_000,
+  },
+  {
+    name: "uniform-8-near-full",
+    inputs: [{ widths: new Array(8).fill(2), targetWidth: 15, minWidth: 1 }],
+    iterations: 500_000,
+  },
+  {
+    name: "uniform-16-near-full",
+    inputs: [{ widths: new Array(16).fill(2), targetWidth: 31, minWidth: 1 }],
+    iterations: 250_000,
+  },
+  {
+    name: "uniform-64-near-full",
+    inputs: [{ widths: new Array(64).fill(2), targetWidth: 127, minWidth: 1 }],
+    iterations: 50_000,
+  },
+  {
+    name: "uniform-64-half-filled",
+    inputs: [{ widths: new Array(64).fill(17), targetWidth: 576, minWidth: 1 }],
+    iterations: 50_000,
+  },
+  {
+    name: "uniform-64-remainder-1",
+    inputs: [{ widths: new Array(64).fill(17), targetWidth: 577, minWidth: 1 }],
+    iterations: 50_000,
+  },
+  {
+    name: "uniform-64-remainder-8",
+    inputs: [{ widths: new Array(64).fill(17), targetWidth: 584, minWidth: 1 }],
+    iterations: 50_000,
+  },
+  {
+    name: "uniform-64-near-full-cap16",
+    inputs: [{ widths: new Array(64).fill(17), targetWidth: 1087, minWidth: 1 }],
+    iterations: 50_000,
+  },
+  {
+    name: "uniform-256-near-full",
+    inputs: [{ widths: new Array(256).fill(2), targetWidth: 511, minWidth: 1 }],
+    iterations: 10_000,
+  },
+  {
+    name: "uniform-1024-near-full",
+    inputs: [{ widths: new Array(1024).fill(2), targetWidth: 2047, minWidth: 1 }],
+    iterations: 2_000,
+  },
+  {
+    name: "alternating-64-near-full",
+    inputs: [{ widths: Array.from({ length: 64 }, (_, idx) => 2 + (idx % 2)), targetWidth: 159, minWidth: 1 }],
+    iterations: 20_000,
+  },
+  {
+    name: "alternating-256-near-full",
+    inputs: [{ widths: Array.from({ length: 256 }, (_, idx) => 2 + (idx % 2)), targetWidth: 639, minWidth: 1 }],
+    iterations: 2_000,
+  },
+  {
+    name: "alternating-1024-near-full",
+    inputs: [{ widths: Array.from({ length: 1024 }, (_, idx) => 2 + (idx % 2)), targetWidth: 2559, minWidth: 1 }],
+    iterations: 200,
+  },
+]
+
+let checksum = 0
+
+for (const scenario of scenarios) {
+  const iterations = scenario.iterations
+
+  for (let sample = 0; sample < warmups; sample++) runScenario(scenario, iterations)
+
+  const timings = Array.from({ length: samples }, () => runScenario(scenario, iterations)).sort((a, b) => a - b)
+  const median = timings[Math.floor(timings.length / 2)]!
+  const min = timings[0]!
+  console.log(`${scenario.name.padEnd(28)} median=${median.toFixed(1)} ns/op min=${min.toFixed(1)} ns/op`)
+}
+
+console.log(`checksum=${checksum}`)
+
+function runScenario(scenario: Scenario, iterations: number): number {
+  let localChecksum = 0
+  const start = performance.now()
+
+  for (let iteration = 0; iteration < iterations; iteration++) {
+    const input = scenario.inputs[iteration % scenario.inputs.length]!
+    const result = allocateProportionalColumnWidths(input.widths, input.targetWidth, input.minWidth)
+    localChecksum += result[iteration % result.length]!
+  }
+
+  const elapsed = performance.now() - start
+  checksum = (checksum + localChecksum) >>> 0
+  return (elapsed * 1_000_000) / iterations
+}

--- a/packages/core/src/renderables/TextTable.test.ts
+++ b/packages/core/src/renderables/TextTable.test.ts
@@ -192,6 +192,7 @@ describe("TextTableRenderable", () => {
     expect(allocateProportionalColumnWidths([1000, 100], 401, 1)).toEqual([305, 96])
     expect(allocateProportionalColumnWidths([1000, 100], 402, 1)).toEqual([305, 97])
     expect(allocateProportionalColumnWidths([4, 49, 4, 54, 38], 104, 1)).toEqual([4, 33, 4, 34, 29])
+    expect(allocateProportionalColumnWidths([2_516_760, 2_528_584], 58_886, 1)).toEqual([29_408, 29_478])
   })
 
   test("proportional allocation resolves exact priority ties by lower index", () => {
@@ -199,6 +200,48 @@ describe("TextTableRenderable", () => {
     expect(allocateProportionalColumnWidths([7, 7, 7], 11, 3)).toEqual([4, 4, 3])
     expect(allocateProportionalColumnWidths([7, 7, 7], 12, 3)).toEqual([4, 4, 4])
     expect(allocateProportionalColumnWidths([7, 7, 7], 13, 3)).toEqual([5, 4, 4])
+    expect(allocateProportionalColumnWidths([19, 3], 5, 1)).toEqual([4, 1])
+    expect(allocateProportionalColumnWidths([4_000_000_001, 1_000_000_001], 300_001, 1)).toEqual([200_001, 100_000])
+  })
+
+  test("renders unequal-capacity priority ties in lower column index order", async () => {
+    // Capacities 18 and 2 make the third and first growth cells exact priority ties.
+    const table = new TextTableRenderable(renderer, {
+      left: 0,
+      top: 0,
+      width: 8,
+      wrapMode: "word",
+      content: [[cell("ABCDEFGHIJKLMNOPQRS"), cell("XYZ")]],
+    })
+
+    renderer.root.add(table)
+    await renderOnce()
+
+    const rowY = captureFrame()
+      .split("\n")
+      .findIndex((line) => line.includes("A") && line.includes("X"))
+    expect(rowY).toBeGreaterThanOrEqual(0)
+    expect(findVerticalBorderXs(renderer.currentRenderBuffer, rowY)).toEqual([0, 5, 7])
+  })
+
+  test("renders padded unequal-capacity priority ties in lower column index order", async () => {
+    const table = new TextTableRenderable(renderer, {
+      left: 0,
+      top: 0,
+      width: 12,
+      cellPaddingX: 1,
+      wrapMode: "word",
+      content: [[cell("ABCDEFGHIJKLMNOPQRS"), cell("XYZ")]],
+    })
+
+    renderer.root.add(table)
+    await renderOnce()
+
+    const rowY = captureFrame()
+      .split("\n")
+      .findIndex((line) => line.includes("A") && line.includes("X"))
+    expect(rowY).toBeGreaterThanOrEqual(0)
+    expect(findVerticalBorderXs(renderer.currentRenderBuffer, rowY)).toEqual([0, 7, 11])
   })
 
   test("proportional allocation clamps targets and preserves hard minimums and intrinsic caps", () => {
@@ -226,10 +269,29 @@ describe("TextTableRenderable", () => {
       const minimumTotal = minWidth * widths.length
       const intrinsicTotal = widths.reduce((sum, width) => sum + width, 0)
       let previous = allocateProportionalColumnWidths(widths, minimumTotal, minWidth)
+      const capacity = widths.map((width) => width - minWidth)
+      const expectedGrowth = new Array(widths.length).fill(0)
 
       for (let target = minimumTotal + 1; target <= intrinsicTotal; target++) {
+        let bestIdx = -1
+        for (let idx = 0; idx < capacity.length; idx++) {
+          if (expectedGrowth[idx] >= capacity[idx]!) continue
+          if (bestIdx === -1) {
+            bestIdx = idx
+            continue
+          }
+
+          const candidate = BigInt(expectedGrowth[idx]! + 1)
+          const best = BigInt(expectedGrowth[bestIdx]! + 1)
+          const candidatePriority = candidate * candidate * BigInt(capacity[bestIdx]!)
+          const bestPriority = best * best * BigInt(capacity[idx]!)
+          if (candidatePriority < bestPriority) bestIdx = idx
+        }
+        expectedGrowth[bestIdx] += 1
+
         const next = allocateProportionalColumnWidths(widths, target, minWidth)
         const deltas = next.map((width, idx) => width - previous[idx]!)
+        expect(next).toEqual(expectedGrowth.map((growth) => growth + minWidth))
         expect(next.reduce((sum, width) => sum + width, 0)).toBe(target)
         expect(next.every((width, idx) => width >= minWidth && width <= widths[idx]!)).toBe(true)
         expect(deltas.filter((delta) => delta === 1)).toHaveLength(1)

--- a/packages/core/src/renderables/TextTable.test.ts
+++ b/packages/core/src/renderables/TextTable.test.ts
@@ -200,6 +200,8 @@ describe("TextTableRenderable", () => {
     expect(allocateProportionalColumnWidths([7, 7, 7], 11, 3)).toEqual([4, 4, 3])
     expect(allocateProportionalColumnWidths([7, 7, 7], 12, 3)).toEqual([4, 4, 4])
     expect(allocateProportionalColumnWidths([7, 7, 7], 13, 3)).toEqual([5, 4, 4])
+    expect(allocateProportionalColumnWidths([7, 7, 7], 17, 3)).toEqual([6, 6, 5])
+    expect(allocateProportionalColumnWidths([7, 7, 7], 20, 3)).toEqual([7, 7, 6])
     expect(allocateProportionalColumnWidths([19, 3], 5, 1)).toEqual([4, 1])
     expect(allocateProportionalColumnWidths([4_000_000_001, 1_000_000_001], 300_001, 1)).toEqual([200_001, 100_000])
   })

--- a/packages/core/src/renderables/TextTable.test.ts
+++ b/packages/core/src/renderables/TextTable.test.ts
@@ -7,6 +7,7 @@ import type { CapturedFrame } from "../types.js"
 import { BoxRenderable } from "./Box.js"
 import { ScrollBoxRenderable } from "./ScrollBox.js"
 import { TextRenderable } from "./Text.js"
+import { allocateProportionalColumnWidths } from "./text-table-width.js"
 import { TextTableRenderable, type TextTableCellContent, type TextTableContent } from "./TextTable.js"
 
 const VERTICAL_BORDER_CP = "│".codePointAt(0)!
@@ -185,6 +186,59 @@ afterEach(() => {
 })
 
 describe("TextTableRenderable", () => {
+  test("proportional allocation preserves square-root priority regressions", () => {
+    expect(allocateProportionalColumnWidths([91, 9], 37, 1)).toEqual([28, 9])
+    expect(allocateProportionalColumnWidths([91, 9], 38, 1)).toEqual([29, 9])
+    expect(allocateProportionalColumnWidths([1000, 100], 401, 1)).toEqual([305, 96])
+    expect(allocateProportionalColumnWidths([1000, 100], 402, 1)).toEqual([305, 97])
+    expect(allocateProportionalColumnWidths([4, 49, 4, 54, 38], 104, 1)).toEqual([4, 33, 4, 34, 29])
+  })
+
+  test("proportional allocation resolves exact priority ties by lower index", () => {
+    expect(allocateProportionalColumnWidths([7, 7, 7], 10, 3)).toEqual([4, 3, 3])
+    expect(allocateProportionalColumnWidths([7, 7, 7], 11, 3)).toEqual([4, 4, 3])
+    expect(allocateProportionalColumnWidths([7, 7, 7], 12, 3)).toEqual([4, 4, 4])
+    expect(allocateProportionalColumnWidths([7, 7, 7], 13, 3)).toEqual([5, 4, 4])
+  })
+
+  test("proportional allocation clamps targets and preserves hard minimums and intrinsic caps", () => {
+    expect(allocateProportionalColumnWidths([4, 49, 4, 54, 38], 3, 1)).toEqual([1, 1, 1, 1, 1])
+    expect(allocateProportionalColumnWidths([4, 49, 4, 54, 38], 149, 1)).toEqual([4, 49, 4, 54, 38])
+    expect(allocateProportionalColumnWidths([4, 49, 4, 54, 38], 200, 1)).toEqual([4, 49, 4, 54, 38])
+    expect(allocateProportionalColumnWidths([2, 8, 20], 14, 3)).toEqual([3, 5, 6])
+  })
+
+  test("proportional allocation is exact and prefix-monotonic across deterministic vectors", () => {
+    let seed = 0x1259
+    const vectors = Array.from({ length: 40 }, (_, vectorIdx) => {
+      seed = (seed * 1664525 + 1013904223) >>> 0
+      const minWidth = 1 + (seed % 4)
+      return {
+        minWidth,
+        widths: Array.from({ length: 1 + (vectorIdx % 8) }, () => {
+          seed = (seed * 1664525 + 1013904223) >>> 0
+          return minWidth + (seed % 80)
+        }),
+      }
+    })
+
+    for (const { widths, minWidth } of vectors) {
+      const minimumTotal = minWidth * widths.length
+      const intrinsicTotal = widths.reduce((sum, width) => sum + width, 0)
+      let previous = allocateProportionalColumnWidths(widths, minimumTotal, minWidth)
+
+      for (let target = minimumTotal + 1; target <= intrinsicTotal; target++) {
+        const next = allocateProportionalColumnWidths(widths, target, minWidth)
+        const deltas = next.map((width, idx) => width - previous[idx]!)
+        expect(next.reduce((sum, width) => sum + width, 0)).toBe(target)
+        expect(next.every((width, idx) => width >= minWidth && width <= widths[idx]!)).toBe(true)
+        expect(deltas.filter((delta) => delta === 1)).toHaveLength(1)
+        expect(deltas.every((delta) => delta === 0 || delta === 1)).toBe(true)
+        previous = next
+      }
+    }
+  })
+
   test("renders a basic table with styled cell chunks", async () => {
     const content: TextTableContent = [
       [[bold("Name")], [bold("Status")], [bold("Notes")]],
@@ -364,6 +418,26 @@ describe("TextTableRenderable", () => {
 
     const borderXs = findVerticalBorderXs(renderer.currentRenderBuffer, headerY)
     expect(borderXs).toEqual([0, 4, 8])
+  })
+
+  test("preserves padded hard minimums when constrained", async () => {
+    const table = new TextTableRenderable(renderer, {
+      left: 0,
+      top: 0,
+      width: 13,
+      cellPaddingX: 1,
+      wrapMode: "word",
+      content: [[cell("Alpha"), cell("Bravo"), cell("Charlie")]],
+    })
+
+    renderer.root.add(table)
+    await renderOnce()
+
+    const headerY = captureFrame()
+      .split("\n")
+      .findIndex((line) => line.includes("A") && line.includes("B") && line.includes("C"))
+    expect(headerY).toBeGreaterThanOrEqual(0)
+    expect(findVerticalBorderXs(renderer.currentRenderBuffer, headerY)).toEqual([0, 4, 8, 12])
   })
 
   test("reflows when columnWidthMode is changed after initial render", async () => {
@@ -1313,7 +1387,7 @@ describe("TextTableRenderable", () => {
     root.add(
       new BoxRenderable(renderer, {
         width: "100%",
-        height: 16,
+        height: 18,
         flexGrow: 0,
         flexShrink: 0,
       }),

--- a/packages/core/src/renderables/TextTable.ts
+++ b/packages/core/src/renderables/TextTable.ts
@@ -9,6 +9,7 @@ import { SyntaxStyle } from "../syntax-style.js"
 import { type TextChunk, TextBuffer } from "../text-buffer.js"
 import { TextBufferView } from "../text-buffer-view.js"
 import type { RenderContext } from "../types.js"
+import { allocateProportionalColumnWidths } from "./text-table-width.js"
 
 // Large sentinel height for text measurement. The Zig measure path currently
 // ignores height, but we pass an effectively unbounded value so if height-aware
@@ -769,65 +770,7 @@ export class TextTableRenderable extends Renderable {
 
   private fitColumnWidthsProportional(widths: number[], targetContentWidth: number): number[] {
     const minWidth = 1 + this.getHorizontalCellPadding()
-    const hardMinWidths = new Array(widths.length).fill(minWidth)
-    const baseWidths = widths.map((width) => Math.max(1, Math.floor(width)))
-
-    const preferredMinWidths = baseWidths.map((width) => Math.min(width, minWidth + 1))
-    const preferredMinTotal = preferredMinWidths.reduce((sum, width) => sum + width, 0)
-
-    const floorWidths = preferredMinTotal <= targetContentWidth ? preferredMinWidths : hardMinWidths
-    const floorTotal = floorWidths.reduce((sum, width) => sum + width, 0)
-    const clampedTarget = Math.max(floorTotal, targetContentWidth)
-
-    const totalBaseWidth = baseWidths.reduce((sum, width) => sum + width, 0)
-
-    if (totalBaseWidth <= clampedTarget) {
-      return baseWidths
-    }
-
-    const shrinkable = baseWidths.map((width, idx) => width - floorWidths[idx])
-    const totalShrinkable = shrinkable.reduce((sum, value) => sum + value, 0)
-    if (totalShrinkable <= 0) {
-      return [...floorWidths]
-    }
-
-    const targetShrink = totalBaseWidth - clampedTarget
-    const integerShrink = new Array(baseWidths.length).fill(0)
-    const fractions = new Array(baseWidths.length).fill(0)
-    let usedShrink = 0
-
-    for (let idx = 0; idx < baseWidths.length; idx++) {
-      if (shrinkable[idx] <= 0) continue
-
-      const exact = (shrinkable[idx] / totalShrinkable) * targetShrink
-      const whole = Math.min(shrinkable[idx], Math.floor(exact))
-      integerShrink[idx] = whole
-      fractions[idx] = exact - whole
-      usedShrink += whole
-    }
-
-    let remainingShrink = targetShrink - usedShrink
-
-    while (remainingShrink > 0) {
-      let bestIdx = -1
-      let bestFraction = -1
-
-      for (let idx = 0; idx < baseWidths.length; idx++) {
-        if (shrinkable[idx] - integerShrink[idx] <= 0) continue
-        if (fractions[idx] > bestFraction) {
-          bestFraction = fractions[idx]
-          bestIdx = idx
-        }
-      }
-
-      if (bestIdx === -1) break
-
-      integerShrink[bestIdx] += 1
-      fractions[bestIdx] = 0
-      remainingShrink -= 1
-    }
-
-    return baseWidths.map((width, idx) => Math.max(floorWidths[idx], width - integerShrink[idx]))
+    return allocateProportionalColumnWidths(widths, targetContentWidth, minWidth)
   }
 
   private fitColumnWidthsBalanced(widths: number[], targetContentWidth: number): number[] {

--- a/packages/core/src/renderables/__snapshots__/TextTable.test.ts.snap
+++ b/packages/core/src/renderables/__snapshots__/TextTable.test.ts.snap
@@ -41,22 +41,22 @@ exports[`TextTableRenderable wraps content and fits columns when width is constr
 `;
 
 exports[`TextTableRenderable balanced fitter keeps constrained columns visually closer: fitter proportional constrained 1`] = `
-"┌────┬─────────────┬─────────┬─────────┬───────┬─────────┐  
-│Prov│Compute      │Storage  │Pricing  │Regions│Use Cases│  
-│ider│Services     │Solutions│Model    │       │         │  
-├────┼─────────────┼─────────┼─────────┼───────┼─────────┤  
-│Amaz│EC2          │S3 tiers,│Pay as   │Global │Enterpris│  
-│on W│instances    │ EBS,    │you go,  │regions│e migrati│  
-│eb S│with         │EFS, and │reserved │ and ma│on, analy│  
-│ervi│extensive    │archive  │terms,   │ny edge│tics, ML,│  
-│ces │options for  │classes  │and      │ locati│ and back│  
-│    │general,     │for long │discounte│ons    │end servi│  
-│    │memory, and  │retention│d spot ca│       │ces      │  
-│    │accelerated  │         │pacity   │       │         │  
-│    │workloads    │         │         │       │         │  
-└────┴─────────────┴─────────┴─────────┴───────┴─────────┘  
-                                                            
-                                                            
+"┌─────┬───────────┬─────────┬─────────┬────────┬─────────┐  
+│Provi│Compute    │Storage  │Pricing  │Regions │Use Cases│  
+│der  │Services   │Solutions│Model    │        │         │  
+├─────┼───────────┼─────────┼─────────┼────────┼─────────┤  
+│Amazo│EC2        │S3 tiers,│Pay as   │Global  │Enterpris│  
+│n Web│instances  │ EBS,    │you go,  │regions │e migrati│  
+│ Serv│with       │EFS, and │reserved │and     │on, analy│  
+│ices │extensive  │archive  │terms,   │many    │tics, ML,│  
+│     │options    │classes  │and      │edge    │ and back│  
+│     │for        │for long │discounte│location│end servi│  
+│     │general,   │retention│d spot ca│s       │ces      │  
+│     │memory,    │         │pacity   │        │         │  
+│     │and        │         │         │        │         │  
+│     │accelerated│         │         │        │         │  
+│     │ workloads │         │         │        │         │  
+└─────┴───────────┴─────────┴─────────┴────────┴─────────┘  
 "
 `;
 
@@ -121,18 +121,18 @@ exports[`TextTableRenderable keeps borders aligned with CJK and emoji content: u
 `;
 
 exports[`TextTableRenderable wraps CJK and emoji without grapheme duplication: unicode wrapping 1`] = `
-"┌───┬────────────────────────┐                              
-│Ite│Details                 │                              
-│m  │                        │                              
-├───┼────────────────────────┤                              
-│mix│東京界 🌍 emoji         │                              
-│ed │wrapping continues      │                              
-│   │across lines for width  │                              
-│   │checks                  │                              
-├───┼────────────────────────┤                              
-│emo│Faces 😀😃😄 should     │                              
-│ji │remain stable           │                              
-└───┴────────────────────────┘                              
+"┌─────┬──────────────────────┐                              
+│Item │Details               │                              
+├─────┼──────────────────────┤                              
+│mixed│東京界 🌍 emoji       │                              
+│     │wrapping continues    │                              
+│     │across lines for      │                              
+│     │width checks          │                              
+├─────┼──────────────────────┤                              
+│emoji│Faces 😀😃😄 should   │                              
+│     │remain stable         │                              
+└─────┴──────────────────────┘                              
+                                                            
                                                             
                                                             
                                                             
@@ -141,75 +141,75 @@ exports[`TextTableRenderable wraps CJK and emoji without grapheme duplication: u
 `;
 
 exports[`TextTableRenderable keeps full wrapped table layouts after a wide-to-narrow demo-style resize: demo resize expected primary table 1`] = `
-"┌─────────────────────────┬─────────────┬────────────────────────────┐
-│Task                     │Owner        │ETA                         │
-├─────────────────────────┼─────────────┼────────────────────────────┤
-│Wrap regression in       │core         │done after validating none, │
-│operational status       │platform and │word, and char wrap modes   │
-│dashboard with dynamic   │runtime      │across narrow, medium, wide,│
-│row heights and          │reliability  │ and ultra-wide terminal    │
-│constrained layout       │squad        │widths                      │
-│validation               │             │                            │
-├─────────────────────────┼─────────────┼────────────────────────────┤
-│Unicode layout           │render       │in review with follow-up    │
-│stabilization for mixed  │pipeline     │checks for border style     │
-│Latin, punctuation,      │maintainers  │transitions, cell padding   │
-│symbols, and long        │with         │variants, and selection     │
-│identifiers in adjacent  │fallback     │range consistency           │
-│columns                  │shaping      │                            │
-│                         │support      │                            │
-├─────────────────────────┼─────────────┼────────────────────────────┤
-│Snapshot pass for table  │qa           │today pending final         │
-│rendering in content     │automation   │baseline updates for        │
-│mode and full mode with  │and visual   │oversized fixtures that     │
-│heavy and double border  │diff triage  │intentionally stress        │
-│combinations             │group        │wrapping behavior on high-  │
-│                         │             │resolution terminals        │
-├─────────────────────────┼─────────────┼────────────────────────────┤
-│Document edge cases      │developer    │planned for this sprint     │
-│where long tokens        │experience   │once final reproducible     │
-│without spaces force     │and docs     │examples are captured and   │
-│char wrapping and reveal │tooling      │linked to regression        │
-│per-cell clipping        │             │tracking tickets            │
-│regressions              │             │                            │
-├─────────────────────────┼─────────────┼────────────────────────────┤
-│Performance sweep of     │runtime      │scheduled after review,     │
-│wrapping algorithm under │performance  │with benchmark runs on      │
-│large datasets to        │task force   │laptop and desktop          │
-│confirm stable frame     │             │terminals at 200-plus       │
-│times during rapid key   │             │column widths               │
-│toggling                 │             │                            │
-└─────────────────────────┴─────────────┴────────────────────────────┘
+"┌────────────────────────┬─────────────────┬─────────────────────────┐
+│Task                    │Owner            │ETA                      │
+├────────────────────────┼─────────────────┼─────────────────────────┤
+│Wrap regression in      │core platform    │done after validating    │
+│operational status      │and runtime      │none, word, and char     │
+│dashboard with dynamic  │reliability squad│wrap modes across narrow,│
+│row heights and         │                 │ medium, wide, and ultra-│
+│constrained layout      │                 │wide terminal widths     │
+│validation              │                 │                         │
+├────────────────────────┼─────────────────┼─────────────────────────┤
+│Unicode layout          │render pipeline  │in review with follow-up │
+│stabilization for mixed │maintainers with │checks for border style  │
+│Latin, punctuation,     │fallback shaping │transitions, cell        │
+│symbols, and long       │support          │padding variants, and    │
+│identifiers in adjacent │                 │selection range          │
+│columns                 │                 │consistency              │
+├────────────────────────┼─────────────────┼─────────────────────────┤
+│Snapshot pass for table │qa automation    │today pending final      │
+│rendering in content    │and visual diff  │baseline updates for     │
+│mode and full mode with │triage group     │oversized fixtures that  │
+│heavy and double border │                 │intentionally stress     │
+│combinations            │                 │wrapping behavior on     │
+│                        │                 │high-resolution terminals│
+├────────────────────────┼─────────────────┼─────────────────────────┤
+│Document edge cases     │developer        │planned for this sprint  │
+│where long tokens       │experience and   │once final reproducible  │
+│without spaces force    │docs tooling     │examples are captured    │
+│char wrapping and       │                 │and linked to regression │
+│reveal per-cell         │                 │tracking tickets         │
+│clipping regressions    │                 │                         │
+├────────────────────────┼─────────────────┼─────────────────────────┤
+│Performance sweep of    │runtime          │scheduled after review,  │
+│wrapping algorithm      │performance task │with benchmark runs on   │
+│under large datasets to │force            │laptop and desktop       │
+│confirm stable frame    │                 │terminals at 200-plus    │
+│times during rapid key  │                 │column widths            │
+│toggling                │                 │                         │
+└────────────────────────┴─────────────────┴─────────────────────────┘
 "
 `;
 
 exports[`TextTableRenderable keeps full wrapped table layouts after a wide-to-narrow demo-style resize: demo resize expected unicode table 1`] = `
-"┌─────┬──────────────────────────────────────────────────────────────┐
-│Colum│Wrapped Text                                                  │
-│n    │                                                              │
-├─────┼──────────────────────────────────────────────────────────────┤
-│mixed│CJK and emoji wrapping stress case: こんにちは世界 and        │
-│-lang│안녕하세요 세계 and 你好，世界 followed by long English prose │
-│uages│that keeps flowing to test whether each cell wraps naturally  │
-│     │even when the terminal is extremely wide and the row still    │
-│     │needs multiple visual lines for readability 🌍🚀              │
-├─────┼──────────────────────────────────────────────────────────────┤
-│emoji│Faces 😀😃😄😁😆 plus symbols 🧪📦🛰️🔧📊 mixed with version   │
-│-and-│tags like release-candidate-build-2026-02-very-long-token-    │
-│symbo│without-breaks to ensure char wrapping remains stable and no  │
-│ls   │glyph alignment issues appear at column boundaries            │
-├─────┼──────────────────────────────────────────────────────────────┤
-│long-│長文の日本語テキストと中文段落和한국어문장을連続して配置し、  │
-│cjk- │その後に additional English context describing renderer       │
-│phras│behavior, border intersection handling, and selection         │
-│e    │extraction so that this single cell remains a reliable        │
-│     │wrapping torture test.                                        │
-├─────┼──────────────────────────────────────────────────────────────┤
-│mixed│Wrap behavior with punctuation-heavy content: [alpha]{beta}(  │
-│-punc│gamma)<delta>|epsilon| then repeated fragments, commas,       │
-│tuati│semicolons, and slashes to verify token boundaries do not     │
-│on   │break border drawing logic or spacing consistency in          │
-│     │neighboring columns.                                          │
-└─────┴──────────────────────────────────────────────────────────────┘
+"┌─────────────┬──────────────────────────────────────────────────────┐
+│Column       │Wrapped Text                                          │
+├─────────────┼──────────────────────────────────────────────────────┤
+│mixed-       │CJK and emoji wrapping stress case: こんにちは世界    │
+│languages    │and 안녕하세요 세계 and 你好，世界 followed by long   │
+│             │English prose that keeps flowing to test whether each │
+│             │cell wraps naturally even when the terminal is        │
+│             │extremely wide and the row still needs multiple       │
+│             │visual lines for readability 🌍🚀                     │
+├─────────────┼──────────────────────────────────────────────────────┤
+│emoji-and-   │Faces 😀😃😄😁😆 plus symbols 🧪📦🛰️🔧📊 mixed with   │
+│symbols      │version tags like release-candidate-build-2026-02-    │
+│             │very-long-token-without-breaks to ensure char         │
+│             │wrapping remains stable and no glyph alignment issues │
+│             │appear at column boundaries                           │
+├─────────────┼──────────────────────────────────────────────────────┤
+│long-cjk-    │長文の日本語テキストと中文段落和한국어문장을連続して配│
+│phrase       │置し、その後に additional English context describing r│
+│             │enderer behavior, border intersection handling, and se│
+│             │lection extraction so that this single cell remains a │
+│             │reliable wrapping torture test.                       │
+├─────────────┼──────────────────────────────────────────────────────┤
+│mixed-       │Wrap behavior with punctuation-heavy content: [alpha]{│
+│punctuation  │beta}(gamma)<delta>|epsilon| then repeated fragments, │
+│             │commas, semicolons, and slashes to verify token       │
+│             │boundaries do not break border drawing logic or       │
+│             │spacing consistency in neighboring columns.           │
+└─────────────┴──────────────────────────────────────────────────────┘
 "
 `;

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -27,6 +27,7 @@ let mockMouse: MockMouse
 let renderOnce: () => Promise<void>
 let captureFrame: () => string
 let captureSpans: () => CapturedFrame
+let resizeRenderer: (width: number, height: number) => void
 let markdownTreeSitterClient: TreeSitterClient
 let mockTreeSitterClients: MockTreeSitterClient[] = []
 const HIGHLIGHT_TIMEOUT_MS = 5000
@@ -34,6 +35,10 @@ const HIGHLIGHT_TIMEOUT_MS = 5000
 const syntaxStyle = SyntaxStyle.fromStyles({
   default: { fg: RGBA.fromValues(1, 1, 1, 1) },
 })
+const ISSUE_TABLE_MARKDOWN = `| Rank | Issue | Size | Why It Is Ready | Likely Surface |
+| --- | --- | --- | --- | --- |
+| 1 | A moderately long linked issue title | XS | A longer prose explanation of why the issue is ready. | packages/tui/src/context/sdk.tsx |
+| 2 | Another moderately long linked issue title | XS/S | Another longer prose explanation. | packages/core/src/tool/subagent.ts |`
 
 beforeAll(async () => {
   const dataPath = join(tmpdir(), "tree-sitter-markdown-renderable-test-data")
@@ -51,6 +56,7 @@ beforeEach(async () => {
   renderOnce = testRenderer.renderOnce
   captureFrame = testRenderer.captureCharFrame
   captureSpans = testRenderer.captureSpans
+  resizeRenderer = testRenderer.resize
 })
 
 afterEach(async () => {
@@ -175,6 +181,13 @@ function getMarginBottom(renderable: { getLayoutNode(): { getMargin(edge: Edge):
   return 0
 }
 
+function getTableColumnWidths(headerY: number): number[] {
+  const borderXs = Array.from({ length: renderer.width }, (_, x) => x).filter(
+    (x) => renderer.currentRenderBuffer.buffers.char[headerY * renderer.width + x] === "│".codePointAt(0),
+  )
+  return borderXs.slice(1).map((x, index) => x - borderXs[index]! - 1)
+}
+
 test("basic table alignment", async () => {
   const markdown = `| Name | Age |
 |---|---|
@@ -211,6 +224,61 @@ test("tableOptions.widthMode configures markdown table layout", async () => {
   expect(table).toBeInstanceOf(TextTableRenderable)
   expect(table.columnWidthMode).toBe("full")
   expect(table.columnFitter).toBe("balanced")
+})
+
+test("wide five-column tables preserve short metadata columns", async () => {
+  resizeRenderer(110, 40)
+  const md = createMarkdownRenderable({
+    id: "markdown-wide-metadata-table",
+    content: ISSUE_TABLE_MARKDOWN,
+    syntaxStyle,
+    internalBlockMode: "top-level",
+    tableOptions: { style: "grid" },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const frame = captureFrame()
+  const headerY = frame.split("\n").findIndex((line) => line.includes("Ran"))
+  expect(headerY).toBeGreaterThanOrEqual(0)
+
+  const columnWidths = getTableColumnWidths(headerY)
+
+  expect(columnWidths).toEqual([4, 32, 4, 36, 28])
+  expect(columnWidths.reduce((sum, width) => sum + width, 0)).toBe(104)
+  expect(columnWidths[0]).toBeGreaterThanOrEqual(4)
+  expect(columnWidths[2]).toBeGreaterThanOrEqual(4)
+  expect(columnWidths[1]).toBeGreaterThanOrEqual("Issue".length)
+  expect(columnWidths[3]).toBeGreaterThanOrEqual("Why It Is Ready".length)
+  expect(columnWidths[4]).toBeGreaterThanOrEqual("Likely Surface".length)
+  expect(frame).toContain("│Rank")
+  expect(frame).toContain("│Size")
+  expect(frame).toContain("XS/S")
+})
+
+test("five-column tables still shrink metadata columns when constrained", async () => {
+  resizeRenderer(20, 120)
+  const md = createMarkdownRenderable({
+    id: "markdown-narrow-metadata-table",
+    content: ISSUE_TABLE_MARKDOWN,
+    syntaxStyle,
+    internalBlockMode: "top-level",
+    tableOptions: { style: "grid" },
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  const frame = captureFrame()
+  const headerY = frame.split("\n").findIndex((line) => line.includes("│"))
+  expect(headerY).toBeGreaterThanOrEqual(0)
+
+  const columnWidths = getTableColumnWidths(headerY)
+  expect(columnWidths.reduce((sum, width) => sum + width, 0)).toBe(14)
+  expect(columnWidths.every((width) => width >= 1)).toBe(true)
+  expect(columnWidths[0]).toBeLessThan(4)
+  expect(columnWidths[2]).toBeLessThan(4)
 })
 
 test("tableOptions updates existing markdown table renderable", async () => {

--- a/packages/core/src/renderables/text-table-width.ts
+++ b/packages/core/src/renderables/text-table-width.ts
@@ -1,0 +1,78 @@
+export function allocateProportionalColumnWidths(widths: number[], targetWidth: number, minWidth: number): number[] {
+  const baseWidths = widths.map((width) => Math.max(minWidth, Math.floor(width)))
+  const totalBaseWidth = baseWidths.reduce((sum, width) => sum + width, 0)
+  const capacity = baseWidths.map((width) => width - minWidth)
+  const growth = new Array(baseWidths.length).fill(0)
+  const available = Math.min(
+    Math.max(0, targetWidth - minWidth * baseWidths.length),
+    totalBaseWidth - minWidth * baseWidths.length,
+  )
+
+  if (available === 0) return growth.map(() => minWidth)
+  if (available === capacity.reduce((sum, width) => sum + width, 0)) return baseWidths
+
+  const weights = capacity.map(Math.sqrt)
+  const active = capacity
+    .map((width, idx) => ({ idx, width, weight: weights[idx]! }))
+    .filter((column) => column.width > 0)
+    .sort((a, b) => a.weight - b.weight)
+  let remaining = available
+  let totalWeight = active.reduce((sum, column) => sum + column.weight, 0)
+
+  // Water-fill the arithmetic priority sequences in bulk, capping short columns first.
+  for (const column of active) {
+    if (remaining / totalWeight <= column.weight) break
+    growth[column.idx] = column.width
+    remaining -= column.width
+    totalWeight -= column.weight
+  }
+
+  const level = remaining / totalWeight
+  for (const column of active) {
+    if (growth[column.idx] === column.width) continue
+    growth[column.idx] = Math.min(column.width, Math.floor(level * column.weight))
+  }
+
+  let allocatedGrowth = growth.reduce((sum, width) => sum + width, 0)
+
+  while (allocatedGrowth > available) {
+    let worstIdx = -1
+    let worstPriority = Number.NEGATIVE_INFINITY
+
+    for (let idx = 0; idx < baseWidths.length; idx++) {
+      if (growth[idx] === 0) continue
+
+      const priority = growth[idx] / weights[idx]!
+      if (priority > worstPriority || (priority === worstPriority && idx > worstIdx)) {
+        worstIdx = idx
+        worstPriority = priority
+      }
+    }
+
+    if (worstIdx === -1) break
+    growth[worstIdx] -= 1
+    allocatedGrowth -= 1
+  }
+
+  // Flooring leaves fewer than one cell per active column to resolve by exact priority.
+  while (allocatedGrowth < available) {
+    let bestIdx = -1
+    let bestPriority = Number.POSITIVE_INFINITY
+
+    for (let idx = 0; idx < baseWidths.length; idx++) {
+      if (growth[idx] >= capacity[idx]) continue
+
+      const priority = (growth[idx] + 1) / weights[idx]!
+      if (priority < bestPriority) {
+        bestIdx = idx
+        bestPriority = priority
+      }
+    }
+
+    if (bestIdx === -1) break
+    growth[bestIdx] += 1
+    allocatedGrowth += 1
+  }
+
+  return growth.map((width) => width + minWidth)
+}

--- a/packages/core/src/renderables/text-table-width.ts
+++ b/packages/core/src/renderables/text-table-width.ts
@@ -1,3 +1,17 @@
+function comparePriority(leftGrowth: number, leftCapacity: number, rightGrowth: number, rightCapacity: number): number {
+  // Squared cross-products preserve exact ordering while ordinary table widths stay on the number fast path.
+  const left = leftGrowth * leftGrowth * rightCapacity
+  const right = rightGrowth * rightGrowth * leftCapacity
+
+  if (Number.isSafeInteger(left) && Number.isSafeInteger(right)) {
+    return left < right ? -1 : left > right ? 1 : 0
+  }
+
+  const exactLeft = BigInt(leftGrowth) * BigInt(leftGrowth) * BigInt(rightCapacity)
+  const exactRight = BigInt(rightGrowth) * BigInt(rightGrowth) * BigInt(leftCapacity)
+  return exactLeft < exactRight ? -1 : exactLeft > exactRight ? 1 : 0
+}
+
 export function allocateProportionalColumnWidths(widths: number[], targetWidth: number, minWidth: number): number[] {
   const baseWidths = widths.map((width) => Math.max(minWidth, Math.floor(width)))
   const totalBaseWidth = baseWidths.reduce((sum, width) => sum + width, 0)
@@ -37,15 +51,14 @@ export function allocateProportionalColumnWidths(widths: number[], targetWidth: 
 
   while (allocatedGrowth > available) {
     let worstIdx = -1
-    let worstPriority = Number.NEGATIVE_INFINITY
 
     for (let idx = 0; idx < baseWidths.length; idx++) {
       if (growth[idx] === 0) continue
 
-      const priority = growth[idx] / weights[idx]!
-      if (priority > worstPriority || (priority === worstPriority && idx > worstIdx)) {
+      const comparison =
+        worstIdx === -1 ? 1 : comparePriority(growth[idx]!, capacity[idx]!, growth[worstIdx]!, capacity[worstIdx]!)
+      if (comparison > 0 || (comparison === 0 && idx > worstIdx)) {
         worstIdx = idx
-        worstPriority = priority
       }
     }
 
@@ -57,15 +70,16 @@ export function allocateProportionalColumnWidths(widths: number[], targetWidth: 
   // Flooring leaves fewer than one cell per active column to resolve by exact priority.
   while (allocatedGrowth < available) {
     let bestIdx = -1
-    let bestPriority = Number.POSITIVE_INFINITY
 
     for (let idx = 0; idx < baseWidths.length; idx++) {
       if (growth[idx] >= capacity[idx]) continue
 
-      const priority = (growth[idx] + 1) / weights[idx]!
-      if (priority < bestPriority) {
+      const comparison =
+        bestIdx === -1
+          ? -1
+          : comparePriority(growth[idx]! + 1, capacity[idx]!, growth[bestIdx]! + 1, capacity[bestIdx]!)
+      if (comparison < 0) {
         bestIdx = idx
-        bestPriority = priority
       }
     }
 

--- a/packages/core/src/renderables/text-table-width.ts
+++ b/packages/core/src/renderables/text-table-width.ts
@@ -30,6 +30,11 @@ export function allocateProportionalColumnWidths(widths: number[], targetWidth: 
     .map((width, idx) => ({ idx, width, weight: weights[idx]! }))
     .filter((column) => column.width > 0)
     .sort((a, b) => a.weight - b.weight)
+  if (active.length === capacity.length && capacity.every((width) => width === capacity[0])) {
+    const sharedGrowth = Math.floor(available / capacity.length)
+    const remainder = available % capacity.length
+    return growth.map((_, idx) => minWidth + sharedGrowth + (idx < remainder ? 1 : 0))
+  }
   let remaining = available
   let totalWeight = active.reduce((sum, column) => sum + column.weight, 0)
 


### PR DESCRIPTION
## What

Markdown tables now keep inexpensive metadata columns such as `Rank`, `Size`, and `XS/S` readable while wider prose columns absorb the remaining constraint.

The allocation is monotonic under resize: increasing the available width never makes another column narrower or introduces additional wrapping. This replaces the reviewed target-dependent threshold that could redistribute width backward at a one-cell boundary.

Fixes the OpenTUI-side layout defect reported in anomalyco/opencode#36474.

## How

- `packages/core/src/renderables/text-table-width.ts` starts every column at its hard minimum and treats each additional cell as the next item in that column priority sequence: `(growth + 1) / sqrt(intrinsicCapacity)`.
- A capped water-fill computes the bulk allocation in closed form. Short columns whose intrinsic cap is below the shared level are saturated first, then flooring leaves fewer than one unresolved cell per active column.
- The small remainder is resolved with the exact priority comparison used by the original progressive allocator. Scanning columns in index order preserves deterministic lower-index resolution for exact ties.
- The resulting allocation is the same prefix of one target-independent priority sequence for every target, preserving intrinsic caps, hard minima, exact attainable sums, and the `T` to `T + 1` one-cell monotonic property.
- Runtime is independent of target width: `O(n log n + n²)` worst case for `n` columns and `O(n)` space, instead of `O(targetWidth × n)`.
- Intrinsic widths still come from `TextBufferView`, preserving display-width handling for CJK, emoji, and other Unicode content.
- `packages/core/src/renderables/TextTable.test.ts` covers reviewer vectors, exact tie ordering, target clamping, padded hard minima, and broad deterministic sum/bounds/prefix properties.
- `packages/core/src/renderables/__tests__/Markdown.test.ts` locks the observable five-column widths to `[4, 32, 4, 36, 28]`.

## Performance

The original proportional allocator was roughly `O(n)`. The rejected intermediate progressive allocator made the monotonic semantics straightforward but was `O(targetWidth × n)`; an isolated local measurement took about 289 ms for 100 columns at target width 1,000,000. The final batched allocator trades some column-count scaling for target-width independence: it is `O(n log n + n²)` worst case with `O(n)` memory.

Isolated same-process local microbenchmarks (9-sample medians, not stable CI benchmarks) measured:

| Widths / target | Progressive | Batched | Speedup |
| --- | ---: | ---: | ---: |
| `[91, 9]` / `38` | 0.211 µs/call | 0.190 µs/call | 1.1× |
| `[1000, 100]` / `402` | 3.080 µs/call | 0.229 µs/call | 13.4× |

Adversarial final-allocator measurements were around 2.5 ms for 1,000 columns, 9.5 ms for 2,000, 65.5 ms for 5,000, and 264 ms for 10,000. Ordinary Markdown tables with a handful of columns are negligible. Synchronous layout with thousands of public columns can still stall, and OpenTUI currently has no column-count bound; rendering that many columns is already pathological, so this remains a residual scalability risk rather than a normal-use regression.

No flaky timing assertion was added. Correctness and property coverage protect the allocator's semantics instead.

## Scope

This changes the default proportional fitter used by `TextTableRenderable`. It does not add an OpenCode-specific table option, alter Markdown parsing, impose an arbitrary width limit, or change the opt-in balanced fitter.

## Testing

- `bun test src/renderables/TextTable.test.ts`: 36 passed, 0 failed
- `bun test src/renderables/__tests__/Markdown.test.ts`: 157 passed, 0 failed
- `bun run test:js`: 4,985 passed, 23 skipped, 0 failed
- `bun run lint`: 0 warnings, 0 errors
- `bun run fmt:check`: passed
- Deterministic equivalence check: 1,000 generated vectors matched the original progressive allocator at every attainable target

## Demo

Both screenshots render the exact five-column fixture from anomalyco/opencode#36474 through OpenTUI Markdown/TextTable in a real 110 x 28 PTY. They use identical 2052 x 1080 PNG geometry.

**Before** (upstream/main at `a0b9064`) - measured widths: `[3, 32, 3, 40, 26]`

![Before: Rank, Size, and XS/S wrap unnecessarily](https://github.com/user-attachments/assets/d0f47869-18c3-4566-8f8c-2e4b89374946)

**After** (PR head; allocation remains unchanged) - measured widths: `[4, 32, 4, 36, 28]`

![After: Rank, Size, and XS/S remain intact](https://github.com/user-attachments/assets/176b79eb-71ea-45ce-9219-67924457dfce)

### Additional table shapes

The same read-only MarkdownRenderable/TextTable fixture was rendered at 116 x 52 in both worktrees, producing matched 2160 x 1944 PNGs. Widths below include the two cells of horizontal padding.

**Before** (upstream/main at `a0b9064`)

![Before: metadata wraps in the three- and six-column tables](https://github.com/user-attachments/assets/c7a078d4-0cfd-46c6-a7a5-590eeda0d4c2)

**After** (PR head at `bb2e9bb`)

![After: compact metadata remains intact while prose still wraps](https://github.com/user-attachments/assets/901c51d4-c262-40d2-978d-8a5d9fcbb77e)

- Two columns: unchanged at `[8, 105]`; `Status`, `Ready`, and `Paused` were already intact, and the long description wraps naturally.
- Three columns: `[7, 7, 98]` to `[8, 7, 97]`; `Status`, `Active`, and `Review` remain intact instead of wrapping.
- Six columns: `[4, 7, 7, 8, 9, 74]` to `[4, 7, 7, 9, 10, 72]`; `Command`, `Duration`, and `inspect` remain intact while `Details` still wraps.
- Unicode identifiers: unchanged at `[9, 8, 8, 75]`; the CJK and Unicode cells already fit without constraint.

Arbitrary column counts are covered by the allocator property tests. These screenshots are representative examples, not exhaustive proof.

## Flow

```mermaid
flowchart LR
  A[Intrinsic display widths] --> B[Assign hard minimum to every column]
  B --> C[Water-fill square-root priority sequences]
  C --> D[Cap short columns at intrinsic width]
  D --> E[Floor bulk allocation]
  E --> F[Resolve sub-cell remainder by exact stable priority]
  F --> G[Exact monotonic fitted widths]
```