### PR TITLE
render: bound streaming code highlights

### DIFF
--- a/packages/core/src/lib/tree-sitter/client.test.ts
+++ b/packages/core/src/lib/tree-sitter/client.test.ts
@@ -398,6 +398,44 @@ describe("TreeSitterClient", () => {
     expect(result.warning).toContain("No parser available for filetype unsupported-lang")
   }, 5000)
 
+  test("should reject one-shot highlighting after a correlated worker error", async () => {
+    await client.initialize()
+
+    const internals = client as unknown as {
+      messageCallbacks: Map<string, unknown>
+      worker?: {
+        onmessage: ((event: { data: { type: "ERROR"; messageId: string; error: string } }) => void) | null
+        postMessage: (message: { type?: string; messageId?: string }) => void
+      }
+    }
+    const worker = internals.worker
+    expect(worker).toBeDefined()
+    if (!worker) {
+      throw new Error("Expected initialized client to have a worker")
+    }
+
+    let messageId: string | undefined
+    const originalPostMessage = worker.postMessage.bind(worker)
+    worker.postMessage = (message) => {
+      if (message.type === "ONESHOT_HIGHLIGHT") {
+        messageId = message.messageId
+        return
+      }
+      originalPostMessage(message)
+    }
+
+    const highlighting = client.highlightOnce("const value = 1", "javascript")
+    expect(messageId).toBeDefined()
+    expect(internals.messageCallbacks.size).toBe(1)
+
+    worker.onmessage?.({
+      data: { type: "ERROR", messageId: messageId!, error: "synthetic one-shot failure" },
+    })
+
+    await expect(highlighting).rejects.toThrow("synthetic one-shot failure")
+    expect(internals.messageCallbacks.size).toBe(0)
+  })
+
   test("should perform multiple one-shot highlights independently", async () => {
     await client.initialize()
 

--- a/packages/core/src/lib/tree-sitter/client.ts
+++ b/packages/core/src/lib/tree-sitter/client.ts
@@ -529,6 +529,13 @@ export class TreeSitterClient extends EventEmitter<TreeSitterClientEvents> {
       }
 
       case "ERROR": {
+        if (message.messageId) {
+          const callback = this.messageCallbacks.get(message.messageId)
+          if (callback) {
+            this.messageCallbacks.delete(message.messageId)
+            callback.reject(new Error(message.error))
+          }
+        }
         this.emitError(message.error, message.bufferId)
         return
       }

--- a/packages/core/src/lib/tree-sitter/parser.worker.ts
+++ b/packages/core/src/lib/tree-sitter/parser.worker.ts
@@ -923,10 +923,11 @@ function logMessage(type: TreeSitterWorkerLogType, ...args: unknown[]): void {
   } satisfies TreeSitterWorkerResponse)
 }
 
-function postWorkerError(bufferId: number | undefined, error: unknown): void {
+function postWorkerError(bufferId: number | undefined, messageId: string | undefined, error: unknown): void {
   postWorkerMessage({
     type: "ERROR",
     bufferId,
+    messageId,
     error: error instanceof Error ? error.stack || error.message : String(error),
   } satisfies TreeSitterWorkerResponse)
 }
@@ -1089,10 +1090,11 @@ if (isWorkerRuntime) {
           } satisfies TreeSitterWorkerResponse)
       }
     } catch (error) {
+      const messageId = "messageId" in message ? message.messageId : undefined
       if ("bufferId" in message) {
-        postWorkerError(message.bufferId, error)
+        postWorkerError(message.bufferId, messageId, error)
       } else {
-        postWorkerError(undefined, error)
+        postWorkerError(undefined, messageId, error)
       }
     }
   })

--- a/packages/core/src/lib/tree-sitter/types.ts
+++ b/packages/core/src/lib/tree-sitter/types.ts
@@ -97,7 +97,7 @@ export type TreeSitterWorkerResponse =
   | { type: "UPDATE_DATA_PATH_RESPONSE"; messageId: string; error?: string }
   | { type: "CLEAR_CACHE_RESPONSE"; messageId: string; error?: string }
   | { type: "WARNING"; bufferId?: number; warning: string }
-  | { type: "ERROR"; bufferId?: number; error: string }
+  | { type: "ERROR"; bufferId?: number; messageId?: string; error: string }
   | { type: "WORKER_LOG"; logType: TreeSitterWorkerLogType; data: unknown[] }
 
 export interface TreeSitterClientEvents {

--- a/packages/core/src/renderables/Code.test.ts
+++ b/packages/core/src/renderables/Code.test.ts
@@ -4,7 +4,6 @@ import { SyntaxStyle } from "../syntax-style.js"
 import { RGBA } from "../lib/RGBA.js"
 import { createTestRenderer, type TestRenderer, MockTreeSitterClient, type MockMouse } from "../testing.js"
 import { ManualClock } from "../testing/manual-clock.js"
-import { TreeSitterClient } from "../lib/tree-sitter/index.js"
 import type { SimpleHighlight } from "../lib/tree-sitter/types.js"
 import { BoxRenderable } from "./Box.js"
 import { TextAttributes, type CapturedFrame } from "../types.js"
@@ -86,6 +85,16 @@ async function resolveMockHighlights(codeRenderable: CodeRenderable, mockClient:
   mockClient.resolveAllHighlightOnce()
   await waitForHighlight(codeRenderable)
   await renderOnce()
+}
+
+function recordHighlightContents(mockClient: MockTreeSitterClient): string[] {
+  const contents: string[] = []
+  const highlightOnce = mockClient.highlightOnce.bind(mockClient)
+  mockClient.highlightOnce = async (content, filetype) => {
+    contents.push(content)
+    return highlightOnce(content, filetype)
+  }
+  return contents
 }
 
 afterEach(async () => {
@@ -242,6 +251,167 @@ test("CodeRenderable - multiple content changes during highlighting", async () =
   await waitForHighlight(codeRenderable)
 
   expect(mockClient.isHighlighting()).toBe(false)
+})
+
+test("CodeRenderable - coalesces streaming updates while highlighting", async () => {
+  const syntaxStyle = SyntaxStyle.create()
+  const mockClient = new MockTreeSitterClient()
+  const highlightCalls = recordHighlightContents(mockClient)
+
+  const codeRenderable = new CodeRenderable(currentRenderer, {
+    id: "test-code",
+    content: "initial",
+    filetype: "typescript",
+    syntaxStyle,
+    treeSitterClient: mockClient,
+    streaming: true,
+  })
+
+  currentRenderer.root.add(codeRenderable)
+  await renderOnce()
+
+  for (const content of ["stale", "latest"]) {
+    codeRenderable.content = content
+    await renderOnce()
+  }
+
+  expect(highlightCalls).toEqual(["initial"])
+  const highlightingDone = codeRenderable.highlightingDone
+  let highlightingSettled = false
+  void highlightingDone.then(() => {
+    highlightingSettled = true
+  })
+
+  mockClient.resolveHighlightOnce()
+  await new Promise<void>((resolve) => setImmediate(resolve))
+
+  expect(highlightCalls).toEqual(["initial", "latest"])
+  expect(highlightingSettled).toBe(false)
+
+  for (const content of ["follow-up-stale", "newest"]) {
+    codeRenderable.content = content
+    await renderOnce()
+  }
+
+  expect(highlightCalls).toEqual(["initial", "latest"])
+
+  mockClient.resolveHighlightOnce()
+  await new Promise<void>((resolve) => setImmediate(resolve))
+
+  expect(highlightCalls).toEqual(["initial", "latest", "newest"])
+  expect(highlightingSettled).toBe(false)
+
+  mockClient.resolveHighlightOnce()
+  await highlightingDone
+  expect(codeRenderable.isHighlighting).toBe(false)
+})
+
+test("CodeRenderable - removing filetype shows the latest unstyled streaming content", async () => {
+  const syntaxStyle = SyntaxStyle.create()
+  const mockClient = new MockTreeSitterClient()
+  const highlightCalls = recordHighlightContents(mockClient)
+  const codeRenderable = new CodeRenderable(currentRenderer, {
+    id: "test-code",
+    content: "initial",
+    filetype: "typescript",
+    syntaxStyle,
+    treeSitterClient: mockClient,
+    streaming: true,
+    drawUnstyledText: false,
+  })
+
+  currentRenderer.root.add(codeRenderable)
+  await renderOnce()
+
+  codeRenderable.content = "latest"
+  codeRenderable.filetype = undefined
+  await renderOnce()
+
+  expect(codeRenderable.plainText).toBe("latest")
+  expect(codeRenderable.isHighlighting).toBe(false)
+
+  codeRenderable.filetype = "typescript"
+  await renderOnce()
+
+  expect(highlightCalls).toEqual(["initial"])
+
+  mockClient.resolveHighlightOnce()
+  await flushAsync()
+  await renderOnce()
+
+  expect(codeRenderable.plainText).toBe("latest")
+  expect(highlightCalls).toEqual(["initial", "latest"])
+})
+
+test("CodeRenderable - disabling streaming preserves the queued latest highlight", async () => {
+  const syntaxStyle = SyntaxStyle.create()
+  const mockClient = new MockTreeSitterClient()
+  const highlightCalls = recordHighlightContents(mockClient)
+  const codeRenderable = new CodeRenderable(currentRenderer, {
+    id: "test-code",
+    content: "initial",
+    filetype: "typescript",
+    syntaxStyle,
+    treeSitterClient: mockClient,
+    streaming: true,
+  })
+
+  currentRenderer.root.add(codeRenderable)
+  await renderOnce()
+
+  codeRenderable.content = "latest"
+  await renderOnce()
+
+  codeRenderable.streaming = false
+  await renderOnce()
+
+  expect(highlightCalls).toEqual(["initial"])
+
+  mockClient.resolveHighlightOnce()
+  await new Promise<void>((resolve) => setImmediate(resolve))
+
+  expect(highlightCalls).toEqual(["initial", "latest"])
+
+  const highlightingDone = codeRenderable.highlightingDone
+  mockClient.resolveHighlightOnce()
+  await highlightingDone
+
+  expect(highlightCalls).toEqual(["initial", "latest"])
+  expect(codeRenderable.isHighlighting).toBe(false)
+})
+
+test("CodeRenderable - streaming updates wait behind an unresolved non-streaming highlight", async () => {
+  const syntaxStyle = SyntaxStyle.create()
+  const mockClient = new MockTreeSitterClient()
+  const highlightCalls = recordHighlightContents(mockClient)
+  const codeRenderable = new CodeRenderable(currentRenderer, {
+    id: "test-code",
+    content: "non-streaming",
+    filetype: "typescript",
+    syntaxStyle,
+    treeSitterClient: mockClient,
+  })
+
+  currentRenderer.root.add(codeRenderable)
+  await renderOnce()
+
+  codeRenderable.streaming = true
+  codeRenderable.content = "streaming"
+  await renderOnce()
+
+  codeRenderable.content = "latest"
+  await renderOnce()
+
+  expect(highlightCalls).toEqual(["non-streaming"])
+
+  mockClient.resolveHighlightOnce()
+  await new Promise<void>((resolve) => setImmediate(resolve))
+
+  expect(highlightCalls).toEqual(["non-streaming", "latest"])
+
+  const highlightingDone = codeRenderable.highlightingDone
+  mockClient.resolveHighlightOnce()
+  await highlightingDone
 })
 
 test("CodeRenderable - uses fallback rendering when no filetype provided", async () => {
@@ -441,6 +611,37 @@ test("CodeRenderable - batches concurrent content and filetype updates", async (
   expect(codeRenderable.filetype).toBe("typescript")
 })
 
+test("CodeRenderable - filetype change invalidates an active highlight before rendering", async () => {
+  const syntaxStyle = SyntaxStyle.create()
+  const mockClient = new MockTreeSitterClient()
+  const filetypes: string[] = []
+  const highlightOnce = mockClient.highlightOnce.bind(mockClient)
+  mockClient.highlightOnce = async (content, filetype) => {
+    filetypes.push(filetype)
+    return highlightOnce(content, filetype)
+  }
+  const codeRenderable = new CodeRenderable(currentRenderer, {
+    id: "test-code",
+    content: "const value = 1",
+    filetype: "javascript",
+    syntaxStyle,
+    treeSitterClient: mockClient,
+  })
+
+  currentRenderer.root.add(codeRenderable)
+  await renderOnce()
+
+  codeRenderable.filetype = "typescript"
+  mockClient.resolveHighlightOnce()
+  await flushAsync()
+  await renderOnce()
+
+  expect(filetypes).toEqual(["javascript", "typescript"])
+
+  mockClient.resolveHighlightOnce()
+  await waitForHighlight(codeRenderable)
+})
+
 test("CodeRenderable - batches multiple updates in same tick into single highlight", async () => {
   const syntaxStyle = SyntaxStyle.fromStyles({
     default: { fg: RGBA.fromValues(1, 1, 1, 1) },
@@ -483,7 +684,9 @@ test("CodeRenderable - batches multiple updates in same tick into single highlig
 
   await renderOnce()
 
-  mockClient.resolveAllHighlightOnce()
+  mockClient.resolveHighlightOnce()
+  await new Promise<void>((resolve) => setImmediate(resolve))
+  mockClient.resolveHighlightOnce()
   await waitForHighlight(codeRenderable)
 
   expect(highlightCount).toBe(1)
@@ -522,89 +725,35 @@ test("CodeRenderable - renders markdown with TypeScript injection correctly", as
   expect(codeRenderable.plainText).toContain("typescript")
 })
 
-test("CodeRenderable - continues highlighting after unresolved promise", async () => {
-  const syntaxStyle = SyntaxStyle.fromStyles({
-    default: { fg: RGBA.fromValues(1, 1, 1, 1) },
-    keyword: { fg: RGBA.fromValues(0, 0, 1, 1) },
-  })
-
-  let highlightCount = 0
-  const pendingPromises: Array<{ content: string; filetype: string; never: boolean }> = []
-
-  class HangingMockClient extends TreeSitterClient {
-    constructor() {
-      super({ dataPath: "/tmp/mock" }, { autoStartWorker: false })
-    }
-
-    async highlightOnce(
-      content: string,
-      filetype: string,
-    ): Promise<{ highlights?: SimpleHighlight[]; warning?: string; error?: string }> {
-      highlightCount++
-
-      const shouldHang = highlightCount === 4 && filetype === "typescript"
-
-      pendingPromises.push({ content, filetype, never: shouldHang })
-
-      if (shouldHang) {
-        return new Promise(() => {})
-      }
-
-      return Promise.resolve({ highlights: [] })
-    }
-  }
-
-  const mockClient = new HangingMockClient()
-
+test("CodeRenderable - coalesces non-streaming updates behind an unresolved highlight", async () => {
+  const syntaxStyle = SyntaxStyle.create()
+  const mockClient = new MockTreeSitterClient()
+  const highlightCalls = recordHighlightContents(mockClient)
   const codeRenderable = new CodeRenderable(currentRenderer, {
     id: "test-code",
-    content: "interface User { name: string; }",
+    content: "initial",
     filetype: "typescript",
     syntaxStyle,
     treeSitterClient: mockClient,
-    conceal: false,
   })
 
   currentRenderer.root.add(codeRenderable)
   await renderOnce()
-  await waitForHighlight(codeRenderable)
 
-  highlightCount = 0
-  pendingPromises.length = 0
+  for (const content of ["stale", "latest"]) {
+    codeRenderable.content = content
+    await renderOnce()
+  }
 
-  codeRenderable.content = "const message = 'hello';"
-  codeRenderable.filetype = "javascript"
-  await renderOnce()
-  await waitForHighlight(codeRenderable)
+  expect(highlightCalls).toEqual(["initial"])
 
-  codeRenderable.content = "# Documentation"
-  codeRenderable.filetype = "markdown"
-  await renderOnce()
-  await waitForHighlight(codeRenderable)
+  mockClient.resolveHighlightOnce()
+  await new Promise<void>((resolve) => setImmediate(resolve))
 
-  codeRenderable.content = "const message = 'world';"
-  codeRenderable.filetype = "javascript"
-  await renderOnce()
-  await waitForHighlight(codeRenderable)
+  expect(highlightCalls).toEqual(["initial", "latest"])
 
-  codeRenderable.content = "interface User { name: string; }"
-  codeRenderable.filetype = "typescript"
-  await renderOnce()
-  await flushAsync()
-
-  codeRenderable.content = "# New Documentation"
-  codeRenderable.filetype = "markdown"
-  await renderOnce()
-  await waitForHighlight(codeRenderable)
-
-  const markdownHighlightHappened = pendingPromises.some(
-    (p) => p.content === "# New Documentation" && p.filetype === "markdown",
-  )
-
-  expect(codeRenderable.content).toBe("# New Documentation")
-  expect(codeRenderable.filetype).toBe("markdown")
-  expect(markdownHighlightHappened).toBe(true)
-  expect(highlightCount).toBe(5)
+  mockClient.resolveHighlightOnce()
+  await codeRenderable.highlightingDone
 })
 
 test("CodeRenderable - concealment is enabled by default", async () => {
@@ -991,7 +1140,9 @@ test("CodeRenderable - with drawUnstyledText=false, multiple updates only render
   const frameAfterUpdate = captureFrame()
   expect(frameAfterUpdate.trim()).toBe("")
 
-  mockClient.resolveAllHighlightOnce()
+  mockClient.resolveHighlightOnce()
+  await new Promise<void>((resolve) => setImmediate(resolve))
+  mockClient.resolveHighlightOnce()
   await waitForHighlight(codeRenderable)
   await renderOnce()
   await flushAsync()
@@ -2167,7 +2318,9 @@ test("CodeRenderable - plainText reflects content immediately with drawUnstyledT
   const frame = captureFrame()
   expect(frame.trim()).toBe("")
 
-  mockClient.resolveAllHighlightOnce()
+  mockClient.resolveHighlightOnce()
+  await new Promise<void>((resolve) => setImmediate(resolve))
+  mockClient.resolveHighlightOnce()
   await waitForHighlight(codeRenderable)
   await renderOnce()
 

--- a/packages/core/src/renderables/Code.ts
+++ b/packages/core/src/renderables/Code.ts
@@ -52,6 +52,9 @@ export class CodeRenderable extends TextBufferRenderable {
   private _treeSitterClient: TreeSitterClient
   private _highlightsDirty: boolean = false
   private _highlightSnapshotId: number = 0
+  private _highlightLoopActive: boolean = false
+  private _highlightPromise?: Promise<void>
+  private _highlightRerun: boolean = false
   private _conceal: boolean
   private _drawUnstyledText: boolean
   private _shouldRenderTextBuffer: boolean = true
@@ -106,11 +109,15 @@ export class CodeRenderable extends TextBufferRenderable {
     return this._content
   }
 
+  private invalidateHighlights(): void {
+    this._highlightsDirty = true
+    this._highlightSnapshotId++
+  }
+
   set content(value: string) {
     if (this._content !== value) {
       this._content = value
-      this._highlightsDirty = true
-      this._highlightSnapshotId++
+      this.invalidateHighlights()
 
       if (this._streaming && this._filetype && !this._drawUnstyledText) {
         this.requestRender()
@@ -170,7 +177,7 @@ export class CodeRenderable extends TextBufferRenderable {
   set filetype(value: string | undefined) {
     if (this._filetype !== value) {
       this._filetype = value
-      this._highlightsDirty = true
+      this.invalidateHighlights()
     }
   }
 
@@ -181,7 +188,7 @@ export class CodeRenderable extends TextBufferRenderable {
   set syntaxStyle(value: SyntaxStyle) {
     if (this._syntaxStyle !== value) {
       this._syntaxStyle = value
-      this._highlightsDirty = true
+      this.invalidateHighlights()
     }
   }
 
@@ -192,7 +199,7 @@ export class CodeRenderable extends TextBufferRenderable {
   set conceal(value: boolean) {
     if (this._conceal !== value) {
       this._conceal = value
-      this._highlightsDirty = true
+      this.invalidateHighlights()
     }
   }
 
@@ -203,7 +210,7 @@ export class CodeRenderable extends TextBufferRenderable {
   set drawUnstyledText(value: boolean) {
     if (this._drawUnstyledText !== value) {
       this._drawUnstyledText = value
-      this._highlightsDirty = true
+      this.invalidateHighlights()
     }
   }
 
@@ -214,7 +221,7 @@ export class CodeRenderable extends TextBufferRenderable {
   set initialStyledText(value: StyledText | undefined) {
     if (this._initialStyledText !== value) {
       this._initialStyledText = value
-      this._highlightsDirty = true
+      this.invalidateHighlights()
     }
   }
 
@@ -223,7 +230,7 @@ export class CodeRenderable extends TextBufferRenderable {
       this._streaming = value
       this._hadInitialContent = false
       this._lastHighlights = []
-      this._highlightsDirty = true
+      this.invalidateHighlights()
     }
   }
 
@@ -234,7 +241,7 @@ export class CodeRenderable extends TextBufferRenderable {
   set treeSitterClient(value: TreeSitterClient) {
     if (this._treeSitterClient !== value) {
       this._treeSitterClient = value
-      this._highlightsDirty = true
+      this.invalidateHighlights()
     }
   }
 
@@ -249,14 +256,14 @@ export class CodeRenderable extends TextBufferRenderable {
   set baseHighlight(value: string | undefined) {
     if (this._baseHighlight !== value) {
       this._baseHighlight = value
-      this._highlightsDirty = true
+      this.invalidateHighlights()
     }
   }
 
   set onHighlight(value: OnHighlightCallback | undefined) {
     if (this._onHighlight !== value) {
       this._onHighlight = value
-      this._highlightsDirty = true
+      this.invalidateHighlights()
     }
   }
 
@@ -267,12 +274,12 @@ export class CodeRenderable extends TextBufferRenderable {
   set onChunks(value: OnChunksCallback | undefined) {
     if (this._onChunks !== value) {
       this._onChunks = value
-      this._highlightsDirty = true
+      this.invalidateHighlights()
     }
   }
 
   get isHighlighting(): boolean {
-    return this._isHighlighting
+    return this._isHighlighting || this._highlightRerun
   }
 
   get highlightingDone(): Promise<void> {
@@ -420,6 +427,25 @@ export class CodeRenderable extends TextBufferRenderable {
     }
   }
 
+  private async runHighlights(): Promise<void> {
+    try {
+      do {
+        this._highlightRerun = false
+        await this.startHighlight()
+      } while (this._highlightRerun && !this.isDestroyed && this._content.length > 0 && this._filetype)
+    } finally {
+      this._highlightLoopActive = false
+      this._highlightRerun = false
+    }
+  }
+
+  private clearPendingHighlight(): void {
+    this._highlightSnapshotId++
+    this._isHighlighting = false
+    this._highlightRerun = false
+    this._highlightingPromise = Promise.resolve()
+  }
+
   private setRenderedLineSources(lineSources: number[] | undefined): void {
     this._renderedLineSources = lineSources
     this._mappedLineInfo = undefined
@@ -536,20 +562,55 @@ export class CodeRenderable extends TextBufferRenderable {
     if (this._highlightsDirty) {
       if (this.isDestroyed) return
 
-      if (this._content.length === 0) {
-        this._shouldRenderTextBuffer = false
+      const hasContent = this._content.length > 0
+      if (!hasContent || !this._filetype) {
+        this._shouldRenderTextBuffer = hasContent
         this._highlightsDirty = false
-      } else if (!this._filetype) {
-        this._shouldRenderTextBuffer = true
-        this._highlightsDirty = false
+        this.clearPendingHighlight()
+
+        if (hasContent) {
+          this.textBuffer.setText(this._content)
+          this.setRenderedLineSources(undefined)
+          this.updateTextInfo()
+        }
       } else {
         this.ensureVisibleTextBeforeHighlight()
         this._highlightsDirty = false
-        this._highlightingPromise = this.startHighlight()
+        if (this._highlightLoopActive) {
+          this._isHighlighting = true
+          this._highlightRerun = true
+          this._highlightingPromise = this._highlightPromise!
+        } else {
+          const { promise: highlightingPromise, resolve, reject } = Promise.withResolvers<void>()
+          this._highlightLoopActive = true
+          this._highlightPromise = highlightingPromise
+          this._highlightingPromise = highlightingPromise
+          const clearHighlight = () => {
+            if (this._highlightPromise === highlightingPromise) {
+              this._highlightPromise = undefined
+            }
+          }
+          void this.runHighlights().then(
+            () => {
+              clearHighlight()
+              resolve()
+            },
+            (error) => {
+              clearHighlight()
+              reject(error)
+            },
+          )
+        }
       }
     }
 
     if (!this._shouldRenderTextBuffer) return
     super.renderSelf(buffer)
+  }
+
+  public override destroy(): void {
+    if (this.isDestroyed) return
+    this.clearPendingHighlight()
+    super.destroy()
   }
 }

--- a/packages/core/src/renderables/__tests__/renderable-test-utils.ts
+++ b/packages/core/src/renderables/__tests__/renderable-test-utils.ts
@@ -2,7 +2,6 @@ import { TextareaRenderable } from "../Textarea.js"
 import { type TestRenderer } from "../../testing/test-renderer.js"
 import { type TextareaOptions } from "../Textarea.js"
 import type { DiffRenderable } from "../Diff.js"
-import type { CodeRenderable } from "../Code.js"
 import type { MockTreeSitterClient } from "../../testing/mock-tree-sitter-client.js"
 import type { ManualClock } from "../../testing/manual-clock.js"
 
@@ -18,14 +17,7 @@ export async function createTextareaRenderable(
   return { textarea: textareaRenderable, root: renderer.root }
 }
 
-// Settle Diff highlighting deterministically. Each iteration:
-// 1. Render twice — the first render may trigger Diff.requestRebuild via microtask
-//    (runs during renderOnce's internal awaits), which calls requestRender while
-//    rendering=true, setting immediateRerenderRequested. The resulting re-render
-//    is scheduled via clock.setTimeout (ManualClock), so needs a second renderOnce.
-// 2. Resolve all pending highlights (proper signal via mock)
-// 3. Await Code.highlightingDone on both sides (proper signal from Code)
-// Loop exits when mock has no more pending requests (state-based, not count-based).
+// Render twice to flush Diff rebuilds, then drain each serialized highlight batch.
 export async function settleDiffHighlighting(
   diff: DiffRenderable,
   client: MockTreeSitterClient,
@@ -37,10 +29,7 @@ export async function settleDiffHighlighting(
     await render()
     if (!client.isHighlighting()) break
     client.resolveAllHighlightOnce()
-    const left: CodeRenderable | null = (diff as any).leftCodeRenderable
-    const right: CodeRenderable | null = (diff as any).rightCodeRenderable
-    if (left) await left.highlightingDone
-    if (right) await right.highlightingDone
+    await new Promise<void>((resolve) => setImmediate(resolve))
   }
 }
 

--- a/packages/core/src/tests/renderer.scrollback-surface.test.ts
+++ b/packages/core/src/tests/renderer.scrollback-surface.test.ts
@@ -216,6 +216,43 @@ test("ScrollbackSurface.settle waits for code highlighting before commit", async
   }
 })
 
+test("ScrollbackSurface.settle renders a queued streaming highlight", async () => {
+  const { renderer } = await createSplitFooterRenderer()
+  const surface = renderer.createScrollbackSurface({ startOnNewLine: true })
+  const mockTreeSitterClient = createMockTreeSitterClient()
+  const highlightCalls: string[] = []
+  const highlightOnce = mockTreeSitterClient.highlightOnce.bind(mockTreeSitterClient)
+  mockTreeSitterClient.highlightOnce = async (content, filetype) => {
+    highlightCalls.push(content)
+    return highlightOnce(content, filetype)
+  }
+  const code = new CodeRenderable(surface.renderContext, {
+    id: "surface-code-streaming",
+    content: "initial",
+    filetype: "typescript",
+    syntaxStyle,
+    streaming: true,
+    treeSitterClient: mockTreeSitterClient,
+    width: "100%",
+  })
+
+  surface.root.add(code)
+  surface.render()
+  code.content = "latest"
+
+  const settlePromise = surface.settle()
+  void settlePromise.catch(() => {})
+  expect(highlightCalls).toEqual(["initial"])
+
+  mockTreeSitterClient.resolveHighlightOnce()
+  await new Promise<void>((resolve) => setImmediate(resolve))
+
+  expect(highlightCalls).toEqual(["initial", "latest"])
+
+  mockTreeSitterClient.resolveHighlightOnce()
+  await settlePromise
+})
+
 test("ScrollbackSurface works with MarkdownRenderable top-level blocks", async () => {
   const { renderer } = await createSplitFooterRenderer()
   const surface = renderer.createScrollbackSurface({ startOnNewLine: true })


### PR DESCRIPTION
Serialize Tree-sitter highlighting per CodeRenderable and coalesce pending updates to the latest snapshot, preventing obsolete streamed content from creating unbounded worker work. Include queued reruns in highlight settlement so rendered and scrollback surfaces converge to current content.

Correlate one-shot worker errors with their message IDs so failed requests reject instead of remaining unresolved.

Fix #1321