### PR TITLE
fix(core): guard non-string bundled asset path

### DIFF
--- a/packages/core/src/platform/runtime.test.ts
+++ b/packages/core/src/platform/runtime.test.ts
@@ -84,6 +84,24 @@ describe("platform/runtime", () => {
     expect(fallbackCalled).toBe(!isBun)
   })
 
+  test("falls back to the source path when a bundled asset module's default is not a path string", async () => {
+    const fallbackUrl = new URL("./fallback-tree-sitter.wasm", import.meta.url)
+    let fallbackCalled = false
+
+    const resolved = await resolveBundledFilePath(
+      "web-tree-sitter/tree-sitter.wasm",
+      async () => ({ default: undefined as unknown as string }),
+      () => {
+        fallbackCalled = true
+        return fallbackUrl
+      },
+      import.meta.url,
+    )
+
+    expect(resolved).toBe(fileURLToPath(fallbackUrl))
+    expect(fallbackCalled).toBe(true)
+  })
+
   test("resolves Bun-emitted asset modules when a non-Bun bundle has no source fallback", async () => {
     const bundledUrl = new URL("./bundled-tree-sitter.wasm", import.meta.url).href
     const bundledModuleSpecifier = `data:text/javascript,${encodeURIComponent(

--- a/packages/core/src/platform/runtime.ts
+++ b/packages/core/src/platform/runtime.ts
@@ -69,7 +69,14 @@ export async function resolveBundledFilePath(
     return (await loadBundledFilePath(loadBundledFile, metaUrl, options.loadBundledFileFallback ?? false)) ?? path
   }
 
-  return normalizeLoadedFilePath((await loadBundledFile()).default, metaUrl)
+  // A bundled `type: "file"` import can resolve to a module whose `default` is not a path string
+  // (e.g. when the same file is also emitted as a build entrypoint), so fall back to the source path.
+  const loaded = (await loadBundledFile()).default
+  if (typeof loaded !== "string") {
+    return resolveFallbackFilePath(fallbackPath, metaUrl)
+  }
+
+  return normalizeLoadedFilePath(loaded, metaUrl)
 }
 
 function resolveFallbackFilePath(fallbackPath: FilePathFallback, metaUrl: string): string {


### PR DESCRIPTION
## Problem

Since `@opentui/core@0.4.5`, importing the package inside a `bun build --compile` binary crashes at module load with `undefined is not an object (evaluating 'loadedPath.startsWith')`. The Bun branch of `resolveBundledFilePath` dereferences a `type: "file"` import's `.default` unconditionally, but that value can be `undefined` — e.g. when the same file is also emitted as a `Bun.build` entrypoint, so the specifier resolves to a JS module namespace with no path `default`.

## Solution

- Guard the Bun branch of `resolveBundledFilePath`: when the bundled module's `default` is not a string, fall back to the source path via the existing `resolveFallbackFilePath` (mirroring the non-Bun branch) instead of dereferencing `undefined`.
- Add a regression test covering the non-string `default` case.
- This reconnects failures to the existing downstream handling rather than adding new machinery: `TreeSitterClient.startWorker()` already installs `worker.onerror` (logs + emits + degrades to plain text) — the import-time crash just happened before that could run. Net effect: pre-0.4.5 graceful degradation is restored.
- Consumers that set `OTUI_TREE_SITTER_WORKER_PATH` (env or build-time define) regain full highlighting, since it takes precedence in `resolveWorkerPath()` over the default resolution path where the crash lived.

## Notes

- Testing: `bun test src/platform/runtime.test.ts` → 8 pass / 0 fail (includes the new regression test, which fails on the unpatched code with the exact `startsWith` TypeError). `oxfmt --check` and `oxlint` clean on both changed files.
- Scope: guard only, deliberately. Making the module-scope resolution lazy would ripple async through the synchronous `resolveWorkerPath()` chain in `client.ts` and both `runtime-assets` platform variants, and with this guard in place it would resolve to the same fallback path anyway — happy to explore that separately if preferred.
- Fixes #1275. Downstream trigger: anomalyco/opencode#37556 (which has been worked around by downgrading OpenCode to use OpenTUI 0.4.3).
- AI Assistance: OpenCode + Claude Opus 4.8
- Work attribution: Human operator driven and reviewed
