### PR TITLE
fix(runtime): bundled asset path fallback

### DIFF
--- a/packages/core/src/platform/runtime.test.ts
+++ b/packages/core/src/platform/runtime.test.ts
@@ -84,6 +84,19 @@ describe("platform/runtime", () => {
     expect(fallbackCalled).toBe(!isBun)
   })
 
+  test("falls back to the source path when a bundled asset module's default is not a path string", async () => {
+    const fallbackUrl = new URL("./fallback-tree-sitter.wasm", import.meta.url)
+
+    const resolved = await resolveBundledFilePath(
+      "web-tree-sitter/tree-sitter.wasm",
+      async () => ({ default: undefined as unknown as string }),
+      fallbackUrl,
+      import.meta.url,
+    )
+
+    expect(resolved).toBe(fileURLToPath(fallbackUrl))
+  })
+
   test("resolves Bun-emitted asset modules when a non-Bun bundle has no source fallback", async () => {
     const bundledUrl = new URL("./bundled-tree-sitter.wasm", import.meta.url).href
     const bundledModuleSpecifier = `data:text/javascript,${encodeURIComponent(

--- a/packages/core/src/platform/runtime.ts
+++ b/packages/core/src/platform/runtime.ts
@@ -69,7 +69,14 @@ export async function resolveBundledFilePath(
     return (await loadBundledFilePath(loadBundledFile, metaUrl, options.loadBundledFileFallback ?? false)) ?? path
   }
 
-  return normalizeLoadedFilePath((await loadBundledFile()).default, metaUrl)
+  // A bundled `type: "file"` import can resolve to a module whose `default` is not a path string
+  // (e.g. when the same file is also emitted as a build entrypoint), so fall back to the source path.
+  const loaded = (await loadBundledFile()).default
+  if (typeof loaded !== "string") {
+    return resolveFallbackFilePath(fallbackPath, metaUrl)
+  }
+
+  return normalizeLoadedFilePath(loaded, metaUrl)
 }
 
 function resolveFallbackFilePath(fallbackPath: FilePathFallback, metaUrl: string): string {


### PR DESCRIPTION
A `type: "file"` import can resolve to a module whose default export
is not a path string when the same file is also a build entrypoint.
Fall back to the source path instead of treating a non-string default
as a resolved asset path.

Fix #1275
