### PR TITLE
feat(core): add embedded terminal runtime

### DIFF
--- a/packages/core/src/zig/build.zig.zon
+++ b/packages/core/src/zig/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "uucode-0.2.0-ZZjBPuS4VABmt0lQ-jDiKB4afmuZVvZpbX09FP5JrR8N",
         },
         .ghostty = .{
-            .url = "https://github.com/ghostty-org/ghostty/archive/b988efcfe584e88a3d0330e2c17c386ffa419d72.tar.gz",
-            .hash = "ghostty-1.3.2-dev-5UdBC9WdJAU1k1nuTdAexwmdzbmW1VTy6KhL_EfHjoTt",
+            .url = "https://github.com/ghostty-org/ghostty/archive/727b8a02f8734840de664c060678dd66f01931f6.tar.gz",
+            .hash = "ghostty-1.3.2-dev-5UdBC1isOwU05h63E04-9yG3l4mK3tQ3kUxAs9P2rUPH",
             .lazy = true,
         },
         .yoga = .{

--- a/packages/core/src/zig/embedded-terminal/ghostty.zig
+++ b/packages/core/src/zig/embedded-terminal/ghostty.zig
@@ -1,0 +1,54 @@
+const vt = @import("../ghostty-vt.zig").vt;
+
+pub const Terminal = vt.Terminal;
+pub const TerminalStream = vt.TerminalStream;
+pub const Coordinate = vt.Coordinate;
+
+pub const Key = struct {
+    action: vt.input.KeyAction = .press,
+    key: vt.input.Key = .unidentified,
+    mods: vt.input.KeyMods = .{},
+    consumed_mods: vt.input.KeyMods = .{},
+    composing: bool = false,
+    utf8: []const u8 = "",
+    unshifted_codepoint: u21 = 0,
+
+    pub fn event(self: Key) vt.input.KeyEvent {
+        return .{
+            .action = self.action,
+            .key = self.key,
+            .mods = self.mods,
+            .consumed_mods = self.consumed_mods,
+            .composing = self.composing,
+            .utf8 = self.utf8,
+            .unshifted_codepoint = self.unshifted_codepoint,
+        };
+    }
+};
+
+pub const Mouse = struct {
+    action: vt.input.MouseAction,
+    button: ?vt.input.MouseButton = null,
+    mods: vt.input.KeyMods = .{},
+    x: f32,
+    y: f32,
+    any_button_pressed: bool = false,
+
+    pub fn event(self: Mouse) vt.input.MouseEncodeEvent {
+        return .{
+            .action = self.action,
+            .button = self.button,
+            .mods = self.mods,
+            .pos = .{ .x = self.x, .y = self.y },
+        };
+    }
+};
+
+pub const KeyEncodeOptions = vt.input.KeyEncodeOptions;
+pub const MouseEncodeOptions = vt.input.MouseEncodeOptions;
+pub const PasteOptions = vt.input.PasteOptions;
+pub const FocusEvent = vt.input.FocusEvent;
+pub const encodeKey = vt.input.encodeKey;
+pub const encodeMouse = vt.input.encodeMouse;
+pub const encodePaste = vt.input.encodePaste;
+pub const encodeFocus = vt.input.encodeFocus;

--- a/packages/core/src/zig/embedded-terminal/main.zig
+++ b/packages/core/src/zig/embedded-terminal/main.zig
@@ -1,0 +1,210 @@
+const std = @import("std");
+const ghostty = @import("ghostty.zig");
+
+pub const Error = error{
+    InvalidValue,
+    ProcessingFailed,
+    ResponseOverflow,
+} || std.mem.Allocator.Error;
+
+pub const Options = struct {
+    cols: u16,
+    rows: u16,
+    max_scrollback: usize = 10_000,
+};
+
+pub const parser_allocation_limit = 1024 * 1024;
+pub const response_limit = 1024 * 1024;
+
+const TrackingAllocator = struct {
+    child: std.mem.Allocator,
+    failed: bool = false,
+
+    fn allocator(self: *TrackingAllocator) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+
+    const vtable: std.mem.Allocator.VTable = .{
+        .alloc = alloc,
+        .resize = resize,
+        .remap = remap,
+        .free = free,
+    };
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
+        const self: *TrackingAllocator = @ptrCast(@alignCast(ctx));
+        const result = self.child.rawAlloc(len, alignment, ret_addr);
+        if (result == null) self.failed = true;
+        return result;
+    }
+
+    fn resize(
+        ctx: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        ret_addr: usize,
+    ) bool {
+        const self: *TrackingAllocator = @ptrCast(@alignCast(ctx));
+        return self.child.rawResize(memory, alignment, new_len, ret_addr);
+    }
+
+    fn remap(
+        ctx: *anyopaque,
+        memory: []u8,
+        alignment: std.mem.Alignment,
+        new_len: usize,
+        ret_addr: usize,
+    ) ?[*]u8 {
+        const self: *TrackingAllocator = @ptrCast(@alignCast(ctx));
+        return self.child.rawRemap(memory, alignment, new_len, ret_addr);
+    }
+
+    fn free(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
+        const self: *TrackingAllocator = @ptrCast(@alignCast(ctx));
+        self.child.rawFree(memory, alignment, ret_addr);
+    }
+};
+
+pub const EmbeddedTerminal = struct {
+    allocator: std.mem.Allocator,
+    terminal: ghostty.Terminal,
+    stream: ghostty.TerminalStream,
+    cols: u16,
+    rows: u16,
+    responses: std.ArrayListUnmanaged(u8) = .empty,
+    response_error: ?Error = null,
+    mouse_last_cell: ?ghostty.Coordinate = null,
+    parser_buffer: [parser_allocation_limit]u8 = undefined,
+    parser_fixed_allocator: std.heap.FixedBufferAllocator = undefined,
+    parser_allocator: TrackingAllocator = undefined,
+
+    pub fn init(allocator: std.mem.Allocator, options: Options) Error!*EmbeddedTerminal {
+        if (options.cols == 0 or options.rows == 0) return error.InvalidValue;
+
+        const self = try allocator.create(EmbeddedTerminal);
+        errdefer allocator.destroy(self);
+
+        self.* = .{
+            .allocator = allocator,
+            .terminal = try .init(allocator, .{
+                .cols = options.cols,
+                .rows = options.rows,
+                .max_scrollback = options.max_scrollback,
+            }),
+            .stream = undefined,
+            .cols = options.cols,
+            .rows = options.rows,
+        };
+        errdefer self.terminal.deinit(allocator);
+
+        self.parser_fixed_allocator = .init(&self.parser_buffer);
+        self.parser_allocator = .{ .child = self.parser_fixed_allocator.allocator() };
+        var handler = self.terminal.vtHandler();
+        handler.effects.write_pty = &writePty;
+        self.stream = .initAlloc(self.parser_allocator.allocator(), handler);
+        return self;
+    }
+
+    pub fn deinit(self: *EmbeddedTerminal) void {
+        const allocator = self.allocator;
+        self.stream.deinit();
+        self.terminal.deinit(allocator);
+        self.responses.deinit(allocator);
+        allocator.destroy(self);
+    }
+
+    pub fn write(self: *EmbeddedTerminal, bytes: []const u8) Error!void {
+        self.parser_allocator.failed = false;
+        self.stream.nextSlice(bytes);
+        if (self.parser_allocator.failed or self.stream.handler.semantic_failure) return error.ProcessingFailed;
+    }
+
+    pub fn resize(self: *EmbeddedTerminal, cols: u16, rows: u16) Error!void {
+        if (cols == 0 or rows == 0) return error.InvalidValue;
+        self.stream.handler.resize(.{ .cols = cols, .rows = rows }) catch |err| switch (err) {
+            error.InvalidValue => return error.InvalidValue,
+            error.OutOfMemory => return error.OutOfMemory,
+        };
+        self.cols = cols;
+        self.rows = rows;
+    }
+
+    pub fn scroll(self: *EmbeddedTerminal, delta: i32) void {
+        self.terminal.scrollViewport(.{ .delta = delta });
+    }
+
+    pub fn encodeKey(self: *EmbeddedTerminal, key: ghostty.Key) Error![]u8 {
+        var output: std.Io.Writer.Allocating = .init(self.allocator);
+        errdefer output.deinit();
+        ghostty.encodeKey(&output.writer, key.event(), .fromTerminal(&self.terminal)) catch return error.OutOfMemory;
+        return output.toOwnedSlice();
+    }
+
+    pub fn encodeMouse(self: *EmbeddedTerminal, mouse: ghostty.Mouse) Error![]u8 {
+        const MouseSize = @FieldType(ghostty.MouseEncodeOptions, "size");
+        const size: MouseSize = .{
+            .screen = .{ .width = self.cols, .height = self.rows },
+            .cell = .{ .width = 1, .height = 1 },
+            .padding = .{},
+        };
+        var options = ghostty.MouseEncodeOptions.fromTerminal(&self.terminal, size);
+        // OpenTUI receives terminal-cell coordinates, not physical pixels.
+        if (options.format == .sgr_pixels) return self.allocator.alloc(u8, 0);
+        options.any_button_pressed = mouse.any_button_pressed;
+        options.last_cell = &self.mouse_last_cell;
+
+        var output: std.Io.Writer.Allocating = .init(self.allocator);
+        errdefer output.deinit();
+        ghostty.encodeMouse(&output.writer, mouse.event(), options) catch return error.OutOfMemory;
+        return output.toOwnedSlice();
+    }
+
+    pub fn encodePaste(self: *EmbeddedTerminal, input: []const u8) Error![]u8 {
+        const copy = try self.allocator.dupe(u8, input);
+        defer self.allocator.free(copy);
+        const parts = ghostty.encodePaste(copy, .fromTerminal(&self.terminal));
+
+        var output: std.Io.Writer.Allocating = .init(self.allocator);
+        errdefer output.deinit();
+        for (parts) |part| output.writer.writeAll(part) catch return error.OutOfMemory;
+        return output.toOwnedSlice();
+    }
+
+    pub fn encodeFocus(self: *EmbeddedTerminal, focused: bool) Error![]u8 {
+        if (!self.terminal.modes.get(.focus_event)) return self.allocator.alloc(u8, 0);
+
+        var output: std.Io.Writer.Allocating = .init(self.allocator);
+        errdefer output.deinit();
+        ghostty.encodeFocus(&output.writer, if (focused) .gained else .lost) catch return error.OutOfMemory;
+        return output.toOwnedSlice();
+    }
+
+    pub fn freeEncoded(self: *EmbeddedTerminal, bytes: []u8) void {
+        self.allocator.free(bytes);
+    }
+
+    pub fn drainResponses(self: *EmbeddedTerminal, output: []u8) Error!usize {
+        if (self.response_error) |err| {
+            self.response_error = null;
+            return err;
+        }
+        const count = @min(output.len, self.responses.items.len);
+        @memcpy(output[0..count], self.responses.items[0..count]);
+        std.mem.copyForwards(u8, self.responses.items[0 .. self.responses.items.len - count], self.responses.items[count..]);
+        self.responses.items.len -= count;
+        return count;
+    }
+
+    fn writePty(handler: *ghostty.TerminalStream.Handler, data: [:0]const u8) void {
+        const self: *EmbeddedTerminal = @fieldParentPtr("terminal", handler.terminal);
+        if (self.response_error != null) return;
+        if (data.len > response_limit - @min(self.responses.items.len, response_limit)) {
+            self.response_error = error.ResponseOverflow;
+            return;
+        }
+        self.responses.appendSlice(self.allocator, data) catch {
+            self.response_error = error.OutOfMemory;
+        };
+    }
+};

--- a/packages/core/src/zig/embedded-terminal/main.zig
+++ b/packages/core/src/zig/embedded-terminal/main.zig
@@ -130,6 +130,7 @@ pub const EmbeddedTerminal = struct {
 
     pub fn write(self: *EmbeddedTerminal, bytes: []const u8) Error!void {
         self.parser_allocator.failed = false;
+        self.stream.handler.semantic_failure = false;
         self.stream.nextSlice(bytes);
         if (self.parser_allocator.failed or self.stream.handler.semantic_failure) return error.ProcessingFailed;
     }

--- a/packages/core/src/zig/embedded-terminal/main.zig
+++ b/packages/core/src/zig/embedded-terminal/main.zig
@@ -13,75 +13,7 @@ pub const Options = struct {
     max_scrollback: usize = 10_000,
 };
 
-pub const parser_allocation_limit = 1024 * 1024;
 pub const response_limit = 1024 * 1024;
-
-const BoundedAllocator = struct {
-    child: std.mem.Allocator,
-    limit: usize,
-    used: usize = 0,
-    failed: bool = false,
-
-    fn allocator(self: *BoundedAllocator) std.mem.Allocator {
-        return .{ .ptr = self, .vtable = &vtable };
-    }
-
-    const vtable: std.mem.Allocator.VTable = .{
-        .alloc = alloc,
-        .resize = resize,
-        .remap = remap,
-        .free = free,
-    };
-
-    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
-        const self: *BoundedAllocator = @ptrCast(@alignCast(ctx));
-        if (len > self.limit -| self.used) {
-            self.failed = true;
-            return null;
-        }
-        const result = self.child.rawAlloc(len, alignment, ret_addr);
-        if (result) |_| {
-            self.used += len;
-        } else {
-            self.failed = true;
-        }
-        return result;
-    }
-
-    fn resize(
-        ctx: *anyopaque,
-        memory: []u8,
-        alignment: std.mem.Alignment,
-        new_len: usize,
-        ret_addr: usize,
-    ) bool {
-        const self: *BoundedAllocator = @ptrCast(@alignCast(ctx));
-        if (new_len > memory.len and new_len - memory.len > self.limit -| self.used) return false;
-        if (!self.child.rawResize(memory, alignment, new_len, ret_addr)) return false;
-        self.used = self.used - memory.len + new_len;
-        return true;
-    }
-
-    fn remap(
-        ctx: *anyopaque,
-        memory: []u8,
-        alignment: std.mem.Alignment,
-        new_len: usize,
-        ret_addr: usize,
-    ) ?[*]u8 {
-        const self: *BoundedAllocator = @ptrCast(@alignCast(ctx));
-        if (new_len > memory.len and new_len - memory.len > self.limit -| self.used) return null;
-        const result = self.child.rawRemap(memory, alignment, new_len, ret_addr) orelse return null;
-        self.used = self.used - memory.len + new_len;
-        return result;
-    }
-
-    fn free(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
-        const self: *BoundedAllocator = @ptrCast(@alignCast(ctx));
-        self.child.rawFree(memory, alignment, ret_addr);
-        self.used -= memory.len;
-    }
-};
 
 pub const EmbeddedTerminal = struct {
     allocator: std.mem.Allocator,
@@ -92,7 +24,6 @@ pub const EmbeddedTerminal = struct {
     responses: std.ArrayListUnmanaged(u8) = .empty,
     response_error: ?Error = null,
     mouse_last_cell: ?ghostty.Coordinate = null,
-    parser_allocator: BoundedAllocator = undefined,
 
     pub fn init(io: std.Io, allocator: std.mem.Allocator, options: Options) Error!*EmbeddedTerminal {
         if (options.cols == 0 or options.rows == 0) return error.InvalidValue;
@@ -113,10 +44,9 @@ pub const EmbeddedTerminal = struct {
         };
         errdefer self.terminal.deinit(allocator);
 
-        self.parser_allocator = .{ .child = allocator, .limit = parser_allocation_limit };
         var handler = self.terminal.vtHandler();
         handler.effects.write_pty = &writePty;
-        self.stream = .initAlloc(self.parser_allocator.allocator(), handler);
+        self.stream = .init(handler);
         return self;
     }
 
@@ -129,10 +59,9 @@ pub const EmbeddedTerminal = struct {
     }
 
     pub fn write(self: *EmbeddedTerminal, bytes: []const u8) Error!void {
-        self.parser_allocator.failed = false;
         self.stream.handler.semantic_failure = false;
         self.stream.nextSlice(bytes);
-        if (self.parser_allocator.failed or self.stream.handler.semantic_failure) return error.ProcessingFailed;
+        if (self.stream.handler.semantic_failure) return error.ProcessingFailed;
     }
 
     pub fn resize(self: *EmbeddedTerminal, cols: u16, rows: u16) Error!void {

--- a/packages/core/src/zig/embedded-terminal/main.zig
+++ b/packages/core/src/zig/embedded-terminal/main.zig
@@ -94,7 +94,7 @@ pub const EmbeddedTerminal = struct {
     mouse_last_cell: ?ghostty.Coordinate = null,
     parser_allocator: BoundedAllocator = undefined,
 
-    pub fn init(allocator: std.mem.Allocator, options: Options) Error!*EmbeddedTerminal {
+    pub fn init(io: std.Io, allocator: std.mem.Allocator, options: Options) Error!*EmbeddedTerminal {
         if (options.cols == 0 or options.rows == 0) return error.InvalidValue;
 
         const self = try allocator.create(EmbeddedTerminal);
@@ -102,7 +102,7 @@ pub const EmbeddedTerminal = struct {
 
         self.* = .{
             .allocator = allocator,
-            .terminal = try .init(allocator, .{
+            .terminal = try .init(io, allocator, .{
                 .cols = options.cols,
                 .rows = options.rows,
                 .max_scrollback = options.max_scrollback,

--- a/packages/core/src/zig/embedded-terminal/main.zig
+++ b/packages/core/src/zig/embedded-terminal/main.zig
@@ -143,6 +143,7 @@ pub const EmbeddedTerminal = struct {
         };
         self.cols = cols;
         self.rows = rows;
+        self.mouse_last_cell = null;
     }
 
     pub fn scroll(self: *EmbeddedTerminal, delta: i32) void {

--- a/packages/core/src/zig/embedded-terminal/main.zig
+++ b/packages/core/src/zig/embedded-terminal/main.zig
@@ -36,7 +36,7 @@ pub const EmbeddedTerminal = struct {
             .terminal = try .init(io, allocator, .{
                 .cols = options.cols,
                 .rows = options.rows,
-                .max_scrollback = options.max_scrollback,
+                .max_scrollback_bytes = options.max_scrollback,
             }),
             .stream = undefined,
             .cols = options.cols,
@@ -46,7 +46,7 @@ pub const EmbeddedTerminal = struct {
 
         var handler = self.terminal.vtHandler();
         handler.effects.write_pty = &writePty;
-        self.stream = .init(handler);
+        self.stream = .init(.{ .allocator = allocator, .handler = handler });
         return self;
     }
 

--- a/packages/core/src/zig/embedded-terminal/main.zig
+++ b/packages/core/src/zig/embedded-terminal/main.zig
@@ -16,11 +16,13 @@ pub const Options = struct {
 pub const parser_allocation_limit = 1024 * 1024;
 pub const response_limit = 1024 * 1024;
 
-const TrackingAllocator = struct {
+const BoundedAllocator = struct {
     child: std.mem.Allocator,
+    limit: usize,
+    used: usize = 0,
     failed: bool = false,
 
-    fn allocator(self: *TrackingAllocator) std.mem.Allocator {
+    fn allocator(self: *BoundedAllocator) std.mem.Allocator {
         return .{ .ptr = self, .vtable = &vtable };
     }
 
@@ -32,9 +34,17 @@ const TrackingAllocator = struct {
     };
 
     fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
-        const self: *TrackingAllocator = @ptrCast(@alignCast(ctx));
+        const self: *BoundedAllocator = @ptrCast(@alignCast(ctx));
+        if (len > self.limit -| self.used) {
+            self.failed = true;
+            return null;
+        }
         const result = self.child.rawAlloc(len, alignment, ret_addr);
-        if (result == null) self.failed = true;
+        if (result) |_| {
+            self.used += len;
+        } else {
+            self.failed = true;
+        }
         return result;
     }
 
@@ -45,8 +55,11 @@ const TrackingAllocator = struct {
         new_len: usize,
         ret_addr: usize,
     ) bool {
-        const self: *TrackingAllocator = @ptrCast(@alignCast(ctx));
-        return self.child.rawResize(memory, alignment, new_len, ret_addr);
+        const self: *BoundedAllocator = @ptrCast(@alignCast(ctx));
+        if (new_len > memory.len and new_len - memory.len > self.limit -| self.used) return false;
+        if (!self.child.rawResize(memory, alignment, new_len, ret_addr)) return false;
+        self.used = self.used - memory.len + new_len;
+        return true;
     }
 
     fn remap(
@@ -56,13 +69,17 @@ const TrackingAllocator = struct {
         new_len: usize,
         ret_addr: usize,
     ) ?[*]u8 {
-        const self: *TrackingAllocator = @ptrCast(@alignCast(ctx));
-        return self.child.rawRemap(memory, alignment, new_len, ret_addr);
+        const self: *BoundedAllocator = @ptrCast(@alignCast(ctx));
+        if (new_len > memory.len and new_len - memory.len > self.limit -| self.used) return null;
+        const result = self.child.rawRemap(memory, alignment, new_len, ret_addr) orelse return null;
+        self.used = self.used - memory.len + new_len;
+        return result;
     }
 
     fn free(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
-        const self: *TrackingAllocator = @ptrCast(@alignCast(ctx));
+        const self: *BoundedAllocator = @ptrCast(@alignCast(ctx));
         self.child.rawFree(memory, alignment, ret_addr);
+        self.used -= memory.len;
     }
 };
 
@@ -75,9 +92,7 @@ pub const EmbeddedTerminal = struct {
     responses: std.ArrayListUnmanaged(u8) = .empty,
     response_error: ?Error = null,
     mouse_last_cell: ?ghostty.Coordinate = null,
-    parser_buffer: [parser_allocation_limit]u8 = undefined,
-    parser_fixed_allocator: std.heap.FixedBufferAllocator = undefined,
-    parser_allocator: TrackingAllocator = undefined,
+    parser_allocator: BoundedAllocator = undefined,
 
     pub fn init(allocator: std.mem.Allocator, options: Options) Error!*EmbeddedTerminal {
         if (options.cols == 0 or options.rows == 0) return error.InvalidValue;
@@ -98,8 +113,7 @@ pub const EmbeddedTerminal = struct {
         };
         errdefer self.terminal.deinit(allocator);
 
-        self.parser_fixed_allocator = .init(&self.parser_buffer);
-        self.parser_allocator = .{ .child = self.parser_fixed_allocator.allocator() };
+        self.parser_allocator = .{ .child = allocator, .limit = parser_allocation_limit };
         var handler = self.terminal.vtHandler();
         handler.effects.write_pty = &writePty;
         self.stream = .initAlloc(self.parser_allocator.allocator(), handler);

--- a/packages/core/src/zig/embedded-terminal/tests.zig
+++ b/packages/core/src/zig/embedded-terminal/tests.zig
@@ -84,7 +84,7 @@ test "embedded terminal bounds parser allocations" {
     @memset(input, 'x');
     @memcpy(input[0..7], "\x1b]52;c;");
     try std.testing.expectError(error.ProcessingFailed, terminal.write(input));
-    try std.testing.expect(terminal.parser_fixed_allocator.end_index <= @import("main.zig").parser_allocation_limit);
+    try std.testing.expect(terminal.parser_allocator.used <= @import("main.zig").parser_allocation_limit);
 }
 
 test "embedded terminal preserves queued responses when the bound is reached" {

--- a/packages/core/src/zig/embedded-terminal/tests.zig
+++ b/packages/core/src/zig/embedded-terminal/tests.zig
@@ -106,6 +106,15 @@ test "embedded terminal preserves queued responses when the bound is reached" {
     try std.testing.expect(preserved_len > 0);
 }
 
+test "embedded terminal reports semantic failures per write" {
+    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    defer terminal.deinit();
+
+    terminal.stream.handler.semantic_failure = true;
+    try terminal.write("ok");
+    try std.testing.expect(!terminal.stream.handler.semantic_failure);
+}
+
 comptime {
     _ = ghostty;
 }

--- a/packages/core/src/zig/embedded-terminal/tests.zig
+++ b/packages/core/src/zig/embedded-terminal/tests.zig
@@ -75,25 +75,6 @@ test "embedded terminal drains generated PTY responses incrementally" {
     try std.testing.expectEqualStrings("\x1b[0n", combined[0 .. first_len + rest_len]);
 }
 
-test "embedded terminal drops oversized OSC and resumes parsing" {
-    const terminal = try EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 20, .rows = 4 });
-    defer terminal.deinit();
-
-    const prefix = "\x1b]52;c;";
-    const suffix = "\x07\x1b[5n";
-    const payload_len = 4096;
-    const input = try std.testing.allocator.alloc(u8, prefix.len + payload_len + suffix.len);
-    defer std.testing.allocator.free(input);
-    @memcpy(input[0..prefix.len], prefix);
-    @memset(input[prefix.len .. prefix.len + payload_len], 'x');
-    @memcpy(input[prefix.len + payload_len ..], suffix);
-
-    try terminal.write(input);
-    var response: [16]u8 = undefined;
-    const response_len = try terminal.drainResponses(&response);
-    try std.testing.expectEqualStrings("\x1b[0n", response[0..response_len]);
-}
-
 test "embedded terminal preserves queued responses when the bound is reached" {
     const terminal = try EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 20, .rows = 4 });
     defer terminal.deinit();

--- a/packages/core/src/zig/embedded-terminal/tests.zig
+++ b/packages/core/src/zig/embedded-terminal/tests.zig
@@ -1,0 +1,111 @@
+const std = @import("std");
+const EmbeddedTerminal = @import("main.zig").EmbeddedTerminal;
+const ghostty = @import("ghostty.zig");
+
+test "embedded terminal supports lifecycle, resize, and viewport scroll" {
+    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 80, .rows = 24 });
+    defer terminal.deinit();
+
+    try terminal.write("hello");
+    try terminal.resize(100, 40);
+    terminal.scroll(-3);
+    terminal.scroll(3);
+
+    try std.testing.expectEqual(@as(u16, 100), terminal.cols);
+    try std.testing.expectEqual(@as(u16, 40), terminal.rows);
+    try std.testing.expectError(error.InvalidValue, terminal.resize(0, 40));
+    try std.testing.expectError(error.InvalidValue, terminal.resize(100, 0));
+    try std.testing.expectError(error.InvalidValue, EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 0, .rows = 24 }));
+}
+
+test "embedded terminal preserves parser state and provides mode-aware input" {
+    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    defer terminal.deinit();
+
+    try terminal.write("\x1b[?20");
+    try terminal.write("04h\x1b[?1004h\x1b[?1000h\x1b[?1006h");
+
+    const paste = try terminal.encodePaste("one\ntwo");
+    defer terminal.freeEncoded(paste);
+    try std.testing.expectEqualStrings("\x1b[200~one\ntwo\x1b[201~", paste);
+
+    const focus = try terminal.encodeFocus(true);
+    defer terminal.freeEncoded(focus);
+    try std.testing.expectEqualStrings("\x1b[I", focus);
+
+    const key = try terminal.encodeKey(.{ .key = .enter });
+    defer terminal.freeEncoded(key);
+    try std.testing.expectEqualStrings("\r", key);
+
+    const mouse = try terminal.encodeMouse(.{
+        .action = .press,
+        .button = .left,
+        .x = 0,
+        .y = 0,
+        .any_button_pressed = true,
+    });
+    defer terminal.freeEncoded(mouse);
+    try std.testing.expectEqualStrings("\x1b[<0;1;1M", mouse);
+}
+
+test "embedded terminal encodes long Kitty associated text" {
+    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    defer terminal.deinit();
+    try terminal.write("\x1b[>19u");
+
+    const text = "x" ** 2048;
+    const encoded = try terminal.encodeKey(.{ .key = .unidentified, .utf8 = text });
+    defer terminal.freeEncoded(encoded);
+    try std.testing.expectEqualStrings(text, encoded);
+}
+
+test "embedded terminal drains generated PTY responses incrementally" {
+    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    defer terminal.deinit();
+
+    try terminal.write("\x1b[5n");
+    var first: [2]u8 = undefined;
+    var rest: [16]u8 = undefined;
+    const first_len = try terminal.drainResponses(&first);
+    const rest_len = try terminal.drainResponses(&rest);
+
+    var combined: [18]u8 = undefined;
+    @memcpy(combined[0..first_len], first[0..first_len]);
+    @memcpy(combined[first_len .. first_len + rest_len], rest[0..rest_len]);
+    try std.testing.expectEqualStrings("\x1b[0n", combined[0 .. first_len + rest_len]);
+}
+
+test "embedded terminal bounds parser allocations" {
+    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    defer terminal.deinit();
+
+    const input = try std.testing.allocator.alloc(u8, @import("main.zig").parser_allocation_limit + 32);
+    defer std.testing.allocator.free(input);
+    @memset(input, 'x');
+    @memcpy(input[0..7], "\x1b]52;c;");
+    try std.testing.expectError(error.ProcessingFailed, terminal.write(input));
+    try std.testing.expect(terminal.parser_fixed_allocator.end_index <= @import("main.zig").parser_allocation_limit);
+}
+
+test "embedded terminal preserves queued responses when the bound is reached" {
+    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    defer terminal.deinit();
+
+    const query = "\x1b[5n";
+    const count = @import("main.zig").response_limit / query.len + 1;
+    const input = try std.testing.allocator.alloc(u8, count * query.len);
+    defer std.testing.allocator.free(input);
+    for (0..count) |index| @memcpy(input[index * query.len ..][0..query.len], query);
+
+    try terminal.write(input);
+    var byte: [1]u8 = undefined;
+    try std.testing.expectError(error.ResponseOverflow, terminal.drainResponses(&byte));
+
+    var preserved: [16]u8 = undefined;
+    const preserved_len = try terminal.drainResponses(&preserved);
+    try std.testing.expect(preserved_len > 0);
+}
+
+comptime {
+    _ = ghostty;
+}

--- a/packages/core/src/zig/embedded-terminal/tests.zig
+++ b/packages/core/src/zig/embedded-terminal/tests.zig
@@ -75,16 +75,23 @@ test "embedded terminal drains generated PTY responses incrementally" {
     try std.testing.expectEqualStrings("\x1b[0n", combined[0 .. first_len + rest_len]);
 }
 
-test "embedded terminal bounds parser allocations" {
+test "embedded terminal drops oversized OSC and resumes parsing" {
     const terminal = try EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 20, .rows = 4 });
     defer terminal.deinit();
 
-    const input = try std.testing.allocator.alloc(u8, @import("main.zig").parser_allocation_limit + 32);
+    const prefix = "\x1b]52;c;";
+    const suffix = "\x07\x1b[5n";
+    const payload_len = 4096;
+    const input = try std.testing.allocator.alloc(u8, prefix.len + payload_len + suffix.len);
     defer std.testing.allocator.free(input);
-    @memset(input, 'x');
-    @memcpy(input[0..7], "\x1b]52;c;");
-    try std.testing.expectError(error.ProcessingFailed, terminal.write(input));
-    try std.testing.expect(terminal.parser_allocator.used <= @import("main.zig").parser_allocation_limit);
+    @memcpy(input[0..prefix.len], prefix);
+    @memset(input[prefix.len .. prefix.len + payload_len], 'x');
+    @memcpy(input[prefix.len + payload_len ..], suffix);
+
+    try terminal.write(input);
+    var response: [16]u8 = undefined;
+    const response_len = try terminal.drainResponses(&response);
+    try std.testing.expectEqualStrings("\x1b[0n", response[0..response_len]);
 }
 
 test "embedded terminal preserves queued responses when the bound is reached" {

--- a/packages/core/src/zig/embedded-terminal/tests.zig
+++ b/packages/core/src/zig/embedded-terminal/tests.zig
@@ -3,7 +3,7 @@ const EmbeddedTerminal = @import("main.zig").EmbeddedTerminal;
 const ghostty = @import("ghostty.zig");
 
 test "embedded terminal supports lifecycle, resize, and viewport scroll" {
-    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 80, .rows = 24 });
+    const terminal = try EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 80, .rows = 24 });
     defer terminal.deinit();
 
     try terminal.write("hello");
@@ -15,11 +15,11 @@ test "embedded terminal supports lifecycle, resize, and viewport scroll" {
     try std.testing.expectEqual(@as(u16, 40), terminal.rows);
     try std.testing.expectError(error.InvalidValue, terminal.resize(0, 40));
     try std.testing.expectError(error.InvalidValue, terminal.resize(100, 0));
-    try std.testing.expectError(error.InvalidValue, EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 0, .rows = 24 }));
+    try std.testing.expectError(error.InvalidValue, EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 0, .rows = 24 }));
 }
 
 test "embedded terminal preserves parser state and provides mode-aware input" {
-    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    const terminal = try EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 20, .rows = 4 });
     defer terminal.deinit();
 
     try terminal.write("\x1b[?20");
@@ -49,7 +49,7 @@ test "embedded terminal preserves parser state and provides mode-aware input" {
 }
 
 test "embedded terminal encodes long Kitty associated text" {
-    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    const terminal = try EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 20, .rows = 4 });
     defer terminal.deinit();
     try terminal.write("\x1b[>19u");
 
@@ -60,7 +60,7 @@ test "embedded terminal encodes long Kitty associated text" {
 }
 
 test "embedded terminal drains generated PTY responses incrementally" {
-    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    const terminal = try EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 20, .rows = 4 });
     defer terminal.deinit();
 
     try terminal.write("\x1b[5n");
@@ -76,7 +76,7 @@ test "embedded terminal drains generated PTY responses incrementally" {
 }
 
 test "embedded terminal bounds parser allocations" {
-    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    const terminal = try EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 20, .rows = 4 });
     defer terminal.deinit();
 
     const input = try std.testing.allocator.alloc(u8, @import("main.zig").parser_allocation_limit + 32);
@@ -88,7 +88,7 @@ test "embedded terminal bounds parser allocations" {
 }
 
 test "embedded terminal preserves queued responses when the bound is reached" {
-    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    const terminal = try EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 20, .rows = 4 });
     defer terminal.deinit();
 
     const query = "\x1b[5n";
@@ -107,7 +107,7 @@ test "embedded terminal preserves queued responses when the bound is reached" {
 }
 
 test "embedded terminal reports semantic failures per write" {
-    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    const terminal = try EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 20, .rows = 4 });
     defer terminal.deinit();
 
     terminal.stream.handler.semantic_failure = true;
@@ -116,7 +116,7 @@ test "embedded terminal reports semantic failures per write" {
 }
 
 test "embedded terminal resets mouse motion deduplication after resize" {
-    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    const terminal = try EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 20, .rows = 4 });
     defer terminal.deinit();
     try terminal.write("\x1b[?1003h\x1b[?1006h");
 

--- a/packages/core/src/zig/embedded-terminal/tests.zig
+++ b/packages/core/src/zig/embedded-terminal/tests.zig
@@ -115,6 +115,26 @@ test "embedded terminal reports semantic failures per write" {
     try std.testing.expect(!terminal.stream.handler.semantic_failure);
 }
 
+test "embedded terminal resets mouse motion deduplication after resize" {
+    const terminal = try EmbeddedTerminal.init(std.testing.allocator, .{ .cols = 20, .rows = 4 });
+    defer terminal.deinit();
+    try terminal.write("\x1b[?1003h\x1b[?1006h");
+
+    const mouse: ghostty.Mouse = .{ .action = .motion, .x = 0, .y = 0 };
+    const first = try terminal.encodeMouse(mouse);
+    defer terminal.freeEncoded(first);
+    try std.testing.expect(first.len > 0);
+
+    const duplicate = try terminal.encodeMouse(mouse);
+    defer terminal.freeEncoded(duplicate);
+    try std.testing.expectEqual(@as(usize, 0), duplicate.len);
+
+    try terminal.resize(10, 4);
+    const after_resize = try terminal.encodeMouse(mouse);
+    defer terminal.freeEncoded(after_resize);
+    try std.testing.expect(after_resize.len > 0);
+}
+
 comptime {
     _ = ghostty;
 }

--- a/packages/core/src/zig/test.zig
+++ b/packages/core/src/zig/test.zig
@@ -37,6 +37,7 @@ const handles_tests = @import("tests/handles_test.zig");
 const yoga_tests = @import("tests/yoga_test.zig");
 const ansi_tests = @import("tests/ansi_test.zig");
 const ghostty_vt_tests = @import("tests/ghostty_vt_test.zig");
+const embedded_terminal_tests = @import("embedded-terminal/tests.zig");
 const image_tests = @import("tests/image_test.zig");
 const terminal_image_tests = @import("tests/terminal-image_test.zig");
 const lib_tests = @import("lib.zig");
@@ -83,6 +84,7 @@ comptime {
     _ = yoga_tests;
     _ = ansi_tests;
     _ = ghostty_vt_tests;
+    _ = embedded_terminal_tests;
     _ = image_tests;
     _ = terminal_image_tests;
     _ = lib_tests;


### PR DESCRIPTION
## Problem

PR #1317 pins Ghostty and makes its VT module available to OpenTUI, but OpenTUI still has no owned terminal state or mode-aware input boundary. The previous runtime PR (#1307) proved the behavior through a dynamic C loader; that implementation no longer matches the merged static Zig-module architecture.

This PR rebuilds only the internal runtime layer on the pinned Ghostty module. It deliberately excludes OpenTUI composition, native handles/FFI, TypeScript, and the public renderable so terminal ownership and input semantics can be reviewed independently.

## Changes

- Own a Ghostty `Terminal` and persistent `TerminalStream` across the complete runtime lifetime.
- Preserve parser state across split CSI, OSC, and UTF-8 writes.
- Bound parser-driven allocations at 1 MiB and report processing failures.
- Support resize, viewport scrolling, keyboard, mouse, paste, and focus encoding from current terminal modes.
- Suppress SGR-pixel mouse reports because OpenTUI currently receives cell coordinates rather than physical pixels.
- Capture terminal-generated PTY responses with a 1 MiB bound, partial drains, and recoverable overflow reporting.
- Preserve already queued responses when later output exceeds the bound.
- Use growable owned encoder output rather than fixed native buffers.

## Scope

This is the internal adapter/runtime layer. It does not add native handles, C/TypeScript FFI, `OptimizedBuffer` composition, cursor projection, `EmbeddedTerminalRenderable`, screen observation, benchmarks, or examples.

The next stack layer will port the proven compositor and renderable behavior from closed PR #1308 onto this runtime.

## Testing

- Focused embedded-terminal native suite (6 passed)
- `bun run test:native` (1873 passed, 6 skipped)
- `bun run fmt:check`
- `bun run lint`