### PR TITLE
fix(core): prevent duplicate live frame timers

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -4372,13 +4372,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private async loop(): Promise<void> {
     if (this.rendering || this._isDestroyed) return
-    this.renderTimeout = null
-
-    this.rendering = true
     if (this.renderTimeout) {
       this.clock.clearTimeout(this.renderTimeout)
       this.renderTimeout = null
     }
+    this.rendering = true
     try {
       // Bump before any work so all callers this iteration see the new id.
       this._frameId++

--- a/packages/core/src/tests/renderer.clock.test.ts
+++ b/packages/core/src/tests/renderer.clock.test.ts
@@ -151,6 +151,19 @@ test("maxFps setter updates requestRender throttle timing", async () => {
   expect(renderCalled).toBe(true)
 })
 
+test("intermediateRender() replaces the pending live frame timer", async () => {
+  renderer.requestLive()
+  await Promise.resolve()
+
+  // @ts-expect-error - inspect private manual clock timers in regression test
+  expect(clock.timers.size).toBe(1)
+
+  renderer.intermediateRender()
+
+  // @ts-expect-error - inspect private manual clock timers in regression test
+  expect(clock.timers.size).toBe(1)
+})
+
 test("threaded output backpressure retries a skipped native frame", async () => {
   const internals = renderer as unknown as {
     lib: { render: (...args: unknown[]) => number }


### PR DESCRIPTION
## What

Prevent an immediate render during a live render loop from creating a second frame-timer chain. Under frequent updates, duplicate chains could multiply and drive rendering far above the configured `targetFps` and `maxFps`.

## Before / After

**Before:** A live renderer scheduled its next frame and stored the timer in `renderTimeout`. If `intermediateRender()` started another frame before that timer fired, `loop()` nulled the handle before attempting cleanup. The pending timer became unreachable, both frames scheduled successors, and repeated immediate renders multiplied the number of active chains. In OpenCode's streaming transcript workload this reached about 1,625 frames per second despite a 60 FPS limit.

**After:** `loop()` clears the pending timer before nulling its handle. An immediate frame replaces the scheduled frame, preserving the invariant that the live loop has at most one pending frame timer. The same OpenCode workload now renders at about 52 frames per second, with OpenTUI reporting a median 58 FPS.

## How

- `packages/core/src/renderer.ts` reorders pending-timer cleanup at the start of `CliRenderer.loop()`.
- `packages/core/src/tests/renderer.clock.test.ts` reproduces the failure with `ManualClock`: a live renderer has one pending timer before and after `intermediateRender()`.

## Scope

This only fixes duplicate timer chains in the live renderer loop. It does not change frame-rate configuration, animation APIs, or consumer-specific rendering behavior.

## Testing

- `bun test src/tests/renderer.clock.test.ts`: 11 passed, 0 failed.
- `bun run test:js`: 5,103 passed, 23 skipped, 0 failed.
- `bunx oxfmt --check packages/core/src/renderer.ts packages/core/src/tests/renderer.clock.test.ts`
- `bunx oxlint packages/core/src/renderer.ts packages/core/src/tests/renderer.clock.test.ts`: 0 warnings, 0 errors.
- End-to-end OpenCode streaming plus live-tab workload: reduced from about 1,625 frames/sec before the fix to 52 frames/sec after it; median reported FPS was 58.
