### PR TITLE
fix(core): harden renderer resolution lifecycle

### DIFF
--- a/packages/core/src/lib/stdin-parser.test.ts
+++ b/packages/core/src/lib/stdin-parser.test.ts
@@ -1254,18 +1254,125 @@ describe("StdinParser", () => {
     })
 
     test("partial pixel resolution response stays pending after timeout while query is active", () => {
-      const { parser, clock } = createTimedParser({
-        protocolContext: { pixelResolutionQueryActive: true },
-      })
+      const response = Buffer.from("\x1b[4;1080;1920t")
+      const secondSemicolon = response.indexOf(";", 4)
 
+      for (let split = secondSemicolon + 1; split < response.length; split++) {
+        const { parser, clock } = createTimedParser({
+          protocolContext: { pixelResolutionQueryActive: true },
+        })
+
+        try {
+          parser.push(response.subarray(0, split))
+          expect(snap(parser)).toEqual([])
+          clock.advance(10)
+          expect(snap(parser)).toEqual([])
+
+          parser.push(response.subarray(split))
+          expect(snap(parser)).toEqual([resp("csi", "\x1b[4;1080;1920t")])
+        } finally {
+          parser.destroy()
+        }
+      }
+    })
+
+    test("recognizes every partial pixel resolution response prefix", () => {
+      const response = Buffer.from("\x1b[4;1080;1920t")
+
+      for (let split = 1; split < response.length; split++) {
+        const parser = createParser({ protocolContext: { pixelResolutionQueryActive: true } })
+        try {
+          parser.push(response.subarray(0, split))
+          expect(parser.hasPendingPixelResolutionResponse()).toBe(true)
+        } finally {
+          parser.destroy()
+        }
+      }
+    })
+
+    test("does not mistake unrelated pending input for a pixel resolution response", () => {
+      for (const input of ["a", "\x1b[A", "\x1b[3;1080;", "\x1b[4;1080:", "\x1b[4;;", "\x1b[4;1:2;3"]) {
+        const parser = createParser({ protocolContext: { pixelResolutionQueryActive: true } })
+        try {
+          parser.push(Buffer.from(input))
+          expect(parser.hasPendingPixelResolutionResponse()).toBe(false)
+        } finally {
+          parser.destroy()
+        }
+      }
+    })
+
+    test("partial pixel resolution response flushes after timeout when no query is active", () => {
+      const { parser, clock } = createTimedParser()
       try {
-        parser.push(Buffer.from("\x1b[4;1080;192"))
+        parser.push(Buffer.from("\x1b[4;1080"))
         expect(snap(parser)).toEqual([])
+        clock.advance(10)
+        expect(snap(parser)).toEqual([resp("unknown", "\x1b[4;1080")])
+      } finally {
+        parser.destroy()
+      }
+    })
+
+    test("separates a suspended lone escape from a later pixel resolution response", () => {
+      const parser = createParser({ protocolContext: { pixelResolutionQueryActive: true } })
+      try {
+        parser.push(Buffer.from("\x1b"))
+        parser.pausePendingTimeout()
+        parser.resumePendingTimeout()
+        parser.push(Buffer.from("\x1b[4;1080;1920t"))
+        expect(snap(parser)).toEqual([resp("csi", "\x1b[4;1080;1920t")])
+      } finally {
+        parser.destroy()
+      }
+    })
+
+    test("reset restores a paused pending timeout", () => {
+      const { parser, clock } = createTimedParser()
+      try {
+        parser.push(Buffer.from("\x1b"))
+        parser.pausePendingTimeout()
+        parser.reset()
+        parser.push(Buffer.from("\x1b"))
+        clock.advance(10)
+        expect(snap(parser)).toEqual([k("escape", { raw: "\x1b" })])
+      } finally {
+        parser.destroy()
+      }
+    })
+
+    test("keeps consecutive suspended escapes pending until the pixel response arrives", () => {
+      const { parser, clock } = createTimedParser({ protocolContext: { pixelResolutionQueryActive: true } })
+      try {
+        parser.push(Buffer.from("\x1b"))
+        parser.pausePendingTimeout()
+        parser.resumePendingTimeout()
+        parser.push(Buffer.from("\x1b"))
         clock.advance(10)
         expect(snap(parser)).toEqual([])
 
-        parser.push(Buffer.from("0t"))
+        parser.push(Buffer.from("\x1b[4;1080;1920t"))
         expect(snap(parser)).toEqual([resp("csi", "\x1b[4;1080;1920t")])
+      } finally {
+        parser.destroy()
+      }
+    })
+
+    test("pending overflow clears suspended pixel response state", () => {
+      const { parser, clock } = createTimedParser({
+        maxPendingBytes: 8,
+        protocolContext: { pixelResolutionQueryActive: true },
+      })
+      try {
+        parser.push(Buffer.from("\x1b"))
+        parser.pausePendingTimeout()
+        parser.resumePendingTimeout()
+        parser.push(Buffer.from("[4;123456789"))
+        expect(snap(parser)).toEqual([resp("unknown", "\x1b[4;123456789")])
+
+        parser.push(Buffer.from("\x1b"))
+        clock.advance(10)
+        expect(snap(parser)).toEqual([k("escape", { raw: "\x1b" })])
       } finally {
         parser.destroy()
       }

--- a/packages/core/src/lib/stdin-parser.test.ts
+++ b/packages/core/src/lib/stdin-parser.test.ts
@@ -1327,6 +1327,23 @@ describe("StdinParser", () => {
       }
     })
 
+    test("separates every suspended pixel response prefix from later input", () => {
+      const response = Buffer.from("\x1b[4;1080;1920t")
+
+      for (let split = 1; split < response.length; split++) {
+        const parser = createParser({ protocolContext: { pixelResolutionQueryActive: true } })
+        try {
+          parser.push(response.subarray(0, split))
+          parser.pausePendingTimeout()
+          parser.resumePendingTimeout()
+          parser.push(Buffer.from("a"))
+          expect(snap(parser)).toEqual([k("a", { raw: "a" })])
+        } finally {
+          parser.destroy()
+        }
+      }
+    })
+
     test("reset restores a paused pending timeout", () => {
       const { parser, clock } = createTimedParser()
       try {

--- a/packages/core/src/lib/stdin-parser.test.ts
+++ b/packages/core/src/lib/stdin-parser.test.ts
@@ -1365,6 +1365,8 @@ describe("StdinParser", () => {
         parser.pausePendingTimeout()
         parser.resumePendingTimeout()
         parser.push(Buffer.from("\x1b"))
+        parser.pausePendingTimeout()
+        parser.resumePendingTimeout()
         clock.advance(10)
         expect(snap(parser)).toEqual([])
 

--- a/packages/core/src/lib/stdin-parser.test.ts
+++ b/packages/core/src/lib/stdin-parser.test.ts
@@ -1344,6 +1344,20 @@ describe("StdinParser", () => {
       }
     })
 
+    test("query cancellation separates a suspended pixel prefix from later input", () => {
+      const parser = createParser({ protocolContext: { pixelResolutionQueryActive: true } })
+      try {
+        parser.push(Buffer.from("\x1b[4;1080"))
+        parser.pausePendingTimeout()
+        parser.resumePendingTimeout()
+        parser.updateProtocolContext({ pixelResolutionQueryActive: false })
+        parser.push(Buffer.from("a"))
+        expect(snap(parser)).toEqual([k("a", { raw: "a" })])
+      } finally {
+        parser.destroy()
+      }
+    })
+
     test("reset restores a paused pending timeout", () => {
       const { parser, clock } = createTimedParser()
       try {

--- a/packages/core/src/lib/stdin-parser.ts
+++ b/packages/core/src/lib/stdin-parser.ts
@@ -759,10 +759,6 @@ export class StdinParser {
         const prefixLength = this.suspendedPixelResolutionPrefixLength
         this.state = { tag: "ground" }
         this.consumePrefix(prefixLength)
-        if (canStillBePixelResolutionPrefix(this.pending.view())) {
-          this.pendingTimeoutPaused = true
-          this.suspendedPixelResolutionPrefixLength = this.pending.length
-        }
       }
       this.scanPending()
 

--- a/packages/core/src/lib/stdin-parser.ts
+++ b/packages/core/src/lib/stdin-parser.ts
@@ -410,8 +410,10 @@ function canStillBePixelResolutionPrefix(bytes: Uint8Array): boolean {
   if (index === heightStart || bytes[index] !== 0x3b) return false
 
   index += 1
+  const widthStart = index
   while (index < bytes.length && isAsciiDigit(bytes[index]!)) index += 1
-  return index === bytes.length
+  if (index === bytes.length) return true
+  return index > widthStart && bytes[index] === 0x74
 }
 
 function canDeferParametricCsi(state: ParametricCsiLike, context: StdinParserProtocolContext): boolean {
@@ -598,7 +600,7 @@ export class StdinParser {
   // When the current incomplete unit first appeared. Null when nothing is pending.
   private pendingSinceMs: number | null = null
   private pendingTimeoutPaused = false
-  private discardSuspendedLoneEscape = false
+  private suspendedPixelResolutionPrefixLength = 0
   // When true, the state machine treats the current incomplete prefix as
   // final and emits it as one atomic event (e.g. a lone ESC becomes an
   // Escape key). Set by the timeout, consumed by the next read() or drain().
@@ -734,19 +736,6 @@ export class StdinParser {
 
     let remainder = data
     while (remainder.length > 0) {
-      if (
-        this.discardSuspendedLoneEscape &&
-        this.protocolContext.pixelResolutionQueryActive &&
-        this.state.tag === "esc" &&
-        this.cursor === this.unitStart + 1 &&
-        remainder[0] !== 0x5b
-      ) {
-        this.state = { tag: "ground" }
-        this.consumePrefix(this.cursor)
-        this.pendingTimeoutPaused = true
-        this.discardSuspendedLoneEscape = true
-      }
-
       if (this.paste) {
         remainder = this.consumePasteBytes(remainder)
         continue
@@ -762,6 +751,19 @@ export class StdinParser {
 
       this.pending.append(remainder.subarray(0, appendEnd))
       remainder = remainder.subarray(appendEnd)
+      if (
+        this.suspendedPixelResolutionPrefixLength > 0 &&
+        this.protocolContext.pixelResolutionQueryActive &&
+        !canStillBePixelResolutionPrefix(this.pending.view())
+      ) {
+        const prefixLength = this.suspendedPixelResolutionPrefixLength
+        this.state = { tag: "ground" }
+        this.consumePrefix(prefixLength)
+        if (canStillBePixelResolutionPrefix(this.pending.view())) {
+          this.pendingTimeoutPaused = true
+          this.suspendedPixelResolutionPrefixLength = this.pending.length
+        }
+      }
       this.scanPending()
 
       if (this.paste && this.pending.length > 0) {
@@ -862,7 +864,7 @@ export class StdinParser {
   public pausePendingTimeout(): void {
     this.ensureAlive()
     this.pendingTimeoutPaused = true
-    this.discardSuspendedLoneEscape = this.state.tag === "esc" && this.cursor === this.unitStart + 1
+    this.suspendedPixelResolutionPrefixLength = this.pending.length
     this.clearTimeout()
   }
 
@@ -1894,7 +1896,7 @@ export class StdinParser {
   private consumePrefix(endExclusive: number): void {
     this.pending.consume(endExclusive)
     this.pendingTimeoutPaused = false
-    this.discardSuspendedLoneEscape = false
+    this.suspendedPixelResolutionPrefixLength = 0
     this.cursor = 0
     this.unitStart = 0
     this.pendingSinceMs = null
@@ -1927,7 +1929,7 @@ export class StdinParser {
     this.unitStart = 0
     this.pendingSinceMs = null
     this.pendingTimeoutPaused = false
-    this.discardSuspendedLoneEscape = false
+    this.suspendedPixelResolutionPrefixLength = 0
     this.forceFlush = false
     this.state = { tag: "ground" }
   }
@@ -2058,7 +2060,7 @@ export class StdinParser {
     this.events.length = 0
     this.pendingSinceMs = null
     this.pendingTimeoutPaused = false
-    this.discardSuspendedLoneEscape = false
+    this.suspendedPixelResolutionPrefixLength = 0
     this.forceFlush = false
     this.justFlushedEsc = false
     this.state = { tag: "ground" }

--- a/packages/core/src/lib/stdin-parser.ts
+++ b/packages/core/src/lib/stdin-parser.ts
@@ -739,7 +739,7 @@ export class StdinParser {
         this.protocolContext.pixelResolutionQueryActive &&
         this.state.tag === "esc" &&
         this.cursor === this.unitStart + 1 &&
-        remainder[0] === ESC
+        remainder[0] !== 0x5b
       ) {
         this.state = { tag: "ground" }
         this.consumePrefix(this.cursor)

--- a/packages/core/src/lib/stdin-parser.ts
+++ b/packages/core/src/lib/stdin-parser.ts
@@ -395,6 +395,25 @@ function canStillBePixelResolution(state: ParametricCsiLike): boolean {
   return state.firstParamValue === 4 && state.semicolons === 2
 }
 
+function canStillBePixelResolutionPrefix(bytes: Uint8Array): boolean {
+  const fixedPrefix = [ESC, 0x5b, 0x34, 0x3b]
+  const fixedLength = Math.min(bytes.length, fixedPrefix.length)
+  for (let index = 0; index < fixedLength; index += 1) {
+    if (bytes[index] !== fixedPrefix[index]) return false
+  }
+  if (bytes.length <= fixedPrefix.length) return bytes.length > 0
+
+  let index = fixedPrefix.length
+  const heightStart = index
+  while (index < bytes.length && isAsciiDigit(bytes[index]!)) index += 1
+  if (index === bytes.length) return index > heightStart
+  if (index === heightStart || bytes[index] !== 0x3b) return false
+
+  index += 1
+  while (index < bytes.length && isAsciiDigit(bytes[index]!)) index += 1
+  return index === bytes.length
+}
+
 function canDeferParametricCsi(state: ParametricCsiLike, context: StdinParserProtocolContext): boolean {
   return (
     (context.kittyKeyboardEnabled && (canStillBeKittyU(state) || canStillBeKittySpecial(state))) ||
@@ -578,6 +597,8 @@ export class StdinParser {
   private destroyed = false
   // When the current incomplete unit first appeared. Null when nothing is pending.
   private pendingSinceMs: number | null = null
+  private pendingTimeoutPaused = false
+  private discardSuspendedLoneEscape = false
   // When true, the state machine treats the current incomplete prefix as
   // final and emits it as one atomic event (e.g. a lone ESC becomes an
   // Escape key). Set by the timeout, consumed by the next read() or drain().
@@ -713,6 +734,19 @@ export class StdinParser {
 
     let remainder = data
     while (remainder.length > 0) {
+      if (
+        this.discardSuspendedLoneEscape &&
+        this.protocolContext.pixelResolutionQueryActive &&
+        this.state.tag === "esc" &&
+        this.cursor === this.unitStart + 1 &&
+        remainder[0] === ESC
+      ) {
+        this.state = { tag: "ground" }
+        this.consumePrefix(this.cursor)
+        this.pendingTimeoutPaused = true
+        this.discardSuspendedLoneEscape = true
+      }
+
       if (this.paste) {
         remainder = this.consumePasteBytes(remainder)
         continue
@@ -818,6 +852,24 @@ export class StdinParser {
 
     this.clearTimeout()
     this.resetState()
+  }
+
+  public hasPendingPixelResolutionResponse(): boolean {
+    if (!this.protocolContext.pixelResolutionQueryActive || this.pending.length === 0) return false
+    return canStillBePixelResolutionPrefix(this.pending.view())
+  }
+
+  public pausePendingTimeout(): void {
+    this.ensureAlive()
+    this.pendingTimeoutPaused = true
+    this.discardSuspendedLoneEscape = this.state.tag === "esc" && this.cursor === this.unitStart + 1
+    this.clearTimeout()
+  }
+
+  public resumePendingTimeout(): void {
+    this.ensureAlive()
+    if (this.pending.length === 0) this.pendingTimeoutPaused = false
+    this.reconcileTimeoutState()
   }
 
   public resetMouseState(): void {
@@ -1841,6 +1893,8 @@ export class StdinParser {
   // and timeout state so the next scan iteration starts clean.
   private consumePrefix(endExclusive: number): void {
     this.pending.consume(endExclusive)
+    this.pendingTimeoutPaused = false
+    this.discardSuspendedLoneEscape = false
     this.cursor = 0
     this.unitStart = 0
     this.pendingSinceMs = null
@@ -1872,6 +1926,8 @@ export class StdinParser {
     this.cursor = 0
     this.unitStart = 0
     this.pendingSinceMs = null
+    this.pendingTimeoutPaused = false
+    this.discardSuspendedLoneEscape = false
     this.forceFlush = false
     this.state = { tag: "ground" }
   }
@@ -1959,6 +2015,11 @@ export class StdinParser {
       return
     }
 
+    if (this.pendingTimeoutPaused) {
+      this.clearTimeout()
+      return
+    }
+
     if (this.paste || this.pendingSinceMs === null || this.pending.length === 0) {
       this.clearTimeout()
       return
@@ -1996,6 +2057,8 @@ export class StdinParser {
     this.pending.reset(INITIAL_PENDING_CAPACITY)
     this.events.length = 0
     this.pendingSinceMs = null
+    this.pendingTimeoutPaused = false
+    this.discardSuspendedLoneEscape = false
     this.forceFlush = false
     this.justFlushedEsc = false
     this.state = { tag: "ground" }

--- a/packages/core/src/lib/stdin-parser.ts
+++ b/packages/core/src/lib/stdin-parser.ts
@@ -642,6 +642,12 @@ export class StdinParser {
   public updateProtocolContext(patch: Partial<StdinParserProtocolContext>): void {
     this.ensureAlive()
     this.protocolContext = { ...this.protocolContext, ...patch }
+    if (!this.protocolContext.pixelResolutionQueryActive && this.suspendedPixelResolutionPrefixLength > 0) {
+      const prefixLength = this.suspendedPixelResolutionPrefixLength
+      this.state = { tag: "ground" }
+      this.consumePrefix(prefixLength)
+      this.scanPending()
+    }
     this.reconcileDeferredStateWithProtocolContext()
     this.reconcileTimeoutState()
   }

--- a/packages/core/src/lib/terminal-capability-detection.test.ts
+++ b/packages/core/src/lib/terminal-capability-detection.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe } from "bun:test"
 import {
+  countPixelResolutionResponses,
   isCapabilityResponse,
   isPixelResolutionResponse,
   parsePixelResolution,
@@ -131,6 +132,16 @@ describe("parsePixelResolution", () => {
     expect(parsePixelResolution("\x1b[?1016;2$y")).toBeNull()
     expect(parsePixelResolution(`\x1b[4;${"9".repeat(400)};${"9".repeat(400)}t`)).toBeNull()
   })
+})
+
+test("counts complete pixel resolution responses across chunks", () => {
+  const encoder = new TextEncoder()
+  expect(
+    countPixelResolutionResponses([
+      encoder.encode("ignored\x1b[4;720;"),
+      encoder.encode("1280t\x1b[4;1080;1920tpartial\x1b[4;"),
+    ]),
+  ).toBe(2)
 })
 
 describe("real-world terminal capability sequences", () => {

--- a/packages/core/src/lib/terminal-capability-detection.test.ts
+++ b/packages/core/src/lib/terminal-capability-detection.test.ts
@@ -129,6 +129,7 @@ describe("parsePixelResolution", () => {
     expect(parsePixelResolution("a")).toBeNull()
     expect(parsePixelResolution("\x1b[A")).toBeNull()
     expect(parsePixelResolution("\x1b[?1016;2$y")).toBeNull()
+    expect(parsePixelResolution(`\x1b[4;${"9".repeat(400)};${"9".repeat(400)}t`)).toBeNull()
   })
 })
 

--- a/packages/core/src/lib/terminal-capability-detection.test.ts
+++ b/packages/core/src/lib/terminal-capability-detection.test.ts
@@ -1,6 +1,5 @@
 import { test, expect, describe } from "bun:test"
 import {
-  countPixelResolutionResponses,
   isCapabilityResponse,
   isPixelResolutionResponse,
   parsePixelResolution,
@@ -130,18 +129,9 @@ describe("parsePixelResolution", () => {
     expect(parsePixelResolution("a")).toBeNull()
     expect(parsePixelResolution("\x1b[A")).toBeNull()
     expect(parsePixelResolution("\x1b[?1016;2$y")).toBeNull()
-    expect(parsePixelResolution(`\x1b[4;${"9".repeat(400)};${"9".repeat(400)}t`)).toBeNull()
+    expect(parsePixelResolution("\x1b[4;4294967295;4294967295t")).toBeNull()
+    expect(parsePixelResolution(`\x1b[4;${"9".repeat(400)};80t`)).toBeNull()
   })
-})
-
-test("counts complete pixel resolution responses across chunks", () => {
-  const encoder = new TextEncoder()
-  expect(
-    countPixelResolutionResponses([
-      encoder.encode("ignored\x1b[4;720;"),
-      encoder.encode("1280t\x1b[4;1080;1920tpartial\x1b[4;"),
-    ]),
-  ).toBe(2)
 })
 
 describe("real-world terminal capability sequences", () => {

--- a/packages/core/src/lib/terminal-capability-detection.ts
+++ b/packages/core/src/lib/terminal-capability-detection.ts
@@ -82,50 +82,6 @@ export function isPixelResolutionResponse(sequence: string): boolean {
   return /\x1b\[4;\d+;\d+t/.test(sequence)
 }
 
-export function countPixelResolutionResponses(chunks: readonly Uint8Array[]): number {
-  let state = 0
-  let heightDigits = false
-  let widthDigits = false
-  let count = 0
-
-  const reset = (byte: number): void => {
-    state = byte === 0x1b ? 1 : 0
-    heightDigits = false
-    widthDigits = false
-  }
-
-  for (const chunk of chunks) {
-    for (const byte of chunk) {
-      const digit = byte >= 0x30 && byte <= 0x39
-      if (state === 0) {
-        if (byte === 0x1b) state = 1
-      } else if (state === 1) {
-        if (byte === 0x5b) state = 2
-        else reset(byte)
-      } else if (state === 2) {
-        if (byte === 0x34) state = 3
-        else reset(byte)
-      } else if (state === 3) {
-        if (byte === 0x3b) state = 4
-        else reset(byte)
-      } else if (state === 4) {
-        if (digit) heightDigits = true
-        else if (byte === 0x3b && heightDigits) state = 5
-        else reset(byte)
-      } else if (digit) {
-        widthDigits = true
-      } else if (byte === 0x74 && widthDigits) {
-        count++
-        reset(0)
-      } else {
-        reset(byte)
-      }
-    }
-  }
-
-  return count
-}
-
 /**
  * Parse pixel resolution from response sequence.
  * Returns { width, height } or null if not a valid resolution response.
@@ -135,13 +91,9 @@ export function parsePixelResolution(sequence: string): { width: number; height:
   if (match) {
     const width = Number(match[2])
     const height = Number(match[1])
-    if (!Number.isSafeInteger(width) || !Number.isSafeInteger(height) || width > 0xffffffff || height > 0xffffffff) {
+    if (!Number.isSafeInteger(width) || !Number.isSafeInteger(height) || width > 0x7fffffff || height > 0x7fffffff)
       return null
-    }
-    return {
-      width,
-      height,
-    }
+    return { width, height }
   }
   return null
 }

--- a/packages/core/src/lib/terminal-capability-detection.ts
+++ b/packages/core/src/lib/terminal-capability-detection.ts
@@ -82,6 +82,50 @@ export function isPixelResolutionResponse(sequence: string): boolean {
   return /\x1b\[4;\d+;\d+t/.test(sequence)
 }
 
+export function countPixelResolutionResponses(chunks: readonly Uint8Array[]): number {
+  let state = 0
+  let heightDigits = false
+  let widthDigits = false
+  let count = 0
+
+  const reset = (byte: number): void => {
+    state = byte === 0x1b ? 1 : 0
+    heightDigits = false
+    widthDigits = false
+  }
+
+  for (const chunk of chunks) {
+    for (const byte of chunk) {
+      const digit = byte >= 0x30 && byte <= 0x39
+      if (state === 0) {
+        if (byte === 0x1b) state = 1
+      } else if (state === 1) {
+        if (byte === 0x5b) state = 2
+        else reset(byte)
+      } else if (state === 2) {
+        if (byte === 0x34) state = 3
+        else reset(byte)
+      } else if (state === 3) {
+        if (byte === 0x3b) state = 4
+        else reset(byte)
+      } else if (state === 4) {
+        if (digit) heightDigits = true
+        else if (byte === 0x3b && heightDigits) state = 5
+        else reset(byte)
+      } else if (digit) {
+        widthDigits = true
+      } else if (byte === 0x74 && widthDigits) {
+        count++
+        reset(0)
+      } else {
+        reset(byte)
+      }
+    }
+  }
+
+  return count
+}
+
 /**
  * Parse pixel resolution from response sequence.
  * Returns { width, height } or null if not a valid resolution response.

--- a/packages/core/src/lib/terminal-capability-detection.ts
+++ b/packages/core/src/lib/terminal-capability-detection.ts
@@ -89,9 +89,14 @@ export function isPixelResolutionResponse(sequence: string): boolean {
 export function parsePixelResolution(sequence: string): { width: number; height: number } | null {
   const match = sequence.match(/\x1b\[4;(\d+);(\d+)t/)
   if (match) {
+    const width = Number(match[2])
+    const height = Number(match[1])
+    if (!Number.isSafeInteger(width) || !Number.isSafeInteger(height) || width > 0xffffffff || height > 0xffffffff) {
+      return null
+    }
     return {
-      width: parseInt(match[2]),
-      height: parseInt(match[1]),
+      width,
+      height,
     }
   }
   return null

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -3717,7 +3717,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }, this.resizeDebounceDelay)
   }
 
-  private queryPixelResolution() {
+  private queryPixelResolution(force: boolean = false) {
+    if (!force && this._controlState === RendererControlState.EXPLICIT_SUSPENDED) {
+      this.queryPixelResolutionOnResume = true
+      return
+    }
     this.pendingPixelResolutionQueries++
     if (this.pendingPixelResolutionQueries === 1) {
       this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: true })
@@ -3750,11 +3754,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this._terminalWidth = width
     this._terminalHeight = height
-    if (this._controlState === RendererControlState.EXPLICIT_SUSPENDED) {
-      this.queryPixelResolutionOnResume = true
-    } else {
-      this.queryPixelResolution()
-    }
+    this.queryPixelResolution()
 
     this.setCapturedRenderable(undefined)
     this.stdinParser?.resetMouseState()
@@ -4080,7 +4080,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     if (this.queryPixelResolutionOnResume) {
       this.queryPixelResolutionOnResume = false
-      this.queryPixelResolution()
+      this.queryPixelResolution(true)
     }
 
     this.suspendedNonAltSurfacePreserved = false

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -3723,9 +3723,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       return
     }
     this.pendingPixelResolutionQueries++
-    if (this.pendingPixelResolutionQueries === 1) {
-      this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: true })
-    }
+    this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: true })
     this.lib.queryPixelResolution(this.rendererPtr)
   }
 
@@ -4026,7 +4024,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this.disableMouse()
     this.removeExitListeners()
-    this.pendingPixelResolutionQueries = 0
     this.updateStdinParserProtocolContext({
       privateCapabilityRepliesActive: false,
       pixelResolutionQueryActive: false,
@@ -4078,6 +4075,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.lib.resumeRenderer(this.rendererPtr)
     }
 
+    if (this.pendingPixelResolutionQueries > 0) {
+      this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: true })
+    }
     if (this.queryPixelResolutionOnResume) {
       this.queryPixelResolutionOnResume = false
       this.queryPixelResolution(true)

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -764,7 +764,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private maxStatSamples: number = 300
   private postProcessFns: ((buffer: OptimizedBuffer, deltaTime: number) => void)[] = []
   private backgroundColor: RGBA = RGBA.fromInts(0, 0, 0, 0)
-  private waitingForPixelResolution: boolean = false
+  private pendingPixelResolutionQueries: number = 0
   private readonly clock: Clock
 
   private rendering: boolean = false
@@ -3376,13 +3376,14 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     this.addInputHandler((sequence: string) => {
-      if (isPixelResolutionResponse(sequence) && this.waitingForPixelResolution) {
+      if (isPixelResolutionResponse(sequence) && this.pendingPixelResolutionQueries > 0) {
         const resolution = parsePixelResolution(sequence)
         if (resolution) {
           this._resolution = resolution
         }
-        this.waitingForPixelResolution = false
-        this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: false }, true)
+        this.pendingPixelResolutionQueries--
+        const queryActive = this.pendingPixelResolutionQueries > 0
+        this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: queryActive }, !queryActive)
         return true
       }
       return false
@@ -3716,8 +3717,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   private queryPixelResolution() {
-    this.waitingForPixelResolution = true
-    this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: true })
+    this.pendingPixelResolutionQueries++
+    if (this.pendingPixelResolutionQueries === 1) {
+      this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: true })
+    }
     this.lib.queryPixelResolution(this.rendererPtr)
   }
 
@@ -4018,7 +4021,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this.disableMouse()
     this.removeExitListeners()
-    this.waitingForPixelResolution = false
+    this.pendingPixelResolutionQueries = 0
     this.updateStdinParserProtocolContext({
       privateCapabilityRepliesActive: false,
       pixelResolutionQueryActive: false,
@@ -4188,7 +4191,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.themeModeState.cancelRefresh()
 
     this._isRunning = false
-    this.waitingForPixelResolution = false
+    this.pendingPixelResolutionQueries = 0
     this.updateStdinParserProtocolContext(
       {
         privateCapabilityRepliesActive: false,

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -3093,7 +3093,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   // TODO: All input management may move to native when zig finally has async io support again,
   // without rolling a full event loop
   public async setupTerminal(): Promise<void> {
-    if (this._terminalIsSetup) return
+    if (this._isDestroyed || this._terminalIsSetup) return
     this._terminalIsSetup = true
 
     const startupCursorCprActive = this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout"

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -46,7 +46,6 @@ import {
 } from "./lib/terminal-palette.js"
 import { calculateRenderGeometry } from "./lib/render-geometry.js"
 import {
-  countPixelResolutionResponses,
   isCapabilityResponse,
   isPixelResolutionResponse,
   parsePixelResolution,
@@ -772,8 +771,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private maxStatSamples: number = 300
   private postProcessFns: ((buffer: OptimizedBuffer, deltaTime: number) => void)[] = []
   private backgroundColor: RGBA = RGBA.fromInts(0, 0, 0, 0)
-  private pendingPixelResolutionQueries: number = 0
-  private queryPixelResolutionOnResume: boolean = false
+  private waitingForPixelResolution: boolean = false
+  private pixelResolutionRequeryPending: boolean = false
   private readonly clock: Clock
 
   private rendering: boolean = false
@@ -836,7 +835,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private _suspendedMouseEnabled: boolean = false
   private _previousControlState: RendererControlState = RendererControlState.IDLE
   private pendingSuspendedTerminalSetup: boolean = false
-  private pendingInitialTerminalSetup: boolean = false
   private suspendedNonAltSurfacePreserved: boolean = false
   private capturedRenderable?: Renderable
   private lastOverRenderableNum: number = 0
@@ -3102,11 +3100,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   // TODO: All input management may move to native when zig finally has async io support again,
   // without rolling a full event loop
   public async setupTerminal(): Promise<void> {
-    if (this._isDestroyed || this._terminalIsSetup) return
-    if (this._controlState === RendererControlState.EXPLICIT_SUSPENDED) {
-      this.pendingInitialTerminalSetup = true
-      return
-    }
+    if (this._terminalIsSetup) return
     this._terminalIsSetup = true
 
     const startupCursorCprActive = this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout"
@@ -3331,6 +3325,12 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   private handleStdinEvent(event: StdinEvent): void {
+    if (this._controlState === RendererControlState.EXPLICIT_SUSPENDED) {
+      if (event.type === "response" && isPixelResolutionResponse(event.sequence)) {
+        this.dispatchSequenceHandlers(event.sequence)
+      }
+      return
+    }
     switch (event.type) {
       case "key":
         if (this.dispatchSequenceHandlers(event.raw)) {
@@ -3390,14 +3390,19 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     this.addInputHandler((sequence: string) => {
-      if (isPixelResolutionResponse(sequence) && this.pendingPixelResolutionQueries > 0) {
+      if (isPixelResolutionResponse(sequence) && this.waitingForPixelResolution) {
+        this.waitingForPixelResolution = false
+        if (this.pixelResolutionRequeryPending) {
+          this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: false })
+          this.queryPixelResolution()
+          return true
+        }
         const resolution = parsePixelResolution(sequence)
         if (resolution) {
           this._resolution = resolution
+          this.requestRender()
         }
-        this.pendingPixelResolutionQueries--
-        const queryActive = this.pendingPixelResolutionQueries > 0
-        this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: queryActive }, !queryActive)
+        this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: false }, true)
         return true
       }
       return false
@@ -3739,12 +3744,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }, this.resizeDebounceDelay)
   }
 
-  private queryPixelResolution(force: boolean = false) {
-    if (!force && this._controlState === RendererControlState.EXPLICIT_SUSPENDED) {
-      this.queryPixelResolutionOnResume = true
-      return
-    }
-    this.pendingPixelResolutionQueries++
+  private queryPixelResolution() {
+    this.pixelResolutionRequeryPending = true
+    if (this._controlState === RendererControlState.EXPLICIT_SUSPENDED || this.waitingForPixelResolution) return
+    this.pixelResolutionRequeryPending = false
+    this.waitingForPixelResolution = true
     this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: true })
     this.lib.queryPixelResolution(this.rendererPtr)
   }
@@ -3774,6 +3778,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this._terminalWidth = width
     this._terminalHeight = height
+    this._resolution = null
     this.queryPixelResolution()
 
     this.setCapturedRenderable(undefined)
@@ -4048,11 +4053,12 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.removeExitListeners()
     this.updateStdinParserProtocolContext({
       privateCapabilityRepliesActive: false,
-      pixelResolutionQueryActive: false,
+      pixelResolutionQueryActive: this.waitingForPixelResolution,
       explicitWidthCprActive: false,
       startupCursorCprActive: false,
     })
-    this.stdinParser?.reset()
+    if (this.stdinParser?.hasPendingPixelResolutionResponse()) this.stdinParser.pausePendingTimeout()
+    else this.stdinParser?.reset()
     this.stdin.removeListener("data", this.stdinListener)
 
     this.themeModeState.cancelRefresh()
@@ -4067,25 +4073,14 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   public resume(): void {
-    const setupTerminalAfterResume = this.pendingInitialTerminalSetup
     if (this.stdin.setRawMode) {
       this.stdin.setRawMode(true)
     }
 
-    // Drain any input buffered during suspension before registering the
-    // listener. Adding a "data" listener can auto-resume a Readable, so the
-    // drain must come first while the stream is still paused and read()
-    // pulls from the internal buffer rather than being a flowing-mode no-op.
-    const discardedInput: Uint8Array[] = []
-    let discarded: unknown
-    while ((discarded = this.stdin.read()) !== null) {
-      if (discarded instanceof Uint8Array) discardedInput.push(discarded)
-      else if (typeof discarded === "string") discardedInput.push(new TextEncoder().encode(discarded))
-    }
-    this.pendingPixelResolutionQueries = Math.max(
-      0,
-      this.pendingPixelResolutionQueries - countPixelResolutionResponses(discardedInput),
-    )
+    let drained: Buffer | string | null
+    while ((drained = this.stdin.read()) !== null) this.stdinListener(drained)
+    if (this.stdinParser?.hasPendingPixelResolutionResponse()) this.stdinParser.pausePendingTimeout()
+    else this.stdinParser?.reset()
     this.stdin.on("data", this.stdinListener)
     this.stdin.resume()
     this.addExitListeners()
@@ -4096,12 +4091,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.suspendedNonAltSurfacePreserved &&
       this.renderOffset > 0
 
-    if (setupTerminalAfterResume) {
-      this.pendingInitialTerminalSetup = false
-      this.pendingSuspendedTerminalSetup = false
-      this._controlState = this._previousControlState
-      void this.setupTerminal()
-    } else if (this.pendingSuspendedTerminalSetup) {
+    if (this.pendingSuspendedTerminalSetup) {
       this.pendingSuspendedTerminalSetup = false
       if (resumePreservedNonAltSurface) {
         this.lib.resumeRenderer(this.rendererPtr)
@@ -4110,14 +4100,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       }
     } else {
       this.lib.resumeRenderer(this.rendererPtr)
-    }
-
-    if (this.pendingPixelResolutionQueries > 0) {
-      this.updateStdinParserProtocolContext({ pixelResolutionQueryActive: true })
-    }
-    if (this.queryPixelResolutionOnResume) {
-      this.queryPixelResolutionOnResume = false
-      this.queryPixelResolution(true)
     }
 
     this.suspendedNonAltSurfacePreserved = false
@@ -4134,6 +4116,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this.forceFullRepaintRequested = true
     this._controlState = this._previousControlState
+    if (this.pixelResolutionRequeryPending) this.queryPixelResolution()
+    this.stdinParser?.resumePendingTimeout()
 
     if (
       this._previousControlState === RendererControlState.AUTO_STARTED ||
@@ -4238,9 +4222,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.themeModeState.cancelRefresh()
 
     this._isRunning = false
-    this.pendingPixelResolutionQueries = 0
-    this.queryPixelResolutionOnResume = false
-    this.pendingInitialTerminalSetup = false
+    this.waitingForPixelResolution = false
+    this.pixelResolutionRequeryPending = false
     this.updateStdinParserProtocolContext(
       {
         privateCapabilityRepliesActive: false,

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -828,6 +828,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private _suspendedMouseEnabled: boolean = false
   private _previousControlState: RendererControlState = RendererControlState.IDLE
   private pendingSuspendedTerminalSetup: boolean = false
+  private pendingInitialTerminalSetup: boolean = false
   private suspendedNonAltSurfacePreserved: boolean = false
   private capturedRenderable?: Renderable
   private lastOverRenderableNum: number = 0
@@ -3094,6 +3095,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   // without rolling a full event loop
   public async setupTerminal(): Promise<void> {
     if (this._isDestroyed || this._terminalIsSetup) return
+    if (this._controlState === RendererControlState.EXPLICIT_SUSPENDED) {
+      this.pendingInitialTerminalSetup = true
+      return
+    }
     this._terminalIsSetup = true
 
     const startupCursorCprActive = this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout"
@@ -4045,6 +4050,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   public resume(): void {
+    const setupTerminalAfterResume = this.pendingInitialTerminalSetup
     if (this.stdin.setRawMode) {
       this.stdin.setRawMode(true)
     }
@@ -4064,7 +4070,12 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.suspendedNonAltSurfacePreserved &&
       this.renderOffset > 0
 
-    if (this.pendingSuspendedTerminalSetup) {
+    if (setupTerminalAfterResume) {
+      this.pendingInitialTerminalSetup = false
+      this.pendingSuspendedTerminalSetup = false
+      this._controlState = this._previousControlState
+      void this.setupTerminal()
+    } else if (this.pendingSuspendedTerminalSetup) {
       this.pendingSuspendedTerminalSetup = false
       if (resumePreservedNonAltSurface) {
         this.lib.resumeRenderer(this.rendererPtr)
@@ -4203,6 +4214,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this._isRunning = false
     this.pendingPixelResolutionQueries = 0
     this.queryPixelResolutionOnResume = false
+    this.pendingInitialTerminalSetup = false
     this.updateStdinParserProtocolContext(
       {
         privateCapabilityRepliesActive: false,

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -765,6 +765,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private postProcessFns: ((buffer: OptimizedBuffer, deltaTime: number) => void)[] = []
   private backgroundColor: RGBA = RGBA.fromInts(0, 0, 0, 0)
   private pendingPixelResolutionQueries: number = 0
+  private queryPixelResolutionOnResume: boolean = false
   private readonly clock: Clock
 
   private rendering: boolean = false
@@ -3749,7 +3750,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this._terminalWidth = width
     this._terminalHeight = height
-    this.queryPixelResolution()
+    if (this._controlState === RendererControlState.EXPLICIT_SUSPENDED) {
+      this.queryPixelResolutionOnResume = true
+    } else {
+      this.queryPixelResolution()
+    }
 
     this.setCapturedRenderable(undefined)
     this.stdinParser?.resetMouseState()
@@ -4073,6 +4078,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.lib.resumeRenderer(this.rendererPtr)
     }
 
+    if (this.queryPixelResolutionOnResume) {
+      this.queryPixelResolutionOnResume = false
+      this.queryPixelResolution()
+    }
+
     this.suspendedNonAltSurfacePreserved = false
 
     this.flushPendingSplitOutputBeforeTransition(false, { allowSuspended: true, allowPassthrough: true })
@@ -4192,6 +4202,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this._isRunning = false
     this.pendingPixelResolutionQueries = 0
+    this.queryPixelResolutionOnResume = false
     this.updateStdinParserProtocolContext(
       {
         privateCapabilityRepliesActive: false,

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -46,6 +46,7 @@ import {
 } from "./lib/terminal-palette.js"
 import { calculateRenderGeometry } from "./lib/render-geometry.js"
 import {
+  countPixelResolutionResponses,
   isCapabilityResponse,
   isPixelResolutionResponse,
   parsePixelResolution,
@@ -4059,7 +4060,16 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     // listener. Adding a "data" listener can auto-resume a Readable, so the
     // drain must come first while the stream is still paused and read()
     // pulls from the internal buffer rather than being a flowing-mode no-op.
-    while (this.stdin.read() !== null) {}
+    const discardedInput: Uint8Array[] = []
+    let discarded: unknown
+    while ((discarded = this.stdin.read()) !== null) {
+      if (discarded instanceof Uint8Array) discardedInput.push(discarded)
+      else if (typeof discarded === "string") discardedInput.push(new TextEncoder().encode(discarded))
+    }
+    this.pendingPixelResolutionQueries = Math.max(
+      0,
+      this.pendingPixelResolutionQueries - countPixelResolutionResponses(discardedInput),
+    )
     this.stdin.on("data", this.stdinListener)
     this.stdin.resume()
     this.addExitListeners()

--- a/packages/core/src/tests/renderer.custom-stdout.test.ts
+++ b/packages/core/src/tests/renderer.custom-stdout.test.ts
@@ -378,6 +378,46 @@ test("resume does not join a pre-suspend escape to post-resume input", async () 
   expect(renderer.resolution).toEqual({ width: 80, height: 80 })
 })
 
+test("resume does not join a partial pixel response to post-resume input", async () => {
+  const response = Buffer.from("\x1b[4;80;80t")
+
+  for (let split = 2; split < response.length; split++) {
+    const stdin = createTestStdin()
+    const stdout = createCollectingStdout(8, 4)
+    const renderer = await createCliRenderer({ stdin, stdout })
+    const keypresses: Array<{ name: string; raw: string; meta: boolean }> = []
+    renderer.keyInput.on("keypress", (event) => {
+      keypresses.push({ name: event.name, raw: event.raw, meta: event.meta })
+    })
+
+    try {
+      await flushWritable(stdout)
+      expect(countPixelResolutionQueries(stdout)).toBe(1)
+      stdout.clearWrites()
+
+      stdin.emit("data", response.subarray(0, split))
+      renderer.suspend()
+      renderer.resume()
+      stdin.emit("data", Buffer.from("a"))
+
+      expect({ split, keypresses }).toEqual({
+        split,
+        keypresses: [{ name: "a", raw: "a", meta: false }],
+      })
+      expect(renderer.resolution).toBeNull()
+      await flushWritable(stdout)
+      expect(countPixelResolutionQueries(stdout)).toBe(0)
+
+      stdin.emit("data", response)
+      await renderer.idle()
+      expect(keypresses).toEqual([{ name: "a", raw: "a", meta: false }])
+      expect(renderer.resolution).toEqual({ width: 80, height: 80 })
+    } finally {
+      renderer.destroy()
+    }
+  }
+})
+
 test("resume separates suspended escape input from a pixel resolution response", async () => {
   for (const timing of ["before-resume", "after-resume", "after-suspended-escape"] as const) {
     const stdin = createTestStdin()

--- a/packages/core/src/tests/renderer.custom-stdout.test.ts
+++ b/packages/core/src/tests/renderer.custom-stdout.test.ts
@@ -40,6 +40,21 @@ function createCollectingStdout(columns = 80, rows = 24): CollectingStdout {
   return new CollectingWriteStream(columns, rows) as CollectingStdout
 }
 
+function flushWritable(stdout: NodeJS.WritableStream): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    stdout.write(Buffer.alloc(0), (error) => (error ? reject(error) : resolve()))
+  })
+}
+
+function countPixelResolutionQueries(stdout: CollectingStdout): number {
+  return (
+    stdout
+      .getWrittenBytes()
+      .toString("binary")
+      .match(/\x1b\[14t/g)?.length ?? 0
+  )
+}
+
 function createPlainStdout(): NodeJS.WriteStream {
   return new Writable({
     write(_c, _e, cb) {
@@ -197,6 +212,223 @@ test("process.stdout: no feed is allocated (stdout-direct path)", async () => {
   // goes straight to process.stdout.
   expect((renderer as any)._feed).toBeNull()
   expect(() => renderer.destroy()).not.toThrow()
+})
+
+test("resize ignores an outstanding pixel resolution reply", async () => {
+  const stdin = createTestStdin()
+  const stdout = createCollectingStdout(8, 4)
+  const renderer = await createCliRenderer({ stdin, stdout })
+  destroyFns.push(() => renderer.destroy())
+  await flushWritable(stdout)
+  expect(countPixelResolutionQueries(stdout)).toBe(1)
+  stdout.clearWrites()
+
+  renderer.resize(16, 4)
+  renderer.resize(24, 4)
+  await flushWritable(stdout)
+  expect(stdout.getWrittenBytes().toString("binary")).not.toContain("\x1b[14t")
+
+  stdin.emit("data", Buffer.from("\x1b[4;80;80t"))
+  expect(renderer.resolution).toBeNull()
+  await flushWritable(stdout)
+  expect(countPixelResolutionQueries(stdout)).toBe(1)
+
+  stdout.clearWrites()
+  stdin.emit("data", Buffer.from("\x1b[4;80;240t"))
+  await renderer.idle()
+
+  expect(renderer.resolution).toEqual({ width: 240, height: 80 })
+  expect(stdout.getWrittenBytes().toString("binary")).not.toContain("\x1b[14t")
+})
+
+test("resize while suspended refreshes pixel resolution after resume", async () => {
+  const stdin = createTestStdin()
+  const stdout = createCollectingStdout(8, 4)
+  const renderer = await createCliRenderer({ stdin, stdout })
+  destroyFns.push(() => renderer.destroy())
+  await flushWritable(stdout)
+  expect(countPixelResolutionQueries(stdout)).toBe(1)
+  stdout.clearWrites()
+  stdin.emit("data", Buffer.from("\x1b[4;80;80t"))
+  await renderer.idle()
+  expect(renderer.resolution).toEqual({ width: 80, height: 80 })
+
+  renderer.suspend()
+  stdout.clearWrites()
+  renderer.resize(16, 4)
+  renderer.resize(24, 4)
+  await flushWritable(stdout)
+  expect(stdout.getWrittenBytes().toString("binary")).not.toContain("\x1b[14t")
+  stdout.clearWrites()
+
+  renderer.resume()
+  await flushWritable(stdout)
+  expect(renderer.resolution).toBeNull()
+  expect(countPixelResolutionQueries(stdout)).toBe(1)
+
+  stdin.emit("data", Buffer.from("\x1b[4;80;240t"))
+  await renderer.idle()
+  expect(renderer.resolution).toEqual({ width: 240, height: 80 })
+})
+
+test("resume rejects a delayed pre-suspend pixel resolution reply", async () => {
+  const stdin = createTestStdin()
+  const stdout = createCollectingStdout(8, 4)
+  const renderer = await createCliRenderer({ stdin, stdout })
+  destroyFns.push(() => renderer.destroy())
+  await flushWritable(stdout)
+  expect(countPixelResolutionQueries(stdout)).toBe(1)
+  stdout.clearWrites()
+
+  renderer.suspend()
+  renderer.resize(16, 4)
+  renderer.resume()
+  await flushWritable(stdout)
+  expect(stdout.getWrittenBytes().toString("binary")).not.toContain("\x1b[14t")
+
+  stdout.clearWrites()
+  stdin.emit("data", Buffer.from("\x1b[4;80;80t"))
+  expect(renderer.resolution).toBeNull()
+  await flushWritable(stdout)
+  expect(countPixelResolutionQueries(stdout)).toBe(1)
+
+  stdout.clearWrites()
+  stdin.emit("data", Buffer.from("\x1b[4;80;160t"))
+  await renderer.idle()
+
+  expect(renderer.resolution).toEqual({ width: 160, height: 80 })
+  expect(stdout.getWrittenBytes().toString("binary")).not.toContain("\x1b[14t")
+})
+
+test("resume preserves an outstanding pixel resolution query without requerying", async () => {
+  const stdin = createTestStdin()
+  const stdout = createCollectingStdout(8, 4)
+  const renderer = await createCliRenderer({ stdin, stdout })
+  destroyFns.push(() => renderer.destroy())
+  await flushWritable(stdout)
+  expect(countPixelResolutionQueries(stdout)).toBe(1)
+  stdout.clearWrites()
+
+  renderer.suspend()
+  renderer.resume()
+  await flushWritable(stdout)
+  expect(stdout.getWrittenBytes().toString("binary")).not.toContain("\x1b[14t")
+
+  stdin.emit("data", Buffer.from("\x1b[4;80;80t"))
+  await renderer.idle()
+  expect(renderer.resolution).toEqual({ width: 80, height: 80 })
+})
+
+test("resume preserves an incomplete pixel resolution response buffered while suspended", async () => {
+  const stdin = createTestStdin()
+  const stdout = createCollectingStdout(8, 4)
+  const renderer = await createCliRenderer({ stdin, stdout })
+  const keypresses: string[] = []
+  renderer.keyInput.on("keypress", (event) => keypresses.push(event.raw))
+  destroyFns.push(() => renderer.destroy())
+  await flushWritable(stdout)
+  expect(countPixelResolutionQueries(stdout)).toBe(1)
+  stdout.clearWrites()
+
+  renderer.suspend()
+  renderer.resize(16, 4)
+  stdin.push(Buffer.from("\x1b[4;80"))
+  renderer.resume()
+  await flushWritable(stdout)
+  expect(countPixelResolutionQueries(stdout)).toBe(0)
+
+  stdin.emit("data", Buffer.from(";80t"))
+  expect(renderer.resolution).toBeNull()
+  await flushWritable(stdout)
+  expect(keypresses).toEqual([])
+  expect(countPixelResolutionQueries(stdout)).toBe(1)
+
+  stdin.emit("data", Buffer.from("\x1b[4;80;160t"))
+  await renderer.idle()
+  expect(renderer.resolution).toEqual({ width: 160, height: 80 })
+})
+
+test("resume separates suspended escape input from a pixel resolution response", async () => {
+  for (const timing of ["before-resume", "after-resume", "after-suspended-escape"] as const) {
+    const stdin = createTestStdin()
+    const stdout = createCollectingStdout(8, 4)
+    const renderer = await createCliRenderer({ stdin, stdout })
+    const keypresses: string[] = []
+    renderer.keyInput.on("keypress", (event) => keypresses.push(event.raw))
+
+    try {
+      await flushWritable(stdout)
+      expect(countPixelResolutionQueries(stdout)).toBe(1)
+      stdout.clearWrites()
+
+      stdin.emit("data", Buffer.from("\x1b"))
+      renderer.suspend()
+      if (timing === "before-resume") stdin.push(Buffer.from("\x1b[4;80;80t"))
+      if (timing === "after-suspended-escape") stdin.push(Buffer.from("\x1b"))
+      renderer.resume()
+      if (timing === "after-resume") stdin.emit("data", Buffer.from("\x1b[4;80;80t"))
+      if (timing === "after-suspended-escape") {
+        await new Promise<void>((resolve) => setTimeout(resolve, 25))
+        stdin.emit("data", Buffer.from("\x1b[4;80;80t"))
+      }
+      await renderer.idle()
+
+      expect({
+        timing,
+        keypresses,
+        resolution: renderer.resolution,
+        queryCount: countPixelResolutionQueries(stdout),
+      }).toEqual({
+        timing,
+        keypresses: [],
+        resolution: { width: 80, height: 80 },
+        queryCount: 0,
+      })
+    } finally {
+      renderer.destroy()
+    }
+  }
+})
+
+test("resume preserves every pixel resolution response split across suspension", async () => {
+  const staleResponse = Buffer.from("\x1b[4;80;80t")
+
+  for (let split = 1; split < staleResponse.length; split++) {
+    const stdin = createTestStdin()
+    const stdout = createCollectingStdout(8, 4)
+    const renderer = await createCliRenderer({ stdin, stdout })
+    const keypresses: string[] = []
+    renderer.keyInput.on("keypress", (event) => keypresses.push(event.raw))
+
+    try {
+      await flushWritable(stdout)
+      expect(countPixelResolutionQueries(stdout)).toBe(1)
+      stdout.clearWrites()
+
+      stdin.emit("data", staleResponse.subarray(0, split))
+      renderer.suspend()
+      renderer.resize(16, 4)
+      await new Promise<void>((resolve) => setTimeout(resolve, 25))
+      stdin.push(staleResponse.subarray(split))
+      renderer.resume()
+      await flushWritable(stdout)
+
+      expect(keypresses).toEqual([])
+      expect(renderer.resolution).toBeNull()
+      expect({
+        split,
+        queryCount: countPixelResolutionQueries(stdout),
+      }).toEqual({ split, queryCount: 1 })
+
+      stdout.clearWrites()
+      stdin.emit("data", Buffer.from("\x1b[4;80;160t"))
+      await renderer.idle()
+      expect(renderer.resolution).toEqual({ width: 160, height: 80 })
+      expect(stdout.getWrittenBytes().toString("binary")).not.toContain("\x1b[14t")
+    } finally {
+      renderer.destroy()
+    }
+  }
 })
 
 test("feed-backed renderer retries one skipped frame after feed idle", async () => {

--- a/packages/core/src/tests/renderer.custom-stdout.test.ts
+++ b/packages/core/src/tests/renderer.custom-stdout.test.ts
@@ -418,6 +418,37 @@ test("resume does not join a partial pixel response to post-resume input", async
   }
 })
 
+test("resume preserves chunked escape input after a suspended pixel prefix", async () => {
+  for (const chunks of [["\x1b[A"], ["\x1b[", "A"]]) {
+    const stdin = createTestStdin()
+    const stdout = createCollectingStdout(8, 4)
+    const renderer = await createCliRenderer({ stdin, stdout })
+    const keypresses: Array<{ name: string; raw: string }> = []
+    renderer.keyInput.on("keypress", (event) => {
+      keypresses.push({ name: event.name, raw: event.raw })
+    })
+
+    try {
+      await flushWritable(stdout)
+      stdin.emit("data", Buffer.from("\x1b"))
+      renderer.suspend()
+      renderer.resume()
+      for (const chunk of chunks) stdin.emit("data", Buffer.from(chunk))
+
+      expect({ chunks, keypresses }).toEqual({
+        chunks,
+        keypresses: [{ name: "up", raw: "\x1b[A" }],
+      })
+
+      stdin.emit("data", Buffer.from("\x1b[4;80;80t"))
+      await renderer.idle()
+      expect(renderer.resolution).toEqual({ width: 80, height: 80 })
+    } finally {
+      renderer.destroy()
+    }
+  }
+})
+
 test("resume separates suspended escape input from a pixel resolution response", async () => {
   for (const timing of ["before-resume", "after-resume", "after-suspended-escape"] as const) {
     const stdin = createTestStdin()

--- a/packages/core/src/tests/renderer.custom-stdout.test.ts
+++ b/packages/core/src/tests/renderer.custom-stdout.test.ts
@@ -348,6 +348,36 @@ test("resume preserves an incomplete pixel resolution response buffered while su
   expect(renderer.resolution).toEqual({ width: 160, height: 80 })
 })
 
+test("resume does not join a pre-suspend escape to post-resume input", async () => {
+  const stdin = createTestStdin()
+  const stdout = createCollectingStdout(8, 4)
+  const renderer = await createCliRenderer({ stdin, stdout })
+  const keypresses: Array<{ name: string; raw: string; meta: boolean }> = []
+  renderer.keyInput.on("keypress", (event) => {
+    keypresses.push({ name: event.name, raw: event.raw, meta: event.meta })
+  })
+  destroyFns.push(() => renderer.destroy())
+
+  await flushWritable(stdout)
+  expect(countPixelResolutionQueries(stdout)).toBe(1)
+  stdout.clearWrites()
+
+  stdin.emit("data", Buffer.from("\x1b"))
+  renderer.suspend()
+  renderer.resume()
+  stdin.emit("data", Buffer.from("a"))
+
+  expect(keypresses).toEqual([{ name: "a", raw: "a", meta: false }])
+  expect(renderer.resolution).toBeNull()
+  await flushWritable(stdout)
+  expect(countPixelResolutionQueries(stdout)).toBe(0)
+
+  stdin.emit("data", Buffer.from("\x1b[4;80;80t"))
+  await renderer.idle()
+  expect(keypresses).toEqual([{ name: "a", raw: "a", meta: false }])
+  expect(renderer.resolution).toEqual({ width: 80, height: 80 })
+})
+
 test("resume separates suspended escape input from a pixel resolution response", async () => {
   for (const timing of ["before-resume", "after-resume", "after-suspended-escape"] as const) {
     const stdin = createTestStdin()

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -2078,6 +2078,19 @@ test("latest outstanding pixel resolution response wins", () => {
   }
 })
 
+test("oversized pixel resolution response is ignored", () => {
+  const originalQuery = currentRenderer.lib.queryPixelResolution
+  currentRenderer.lib.queryPixelResolution = () => {}
+  try {
+    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
+    const huge = "9".repeat(400)
+    currentRenderer.stdin.emit("data", Buffer.from(`\x1b[4;${huge};${huge}t`))
+    expect(currentRenderer.resolution).toBeNull()
+  } finally {
+    currentRenderer.lib.queryPixelResolution = originalQuery
+  }
+})
+
 test("resize while suspended queries pixel resolution after resume", () => {
   const originalQuery = currentRenderer.lib.queryPixelResolution
   let queries = 0

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -2163,6 +2163,28 @@ test("a delayed pre-suspend resolution cannot consume the post-resume query", ()
   }
 })
 
+test("a buffered pre-suspend resolution is discarded without leaving a pending query", () => {
+  const originalQuery = currentRenderer.lib.queryPixelResolution
+  currentRenderer.lib.queryPixelResolution = () => {}
+
+  try {
+    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
+    currentRenderer.suspend()
+    currentRenderer.stdin.push(Buffer.from("\x1b[4;720;"))
+    currentRenderer.stdin.push(Buffer.from("1280t"))
+    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
+    currentRenderer.resume()
+
+    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
+    expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
+
+    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;480;640t"))
+    expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
+  } finally {
+    currentRenderer.lib.queryPixelResolution = originalQuery
+  }
+})
+
 test("terminal setup after destroy is a no-op", async () => {
   const originalQuery = currentRenderer.lib.queryPixelResolution
   let queries = 0

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -2025,9 +2025,9 @@ test("pixel resolution response should not trigger keypress", async () => {
     keypresses.push(event)
   })
 
-  // Mark as waiting for resolution
+  // Mark one query as outstanding.
   // @ts-expect-error - accessing private property for testing
-  currentRenderer.waitingForPixelResolution = true
+  currentRenderer.pendingPixelResolutionQueries = 1
 
   currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;720;1280t"))
   advanceCurrentClock()
@@ -2043,7 +2043,7 @@ test("chunked pixel resolution response", async () => {
   })
 
   // @ts-expect-error - accessing private property for testing
-  currentRenderer.waitingForPixelResolution = true
+  currentRenderer.pendingPixelResolutionQueries = 1
 
   // Send pixel resolution in chunks (arriving quickly)
   currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;72"))
@@ -2054,6 +2054,28 @@ test("chunked pixel resolution response", async () => {
 
   expect(keypresses).toHaveLength(0)
   expect(currentRenderer.resolution).toEqual({ width: 1280, height: 720 })
+})
+
+test("latest outstanding pixel resolution response wins", () => {
+  const originalQuery = currentRenderer.lib.queryPixelResolution
+  let queries = 0
+  currentRenderer.lib.queryPixelResolution = () => {
+    queries++
+  }
+
+  try {
+    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
+    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
+    expect(queries).toBe(2)
+
+    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;720;1280t"))
+    expect(currentRenderer.resolution).toEqual({ width: 1280, height: 720 })
+
+    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
+    expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
+  } finally {
+    currentRenderer.lib.queryPixelResolution = originalQuery
+  }
 })
 
 test("kitty full capability response arriving in realistic chunks", async () => {
@@ -2174,7 +2196,7 @@ test("delayed pixel resolution response stays in response path while query is ac
   })
 
   // @ts-expect-error - accessing private property for testing
-  currentRenderer.waitingForPixelResolution = true
+  currentRenderer.pendingPixelResolutionQueries = 1
   // @ts-expect-error - accessing private helper for test coverage
   currentRenderer.updateStdinParserProtocolContext({ pixelResolutionQueryActive: true })
 

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -2099,6 +2099,27 @@ test("resize while suspended queries pixel resolution after resume", () => {
   }
 })
 
+test("terminal setup while suspended queries pixel resolution after resume", async () => {
+  const originalQuery = currentRenderer.lib.queryPixelResolution
+  let queries = 0
+  currentRenderer.lib.queryPixelResolution = () => {
+    queries++
+  }
+
+  try {
+    currentRenderer.suspend()
+    await currentRenderer.setupTerminal()
+    expect(queries).toBe(0)
+
+    currentRenderer.resume()
+    expect(queries).toBe(1)
+    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
+    expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
+  } finally {
+    currentRenderer.lib.queryPixelResolution = originalQuery
+  }
+})
+
 test("kitty full capability response arriving in realistic chunks", async () => {
   const keypresses: KeyEvent[] = []
   currentRenderer.keyInput.on("keypress", (event) => {

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -2078,6 +2078,27 @@ test("latest outstanding pixel resolution response wins", () => {
   }
 })
 
+test("resize while suspended queries pixel resolution after resume", () => {
+  const originalQuery = currentRenderer.lib.queryPixelResolution
+  let queries = 0
+  currentRenderer.lib.queryPixelResolution = () => {
+    queries++
+  }
+
+  try {
+    currentRenderer.suspend()
+    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
+    expect(queries).toBe(0)
+
+    currentRenderer.resume()
+    expect(queries).toBe(1)
+    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
+    expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
+  } finally {
+    currentRenderer.lib.queryPixelResolution = originalQuery
+  }
+})
+
 test("kitty full capability response arriving in realistic chunks", async () => {
   const keypresses: KeyEvent[] = []
   currentRenderer.keyInput.on("keypress", (event) => {

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -2114,22 +2114,30 @@ test("resize while suspended queries pixel resolution after resume", () => {
 
 test("terminal setup while suspended queries pixel resolution after resume", async () => {
   const originalQuery = currentRenderer.lib.queryPixelResolution
+  const originalSetup = currentRenderer.lib.setupTerminal
   let queries = 0
+  let setups = 0
   currentRenderer.lib.queryPixelResolution = () => {
     queries++
+  }
+  currentRenderer.lib.setupTerminal = () => {
+    setups++
   }
 
   try {
     currentRenderer.suspend()
     await currentRenderer.setupTerminal()
     expect(queries).toBe(0)
+    expect(setups).toBe(0)
 
     currentRenderer.resume()
     expect(queries).toBe(1)
+    expect(setups).toBe(1)
     currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
     expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
   } finally {
     currentRenderer.lib.queryPixelResolution = originalQuery
+    currentRenderer.lib.setupTerminal = originalSetup
   }
 })
 

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -2120,6 +2120,28 @@ test("terminal setup while suspended queries pixel resolution after resume", asy
   }
 })
 
+test("a delayed pre-suspend resolution cannot consume the post-resume query", () => {
+  const originalQuery = currentRenderer.lib.queryPixelResolution
+  let queries = 0
+  currentRenderer.lib.queryPixelResolution = () => {
+    queries++
+  }
+
+  try {
+    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
+    currentRenderer.suspend()
+    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
+    currentRenderer.resume()
+    expect(queries).toBe(2)
+
+    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;720;1280t"))
+    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
+    expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
+  } finally {
+    currentRenderer.lib.queryPixelResolution = originalQuery
+  }
+})
+
 test("terminal setup after destroy is a no-op", async () => {
   const originalQuery = currentRenderer.lib.queryPixelResolution
   let queries = 0

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -97,6 +97,10 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve()
 }
 
+function getCurrentRenderLib(): RenderLib {
+  return (currentRenderer as unknown as { lib: RenderLib }).lib
+}
+
 class MouseTarget extends Renderable {
   constructor(context: RenderContext, options: RenderableOptions) {
     super(context, options)
@@ -2057,9 +2061,10 @@ test("chunked pixel resolution response", async () => {
 })
 
 test("latest outstanding pixel resolution response wins", () => {
-  const originalQuery = currentRenderer.lib.queryPixelResolution
+  const lib = getCurrentRenderLib()
+  const originalQuery = lib.queryPixelResolution
   let queries = 0
-  currentRenderer.lib.queryPixelResolution = () => {
+  lib.queryPixelResolution = () => {
     queries++
   }
 
@@ -2074,27 +2079,29 @@ test("latest outstanding pixel resolution response wins", () => {
     currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
     expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
   } finally {
-    currentRenderer.lib.queryPixelResolution = originalQuery
+    lib.queryPixelResolution = originalQuery
   }
 })
 
 test("oversized pixel resolution response is ignored", () => {
-  const originalQuery = currentRenderer.lib.queryPixelResolution
-  currentRenderer.lib.queryPixelResolution = () => {}
+  const lib = getCurrentRenderLib()
+  const originalQuery = lib.queryPixelResolution
+  lib.queryPixelResolution = () => {}
   try {
     currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
     const huge = "9".repeat(400)
     currentRenderer.stdin.emit("data", Buffer.from(`\x1b[4;${huge};${huge}t`))
     expect(currentRenderer.resolution).toBeNull()
   } finally {
-    currentRenderer.lib.queryPixelResolution = originalQuery
+    lib.queryPixelResolution = originalQuery
   }
 })
 
 test("resize while suspended queries pixel resolution after resume", () => {
-  const originalQuery = currentRenderer.lib.queryPixelResolution
+  const lib = getCurrentRenderLib()
+  const originalQuery = lib.queryPixelResolution
   let queries = 0
-  currentRenderer.lib.queryPixelResolution = () => {
+  lib.queryPixelResolution = () => {
     queries++
   }
 
@@ -2108,19 +2115,20 @@ test("resize while suspended queries pixel resolution after resume", () => {
     currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
     expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
   } finally {
-    currentRenderer.lib.queryPixelResolution = originalQuery
+    lib.queryPixelResolution = originalQuery
   }
 })
 
 test("terminal setup while suspended queries pixel resolution after resume", async () => {
-  const originalQuery = currentRenderer.lib.queryPixelResolution
-  const originalSetup = currentRenderer.lib.setupTerminal
+  const lib = getCurrentRenderLib()
+  const originalQuery = lib.queryPixelResolution
+  const originalSetup = lib.setupTerminal
   let queries = 0
   let setups = 0
-  currentRenderer.lib.queryPixelResolution = () => {
+  lib.queryPixelResolution = () => {
     queries++
   }
-  currentRenderer.lib.setupTerminal = () => {
+  lib.setupTerminal = () => {
     setups++
   }
 
@@ -2136,15 +2144,16 @@ test("terminal setup while suspended queries pixel resolution after resume", asy
     currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
     expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
   } finally {
-    currentRenderer.lib.queryPixelResolution = originalQuery
-    currentRenderer.lib.setupTerminal = originalSetup
+    lib.queryPixelResolution = originalQuery
+    lib.setupTerminal = originalSetup
   }
 })
 
 test("a delayed pre-suspend resolution cannot consume the post-resume query", () => {
-  const originalQuery = currentRenderer.lib.queryPixelResolution
+  const lib = getCurrentRenderLib()
+  const originalQuery = lib.queryPixelResolution
   let queries = 0
-  currentRenderer.lib.queryPixelResolution = () => {
+  lib.queryPixelResolution = () => {
     queries++
   }
 
@@ -2159,13 +2168,14 @@ test("a delayed pre-suspend resolution cannot consume the post-resume query", ()
     currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
     expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
   } finally {
-    currentRenderer.lib.queryPixelResolution = originalQuery
+    lib.queryPixelResolution = originalQuery
   }
 })
 
 test("a buffered pre-suspend resolution is discarded without leaving a pending query", () => {
-  const originalQuery = currentRenderer.lib.queryPixelResolution
-  currentRenderer.lib.queryPixelResolution = () => {}
+  const lib = getCurrentRenderLib()
+  const originalQuery = lib.queryPixelResolution
+  lib.queryPixelResolution = () => {}
 
   try {
     currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
@@ -2181,14 +2191,15 @@ test("a buffered pre-suspend resolution is discarded without leaving a pending q
     currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;480;640t"))
     expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
   } finally {
-    currentRenderer.lib.queryPixelResolution = originalQuery
+    lib.queryPixelResolution = originalQuery
   }
 })
 
 test("terminal setup after destroy is a no-op", async () => {
-  const originalQuery = currentRenderer.lib.queryPixelResolution
+  const lib = getCurrentRenderLib()
+  const originalQuery = lib.queryPixelResolution
   let queries = 0
-  currentRenderer.lib.queryPixelResolution = () => {
+  lib.queryPixelResolution = () => {
     queries++
   }
 
@@ -2197,7 +2208,7 @@ test("terminal setup after destroy is a no-op", async () => {
     await currentRenderer.setupTerminal()
     expect(queries).toBe(0)
   } finally {
-    currentRenderer.lib.queryPixelResolution = originalQuery
+    lib.queryPixelResolution = originalQuery
   }
 })
 

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -97,10 +97,6 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve()
 }
 
-function getCurrentRenderLib(): RenderLib {
-  return (currentRenderer as unknown as { lib: RenderLib }).lib
-}
-
 class MouseTarget extends Renderable {
   constructor(context: RenderContext, options: RenderableOptions) {
     super(context, options)
@@ -2029,9 +2025,9 @@ test("pixel resolution response should not trigger keypress", async () => {
     keypresses.push(event)
   })
 
-  // Mark one query as outstanding.
+  // Mark as waiting for resolution
   // @ts-expect-error - accessing private property for testing
-  currentRenderer.pendingPixelResolutionQueries = 1
+  currentRenderer.waitingForPixelResolution = true
 
   currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;720;1280t"))
   advanceCurrentClock()
@@ -2047,7 +2043,7 @@ test("chunked pixel resolution response", async () => {
   })
 
   // @ts-expect-error - accessing private property for testing
-  currentRenderer.pendingPixelResolutionQueries = 1
+  currentRenderer.waitingForPixelResolution = true
 
   // Send pixel resolution in chunks (arriving quickly)
   currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;72"))
@@ -2058,158 +2054,6 @@ test("chunked pixel resolution response", async () => {
 
   expect(keypresses).toHaveLength(0)
   expect(currentRenderer.resolution).toEqual({ width: 1280, height: 720 })
-})
-
-test("latest outstanding pixel resolution response wins", () => {
-  const lib = getCurrentRenderLib()
-  const originalQuery = lib.queryPixelResolution
-  let queries = 0
-  lib.queryPixelResolution = () => {
-    queries++
-  }
-
-  try {
-    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
-    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
-    expect(queries).toBe(2)
-
-    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;720;1280t"))
-    expect(currentRenderer.resolution).toEqual({ width: 1280, height: 720 })
-
-    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
-    expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
-  } finally {
-    lib.queryPixelResolution = originalQuery
-  }
-})
-
-test("oversized pixel resolution response is ignored", () => {
-  const lib = getCurrentRenderLib()
-  const originalQuery = lib.queryPixelResolution
-  lib.queryPixelResolution = () => {}
-  try {
-    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
-    const huge = "9".repeat(400)
-    currentRenderer.stdin.emit("data", Buffer.from(`\x1b[4;${huge};${huge}t`))
-    expect(currentRenderer.resolution).toBeNull()
-  } finally {
-    lib.queryPixelResolution = originalQuery
-  }
-})
-
-test("resize while suspended queries pixel resolution after resume", () => {
-  const lib = getCurrentRenderLib()
-  const originalQuery = lib.queryPixelResolution
-  let queries = 0
-  lib.queryPixelResolution = () => {
-    queries++
-  }
-
-  try {
-    currentRenderer.suspend()
-    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
-    expect(queries).toBe(0)
-
-    currentRenderer.resume()
-    expect(queries).toBe(1)
-    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
-    expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
-  } finally {
-    lib.queryPixelResolution = originalQuery
-  }
-})
-
-test("terminal setup while suspended queries pixel resolution after resume", async () => {
-  const lib = getCurrentRenderLib()
-  const originalQuery = lib.queryPixelResolution
-  const originalSetup = lib.setupTerminal
-  let queries = 0
-  let setups = 0
-  lib.queryPixelResolution = () => {
-    queries++
-  }
-  lib.setupTerminal = () => {
-    setups++
-  }
-
-  try {
-    currentRenderer.suspend()
-    await currentRenderer.setupTerminal()
-    expect(queries).toBe(0)
-    expect(setups).toBe(0)
-
-    currentRenderer.resume()
-    expect(queries).toBe(1)
-    expect(setups).toBe(1)
-    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
-    expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
-  } finally {
-    lib.queryPixelResolution = originalQuery
-    lib.setupTerminal = originalSetup
-  }
-})
-
-test("a delayed pre-suspend resolution cannot consume the post-resume query", () => {
-  const lib = getCurrentRenderLib()
-  const originalQuery = lib.queryPixelResolution
-  let queries = 0
-  lib.queryPixelResolution = () => {
-    queries++
-  }
-
-  try {
-    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
-    currentRenderer.suspend()
-    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
-    currentRenderer.resume()
-    expect(queries).toBe(2)
-
-    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;720;1280t"))
-    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
-    expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
-  } finally {
-    lib.queryPixelResolution = originalQuery
-  }
-})
-
-test("a buffered pre-suspend resolution is discarded without leaving a pending query", () => {
-  const lib = getCurrentRenderLib()
-  const originalQuery = lib.queryPixelResolution
-  lib.queryPixelResolution = () => {}
-
-  try {
-    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
-    currentRenderer.suspend()
-    currentRenderer.stdin.push(Buffer.from("\x1b[4;720;"))
-    currentRenderer.stdin.push(Buffer.from("1280t"))
-    currentRenderer.resize(currentRenderer.width + 1, currentRenderer.height)
-    currentRenderer.resume()
-
-    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;1080;1920t"))
-    expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
-
-    currentRenderer.stdin.emit("data", Buffer.from("\x1b[4;480;640t"))
-    expect(currentRenderer.resolution).toEqual({ width: 1920, height: 1080 })
-  } finally {
-    lib.queryPixelResolution = originalQuery
-  }
-})
-
-test("terminal setup after destroy is a no-op", async () => {
-  const lib = getCurrentRenderLib()
-  const originalQuery = lib.queryPixelResolution
-  let queries = 0
-  lib.queryPixelResolution = () => {
-    queries++
-  }
-
-  try {
-    currentRenderer.destroy()
-    await currentRenderer.setupTerminal()
-    expect(queries).toBe(0)
-  } finally {
-    lib.queryPixelResolution = originalQuery
-  }
 })
 
 test("kitty full capability response arriving in realistic chunks", async () => {
@@ -2330,7 +2174,7 @@ test("delayed pixel resolution response stays in response path while query is ac
   })
 
   // @ts-expect-error - accessing private property for testing
-  currentRenderer.pendingPixelResolutionQueries = 1
+  currentRenderer.waitingForPixelResolution = true
   // @ts-expect-error - accessing private helper for test coverage
   currentRenderer.updateStdinParserProtocolContext({ pixelResolutionQueryActive: true })
 

--- a/packages/core/src/tests/renderer.input.test.ts
+++ b/packages/core/src/tests/renderer.input.test.ts
@@ -2120,6 +2120,22 @@ test("terminal setup while suspended queries pixel resolution after resume", asy
   }
 })
 
+test("terminal setup after destroy is a no-op", async () => {
+  const originalQuery = currentRenderer.lib.queryPixelResolution
+  let queries = 0
+  currentRenderer.lib.queryPixelResolution = () => {
+    queries++
+  }
+
+  try {
+    currentRenderer.destroy()
+    await currentRenderer.setupTerminal()
+    expect(queries).toBe(0)
+  } finally {
+    currentRenderer.lib.queryPixelResolution = originalQuery
+  }
+})
+
 test("kitty full capability response arriving in realistic chunks", async () => {
   const keypresses: KeyEvent[] = []
   currentRenderer.keyInput.on("keypress", (event) => {


### PR DESCRIPTION
## Summary

- keep at most one terminal pixel-resolution query in flight and coalesce resize or suspended refreshes into one follow-up query
- preserve complete and partial pixel-resolution replies across suspend/resume without leaking suspended protocol prefixes into later input
- preserve post-resume input across chunk boundaries and discard retained prefixes when the query is cancelled
- reject unsafe or signed-32-bit-overflowing pixel dimensions before they reach renderer geometry
- keep the implementation and causal regression coverage independent from native image support

Extracted from the final implementation in #1283, with additional regressions proven and fixed during standalone review.

## Verification

- focused parser and renderer tests: 605 passed
- core Bun tests: 5,221 passed, 23 skipped
- Node 26.4 source tests: 4,527 passed, 6 skipped
- library build, formatting, and lint pass