### PR TITLE
Fix ScrollBar allowing a negative scroll position

### DIFF
--- a/packages/core/src/renderables/ScrollBar.ts
+++ b/packages/core/src/renderables/ScrollBar.ts
@@ -70,7 +70,7 @@ export class ScrollBarRenderable extends Renderable {
   }
 
   set scrollPosition(value: number) {
-    const newPosition = Math.round(Math.min(Math.max(0, value), this.scrollSize - this.viewportSize))
+    const newPosition = Math.round(Math.max(0, Math.min(value, this.scrollSize - this.viewportSize)))
     if (newPosition !== this._scrollPosition) {
       this._scrollPosition = newPosition
       this.updateSliderFromScrollState()


### PR DESCRIPTION
## Problem

`ScrollBarRenderable`'s `scrollPosition` setter (`packages/core/src/renderables/ScrollBar.ts`) clamps in the wrong order:

```ts
set scrollPosition(value: number) {
  const newPosition = Math.round(Math.min(Math.max(0, value), this.scrollSize - this.viewportSize))
  ...
}
```

When the content is shorter than the viewport (`viewportSize > scrollSize`), `this.scrollSize - this.viewportSize` is **negative**. `Math.min(Math.max(0, value), <negative>)` then collapses to that negative upper bound, so `_scrollPosition` becomes negative instead of being floored at `0`.

## Evidence (intent)

The zero-floor belongs on the outside. Every other "max scroll" clamp in `core` is written `Math.max(0, Math.min(...))` — e.g. `ScrollBox` repeatedly uses `Math.max(0, this.scrollHeight - this.viewport.height)`; the `Math.max(0, Math.min(...))` shape appears **33 times** in `src`. The only other `Math.min(Math.max(0, ...), upper)` is `Select.ts`, where the upper bound is guarded by `length > 0` and can't go negative. This setter is the lone unguarded outlier, and a scroll position is definitionally `>= 0`.

## Reachability

`ScrollBox.recalculateBarProps()` runs on every layout/resize, setting `scrollSize = content.height` then `viewportSize = viewport.height`; the `viewportSize` setter ends with `this.scrollPosition = this.scrollPosition`, re-running this clamp. So any scrollbox whose content fits within its viewport (very common) lands here, and the public `scrollBox.scrollTop` / `scrollLeft` getters return the value verbatim.

## Reproduction

Replaying `recalculateBarProps`'s order for `content=3, viewport=10`:

| | scrollTop |
|---|---|
| before | **-7** ❌ |
| after | 0 ✅ |

## Fix

```ts
const newPosition = Math.round(Math.max(0, Math.min(value, this.scrollSize - this.viewportSize)))
```
