### PR TITLE
fix(core/editor-view): snap visual cursor columns to grapheme boundaries

### DIFF
--- a/packages/core/src/editor-view.test.ts
+++ b/packages/core/src/editor-view.test.ts
@@ -523,7 +523,8 @@ describe("EditorView", () => {
       view.moveDownVisual()
       cursor = view.getVisualCursor()
       expect(cursor.visualRow).toBe(1)
-      expect(cursor.visualCol).toBe(8)
+      // Col 8 sits inside 🌟 (cells 7-8); vertical movement snaps to the leading boundary.
+      expect(cursor.visualCol).toBe(7)
 
       buffer.moveCursorLeft()
       cursor = view.getVisualCursor()

--- a/packages/native/src/editor-view.zig
+++ b/packages/native/src/editor-view.zig
@@ -178,7 +178,16 @@ pub const EditorView = struct {
                 const target_logical_row = @as(u32, @intCast(target_vline.source_line));
 
                 const line_width = iter_mod.lineWidthAt(self.edit_buffer.tb.rope(), target_logical_row);
-                const target_col = @min(cursor.col, line_width);
+                // The cursor col is a display width measured on the source line;
+                // snap it to a grapheme boundary on the target line.
+                const target_col = iter_mod.snapColToGraphemeBoundary(
+                    self.edit_buffer.tb.rope(),
+                    self.edit_buffer.tb.memRegistry(),
+                    target_logical_row,
+                    @min(cursor.col, line_width),
+                    self.edit_buffer.tb.tabWidth(),
+                    self.edit_buffer.tb.widthMethod(),
+                );
 
                 if (self.edit_buffer.cursors.items.len > 0) {
                     const offset = iter_mod.coordsToOffset(self.edit_buffer.tb.rope(), target_logical_row, target_col) orelse return;
@@ -653,14 +662,29 @@ pub const EditorView = struct {
 
         const vline = &vlines[visual_row];
         const clamped_visual_col = @min(visual_col, vline.width_cols);
-        const logical_col = vline.source_col_start + clamped_visual_col;
         const logical_row = @as(u32, @intCast(vline.source_line));
+
+        // A visual column can fall strictly inside a wide grapheme when the
+        // target row's grapheme boundaries differ from the row the column was
+        // measured on. Snap to the cluster's leading boundary so the committed
+        // cursor never splits a grapheme. This also composes with
+        // clampVisualColToStayOnVisualRow, whose one-cell step back from a wrap
+        // boundary can land inside a trailing wide grapheme.
+        const logical_col = iter_mod.snapColToGraphemeBoundary(
+            self.edit_buffer.tb.rope(),
+            self.edit_buffer.tb.memRegistry(),
+            logical_row,
+            vline.source_col_start + clamped_visual_col,
+            self.edit_buffer.tb.tabWidth(),
+            self.edit_buffer.tb.widthMethod(),
+        );
+        const snapped_visual_col = logical_col -| vline.source_col_start;
 
         const offset = iter_mod.coordsToOffset(self.edit_buffer.tb.rope(), logical_row, logical_col) orelse 0;
 
         return .{
             .visual_row = visual_row,
-            .visual_col = clamped_visual_col,
+            .visual_col = snapped_visual_col,
             .logical_row = logical_row,
             .logical_col = logical_col,
             .offset = offset,
@@ -882,17 +906,16 @@ pub const EditorView = struct {
                 }
             }
         }
-        const logical_row = @as(u32, @intCast(vline.source_line));
-        const logical_col = vline.source_col_start + target_visual_col;
-        const offset = iter_mod.coordsToOffset(self.edit_buffer.tb.rope(), logical_row, logical_col) orelse 0;
 
-        return .{
-            .visual_row = vcursor.visual_row,
-            .visual_col = target_visual_col,
-            .logical_row = logical_row,
-            .logical_col = logical_col,
-            .offset = offset,
-        };
+        // Resolve through the snapped visual->logical mapping so an EOL target
+        // that falls inside a wide grapheme lands on its leading boundary.
+        if (self.visualToLogicalCursor(vcursor.visual_row, target_visual_col)) |result| {
+            return result;
+        }
+
+        // Unreachable in practice: visual_row was bounds-checked above
+        const logical_cursor = self.edit_buffer.getEOL();
+        return self.logicalToVisualCursor(logical_cursor.row, logical_cursor.col);
     }
 
     pub fn gotoVisualLineEnd(self: *EditorView) void {

--- a/packages/native/src/tests/editor-view_test.zig
+++ b/packages/native/src/tests/editor-view_test.zig
@@ -3762,3 +3762,338 @@ test "EditorView - convert word selection to cell keeps the range and moves focu
     try std.testing.expectEqual(@as(u32, 0), converted_cursor.row);
     try std.testing.expectEqual(@as(u32, 9), converted_cursor.col);
 }
+test "EditorView - moveDownVisual snaps to leading boundary of wide grapheme" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    // Line 0 grapheme boundaries: 0,2,3,5,7,... (的=0-2, [=2-3, 代=3-5, ...)
+    // Line 1 grapheme boundaries: 0,2,4,6,... (因=0-2, 此=2-4, 签=4-6, ...)
+    try eb.setText("的[代码签名政策](\n因此签名批准者角色");
+
+    // Cursor after 代 (visual col 5). Col 5 on line 1 is inside 签 (cells 4-6).
+    try eb.setCursor(0, 5);
+
+    ev.moveDownVisual();
+    const cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 1), cursor.row);
+    // Must snap back to the leading boundary of 签, not sit inside it
+    try std.testing.expectEqual(@as(u32, 4), cursor.col);
+
+    // Same mapping through the direct visual->logical conversion
+    const vcursor = ev.visualToLogicalCursor(1, 5) orelse return error.MissingVisualCursor;
+    try std.testing.expectEqual(@as(u32, 1), vcursor.logical_row);
+    try std.testing.expectEqual(@as(u32, 4), vcursor.logical_col);
+    try std.testing.expectEqual(@as(u32, 4), vcursor.visual_col);
+}
+
+test "EditorView - moveUpVisual snaps to leading boundary of wide grapheme" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    // Line 0 grapheme boundaries: 0,2,4,6,... (因=0-2, 此=2-4, 签=4-6, ...)
+    // Line 1 grapheme boundaries: 0,2,3,5,7,... (的=0-2, [=2-3, 代=3-5, ...)
+    try eb.setText("因此签名批准者角色\n的[代码签名政策](");
+
+    // Cursor after 代 (visual col 5). Col 5 on line 0 is inside 签 (cells 4-6).
+    try eb.setCursor(1, 5);
+
+    ev.moveUpVisual();
+    const cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 0), cursor.row);
+    try std.testing.expectEqual(@as(u32, 4), cursor.col);
+}
+
+test "EditorView - selection extension after moveDownVisual ends on grapheme boundary" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    try eb.setText("的[代码签名政策](\n因此签名批准者角色");
+
+    // Mirror the shift+down path in EditBufferRenderable: anchor a local selection
+    // at the cursor, move, then extend the selection to the new visual cursor.
+    try eb.setCursor(0, 5);
+    _ = ev.setLocalSelection(5, 0, 5, 0, null, null, true);
+
+    ev.moveDownVisual();
+    const vcursor = ev.getVisualCursor();
+    _ = ev.updateLocalSelection(5, 0, @as(i32, @intCast(vcursor.visual_col)), @as(i32, @intCast(vcursor.visual_row)), null, null, true);
+
+    const cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 1), cursor.row);
+    try std.testing.expectEqual(@as(u32, 4), cursor.col);
+
+    // The selection endpoint synced from the cursor must be the same legal
+    // boundary: under cell occupancy (#1393) sel.end is the *exclusive* end of
+    // the inclusive selection, i.e. the trailing boundary of the focus
+    // grapheme 签 (width 2) — it covers the grapheme exactly, never its middle.
+    const sel = ev.getSelection().?;
+    try std.testing.expectEqual(cursor.offset + 2, sel.end);
+}
+
+test "EditorView - selection extension after moveUpVisual ends on grapheme boundary" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    try eb.setText("因此签名批准者角色\n的[代码签名政策](");
+
+    // Mirror the shift+up path: anchor at the cursor, move up, extend selection.
+    try eb.setCursor(1, 5);
+    _ = ev.setLocalSelection(5, 1, 5, 1, null, null, true);
+
+    ev.moveUpVisual();
+    const vcursor = ev.getVisualCursor();
+    _ = ev.updateLocalSelection(5, 1, @as(i32, @intCast(vcursor.visual_col)), @as(i32, @intCast(vcursor.visual_row)), null, null, true);
+
+    const cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 0), cursor.row);
+    try std.testing.expectEqual(@as(u32, 4), cursor.col);
+
+    // Backward selection: the moved endpoint is the selection start
+    const sel = ev.getSelection().?;
+    try std.testing.expectEqual(cursor.offset, sel.start);
+}
+
+test "EditorView - vertical moves between wrapped visual rows never split wide graphemes" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 10, 10);
+    defer ev.deinit();
+
+    ev.setWrapMode(.char);
+
+    // Boundaries: 0,1,2,3,5,7,9,11,... (aaa=0-3, then width-2 graphemes)
+    // Wraps at width 10 into visual rows [0,9), [9,19), [19,29), [29,35),
+    // so desired col 3 lands inside a wide grapheme on rows 1, 2 and 3.
+    try eb.setText("aaa的代码签名政策因此签名批准者角色");
+
+    const line_info = ev.getCachedLineInfo();
+    try std.testing.expectEqualSlices(u32, &[_]u32{ 9, 10, 10, 6 }, line_info.line_width_cols);
+
+    try eb.setCursor(0, 3);
+
+    // Row 1: abs col 9+3=12 is inside 名 (11-13), snaps to 11
+    ev.moveDownVisual();
+    var cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 0), cursor.row);
+    try std.testing.expectEqual(@as(u32, 11), cursor.col);
+
+    // Row 2: abs col 19+3=22 is inside 批 (21-23), snaps to 21
+    ev.moveDownVisual();
+    cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 21), cursor.col);
+
+    // Row 3: abs col 29+3=32 is inside 角 (31-33), snaps to 31
+    ev.moveDownVisual();
+    cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 31), cursor.col);
+
+    // Moving back up keeps snapping onto legal boundaries
+    ev.moveUpVisual();
+    cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 21), cursor.col);
+
+    ev.moveUpVisual();
+    cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 11), cursor.col);
+
+    ev.moveUpVisual();
+    cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 3), cursor.col);
+}
+
+test "EditorView - moveDownVisual onto short and empty rows clamps without splitting graphemes" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    try eb.setText("的[代码签名政策](\nx\n\n因此签名批准者角色");
+
+    try eb.setCursor(0, 5);
+
+    // Short row (width 1): clamps to col 1
+    ev.moveDownVisual();
+    var cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 1), cursor.row);
+    try std.testing.expectEqual(@as(u32, 1), cursor.col);
+
+    // Empty row: clamps to col 0
+    ev.moveDownVisual();
+    cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 2), cursor.row);
+    try std.testing.expectEqual(@as(u32, 0), cursor.col);
+
+    // Desired col 5 persists across the short/empty rows and snaps on line 3
+    ev.moveDownVisual();
+    cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 3), cursor.row);
+    try std.testing.expectEqual(@as(u32, 4), cursor.col);
+
+    // Round trip back up restores the original legal column without drift
+    ev.moveUpVisual();
+    ev.moveUpVisual();
+    ev.moveUpVisual();
+    cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 0), cursor.row);
+    try std.testing.expectEqual(@as(u32, 5), cursor.col);
+}
+
+test "EditorView - moveDownVisual respects combining mark cluster boundaries" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .unicode, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    // Line 1: "e" + combining acute is one cluster (width 1, cells 0-1),
+    // then 签=1-3, 名=3-5. Desired col 4 falls inside 名.
+    try eb.setText("的代码\ne\u{301}签名");
+
+    try eb.setCursor(0, 4);
+
+    ev.moveDownVisual();
+    const cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 1), cursor.row);
+    // Snaps to 3 (leading boundary of 名), proving the e+mark cluster counts as one cell
+    try std.testing.expectEqual(@as(u32, 3), cursor.col);
+}
+
+test "EditorView - moveDownVisual snaps to leading boundary of ZWJ emoji cluster" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .unicode, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    // Line 1: a=0-1, family ZWJ cluster=1-3, b=3-4, c=4-5.
+    // Desired col 2 falls inside the ZWJ cluster.
+    try eb.setText("的代码\na\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}bc");
+
+    try eb.setCursor(0, 2);
+
+    ev.moveDownVisual();
+    const cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 1), cursor.row);
+    try std.testing.expectEqual(@as(u32, 1), cursor.col);
+}
+
+test "EditorView - vertical move round trip returns to original column without drift" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    // Line 0 and 2 share boundaries 0,2,3,5,...; line 1 has 0,2,4,6,...
+    try eb.setText("的[代码签名政策](\n因此签名批准者角色\n的[代码签名政策](");
+
+    try eb.setCursor(0, 5);
+
+    ev.moveDownVisual();
+    var cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 1), cursor.row);
+    try std.testing.expectEqual(@as(u32, 4), cursor.col);
+
+    // Desired col 5 survives the snapped row and lands legally on line 2
+    ev.moveDownVisual();
+    cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 2), cursor.row);
+    try std.testing.expectEqual(@as(u32, 5), cursor.col);
+
+    ev.moveUpVisual();
+    cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 1), cursor.row);
+    try std.testing.expectEqual(@as(u32, 4), cursor.col);
+
+    ev.moveUpVisual();
+    cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 0), cursor.row);
+    try std.testing.expectEqual(@as(u32, 5), cursor.col);
+}
+
+test "EditorView - insert after snapped vertical move keeps graphemes intact" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    try eb.setText("的[代码签名政策](\n因此签名批准者角色");
+
+    try eb.setCursor(0, 5);
+    ev.moveDownVisual();
+
+    const cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 4), cursor.col);
+
+    // Inserting at the snapped cursor must not split 签
+    try eb.insertText("X");
+
+    var out_buffer: [256]u8 = undefined;
+    const written = eb.getText(&out_buffer);
+    try std.testing.expectEqualStrings("的[代码签名政策](\n因此X签名批准者角色", out_buffer[0..written]);
+}

--- a/packages/native/src/text-buffer-iterators.zig
+++ b/packages/native/src/text-buffer-iterators.zig
@@ -361,6 +361,49 @@ pub fn getPrevGraphemeWidth(rope: *UnifiedRope, mem_registry: *const MemRegistry
     return 0;
 }
 
+/// Snaps a display-width column within a line to the leading (line-start-side)
+/// boundary of the grapheme cluster containing it. Columns already on a
+/// grapheme boundary (including column 0 and end-of-line) pass through unchanged.
+/// Takes mutable rope for lazy marker cache rebuilding
+pub fn snapColToGraphemeBoundary(rope: *UnifiedRope, mem_registry: *const MemRegistry, row: u32, col: u32, tab_width: u8, width_method: utf8.WidthMethod) u32 {
+    const line_width = lineWidthAt(rope, row);
+    if (col == 0 or col >= line_width) return col;
+
+    const linestart = rope.getMarker(.linestart, row) orelse return col;
+    var seg_idx = linestart.leaf_index + 1;
+    var cols_before: u32 = 0;
+
+    while (seg_idx < rope.count()) : (seg_idx += 1) {
+        const seg = rope.get(seg_idx) orelse break;
+        if (seg.isBreak() or seg.isLineStart()) break;
+        if (seg.asText()) |chunk| {
+            const next_cols = cols_before + chunk.width_cols;
+            if (col < next_cols) {
+                const local_col: u32 = col - cols_before;
+                const bytes = chunk.getBytes(mem_registry);
+                const is_ascii = (chunk.flags & TextChunk.Flags.ASCII_ONLY) != 0;
+                // include_start_before=false resolves to the start of the
+                // cluster that would extend past local_col
+                const pos = utf8.findPosByWidth(bytes, local_col, tab_width, is_ascii, false, width_method);
+                if (pos.columns_used <= local_col) {
+                    return cols_before + pos.columns_used;
+                }
+                // local_col sits inside the final cluster of the chunk:
+                // findPosByWidth runs to the end of the text and reports that
+                // cluster's trailing boundary. Step back by the cluster's
+                // width to reach its leading boundary.
+                const prev = utf8.getPrevGraphemeStart(bytes, bytes.len, tab_width, width_method);
+                if (prev) |res| {
+                    return cols_before + pos.columns_used - res.width;
+                }
+                return cols_before;
+            }
+            cols_before = next_cols;
+        }
+    }
+    return col;
+}
+
 /// Extract text between display-width offsets into a buffer
 /// Automatically snaps to grapheme boundaries:
 /// - start_offset excludes graphemes that start before it


### PR DESCRIPTION
Fixes #1289

## Rebase note (2026-08-27)

Rebased onto current `main` across the #1391 source move (`packages/core/src/zig` → `packages/native/src`) and the #1428 wrapped-layout rewrite (`VirtualLine.source_col_offset` → `source_col_start`; the unsnapped arithmetic this PR targets is unchanged, now at `editor-view.zig:655`). `getVisualEOL` keeps the newer viewport/occupancy computation from #1393 and only routes its final visual→logical mapping through the snapped path. One test expectation was aligned with #1393 semantics: under `cell` occupancy a forward inclusive selection stores the *exclusive* end, so the assertion is `sel.end == cursor.offset + width(签)` rather than `sel.end == cursor.offset`.

Sensitivity on this base: without the fix, 8 of the 10 new tests fail; the two selection-extension tests pass because #1393's occupancy machinery already snaps the selection-sync path — the direct-move path (`moveUpVisual`/`moveDownVisual`) remains broken. With the fix, all 10 pass.

## Summary

Vertical cursor movement (`moveUpVisual`/`moveDownVisual`) preserves a desired visual column measured in display cells. When the target row's grapheme boundaries differ from the row the column was measured on — e.g. width-2 CJK graphemes shifted by an odd-width ASCII char — the desired column can fall strictly inside a grapheme. `visualToLogicalCursor` committed it verbatim:

```zig
const clamped_visual_col = @min(visual_col, vline.width_cols);
const logical_col = vline.source_col_start + clamped_visual_col;
```

The terminal caret then renders between the two cells of a wide glyph, and Shift+Up/Down (same code path) can produce a selection endpoint inside a grapheme. All column/offset units here are display-cell widths (`coordsToOffset` = `line_start_weight + col`), so an interior column is not a legal cursor position — it conflates display cells with grapheme boundaries.

Reproduction (headless) is in #1289: buffer `的[代码签名政策](` / `因此签名批准者角色`, cursor after `代` (visual col 5), move down → col 5 lands inside `签` (cells 4..6).

## Fix

Snap the requested visual column to the **leading (line-start-side) boundary** of the containing grapheme cluster before committing the cursor:

- New iterator helper `snapColToGraphemeBoundary` (`text-buffer-iterators.zig`), placed next to `getGraphemeWidthAt`/`getPrevGraphemeWidth` whose segment-walk pattern it mirrors. It reuses `utf8.findPosByWidth(..., include_start_before=false, width_method)`, so it is grapheme-cluster-aware (combining marks, emoji/ZWJ) and width-method-aware; no new width tables. One subtlety: `findPosByWidth`'s final-cluster tail path reports the *trailing* boundary when the column sits inside the last cluster of a chunk — the helper detects `columns_used > local_col` and steps back one cluster width via `utf8.getPrevGraphemeStart`.
- `visualToLogicalCursor` snaps after clamping (central fix; covers Up/Down, Shift+Up/Down, and mouse/TS callers).
- `getVisualEOL` and `makeCursorVisible` had the same unsnapped col arithmetic; both now route through the snapped mapping.

Leading-boundary policy is deterministic, keeps the caret on the grapheme it was aimed at, and composes with `clampVisualColToStayOnVisualRow` (#1078), whose one-cell step back from a wrap boundary can itself land inside a trailing wide grapheme — leading snap resolves that back onto the same visual row instead of drifting onto the next row's start.

Legal boundaries, column 0, end-of-line, and ASCII-only text are identity mappings (verified by the unchanged pre-existing suite).

## Tests

10 new tests in `packages/native/src/tests/editor-view_test.zig`:

- exact issue repro: move down onto interior column snaps to `签`'s leading boundary (col 4), plus the direct `visualToLogicalCursor(1, 5)` mapping
- move up with the same boundary mismatch
- Shift+Up/Down selection extension ends on a legal grapheme boundary (mirrors the TS path: `moveCursorUp/Down` → `getVisualCursor` → `setLocalSelection`/`updateLocalSelection` → `syncCursorToSelectionFocus`)
- vertical moves between soft-wrapped visual rows of one logical line never split wide graphemes
- short and empty target rows: clamping without splitting, desired-col persistence, round trip
- combining-mark cluster and emoji/ZWJ cluster boundaries
- down-down-up-up round trip returns to the original column without drift
- inserting at the snapped cursor keeps graphemes intact (full-text equality)

`zig build test -Dtest-filter="EditorView"`: **118/118 passed**. Full `zig build test`: 2099/2108 (8 skipped; the one failure is an environment-dependent X11 clipboard test that fails identically on pristine `main`). `zig fmt` clean. TS: `bun test src/editor-view.test.ts` **73/73** against the rebuilt native library (including the aligned emoji vertical-nav expectation from the companion commit: col 8 sits inside 🌟 cells 7–8, the snapped leading boundary is 7); `edit-buffer`/`buffer`/`text-buffer` TS suites: 218 passed.

## Out of scope (deliberately; happy to follow up)

- **Mouse selection**: `coordsToCharOffset` (`text-buffer-view.zig`) can commit a raw interior-cell offset into a selection, and `syncCursorToSelectionFocus` (`editor-view.zig`) can then put the cursor there when clicking the second cell of a wide grapheme. Not changed here: snapping in `coordsToCharOffset` would alter selection-range semantics (selection offsets deliberately snap at extraction time), and snapping only the cursor would decouple `cursor.offset` from the selection focus offset the TS layer relies on. Shift+arrow selection **is** covered by this PR because it anchors from the already-snapped committed cursor.
- **Logical-line moves**: `EditBuffer.moveUp`/`moveDown` (`edit-buffer.zig:515,538`) contain the same `@min(desired_col, line_width)` unsnapped arithmetic. `EditBufferRenderable` uses `moveUpVisual`/`moveDownVisual`, so the reported defect path is unaffected; the same one-line helper applies if you want a follow-up.