### PR TITLE
fix(core): scrub reflowed split-footer rows on resize

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -345,6 +345,16 @@ function normalizeFooterHeight(footerHeight: number | undefined): number {
   return normalizedFooterHeight
 }
 
+function calculateSplitFooterResizeClearStart(
+  previousSurfaceTop: number,
+  visiblePreviousSplitHeight: number,
+  prevWidth: number,
+  width: number,
+): number {
+  const reflowRows = visiblePreviousSplitHeight * (Math.ceil(prevWidth / width) - 1)
+  return Math.max(previousSurfaceTop - reflowRows, 1)
+}
+
 function resolveModes(config: CliRendererConfig): {
   screenMode: ScreenMode
   footerHeight: number
@@ -3845,7 +3855,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this._footerHeight,
     )
     const prevWidth = this._terminalWidth
-    const previousTerminalHeight = this._terminalHeight
     const visiblePreviousSplitHeight =
       pendingSplitFooterTransition?.sourceHeight ?? previousGeometry.effectiveFooterHeight
 
@@ -3866,12 +3875,18 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     const splitFooterActive = this._screenMode === "split-footer"
 
     if (splitFooterActive) {
-      // Width shrink historically needs a broader scrub band, but if resize interrupts
-      // a deferred footer transition we also need to clear from that visible source surface.
+      // Width shrink reflows old footer rows upward from the visible surface top. If resize
+      // interrupts a deferred footer transition, that transition owns the visible surface.
       let clearStart: number | null = null
 
       if (width < prevWidth && visiblePreviousSplitHeight > 0) {
-        clearStart = Math.max(previousTerminalHeight - visiblePreviousSplitHeight * 2, 1)
+        const previousSurfaceTop = pendingSplitFooterTransition?.sourceTopLine ?? this.renderOffset + 1
+        clearStart = calculateSplitFooterResizeClearStart(
+          previousSurfaceTop,
+          visiblePreviousSplitHeight,
+          prevWidth,
+          width,
+        )
       }
 
       if (pendingSplitFooterTransition !== null) {

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -1753,7 +1753,7 @@ test("CliRenderer split-footer resize cleanup uses the visible footer surface wh
   result.resize(20, 10)
 
   expect(writeOutSpy).toHaveBeenCalledTimes(1)
-  expect(writeOutSpy.mock.calls[0]?.[0]).toBe(ANSI.moveCursorAndClear(2, 1))
+  expect(writeOutSpy.mock.calls[0]?.[0]).toBe(ANSI.moveCursorAndClear(1, 1))
   expect((renderer as any).pendingSplitFooterTransition).toBeNull()
 
   writeOutSpy.mockRestore()
@@ -1788,10 +1788,42 @@ test("CliRenderer split-footer resize cleanup uses the visible source top line a
   result.resize(20, 12)
 
   expect(writeOutSpy).toHaveBeenCalledTimes(1)
-  expect(writeOutSpy.mock.calls[0]?.[0]).toBe(ANSI.moveCursorAndClear(2, 1))
+  expect(writeOutSpy.mock.calls[0]?.[0]).toBe(ANSI.moveCursorAndClear(1, 1))
 
   writeOutSpy.mockRestore()
 })
+
+test.each([
+  { geometry: "cursor-seeded", prevWidth: 100, width: 70, height: 24, renderOffset: 7, clearStart: 5 },
+  { geometry: "cursor-seeded", prevWidth: 140, width: 70, height: 24, renderOffset: 7, clearStart: 5 },
+  { geometry: "cursor-seeded", prevWidth: 140, width: 50, height: 24, renderOffset: 7, clearStart: 2 },
+  { geometry: "bottom-pinned", prevWidth: 100, width: 70, height: 40, renderOffset: 37, clearStart: 35 },
+])(
+  "CliRenderer split-footer resize cleanup starts at the reflowed $geometry surface for $prevWidth -> $width",
+  async (testCase) => {
+    const result = await createTestRenderer({
+      width: testCase.prevWidth,
+      height: testCase.height,
+      screenMode: "split-footer",
+      footerHeight: 3,
+      externalOutputMode: testCase.geometry === "cursor-seeded" ? "capture-stdout" : "passthrough",
+      consoleMode: "disabled",
+    })
+
+    renderer = result.renderer
+    ;(renderer as any)._terminalIsSetup = true
+    ;(renderer as any).renderOffset = testCase.renderOffset
+
+    const writeOutSpy = spyOn(renderer as any, "writeOut")
+
+    result.resize(testCase.width, testCase.height)
+
+    expect(writeOutSpy).toHaveBeenCalledTimes(1)
+    expect(writeOutSpy.mock.calls[0]?.[0]).toBe(ANSI.moveCursorAndClear(testCase.clearStart, 1))
+
+    writeOutSpy.mockRestore()
+  },
+)
 
 test("CliRenderer split-footer resize cleanup still clears the visible source surface when only height changes while a deferred footer transition is pending", async () => {
   const result = await createTestRenderer({


### PR DESCRIPTION
Fixes #1322.

## Summary

- anchor width-shrink cleanup to the visible split-footer surface top
- subtract the exact reflow expansion for the previous width
- cover cursor-seeded and bottom-pinned surfaces at 1.4x, 2x, and 2.8x narrowing

## Reproduction

A probe rendered three full-width footer rows (`AAA…`, `BBB…`, `CCC…`) in a 24-row tmux window:

| Resize | Band lands | Leftover fragments |
|---|---|---|
| 100 -> 70 | rows 8-10 | rows 5-7 |
| 140 -> 70 | rows 8-10 | rows 5-7 |
| 80 -> 120 | rows 8-10 | none |

The old calculation assumed the footer was bottom-pinned and the reflow ratio was at most two. Captured stdout can instead cursor-seed the surface immediately after existing output, so the scrub started below both the reflowed fragments and the visible band.

After this change, the probe reports zero fragments at 1.4x, 2x, and 2.8x narrowing and across `140 -> 100 -> 70 -> 50`, with all history sentinels intact. Reverting the patch makes the detector report the expected three fragments.

## Tests

- `bun test src/tests/renderer.console-startup.test.ts`: 73 passed
- native suite: 1,859 passed, 6 skipped
- `bun run fmt:check`
- `bun run lint`

Terminal reflow is performed by the emulator, so the headless regression tests assert the clear-row calculation for both surface geometries rather than simulating reflow itself.

The complete Bun suite was also attempted twice in Bun 1.3.3 on Linux arm64. It reproducibly crashed inside Bun after unrelated tests (once while visiting `src/lib/singleton.ts`); no test assertion failed before the runtime crash.