### PR TITLE
fix(renderer): prevent render loop stall by re-checking immediateRerenderRequested in loop() finally block

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -4516,6 +4516,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.rendering = false
       if (this._destroyPending) {
         this.finalizeDestroy()
+      } else if (this.immediateRerenderRequested) {
+        this.immediateRerenderRequested = false
+        setImmediate(() => {
+          if (!this._isDestroyed) this.requestRender()
+        })
       }
       this.resolveIdleIfNeeded()
     }


### PR DESCRIPTION
## Problem

The render loop can silently stall in idle mode (`_isRunning = false`) when a `requestRender()` call arrives in the window between the `if`/`else` scheduling decision and the `finally` block that sets `this.rendering = false`.

### Race condition

1. `loop()` runs, at the scheduling decision sees `_isRunning = false` and `immediateRerenderRequested = false` -> goes to `else` branch, clears timeout, schedules nothing
2. Between the `else` branch and the `finally` block, a `requestRender()` fires -- `rendering` is still `true` -> only sets `immediateRerenderRequested = true` and returns early (line 1507-1509)
3. `finally` sets `this.rendering = false` but does **not** check `immediateRerenderRequested`
4. `activateFrame()` finally sets `this.updateScheduled = false`
5. No timeout was scheduled, and the flag is set but nobody checks it
6. **Render loop is dead** until an external event (SIGWINCH, mouse, keyboard) triggers another `requestRender()`

This manifests as the TUI going black during burst event processing (e.g. when the user presses Enter to submit a prompt and the agent starts working).

## Fix

In `loop()`'s `finally` block, re-check `immediateRerenderRequested`. If it was set during the race window (after the scheduling decision but before `rendering = false`), re-issue via `setImmediate`.

`setImmediate` (not `process.nextTick`) is needed because `activateFrame()` keeps `updateScheduled = true` until its own `finally` after `loop()` returns. `process.nextTick` fires before microtasks resume -- before `activateFrame`'s finally -- so `requestRender()` would be blocked by the `!updateScheduled` guard.

## Related

- OpenCode issue https://github.com/anomalyco/opencode/issues/37803 (black screen when agent starts working)
- OpenCode issues #32361, #33887, #35494 (related black screen reports)
- Original closed PR #1086 (similar approach, this is a re-submission)