### PR TITLE
feat(core): add Ghostty terminal runtime

### DIFF
--- a/packages/core/src/zig/build.zig
+++ b/packages/core/src/zig/build.zig
@@ -76,6 +76,14 @@ fn nativeExecutableTarget(b: *std.Build) std.Build.ResolvedTarget {
     return b.resolveTargetQuery(query);
 }
 
+fn nativeTestTarget(b: *std.Build, use_host_libc: bool) std.Build.ResolvedTarget {
+    if (builtin.os.tag != .linux or !use_host_libc) return nativeExecutableTarget(b);
+    var query = b.graph.host.query;
+    query.abi = .gnu;
+    query.glibc_version = .{ .major = 2, .minor = 17, .patch = 0 };
+    return b.resolveTargetQuery(query);
+}
+
 fn pathExists(path: []const u8) bool {
     if (path.len == 0) return false;
     std.fs.cwd().access(path, .{}) catch return false;
@@ -276,6 +284,7 @@ pub fn build(b: *std.Build) void {
     const target_option = b.option([]const u8, "target", "Build for specific target (e.g., 'x86_64-linux-gnu.2.17').");
     const build_all = b.option(bool, "all", "Build for all supported targets") orelse false;
     const gpa_safe_stats = b.option(bool, "gpa-safe-stats", "Enable GPA safety checks for trustworthy allocator stats") orelse false;
+    const test_host_libc = b.option(bool, "test-host-libc", "Use the host libc for native tests that require dlopen") orelse false;
     const macos_sdk_path = resolveMacOSSDKPath(b);
     const build_options = b.addOptions();
     build_options.addOption(bool, "gpa_safe_stats", gpa_safe_stats);
@@ -302,7 +311,7 @@ pub fn build(b: *std.Build) void {
 
     // Test step (native only)
     const test_step = b.step("test", "Run unit tests");
-    const native_target = nativeExecutableTarget(b);
+    const native_target = nativeTestTarget(b, test_host_libc);
     const test_mod = b.createModule(.{
         .root_source_file = b.path("test.zig"),
         .target = native_target,

--- a/packages/core/src/zig/embedded-terminal/ghostty.zig
+++ b/packages/core/src/zig/embedded-terminal/ghostty.zig
@@ -1,0 +1,253 @@
+const std = @import("std");
+
+pub const Error = error{
+    LibraryNotFound,
+    MissingSymbol,
+    OutOfMemory,
+    InvalidValue,
+    OutOfSpace,
+    NoValue,
+};
+
+pub const Result = enum(c_int) {
+    success = 0,
+    out_of_memory = -1,
+    invalid_value = -2,
+    out_of_space = -3,
+    no_value = -4,
+    _,
+};
+
+pub const Handle = ?*anyopaque;
+
+pub const TerminalOptions = extern struct {
+    cols: u16,
+    rows: u16,
+    max_scrollback: usize,
+};
+
+pub const TerminalOption = enum(c_int) {
+    userdata = 0,
+    write_pty = 1,
+    _,
+};
+
+pub const KeyAction = enum(c_int) {
+    release = 0,
+    press = 1,
+    repeat = 2,
+    _,
+};
+
+pub const MouseAction = enum(c_int) {
+    press = 0,
+    release = 1,
+    motion = 2,
+    _,
+};
+
+pub const MouseButton = enum(c_int) {
+    unknown = 0,
+    left = 1,
+    right = 2,
+    middle = 3,
+    four = 4,
+    five = 5,
+    six = 6,
+    seven = 7,
+    _,
+};
+
+pub const MousePosition = extern struct {
+    x: f32,
+    y: f32,
+};
+
+pub const MouseEncoderOption = enum(c_int) {
+    event = 0,
+    format = 1,
+    size = 2,
+    any_button_pressed = 3,
+    track_last_cell = 4,
+    _,
+};
+
+pub const MouseEncoderSize = extern struct {
+    size: usize = @sizeOf(MouseEncoderSize),
+    screen_width: u32,
+    screen_height: u32,
+    cell_width: u32 = 1,
+    cell_height: u32 = 1,
+    padding_top: u32 = 0,
+    padding_bottom: u32 = 0,
+    padding_right: u32 = 0,
+    padding_left: u32 = 0,
+};
+
+pub const ScrollViewportTag = enum(c_int) {
+    top = 0,
+    bottom = 1,
+    delta = 2,
+    row = 3,
+    _,
+};
+
+pub const ScrollViewportValue = extern union {
+    delta: isize,
+    row: usize,
+    _padding: [2]u64,
+};
+
+pub const ScrollViewport = extern struct {
+    tag: ScrollViewportTag,
+    value: ScrollViewportValue,
+};
+
+const TerminalNew = *const fn (?*const anyopaque, *Handle, TerminalOptions) callconv(.c) Result;
+const TerminalFree = *const fn (Handle) callconv(.c) void;
+const TerminalWrite = *const fn (Handle, ?[*]const u8, usize) callconv(.c) void;
+const TerminalResize = *const fn (Handle, u16, u16, u32, u32) callconv(.c) Result;
+const TerminalSet = *const fn (Handle, TerminalOption, ?*const anyopaque) callconv(.c) Result;
+const TerminalModeGet = *const fn (Handle, u16, *bool) callconv(.c) Result;
+const TerminalScrollViewport = *const fn (Handle, ScrollViewport) callconv(.c) void;
+const KeyEventNew = *const fn (?*const anyopaque, *Handle) callconv(.c) Result;
+const KeyEventFree = *const fn (Handle) callconv(.c) void;
+const KeyEventSetAction = *const fn (Handle, KeyAction) callconv(.c) void;
+const KeyEventSetKey = *const fn (Handle, c_int) callconv(.c) void;
+const KeyEventSetMods = *const fn (Handle, u16) callconv(.c) void;
+const KeyEventSetConsumedMods = *const fn (Handle, u16) callconv(.c) void;
+const KeyEventSetComposing = *const fn (Handle, bool) callconv(.c) void;
+const KeyEventSetUtf8 = *const fn (Handle, ?[*]const u8, usize) callconv(.c) void;
+const KeyEventSetUnshiftedCodepoint = *const fn (Handle, u32) callconv(.c) void;
+const KeyEncoderNew = *const fn (?*const anyopaque, *Handle) callconv(.c) Result;
+const KeyEncoderFree = *const fn (Handle) callconv(.c) void;
+const KeyEncoderFromTerminal = *const fn (Handle, Handle) callconv(.c) void;
+const KeyEncoderEncode = *const fn (Handle, Handle, ?[*]u8, usize, *usize) callconv(.c) Result;
+const MouseEventNew = *const fn (?*const anyopaque, *Handle) callconv(.c) Result;
+const MouseEventFree = *const fn (Handle) callconv(.c) void;
+const MouseEventSetAction = *const fn (Handle, MouseAction) callconv(.c) void;
+const MouseEventSetButton = *const fn (Handle, MouseButton) callconv(.c) void;
+const MouseEventClearButton = *const fn (Handle) callconv(.c) void;
+const MouseEventSetMods = *const fn (Handle, u16) callconv(.c) void;
+const MouseEventSetPosition = *const fn (Handle, MousePosition) callconv(.c) void;
+const MouseEncoderNew = *const fn (?*const anyopaque, *Handle) callconv(.c) Result;
+const MouseEncoderFree = *const fn (Handle) callconv(.c) void;
+const MouseEncoderSetopt = *const fn (Handle, MouseEncoderOption, *const anyopaque) callconv(.c) void;
+const MouseEncoderFromTerminal = *const fn (Handle, Handle) callconv(.c) void;
+const MouseEncoderEncode = *const fn (Handle, Handle, ?[*]u8, usize, *usize) callconv(.c) Result;
+const PasteEncode = *const fn (?[*]u8, usize, bool, ?[*]u8, usize, *usize) callconv(.c) Result;
+const FocusEncode = *const fn (c_int, ?[*]u8, usize, *usize) callconv(.c) Result;
+
+pub const Api = struct {
+    library: std.DynLib,
+    terminal_new: TerminalNew,
+    terminal_free: TerminalFree,
+    terminal_write: TerminalWrite,
+    terminal_resize: TerminalResize,
+    terminal_set: TerminalSet,
+    terminal_mode_get: TerminalModeGet,
+    terminal_scroll_viewport: TerminalScrollViewport,
+    key_event_new: KeyEventNew,
+    key_event_free: KeyEventFree,
+    key_event_set_action: KeyEventSetAction,
+    key_event_set_key: KeyEventSetKey,
+    key_event_set_mods: KeyEventSetMods,
+    key_event_set_consumed_mods: KeyEventSetConsumedMods,
+    key_event_set_composing: KeyEventSetComposing,
+    key_event_set_utf8: KeyEventSetUtf8,
+    key_event_set_unshifted_codepoint: KeyEventSetUnshiftedCodepoint,
+    key_encoder_new: KeyEncoderNew,
+    key_encoder_free: KeyEncoderFree,
+    key_encoder_from_terminal: KeyEncoderFromTerminal,
+    key_encoder_encode: KeyEncoderEncode,
+    mouse_event_new: MouseEventNew,
+    mouse_event_free: MouseEventFree,
+    mouse_event_set_action: MouseEventSetAction,
+    mouse_event_set_button: MouseEventSetButton,
+    mouse_event_clear_button: MouseEventClearButton,
+    mouse_event_set_mods: MouseEventSetMods,
+    mouse_event_set_position: MouseEventSetPosition,
+    mouse_encoder_new: MouseEncoderNew,
+    mouse_encoder_free: MouseEncoderFree,
+    mouse_encoder_setopt: MouseEncoderSetopt,
+    mouse_encoder_from_terminal: MouseEncoderFromTerminal,
+    mouse_encoder_encode: MouseEncoderEncode,
+    paste_encode: PasteEncode,
+    focus_encode: FocusEncode,
+
+    pub fn load(allocator: std.mem.Allocator, explicit_path: ?[]const u8) Error!Api {
+        if (explicit_path) |path| return loadPath(path);
+
+        if (std.process.getEnvVarOwned(allocator, "OPENTUI_GHOSTTY_VT_LIBRARY")) |path| {
+            defer allocator.free(path);
+            return loadPath(path);
+        } else |err| switch (err) {
+            error.EnvironmentVariableNotFound => {},
+            else => return error.OutOfMemory,
+        }
+
+        return error.LibraryNotFound;
+    }
+
+    fn loadPath(path: []const u8) Error!Api {
+        var library = std.DynLib.open(path) catch return error.LibraryNotFound;
+        errdefer library.close();
+        return .{
+            .library = library,
+            .terminal_new = lookup(&library, TerminalNew, "ghostty_terminal_new") orelse return error.MissingSymbol,
+            .terminal_free = lookup(&library, TerminalFree, "ghostty_terminal_free") orelse return error.MissingSymbol,
+            .terminal_write = lookup(&library, TerminalWrite, "ghostty_terminal_vt_write") orelse return error.MissingSymbol,
+            .terminal_resize = lookup(&library, TerminalResize, "ghostty_terminal_resize") orelse return error.MissingSymbol,
+            .terminal_set = lookup(&library, TerminalSet, "ghostty_terminal_set") orelse return error.MissingSymbol,
+            .terminal_mode_get = lookup(&library, TerminalModeGet, "ghostty_terminal_mode_get") orelse return error.MissingSymbol,
+            .terminal_scroll_viewport = lookup(&library, TerminalScrollViewport, "ghostty_terminal_scroll_viewport") orelse return error.MissingSymbol,
+            .key_event_new = lookup(&library, KeyEventNew, "ghostty_key_event_new") orelse return error.MissingSymbol,
+            .key_event_free = lookup(&library, KeyEventFree, "ghostty_key_event_free") orelse return error.MissingSymbol,
+            .key_event_set_action = lookup(&library, KeyEventSetAction, "ghostty_key_event_set_action") orelse return error.MissingSymbol,
+            .key_event_set_key = lookup(&library, KeyEventSetKey, "ghostty_key_event_set_key") orelse return error.MissingSymbol,
+            .key_event_set_mods = lookup(&library, KeyEventSetMods, "ghostty_key_event_set_mods") orelse return error.MissingSymbol,
+            .key_event_set_consumed_mods = lookup(&library, KeyEventSetConsumedMods, "ghostty_key_event_set_consumed_mods") orelse return error.MissingSymbol,
+            .key_event_set_composing = lookup(&library, KeyEventSetComposing, "ghostty_key_event_set_composing") orelse return error.MissingSymbol,
+            .key_event_set_utf8 = lookup(&library, KeyEventSetUtf8, "ghostty_key_event_set_utf8") orelse return error.MissingSymbol,
+            .key_event_set_unshifted_codepoint = lookup(&library, KeyEventSetUnshiftedCodepoint, "ghostty_key_event_set_unshifted_codepoint") orelse return error.MissingSymbol,
+            .key_encoder_new = lookup(&library, KeyEncoderNew, "ghostty_key_encoder_new") orelse return error.MissingSymbol,
+            .key_encoder_free = lookup(&library, KeyEncoderFree, "ghostty_key_encoder_free") orelse return error.MissingSymbol,
+            .key_encoder_from_terminal = lookup(&library, KeyEncoderFromTerminal, "ghostty_key_encoder_setopt_from_terminal") orelse return error.MissingSymbol,
+            .key_encoder_encode = lookup(&library, KeyEncoderEncode, "ghostty_key_encoder_encode") orelse return error.MissingSymbol,
+            .mouse_event_new = lookup(&library, MouseEventNew, "ghostty_mouse_event_new") orelse return error.MissingSymbol,
+            .mouse_event_free = lookup(&library, MouseEventFree, "ghostty_mouse_event_free") orelse return error.MissingSymbol,
+            .mouse_event_set_action = lookup(&library, MouseEventSetAction, "ghostty_mouse_event_set_action") orelse return error.MissingSymbol,
+            .mouse_event_set_button = lookup(&library, MouseEventSetButton, "ghostty_mouse_event_set_button") orelse return error.MissingSymbol,
+            .mouse_event_clear_button = lookup(&library, MouseEventClearButton, "ghostty_mouse_event_clear_button") orelse return error.MissingSymbol,
+            .mouse_event_set_mods = lookup(&library, MouseEventSetMods, "ghostty_mouse_event_set_mods") orelse return error.MissingSymbol,
+            .mouse_event_set_position = lookup(&library, MouseEventSetPosition, "ghostty_mouse_event_set_position") orelse return error.MissingSymbol,
+            .mouse_encoder_new = lookup(&library, MouseEncoderNew, "ghostty_mouse_encoder_new") orelse return error.MissingSymbol,
+            .mouse_encoder_free = lookup(&library, MouseEncoderFree, "ghostty_mouse_encoder_free") orelse return error.MissingSymbol,
+            .mouse_encoder_setopt = lookup(&library, MouseEncoderSetopt, "ghostty_mouse_encoder_setopt") orelse return error.MissingSymbol,
+            .mouse_encoder_from_terminal = lookup(&library, MouseEncoderFromTerminal, "ghostty_mouse_encoder_setopt_from_terminal") orelse return error.MissingSymbol,
+            .mouse_encoder_encode = lookup(&library, MouseEncoderEncode, "ghostty_mouse_encoder_encode") orelse return error.MissingSymbol,
+            .paste_encode = lookup(&library, PasteEncode, "ghostty_paste_encode") orelse return error.MissingSymbol,
+            .focus_encode = lookup(&library, FocusEncode, "ghostty_focus_encode") orelse return error.MissingSymbol,
+        };
+    }
+
+    pub fn deinit(self: *Api) void {
+        self.library.close();
+        self.* = undefined;
+    }
+};
+
+fn lookup(library: *std.DynLib, comptime T: type, name: [:0]const u8) ?T {
+    return library.lookup(T, name);
+}
+
+pub fn result(value: Result) Error!void {
+    return switch (value) {
+        .success => {},
+        .out_of_memory => error.OutOfMemory,
+        .invalid_value => error.InvalidValue,
+        .out_of_space => error.OutOfSpace,
+        .no_value => error.NoValue,
+        else => error.InvalidValue,
+    };
+}

--- a/packages/core/src/zig/embedded-terminal/main.zig
+++ b/packages/core/src/zig/embedded-terminal/main.zig
@@ -1,0 +1,209 @@
+const std = @import("std");
+const ghostty = @import("ghostty.zig");
+
+pub const Error = ghostty.Error;
+pub const KeyAction = ghostty.KeyAction;
+pub const MouseAction = ghostty.MouseAction;
+pub const MouseButton = ghostty.MouseButton;
+
+pub const Key = struct {
+    action: ghostty.KeyAction = .press,
+    key: c_int = 0,
+    mods: u16 = 0,
+    consumed_mods: u16 = 0,
+    composing: bool = false,
+    utf8: []const u8 = "",
+    unshifted_codepoint: u32 = 0,
+};
+
+pub const Mouse = struct {
+    action: ghostty.MouseAction,
+    button: ?ghostty.MouseButton = null,
+    mods: u16 = 0,
+    x: f32,
+    y: f32,
+    any_button_pressed: bool = false,
+};
+
+pub const Options = struct {
+    cols: u16,
+    rows: u16,
+    max_scrollback: usize = 10_000,
+    library_path: ?[]const u8 = null,
+};
+
+pub const EmbeddedTerminal = struct {
+    allocator: std.mem.Allocator,
+    api: ghostty.Api,
+    terminal: ghostty.Handle,
+    key_encoder: ghostty.Handle,
+    key_event: ghostty.Handle,
+    mouse_encoder: ghostty.Handle,
+    mouse_event: ghostty.Handle,
+    cols: u16,
+    rows: u16,
+    responses: std.ArrayListUnmanaged(u8),
+    response_error: bool,
+
+    pub fn init(allocator: std.mem.Allocator, options: Options) Error!*EmbeddedTerminal {
+        if (options.cols == 0 or options.rows == 0) return error.InvalidValue;
+
+        const self = allocator.create(EmbeddedTerminal) catch return error.OutOfMemory;
+        errdefer allocator.destroy(self);
+        self.* = .{
+            .allocator = allocator,
+            .api = try .load(allocator, options.library_path),
+            .terminal = null,
+            .key_encoder = null,
+            .key_event = null,
+            .mouse_encoder = null,
+            .mouse_event = null,
+            .cols = options.cols,
+            .rows = options.rows,
+            .responses = .empty,
+            .response_error = false,
+        };
+        errdefer self.api.deinit();
+
+        try ghostty.result(self.api.terminal_new(null, &self.terminal, .{
+            .cols = options.cols,
+            .rows = options.rows,
+            .max_scrollback = options.max_scrollback,
+        }));
+        errdefer self.api.terminal_free(self.terminal);
+        try ghostty.result(self.api.key_encoder_new(null, &self.key_encoder));
+        errdefer self.api.key_encoder_free(self.key_encoder);
+        try ghostty.result(self.api.key_event_new(null, &self.key_event));
+        errdefer self.api.key_event_free(self.key_event);
+        try ghostty.result(self.api.mouse_encoder_new(null, &self.mouse_encoder));
+        errdefer self.api.mouse_encoder_free(self.mouse_encoder);
+        try ghostty.result(self.api.mouse_event_new(null, &self.mouse_event));
+        errdefer self.api.mouse_event_free(self.mouse_event);
+        try ghostty.result(self.api.terminal_set(self.terminal, .userdata, self));
+        try ghostty.result(self.api.terminal_set(self.terminal, .write_pty, @ptrCast(&writePty)));
+        return self;
+    }
+
+    pub fn deinit(self: *EmbeddedTerminal) void {
+        const allocator = self.allocator;
+        self.api.mouse_event_free(self.mouse_event);
+        self.api.mouse_encoder_free(self.mouse_encoder);
+        self.api.key_event_free(self.key_event);
+        self.api.key_encoder_free(self.key_encoder);
+        self.api.terminal_free(self.terminal);
+        self.api.deinit();
+        self.responses.deinit(allocator);
+        allocator.destroy(self);
+    }
+
+    pub fn write(self: *EmbeddedTerminal, bytes: []const u8) void {
+        self.api.terminal_write(self.terminal, if (bytes.len == 0) null else bytes.ptr, bytes.len);
+    }
+
+    pub fn resize(self: *EmbeddedTerminal, cols: u16, rows: u16) Error!void {
+        if (cols == 0 or rows == 0) return error.InvalidValue;
+        try ghostty.result(self.api.terminal_resize(self.terminal, cols, rows, 0, 0));
+        self.cols = cols;
+        self.rows = rows;
+    }
+
+    pub fn scroll(self: *EmbeddedTerminal, delta: i32) void {
+        self.api.terminal_scroll_viewport(self.terminal, .{
+            .tag = .delta,
+            .value = .{ .delta = delta },
+        });
+    }
+
+    pub fn encodeKey(self: *EmbeddedTerminal, key: Key, output: []u8) Error!usize {
+        self.api.key_encoder_from_terminal(self.key_encoder, self.terminal);
+        self.api.key_event_set_action(self.key_event, key.action);
+        self.api.key_event_set_key(self.key_event, key.key);
+        self.api.key_event_set_mods(self.key_event, key.mods);
+        self.api.key_event_set_consumed_mods(self.key_event, key.consumed_mods);
+        self.api.key_event_set_composing(self.key_event, key.composing);
+        self.api.key_event_set_utf8(self.key_event, if (key.utf8.len == 0) null else key.utf8.ptr, key.utf8.len);
+        self.api.key_event_set_unshifted_codepoint(self.key_event, key.unshifted_codepoint);
+        return encode(self.api.key_encoder_encode, self.key_encoder, self.key_event, output);
+    }
+
+    pub fn encodeMouse(self: *EmbeddedTerminal, mouse: Mouse, output: []u8) Error!usize {
+        self.api.mouse_encoder_from_terminal(self.mouse_encoder, self.terminal);
+        const size: ghostty.MouseEncoderSize = .{
+            .screen_width = self.cols,
+            .screen_height = self.rows,
+        };
+        const track_last_cell = true;
+        self.api.mouse_encoder_setopt(self.mouse_encoder, .size, @ptrCast(&size));
+        self.api.mouse_encoder_setopt(self.mouse_encoder, .any_button_pressed, @ptrCast(&mouse.any_button_pressed));
+        self.api.mouse_encoder_setopt(self.mouse_encoder, .track_last_cell, @ptrCast(&track_last_cell));
+        self.api.mouse_event_set_action(self.mouse_event, mouse.action);
+        if (mouse.button) |button| self.api.mouse_event_set_button(self.mouse_event, button) else self.api.mouse_event_clear_button(self.mouse_event);
+        self.api.mouse_event_set_mods(self.mouse_event, mouse.mods);
+        self.api.mouse_event_set_position(self.mouse_event, .{ .x = mouse.x, .y = mouse.y });
+        return encode(self.api.mouse_encoder_encode, self.mouse_encoder, self.mouse_event, output);
+    }
+
+    pub fn encodePaste(self: *EmbeddedTerminal, input: []const u8, output: []u8) Error!usize {
+        const copy = self.allocator.dupe(u8, input) catch return error.OutOfMemory;
+        defer self.allocator.free(copy);
+        var bracketed = false;
+        try ghostty.result(self.api.terminal_mode_get(self.terminal, 2004, &bracketed));
+        var written: usize = 0;
+        try ghostty.result(self.api.paste_encode(
+            if (copy.len == 0) null else copy.ptr,
+            copy.len,
+            bracketed,
+            if (output.len == 0) null else output.ptr,
+            output.len,
+            &written,
+        ));
+        return written;
+    }
+
+    pub fn encodeFocus(self: *EmbeddedTerminal, focused: bool, output: []u8) Error!usize {
+        var enabled = false;
+        try ghostty.result(self.api.terminal_mode_get(self.terminal, 1004, &enabled));
+        if (!enabled) return 0;
+        var written: usize = 0;
+        try ghostty.result(self.api.focus_encode(
+            if (focused) 0 else 1,
+            if (output.len == 0) null else output.ptr,
+            output.len,
+            &written,
+        ));
+        return written;
+    }
+
+    pub fn drainResponses(self: *EmbeddedTerminal, output: []u8) Error!usize {
+        if (self.response_error) return error.OutOfMemory;
+        const count = @min(output.len, self.responses.items.len);
+        @memcpy(output[0..count], self.responses.items[0..count]);
+        std.mem.copyForwards(u8, self.responses.items[0 .. self.responses.items.len - count], self.responses.items[count..]);
+        self.responses.items.len -= count;
+        return count;
+    }
+
+    fn writePty(_: ghostty.Handle, userdata: ?*anyopaque, data: [*]const u8, len: usize) callconv(.c) void {
+        const self: *EmbeddedTerminal = @ptrCast(@alignCast(userdata orelse return));
+        self.responses.appendSlice(self.allocator, data[0..len]) catch {
+            self.response_error = true;
+        };
+    }
+};
+
+fn encode(
+    function: anytype,
+    encoder: ghostty.Handle,
+    event: ghostty.Handle,
+    output: []u8,
+) Error!usize {
+    var written: usize = 0;
+    try ghostty.result(function(
+        encoder,
+        event,
+        if (output.len == 0) null else output.ptr,
+        output.len,
+        &written,
+    ));
+    return written;
+}

--- a/packages/core/src/zig/embedded-terminal/tests.zig
+++ b/packages/core/src/zig/embedded-terminal/tests.zig
@@ -1,0 +1,85 @@
+const std = @import("std");
+const EmbeddedTerminal = @import("main.zig").EmbeddedTerminal;
+
+fn libraryPath() ![]u8 {
+    return std.process.getEnvVarOwned(std.testing.allocator, "OPENTUI_GHOSTTY_VT_LIBRARY") catch
+        return error.SkipZigTest;
+}
+
+test "embedded terminal reports a missing runtime library" {
+    try std.testing.expectError(
+        error.LibraryNotFound,
+        EmbeddedTerminal.init(std.testing.allocator, .{
+            .cols = 80,
+            .rows = 24,
+            .library_path = "/path/that/does/not/exist/libghostty-vt.so",
+        }),
+    );
+}
+
+test "embedded terminal supports lifecycle, resize, and viewport scroll" {
+    const path = try libraryPath();
+    defer std.testing.allocator.free(path);
+
+    try std.testing.expectError(
+        error.InvalidValue,
+        EmbeddedTerminal.init(std.testing.allocator, .{
+            .cols = 0,
+            .rows = 24,
+            .library_path = path,
+        }),
+    );
+
+    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{
+        .cols = 80,
+        .rows = 24,
+        .library_path = path,
+    });
+    defer terminal.deinit();
+
+    terminal.write("hello");
+    try terminal.resize(100, 40);
+    terminal.scroll(-3);
+    terminal.scroll(3);
+    try std.testing.expectError(error.InvalidValue, terminal.resize(0, 40));
+    try std.testing.expectError(error.InvalidValue, terminal.resize(100, 0));
+}
+
+test "embedded terminal provides mode-aware input encoders and responses" {
+    const path = try libraryPath();
+    defer std.testing.allocator.free(path);
+
+    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{
+        .cols = 20,
+        .rows = 4,
+        .library_path = path,
+    });
+    defer terminal.deinit();
+
+    terminal.write("\x1b[?1004h\x1b[?2004h\x1b[?1000h\x1b[?1006h");
+
+    var output: [128]u8 = undefined;
+    const focus_len = try terminal.encodeFocus(true, &output);
+    try std.testing.expectEqualStrings("\x1b[I", output[0..focus_len]);
+
+    const paste_len = try terminal.encodePaste("one\ntwo", &output);
+    try std.testing.expectEqualStrings("\x1b[200~one\ntwo\x1b[201~", output[0..paste_len]);
+
+    const key_len = try terminal.encodeKey(.{ .key = 58 }, &output);
+    try std.testing.expectEqualStrings("\r", output[0..key_len]);
+
+    const mouse_len = try terminal.encodeMouse(.{
+        .action = .press,
+        .button = .left,
+        .x = 0,
+        .y = 0,
+        .any_button_pressed = true,
+    }, &output);
+    try std.testing.expectEqualStrings("\x1b[<0;1;1M", output[0..mouse_len]);
+
+    terminal.write("\x1b[5n");
+    var response: [6]u8 = undefined;
+    const first_len = try terminal.drainResponses(response[0..2]);
+    const second_len = try terminal.drainResponses(response[first_len..]);
+    try std.testing.expectEqualStrings("\x1b[0n", response[0 .. first_len + second_len]);
+}

--- a/packages/core/src/zig/test.zig
+++ b/packages/core/src/zig/test.zig
@@ -36,6 +36,7 @@ const audio_tests = @import("tests/audio_test.zig");
 const handles_tests = @import("tests/handles_test.zig");
 const yoga_tests = @import("tests/yoga_test.zig");
 const ansi_tests = @import("tests/ansi_test.zig");
+const embedded_terminal_tests = @import("embedded-terminal/tests.zig");
 // const example_tests = @import("example_test.zig");
 
 // Re-export test declarations from individual test files
@@ -78,5 +79,6 @@ comptime {
     _ = handles_tests;
     _ = yoga_tests;
     _ = ansi_tests;
+    _ = embedded_terminal_tests;
     // _ = example_tests;
 }


### PR DESCRIPTION
## Problem

OpenTUI does not currently have a native terminal-state runtime for embedding a PTY-backed terminal. Adding the renderable, compositor, FFI, and distribution work in one change would make the core lifecycle and input contract difficult to review independently.

This PR introduces only the runtime boundary around `libghostty-vt`: terminal ownership, VT input, mode-aware input encoding, and terminal-generated PTY responses. It deliberately does not expose a public TypeScript API or render anything yet.

## Changes

- Dynamically load the required `libghostty-vt` runtime symbols from an explicit path or `OPENTUI_GHOSTTY_VT_LIBRARY`.
- Own and clean up the terminal, key encoder/event, and mouse encoder/event across partial initialization failures.
- Support VT writes, resize, viewport scrolling, keyboard, mouse, paste, and focus encoding.
- Capture terminal-generated PTY responses for the host to drain.
- Add a host-libc native test target so Linux integration tests can load a glibc Ghostty library without changing OpenTUI's default musl test target.
- Cover missing-library behavior, lifecycle and validation, mode-aware encoding, and partial response drains.

The loader intentionally does not probe arbitrary system library names. `libghostty-vt` is still an evolving ABI, so a later packaging layer will provide the exact compatible library path.

## Scope

This is the first layer of the embedded-terminal stack. It excludes the OpenTUI buffer compositor, native handle/FFI exports, TypeScript renderable, runtime packaging, benchmarks, and examples.

## Testing

- `bun run test:native` (1709 passed, 8 skipped)
- `OPENTUI_GHOSTTY_VT_LIBRARY=... bun run test:native -Dtest-host-libc=true` (1713 passed, 4 skipped)
- `bun run build`
- `bun run fmt:check`
- `bun run lint`