### PR TITLE
fix(core/text-buffer-view): fill partially wrapped lines across chunk boundaries

### DIFF
--- a/packages/core/src/zig/tests/word-wrap-editing_test.zig
+++ b/packages/core/src/zig/tests/word-wrap-editing_test.zig
@@ -496,3 +496,378 @@ test "Word wrap - incremental character edits near boundary" {
     try std.testing.expectEqual(@as(u32, 14), vlines[0].width_cols);
     try std.testing.expectEqual(@as(u32, 6), vlines[1].width_cols);
 }
+
+/// Assert that the virtual-line segmentation of `view` (backed by an edited,
+/// potentially multi-chunk buffer) is identical to the segmentation of a fresh
+/// single-chunk buffer set to the same text content. Wrap segmentation must
+/// depend only on text content, never on how the text was edited.
+fn expectSegmentationMatchesFreshSet(
+    pool: *gp.GraphemePool,
+    link_pool: *link.LinkPool,
+    eb: *EditBuffer,
+    view: *TextBufferView,
+    wrap_width: u32,
+) !void {
+    var text_buf: [16384]u8 = undefined;
+    const text_len = eb.getText(&text_buf);
+
+    var fresh_eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer fresh_eb.deinit();
+
+    var fresh_view = try TextBufferView.init(std.testing.allocator, fresh_eb.getTextBuffer());
+    defer fresh_view.deinit();
+
+    fresh_view.setWrapMode(.word);
+    fresh_view.setWrapWidth(wrap_width);
+    try fresh_eb.setText(text_buf[0..text_len]);
+
+    const actual = view.getVirtualLines();
+    const expected = fresh_view.getVirtualLines();
+
+    try std.testing.expectEqual(expected.len, actual.len);
+    for (expected, actual) |exp, act| {
+        try std.testing.expectEqual(exp.source_line, act.source_line);
+        try std.testing.expectEqual(exp.source_col_offset, act.source_col_offset);
+        try std.testing.expectEqual(exp.width_cols, act.width_cols);
+    }
+}
+
+test "Word wrap - insert into soft-wrapped unbreakable line reflows (issue 1288)" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var view = try TextBufferView.init(std.testing.allocator, eb.getTextBuffer());
+    defer view.deinit();
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(56);
+
+    try eb.setText("a" ** 100);
+
+    var vlines = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 2), vlines.len);
+
+    try eb.setCursor(0, 20);
+    try eb.insertText("X");
+
+    vlines = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 2), vlines.len);
+    try std.testing.expectEqual(@as(u32, 56), vlines[0].width_cols);
+    try std.testing.expectEqual(@as(u32, 45), vlines[1].width_cols);
+
+    try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 56);
+}
+
+test "Word wrap - insert at various offsets matches fresh set" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    const offsets = [_]u32{ 0, 20, 56, 80 };
+    for (offsets) |offset| {
+        var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+        defer eb.deinit();
+
+        var view = try TextBufferView.init(std.testing.allocator, eb.getTextBuffer());
+        defer view.deinit();
+
+        view.setWrapMode(.word);
+        view.setWrapWidth(56);
+
+        try eb.setText("a" ** 100);
+        try eb.setCursor(0, offset);
+        try eb.insertText("X");
+
+        try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 56);
+    }
+}
+
+test "Word wrap - delete at various offsets matches fresh set" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    const offsets = [_]u32{ 0, 20, 56, 80 };
+    for (offsets) |offset| {
+        var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+        defer eb.deinit();
+
+        var view = try TextBufferView.init(std.testing.allocator, eb.getTextBuffer());
+        defer view.deinit();
+
+        view.setWrapMode(.word);
+        view.setWrapWidth(56);
+
+        try eb.setText("a" ** 100);
+        try eb.setCursor(0, offset);
+        try eb.deleteForward();
+
+        try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 56);
+    }
+}
+
+test "Word wrap - multi-char insert at various offsets matches fresh set" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    const offsets = [_]u32{ 0, 20, 55, 56, 80 };
+    for (offsets) |offset| {
+        var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+        defer eb.deinit();
+
+        var view = try TextBufferView.init(std.testing.allocator, eb.getTextBuffer());
+        defer view.deinit();
+
+        view.setWrapMode(.word);
+        view.setWrapWidth(56);
+
+        try eb.setText("a" ** 100);
+        try eb.setCursor(0, offset);
+        try eb.insertText("XYZ");
+
+        try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 56);
+    }
+}
+
+test "Word wrap - word boundaries still backtrack after mid-row edit" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var view = try TextBufferView.init(std.testing.allocator, eb.getTextBuffer());
+    defer view.deinit();
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(12);
+
+    try eb.setText("aaaaaaaa bbbb cccc");
+
+    try eb.setCursor(0, 2);
+    try eb.insertText("X");
+
+    try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 12);
+
+    // "aaXaaaaa bbbb cccc": the first word's wrap point must still be used
+    // (row 0 backtracks below the full wrap width instead of hard-filling it).
+    const vlines = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 2), vlines.len);
+    try std.testing.expectEqual(@as(u32, 10), vlines[0].width_cols);
+    try std.testing.expectEqual(@as(u32, 9), vlines[1].width_cols);
+}
+
+test "Word wrap - CJK unbreakable line edited mid-row matches fresh set" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var view = try TextBufferView.init(std.testing.allocator, eb.getTextBuffer());
+    defer view.deinit();
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(56);
+
+    try eb.setText("世" ** 50);
+
+    // Column 40 is the grapheme boundary after the 20th wide char.
+    try eb.setCursor(0, 40);
+    try eb.insertText("界");
+
+    const vlines = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 2), vlines.len);
+    try std.testing.expectEqual(@as(u32, 56), vlines[0].width_cols);
+    try std.testing.expectEqual(@as(u32, 46), vlines[1].width_cols);
+
+    // Hard fills must stay on grapheme boundaries: every row of an
+    // all-wide-char line has an even width.
+    for (vlines) |vline| {
+        try std.testing.expectEqual(@as(u32, 0), vline.width_cols % 2);
+    }
+
+    try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 56);
+}
+
+test "Word wrap - mixed widths with combining marks matches fresh set" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    const unit = "ab" ++ "世" ++ "e\u{301}";
+    const text = unit ** 15;
+
+    const offsets = [_]u32{ 0, 20, 38, 60 };
+    for (offsets) |offset| {
+        var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+        defer eb.deinit();
+
+        var view = try TextBufferView.init(std.testing.allocator, eb.getTextBuffer());
+        defer view.deinit();
+
+        view.setWrapMode(.word);
+        view.setWrapWidth(56);
+
+        try eb.setText(text);
+        try eb.setCursor(0, offset);
+        try eb.insertText("X");
+
+        const vlines = view.getVirtualLines();
+        for (vlines) |vline| {
+            try std.testing.expect(vline.width_cols <= 56);
+        }
+
+        try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 56);
+    }
+}
+
+test "Word wrap - sequential inserts keep matching fresh set" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var view = try TextBufferView.init(std.testing.allocator, eb.getTextBuffer());
+    defer view.deinit();
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(56);
+
+    try eb.setText("a" ** 100);
+    try eb.setCursor(0, 20);
+
+    for ("12345") |c| {
+        try eb.insertText(&[_]u8{c});
+
+        const vlines = view.getVirtualLines();
+        try std.testing.expectEqual(@as(usize, 2), vlines.len);
+        try std.testing.expectEqual(@as(u32, 56), vlines[0].width_cols);
+
+        try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 56);
+    }
+}
+
+test "Word wrap - undo redo restores fresh-set segmentation" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var view = try TextBufferView.init(std.testing.allocator, eb.getTextBuffer());
+    defer view.deinit();
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(56);
+
+    try eb.setText("a" ** 100);
+    try eb.setCursor(0, 20);
+    try eb.insertText("X");
+
+    var vlines = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 2), vlines.len);
+    try std.testing.expectEqual(@as(u32, 56), vlines[0].width_cols);
+    try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 56);
+
+    _ = try eb.undo();
+
+    vlines = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 2), vlines.len);
+    try std.testing.expectEqual(@as(u32, 56), vlines[0].width_cols);
+    try std.testing.expectEqual(@as(u32, 44), vlines[1].width_cols);
+    try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 56);
+
+    _ = try eb.redo();
+
+    vlines = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 2), vlines.len);
+    try std.testing.expectEqual(@as(u32, 56), vlines[0].width_cols);
+    try std.testing.expectEqual(@as(u32, 45), vlines[1].width_cols);
+    try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 56);
+}
+
+test "Word wrap - wrap width change after edit matches fresh set" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var view = try TextBufferView.init(std.testing.allocator, eb.getTextBuffer());
+    defer view.deinit();
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(56);
+
+    try eb.setText("a" ** 100);
+    try eb.setCursor(0, 20);
+    try eb.insertText("X");
+
+    view.setWrapWidth(40);
+
+    var vlines = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 3), vlines.len);
+    try std.testing.expectEqual(@as(u32, 40), vlines[0].width_cols);
+    try std.testing.expectEqual(@as(u32, 40), vlines[1].width_cols);
+    try std.testing.expectEqual(@as(u32, 21), vlines[2].width_cols);
+    try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 40);
+
+    view.setWrapWidth(56);
+
+    vlines = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 2), vlines.len);
+    try std.testing.expectEqual(@as(u32, 56), vlines[0].width_cols);
+    try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 56);
+}
+
+test "Word wrap - wide grapheme that does not fit remaining space is not split" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var view = try TextBufferView.init(std.testing.allocator, eb.getTextBuffer());
+    defer view.deinit();
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(55);
+
+    // Chunk boundary exactly between the ASCII run and the wide chars:
+    // ["a" * 54]["世" * 20]. The line has 1 free column when the first wide
+    // char arrives; it must wrap whole instead of being split across rows.
+    try eb.setText("a" ** 54);
+    try eb.setCursor(0, 54);
+    try eb.insertText("世" ** 20);
+
+    const vlines = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 2), vlines.len);
+    try std.testing.expectEqual(@as(u32, 54), vlines[0].width_cols);
+    try std.testing.expectEqual(@as(u32, 40), vlines[1].width_cols);
+
+    try expectSegmentationMatchesFreshSet(pool, link_pool, eb, view, 55);
+}

--- a/packages/core/src/zig/text-buffer-view.zig
+++ b/packages/core/src/zig/text-buffer-view.zig
@@ -1272,16 +1272,32 @@ pub const UnifiedTextBufferView = struct {
 
                                 continue;
                             } else {
-                                commitVirtualLine(wctx);
+                                // No wrap break was recorded on the current line, so a chunk
+                                // boundary is not a wrap point: hard-fill the remaining space
+                                // on the current line from this chunk, matching the
+                                // line_position == 0 path above. Only commit when the line is
+                                // already full. This keeps multi-chunk lines (after edits)
+                                // segmented identically to single-chunk lines.
+                                if (remaining_on_line == 0) {
+                                    commitVirtualLine(wctx);
+                                }
                                 if (char_offset > 0) {
                                     const pos_result = utf8.findPosByWidth(chunk_bytes, char_offset, wctx.text_buffer.tabWidth(), is_ascii_only, false, wctx.text_buffer.widthMethod());
                                     byte_offset = pos_result.byte_offset;
                                 }
+                                const fill_width = if (remaining_on_line == 0) wctx.lineWrapWidth() else remaining_on_line;
                                 const remaining_bytes = chunk_bytes[byte_offset..];
-                                const wrap_result = utf8.findWrapPosByWidth(remaining_bytes, wctx.lineWrapWidth(), wctx.text_buffer.tabWidth(), is_ascii_only, wctx.text_buffer.widthMethod());
+                                const wrap_result = utf8.findWrapPosByWidth(remaining_bytes, fill_width, wctx.text_buffer.tabWidth(), is_ascii_only, wctx.text_buffer.widthMethod());
                                 to_add = wrap_result.columns_used;
                                 byte_offset += wrap_result.byte_offset;
                                 if (to_add == 0) {
+                                    if (remaining_on_line > 0) {
+                                        // The next grapheme does not fit in the remaining
+                                        // space; commit the short line and let the next loop
+                                        // iteration hard-fill a fresh line.
+                                        commitVirtualLine(wctx);
+                                        continue;
+                                    }
                                     to_add = 1;
                                     const single_result = utf8.findWrapPosByWidth(remaining_bytes, 1, wctx.text_buffer.tabWidth(), is_ascii_only, wctx.text_buffer.widthMethod());
                                     byte_offset += single_result.byte_offset;


### PR DESCRIPTION
Fixes #1288

## Summary

With `wrapMode="word"`, inserting into the middle of an already soft-wrapped logical line anchors the first wrap boundary at the edit offset. The affected row stays truncated — e.g. `initialValue = "a" * 100` at wrap width 56, insert `"X"` at col 20: the virtual line count becomes 3 with row 1 ending at col 21, where a fresh `setText` of the same 101 characters yields 2 full-width rows. Reproduction is in #1288.

## Root cause

This is not stale caching — all wrapping is recomputed from scratch per update by `calculateVirtualLinesGeneric`. It is deterministic chunk-segmentation divergence:

- Rope edits split chunks at the edit offset: after the repro edit the line is chunks `["a"*20]["X"]["a"*80]` instead of one chunk.
- In the word-mode walker (`text-buffer-view.zig`), when a chunk arrives at a partially filled line and no wrap break has been recorded on that line (`remaining_in_chunk > remaining_on_line`, no `last_wrap_that_fits`, `last_wrap_chunk_count == 0`), the final else branch called `commitVirtualLine()` unconditionally — treating the chunk boundary as a wrap point — then filled the *next* line at full width.
- A single-chunk buffer with identical text takes the `line_position == 0` hard-fill branch instead and wraps correctly. Hence "only broken after editing".

## Fix

One hunk in the else branch: a chunk boundary is not a wrap point. Hard-fill the remaining space on the current line from the chunk via `utf8.findWrapPosByWidth(remaining_bytes, remaining_on_line, ...)`, mirroring the `line_position == 0` path. Commit only when:

- the line is already full (`remaining_on_line == 0`), or
- the next grapheme does not fit the remaining space (`columns_used == 0`, e.g. 1 column left and a width-2 CJK grapheme next) — then the short row commits and the next iteration hard-fills a fresh line. The force-one-grapheme guard is kept only for the full-line case, exactly as before; applying it mid-line would have split wide graphemes across rows and changed single-chunk behavior too (single-chunk walks also reach this branch after the first hard-filled row).

All other branches — fit, `last_wrap_that_fits`, `line_position == 0`, and the `last_wrap_chunk_count > 0` backtrack (#1078 machinery) — are byte-identical. This branch only runs when no wrap break was recorded on the current line, so word-wrap backtracking is unaffected.

**Intended behavior change:** an unbreakable run arriving at a partially filled line no longer pushes to the next row. Example: chunks `["hello"]["x"*100]` at wrap 56 (e.g. insert `"hello"` at offset 0 of an x-run) — old: rows `[5, 56, 44]`; new: `[56, 49]`, identical to a fresh `setText` of the same content. Edge behavior preserved: a wide grapheme that doesn't fit the remaining space still wraps whole (`["a"*54]["世"*20]` at wrap 55 → `[54, 40]`, matching single-chunk behavior before and after; pinned by test).

## Tests

11 new tests in `packages/core/src/zig/tests/word-wrap-editing_test.zig` (file already registered in `test.zig`). The central oracle is `expectSegmentationMatchesFreshSet`: read the edited buffer's full text, `setText` it into a fresh buffer + view with the same wrap mode/width, and assert identical virtual-line segmentation (count, `source_line`, `source_col_offset`, `width_cols`) — segmentation must depend only on text content, never on edit history.

- exact issue repro: insert into soft-wrapped unbreakable line reflows (`expected 2, found 3` pre-fix)
- insert / delete / paste-like multi-char insert at several offsets (line start, mid-first-row, row boundary, mid-second-row), oracle-checked
- word boundaries still backtrack after a mid-row edit (spaces; explicit widths + oracle)
- unbreakable CJK line edited mid-row (asserts even row widths = no grapheme split)
- mixed widths with combining marks, oracle at 4 offsets
- five sequential single-char inserts, oracle after each
- undo → redo restores fresh-set segmentation
- wrap width change after edit (56→40→56), oracle-checked
- wide grapheme that does not fit the remaining space is not split (guard for the new branch)

Each was run individually and fails pre-fix except the two behavior guards. `zig build test`: **1877 passed, 6 skipped, 0 failed**. `zig fmt` clean. `wrapMode="char"`/`"none"` untouched — the change is entirely inside the word-mode arm and their existing tests pass unchanged.

## Performance

No asymptotic change: per loop iteration the work is identical — one `findWrapPosByWidth` scan over the same bytes, only the width argument differs, and the tracked `byte_offset` invariant (the O(n²) guard) holds. A commit is *removed* from the common path; the new commit-and-continue is bounded by the number of virtual lines. `zig build bench` ("TextBuffer Wrapping", word wrap avg, before → after): multi-line w40 27.69→18.60 ms, w80 21.52→15.00 ms, w120 17.44→13.19 ms; single-line w40 28.29→25.18 ms, w80 27.74→26.00 ms, w120 26.34→27.22 ms — no regression (differences are machine noise in our favor).
