### PR TITLE
docs/audio: clarify engine lifecycle

### DIFF
--- a/packages/web/src/content/docs/core-concepts/audio.mdx
+++ b/packages/web/src/content/docs/core-concepts/audio.mdx
@@ -26,9 +26,9 @@ const sound = await audio.loadSoundFile("click.wav")
 if (sound != null && audio.start()) {
   audio.play(sound, { volume: 0.8, pan: 0, loop: false })
 }
-
-audio.dispose()
 ```
+
+Keep the engine alive while playback is needed, then call `audio.dispose()` from your application's shutdown lifecycle.
 
 Use `setupAudio(options?)` when you prefer a function wrapper around `Audio.create(options?)`.
 
@@ -235,6 +235,8 @@ Streams use the same mixer and master tap as loaded sounds. Once `enableTap()` i
 ## Starting audio
 
 `start()` starts native playback and returns `false` when no output device is available. Use `isStarted()` to check native playback state.
+
+The playback device remains open until `stop()` or `dispose()` is called, even when no voices are active. `stop()` releases the device while preserving loaded sounds, so call `start()` again before the next playback. Because `play()` returns when a voice starts rather than when it finishes, calling `stop()` immediately afterward can interrupt the sound.
 
 For headless mixing, tests, benchmarks, or manual `mixFrames()` output, use `startMixer()`. It starts the mixer without opening a playback device. Use `isMixerStarted()` to check either mode.
 


### PR DESCRIPTION
The quick-start example disposed the engine immediately after play(),
which tears down playback before sounds can finish. Document that the
device stays open until stop/dispose and that stop right after play can
cut off active voices.

#1282 minor clarification.
