### PR TITLE
solid: don't crash on an empty text node under a non-<text> parent

### DIFF
--- a/packages/solid/src/reconciler.ts
+++ b/packages/solid/src/reconciler.ts
@@ -77,12 +77,19 @@ function _insertNode(parent: DomNode, node: DomNode, anchor?: DomNode): void {
 
   if (isTextNodeRenderable(node)) {
     if (!(parent instanceof TextRenderable) && !isTextNodeRenderable(parent)) {
-      throw new Error(
-        `Orphan text error: "${node
-          .toChunks()
-          .map((c) => c.text)
-          .join("")}" must have a <text> as a parent: ${parent.id} above ${node.id}`,
-      )
+      const text = node
+        .toChunks()
+        .map((c) => c.text)
+        .join("")
+      // An empty text node carries nothing to render. Solid emits empty-string
+      // children for empty dynamic expressions (e.g. `{cond ? <x/> : ""}`, or a
+      // conditional/component that renders to ""), so treating this as a fatal
+      // orphan crashes otherwise-valid trees — mounting a real dashboard on a
+      // terminal that reports its capabilities is enough to hit it. Skip the
+      // empty node; only *non-empty* text under a non-<text> parent is a real
+      // authoring mistake worth reporting.
+      if (text === "") return
+      throw new Error(`Orphan text error: "${text}" must have a <text> as a parent: ${parent.id} above ${node.id}`)
     }
   }
 


### PR DESCRIPTION
## Problem

`@opentui/solid`'s reconciler throws `Orphan text error: "" must have a <text> as a parent` at mount whenever an **empty** text node is inserted under a non-`<text>` parent (a `<box>`, etc.).

This is trivially reachable from ordinary JSX. Solid's `insertExpression` turns an empty-string child into a real (empty) `TextNode`, and Solid emits `""` for empty dynamic expressions — e.g. `{cond ? <x/> : ""}`, a template literal that reduces to `""`, or a conditional/component that renders to nothing. So a valid tree crashes the moment such an expression is empty.

It's also easy to hit yet looks intermittent: mounting a non-trivial dashboard on a **real terminal** (one that answers capability/size queries) reliably triggers it, while a bare pty in tests often doesn't — so it can pass CI and crash for real users.

### Minimal repro
```tsx
// crashes at mount with: Orphan text error: "" must have a <text> as a parent
render(() => <box>{someSignalThatCanBeEmptyString()}</box>)
```

## Fix

In `packages/solid/src/reconciler.ts`, when a text node lands under a non-`<text>` parent, **skip it if it's empty** (it renders nothing anyway) instead of throwing. A *non-empty* text node under a non-`<text>` parent is still a genuine authoring mistake and still throws, unchanged — so no diagnostic value is lost.

This mirrors how `null`/`undefined`/`false` children are already handled (they render nothing); an empty string should be no different.

## Notes
- One-line behavioral change (`if (text === "") return`) plus a comment.
- Downstream we're currently carrying this as a `bun patch`; happy to add a test in whatever form you prefer if that helps land it.