### PR TITLE
bench: add Node JS benchmark runner

### DIFF
--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -1,6 +1,7 @@
 # Zig build cache
 .zig-cache
 .node-test
+.node-benchmark
 ffi-fast-path-paired.json
 zig-out
 src/zig/lib

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
     "test:native": "cd src/zig && zig build test --summary all",
     "bench:native": "cd src/zig && zig build bench -Dbench-optimize=ReleaseFast --",
     "bench:js": "bun src/benchmark/js-benchmark.ts",
+    "bench:js:node": "bun scripts/bench-js-node.ts",
     "bench:layout": "bun src/benchmark/layout-benchmark.ts",
     "bench:box-draw": "bun src/benchmark/box-draw-benchmark.ts",
     "bench:render-traversal": "bun src/benchmark/render-traversal-benchmark.ts",

--- a/packages/core/scripts/bench-js-node.ts
+++ b/packages/core/scripts/bench-js-node.ts
@@ -1,0 +1,53 @@
+import { spawnSync } from "node:child_process"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { requireNode26 } from "../../../scripts/node26.mjs"
+
+const benchmarkArguments = process.argv.slice(2)
+if (benchmarkArguments.length !== 1 || benchmarkArguments[0] !== "--format=json") {
+  process.stderr.write("usage: bench:js --format=json\n")
+  process.exit(2)
+}
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const outputDirectory = resolve(packageRoot, ".node-benchmark")
+const benchmarkEntry = resolve(outputDirectory, "js-benchmark.js")
+const nodePath = requireNode26()
+
+rmSync(outputDirectory, { recursive: true, force: true })
+mkdirSync(outputDirectory, { recursive: true })
+
+try {
+  if (process.env.OTUI_BENCH_NATIVE_PREPARED !== "1") runBuild("bun", ["run", "build:native"])
+  runBuild("bun", [
+    "build",
+    "src/benchmark/js-benchmark.ts",
+    "--target=node",
+    "--format=esm",
+    "--outfile",
+    benchmarkEntry,
+    "--external",
+    "@opentui/core-*",
+  ])
+  writeFileSync(resolve(outputDirectory, "package.json"), JSON.stringify({ type: "module" }))
+  const benchmark = spawnSync(
+    nodePath,
+    ["--experimental-ffi", "--no-warnings", benchmarkEntry, ...benchmarkArguments],
+    { cwd: packageRoot, stdio: "inherit" },
+  )
+  if (benchmark.error) throw benchmark.error
+  process.exitCode = benchmark.status ?? 1
+} finally {
+  rmSync(outputDirectory, { recursive: true, force: true })
+}
+
+function runBuild(command: string, args: string[]): void {
+  const child = spawnSync(command, args, { cwd: packageRoot, encoding: "utf8" })
+  if (child.stdout) process.stderr.write(child.stdout)
+  if (child.stderr) process.stderr.write(child.stderr)
+  if (child.error) throw child.error
+  if (child.status !== 0)
+    throw new Error(`${command} ${args.join(" ")} exited with status ${child.status ?? "unknown"}`)
+}

--- a/packages/core/src/benchmark/js-benchmark-harness.test.ts
+++ b/packages/core/src/benchmark/js-benchmark-harness.test.ts
@@ -5,6 +5,7 @@ import { defaultBenchmarkCases } from "./js-benchmark-cases.js"
 import {
   calculateInnerRsdPpm,
   canonicalJson,
+  createMonotonicClock,
   createManifest,
   manifestHash,
   runBenchmarks,
@@ -86,6 +87,15 @@ describe("statistics and manifest", () => {
 })
 
 describe("runner", () => {
+  test("uses Bun nanoseconds unchanged and an origin-relative Node clock", () => {
+    const bunClock = () => 123
+    expect(createMonotonicClock({ bunNanoseconds: bunClock, nodeNanoseconds: () => 999n })).toBe(bunClock)
+
+    const readings = [9_000_000_000_000_000n, 9_000_000_000_000_007n]
+    const nodeClock = createMonotonicClock({ nodeNanoseconds: () => readings.shift()! })
+    expect(nodeClock()).toBe(7)
+  })
+
   test("times run synchronously while awaiting setup and teardown", async () => {
     let now = 0
     let thenCalls = 0
@@ -354,7 +364,8 @@ describe("CLI", () => {
         ),
       ],
       options: { ...options, clock: () => now++, maxBatchIterations: 1 },
-      bunVersion: "test-bun",
+      jsRuntime: "bun",
+      runtimeVersion: "test-bun",
       zigVersion: "test-zig",
     })
 
@@ -371,7 +382,8 @@ describe("CLI", () => {
       stderr,
       cases: [fakeCase({}, { name: "first" }), fakeCase({}, { name: "second" })],
       options: { ...options, clock: () => now++, maxBatchIterations: 1 },
-      bunVersion: "test-bun",
+      jsRuntime: "node",
+      runtimeVersion: "test-node",
       zigVersion: "test-zig",
     })
 
@@ -380,12 +392,14 @@ describe("CLI", () => {
     expect(stdout.text.trim().split("\n")).toHaveLength(1)
     const document = JSON.parse(stdout.text)
     expect(document).toMatchObject({
-      schema_version: 1,
+      schema_version: 2,
       benchmark_suite: "core-default",
       protocol_version: 1,
-      bun_version: "test-bun",
+      js_runtime: "node",
+      runtime_version: "test-node",
       zig_version: "test-zig",
     })
+    expect(document).not.toHaveProperty("bun_version")
     expect(document.manifest.cases.map(({ name }: BenchmarkCase) => name)).toEqual(["first", "second"])
     expect(document.results.map(({ name }: BenchmarkCase) => name)).toEqual(["first", "second"])
   })

--- a/packages/core/src/benchmark/js-benchmark-harness.ts
+++ b/packages/core/src/benchmark/js-benchmark-harness.ts
@@ -53,6 +53,23 @@ export interface HarnessOptions {
   maxProcessNs: number
 }
 
+interface MonotonicClockRuntime {
+  bunNanoseconds?: () => number
+  nodeNanoseconds(): bigint
+}
+
+export function createMonotonicClock(
+  runtime: MonotonicClockRuntime = {
+    bunNanoseconds: typeof process.versions.bun === "string" ? Bun.nanoseconds : undefined,
+    nodeNanoseconds: process.hrtime.bigint,
+  },
+): () => number {
+  if (runtime.bunNanoseconds) return runtime.bunNanoseconds
+
+  const origin = runtime.nodeNanoseconds()
+  return () => Number(runtime.nodeNanoseconds() - origin)
+}
+
 export function calculateInnerRsdPpm(values: readonly number[]): number {
   if (values.length < 2) throw new Error("RSD requires at least two measured batches")
   for (const value of values) assertPositiveFinite(value, "batch ns/op")
@@ -120,7 +137,7 @@ export async function runBenchmarks(
   cases: readonly BenchmarkCase[],
   options: HarnessOptions,
 ): Promise<{ manifest: BenchmarkManifest; results: BenchmarkResult[] }> {
-  const clock = options.clock ?? Bun.nanoseconds
+  const clock = options.clock ?? createMonotonicClock()
   const processStartedAt = clock()
   const manifest = createManifest(cases, options)
   const results: BenchmarkResult[] = []

--- a/packages/core/src/benchmark/js-benchmark.ts
+++ b/packages/core/src/benchmark/js-benchmark.ts
@@ -1,5 +1,7 @@
-#!/usr/bin/env bun
-
+import { spawnSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import { resolve } from "node:path"
+import type { Writable } from "node:stream"
 import { fileURLToPath } from "node:url"
 
 import { defaultBenchmarkCases } from "./js-benchmark-cases.js"
@@ -29,7 +31,8 @@ interface CliDependencies {
   options?: HarnessOptions
   stdout: OutputWriter
   stderr: OutputWriter
-  bunVersion?: string
+  jsRuntime?: "bun" | "node"
+  runtimeVersion?: string
   zigVersion?: string
 }
 
@@ -47,11 +50,13 @@ export async function runBenchmarkCli(args: readonly string[], dependencies: Cli
   try {
     const options = dependencies.options ?? PROTOCOL
     const { manifest, results } = await runBenchmarks(dependencies.cases ?? defaultBenchmarkCases, options)
+    const runtime = dependencies.jsRuntime ?? detectRuntime()
     const document = {
-      schema_version: 1,
+      schema_version: 2,
       benchmark_suite: "core-default",
       protocol_version: options.protocolVersion,
-      bun_version: dependencies.bunVersion ?? Bun.version,
+      js_runtime: runtime,
+      runtime_version: dependencies.runtimeVersion ?? readRuntimeVersion(runtime),
       zig_version: dependencies.zigVersion ?? readZigVersion(),
       manifest: { hash: manifestHash(manifest), ...manifest },
       results,
@@ -66,20 +71,44 @@ export async function runBenchmarkCli(args: readonly string[], dependencies: Cli
 }
 
 function readZigVersion(): string {
-  const process = Bun.spawnSync(["zig", "version"], {
-    cwd: fileURLToPath(new URL("../zig", import.meta.url)),
-    stdout: "pipe",
-    stderr: "pipe",
+  const sourceZigDirectory = fileURLToPath(new URL("../zig", import.meta.url))
+  const zigDirectory = existsSync(sourceZigDirectory) ? sourceZigDirectory : resolve("src/zig")
+  const child = spawnSync("zig", ["version"], {
+    cwd: zigDirectory,
+    encoding: "utf8",
   })
-  if (process.exitCode !== 0) throw new Error(`zig version failed: ${process.stderr.toString().trim()}`)
-  const version = process.stdout.toString().trim()
+  if (child.error) throw new Error(`zig version failed: ${child.error.message}`, { cause: child.error })
+  if (child.status !== 0) throw new Error(`zig version failed: ${child.stderr.trim()}`)
+  const version = child.stdout.trim()
   if (!version) throw new Error("zig version returned an empty version")
   return version
 }
 
-if (import.meta.main) {
-  // Capture protocol writers before any benchmark initializes a renderer.
-  const stdout = Bun.stdout.writer()
-  const stderr = Bun.stderr.writer()
+function detectRuntime(): "bun" | "node" {
+  return typeof process.versions.bun === "string" ? "bun" : "node"
+}
+
+function readRuntimeVersion(runtime: "bun" | "node"): string {
+  if (runtime === "bun") return process.versions.bun!
+  return process.version.startsWith("v") ? process.version.slice(1) : process.version
+}
+
+function createOutputWriter(stream: Writable): OutputWriter {
+  let pendingDrain: Promise<void> = Promise.resolve()
+  return {
+    write(data) {
+      if (!stream.write(data)) pendingDrain = new Promise((resolve) => stream.once("drain", resolve))
+    },
+    flush() {
+      return pendingDrain
+    },
+  }
+}
+
+const isMain = process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isMain) {
+  // Capture protocol streams before any benchmark initializes a renderer.
+  const stdout = createOutputWriter(process.stdout)
+  const stderr = createOutputWriter(process.stderr)
   process.exitCode = await runBenchmarkCli(process.argv.slice(2), { stdout, stderr })
 }


### PR DESCRIPTION
Port the JS harness off Bun-only APIs so the same suite can run under
Node with a portable clock and runtime metadata.
