### PR TITLE
fix(core/audio): Fix audio decoder error reporting race

### DIFF
--- a/packages/core/src/audio.ts
+++ b/packages/core/src/audio.ts
@@ -989,6 +989,8 @@ export class AudioStream<M = AudioStreamMetadata> extends EventEmitter<AudioStre
     if (this.lifecycleController.signal.aborted) return false
     const status = this.lib.audioEndStream(this.engine, this.nativeStreamId!)
     if (status !== 0) {
+      const nativeError = this.snapshotError(this.readNativeStats())
+      if (nativeError?.context.action === "decoder") throw nativeError
       const context: AudioStreamErrorContext = { action: "end", status }
       throw new AudioStreamError(`Audio stream end failed: ${status}`, context)
     }


### PR DESCRIPTION
Preserve the native decoder failure when end-of-input races with the
decoder entering a terminal state, instead of reporting a generic stream
end error.
