### PR TITLE
fix(core): accept trailing PNG whitespace

### DIFF
--- a/packages/core/src/zig/image.zig
+++ b/packages/core/src/zig/image.zig
@@ -223,10 +223,15 @@ pub fn statusFromError(err: anyerror) Status {
 const PngMetadata = struct {
     width: u32,
     height: u32,
+    encoded_len: usize = 0,
     orientation: u8 = 1,
     has_alpha: bool,
     color_status: ColorStatus = .assumed_srgb,
 };
+
+fn isPngTrailingWhitespace(byte: u8) bool {
+    return byte == 0x20 or byte == 0x09 or byte == 0x0A or byte == 0x0D;
+}
 
 fn parseExifOrientation(data: []const u8) u8 {
     var tiff = data;
@@ -364,7 +369,11 @@ fn scanPng(data: []const u8) !PngMetadata {
         } else if (std.mem.eql(u8, kind, "IDAT")) {
             saw_idat = true;
         } else if (std.mem.eql(u8, kind, "IEND")) {
-            if (length != 0 or !saw_idat or chunk_end != data.len) return error.MalformedInput;
+            if (length != 0 or !saw_idat) return error.MalformedInput;
+            for (data[chunk_end..]) |byte| {
+                if (!isPngTrailingWhitespace(byte)) return error.MalformedInput;
+            }
+            if (metadata) |*value| value.encoded_len = chunk_end;
             saw_iend = true;
             break;
         }
@@ -386,9 +395,10 @@ fn scanPng(data: []const u8) !PngMetadata {
     return result;
 }
 
-fn probeInternal(data: []const u8, limits: Limits, out: *Info, validate_jpeg: bool) Status {
+fn probeInternal(data: []const u8, limits: Limits, out: *Info, effective_len: ?*usize, validate_jpeg: bool) Status {
     if (data.len == 0 or data.len > std.math.maxInt(u32)) return .invalid_argument;
     if (data.len > limits.max_encoded_bytes) return .memory_limit;
+    if (effective_len) |value| value.* = data.len;
     const format = detectFormat(data);
     if (format == .unknown) return .unsupported_format;
     if (format == .jpeg) {
@@ -466,11 +476,13 @@ fn probeInternal(data: []const u8, limits: Limits, out: *Info, validate_jpeg: bo
         return .ok;
     }
     const metadata = scanPng(data) catch |err| return statusFromError(err);
+    if (effective_len) |value| value.* = metadata.encoded_len;
     _ = checkedPixelBytes(metadata.width, metadata.height, limits) catch |err| return statusFromError(err);
 
     var decoder_width: u32 = 0;
     var decoder_height: u32 = 0;
-    const png_probe_status = ot_image_png_probe(data.ptr, @intCast(data.len), &decoder_width, &decoder_height);
+    const png_data = data[0..metadata.encoded_len];
+    const png_probe_status = ot_image_png_probe(png_data.ptr, @intCast(png_data.len), &decoder_width, &decoder_height);
     if (png_probe_status == 2) return .out_of_memory;
     if (png_probe_status != 0 or decoder_width != metadata.width or decoder_height != metadata.height) return .malformed_input;
 
@@ -489,12 +501,12 @@ fn probeInternal(data: []const u8, limits: Limits, out: *Info, validate_jpeg: bo
 }
 
 pub fn probe(data: []const u8, limits: Limits, out: *Info) Status {
-    return probeInternal(data, limits, out, true);
+    return probeInternal(data, limits, out, null, true);
 }
 
 pub fn inspect(allocator: Allocator, data: []const u8, limits: Limits, out: *Info) Status {
     var encoded_info: Info = .{};
-    const probe_status = probeInternal(data, limits, &encoded_info, false);
+    const probe_status = probeInternal(data, limits, &encoded_info, null, false);
     if (probe_status != .ok) return probe_status;
 
     const decoded = decodeInternal(allocator, data, limits, false) catch |err| return statusFromError(err);
@@ -560,7 +572,8 @@ pub fn createFromRgba(allocator: Allocator, pixels: []const u8, width: u32, heig
 
 fn decodeInternal(allocator: Allocator, data: []const u8, limits: Limits, retain_encoded_png: bool) !*Image {
     var image_info: Info = .{};
-    const probe_status = probeInternal(data, limits, &image_info, false);
+    var effective_len = data.len;
+    const probe_status = probeInternal(data, limits, &image_info, &effective_len, false);
     if (probe_status != .ok) return switch (probe_status) {
         .unsupported_format => error.UnsupportedFormat,
         .unsupported_feature => error.UnsupportedFeature,
@@ -576,10 +589,11 @@ fn decodeInternal(allocator: Allocator, data: []const u8, limits: Limits, retain
     var source_owned = true;
     defer if (source_owned) allocator.free(source);
     const format: Format = @enumFromInt(image_info.format);
+    const decode_data = if (format == .png) data[0..effective_len] else data;
     const decode_status = switch (format) {
         .png => ot_image_png_decode(
-            data.ptr,
-            @intCast(data.len),
+            decode_data.ptr,
+            @intCast(decode_data.len),
             source.ptr,
             source.len,
             image_info.source_width,
@@ -622,7 +636,7 @@ fn decodeInternal(allocator: Allocator, data: []const u8, limits: Limits, retain
     if (image_info.orientation == 1) {
         const image = try allocator.create(Image);
         errdefer allocator.destroy(image);
-        const encoded_png = if (format == .png and retain_encoded_png) try allocator.dupe(u8, data) else null;
+        const encoded_png = if (format == .png and retain_encoded_png) try allocator.dupe(u8, decode_data) else null;
         errdefer if (encoded_png) |bytes| allocator.free(bytes);
         image.* = .{
             .allocator = allocator,

--- a/packages/core/src/zig/tests/image_test.zig
+++ b/packages/core/src/zig/tests/image_test.zig
@@ -13,6 +13,28 @@ fn decodeBase64(encoded: []const u8) ![]u8 {
     return decoded;
 }
 
+fn appendBytes(data: []const u8, suffix: []const u8) ![]u8 {
+    const combined = try std.testing.allocator.alloc(u8, data.len + suffix.len);
+    @memcpy(combined[0..data.len], data);
+    @memcpy(combined[data.len..], suffix);
+    return combined;
+}
+
+fn pngChunk(kind: *const [4]u8, payload: []const u8) ![]u8 {
+    const chunk = try std.testing.allocator.alloc(u8, payload.len + 12);
+    std.mem.writeInt(u32, chunk[0..4], @intCast(payload.len), .big);
+    @memcpy(chunk[4..8], kind);
+    @memcpy(chunk[8 .. 8 + payload.len], payload);
+    std.mem.writeInt(u32, chunk[8 + payload.len ..][0..4], std.hash.Crc32.hash(chunk[4 .. 8 + payload.len]), .big);
+    return chunk;
+}
+
+fn expectMalformedPng(data: []const u8) !void {
+    var info: image.Info = .{};
+    try std.testing.expectEqual(image.Status.malformed_input, image.probe(data, .{}, &info));
+    try std.testing.expectError(error.MalformedInput, image.decode(std.testing.allocator, data, .{}));
+}
+
 fn decodePngWithAllocator(allocator: std.mem.Allocator, png: []const u8) !void {
     const decoded = try image.decode(allocator, png, .{});
     defer decoded.deinit();
@@ -68,6 +90,62 @@ test "PNG probe and decode return canonical red RGBA" {
     const decoded = try image.decode(std.testing.allocator, png, .{});
     defer decoded.deinit();
     try std.testing.expectEqualSlices(u8, &[_]u8{ 255, 0, 0, 255 }, decoded.pixels);
+}
+
+test "PNG accepts only ASCII whitespace after IEND and retains the effective PNG range" {
+    const png = try decodeBase64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4AWP4z8DwHwAFAAH/e+m+7wAAAABJRU5ErkJggg==");
+    defer std.testing.allocator.free(png);
+
+    const suffixes = [_][]const u8{ "", " ", " \t\n\r" };
+    for (suffixes) |suffix| {
+        const input = try appendBytes(png, suffix);
+        defer std.testing.allocator.free(input);
+
+        var info: image.Info = .{};
+        try std.testing.expectEqual(image.Status.ok, image.probe(input, .{}, &info));
+        const decoded = try image.decode(std.testing.allocator, input, .{});
+        defer decoded.deinit();
+        try std.testing.expectEqualSlices(u8, &[_]u8{ 255, 0, 0, 255 }, decoded.pixels);
+        try std.testing.expectEqualSlices(u8, png, decoded.encoded_png.?);
+    }
+}
+
+test "PNG rejects non-whitespace data and chunks after IEND" {
+    const png = try decodeBase64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4AWP4z8DwHwAFAAH/e+m+7wAAAABJRU5ErkJggg==");
+    defer std.testing.allocator.free(png);
+
+    const nul_suffix = try appendBytes(png, &[_]u8{0});
+    defer std.testing.allocator.free(nul_suffix);
+    try expectMalformedPng(nul_suffix);
+
+    const binary_suffix = try appendBytes(png, &[_]u8{ 0x01, 0xFE, 0x7F });
+    defer std.testing.allocator.free(binary_suffix);
+    try expectMalformedPng(binary_suffix);
+
+    const extra_chunk = try pngChunk("tEXt", "");
+    defer std.testing.allocator.free(extra_chunk);
+    const chunk_after_iend = try appendBytes(png, extra_chunk);
+    defer std.testing.allocator.free(chunk_after_iend);
+    try expectMalformedPng(chunk_after_iend);
+}
+
+test "PNG rejects malformed IEND and chunk bounds" {
+    const png = try decodeBase64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4AWP4z8DwHwAFAAH/e+m+7wAAAABJRU5ErkJggg==");
+    defer std.testing.allocator.free(png);
+    const iend_offset = png.len - 12;
+
+    const nonzero_iend = try pngChunk("IEND", &[_]u8{0});
+    defer std.testing.allocator.free(nonzero_iend);
+    const with_nonzero_iend = try appendBytes(png[0..iend_offset], nonzero_iend);
+    defer std.testing.allocator.free(with_nonzero_iend);
+    try expectMalformedPng(with_nonzero_iend);
+
+    try expectMalformedPng(png[0 .. png.len - 1]);
+
+    const overflowing_length = try std.testing.allocator.dupe(u8, png);
+    defer std.testing.allocator.free(overflowing_length);
+    std.mem.writeInt(u32, overflowing_length[iend_offset..][0..4], std.math.maxInt(u32), .big);
+    try expectMalformedPng(overflowing_length);
 }
 
 test "PNG rejects cICP after image data" {


### PR DESCRIPTION
## Summary
- accept ASCII space, tab, LF, and CR after a valid PNG `IEND`
- decode and retain only the validated PNG byte range
- keep rejecting malformed chunks and non-whitespace trailing data

## Testing
- `bun run test:native`
- `bun run build`
- `bun run fmt:check`
- `bun run lint`