### PR TITLE
fix(core): repaint alternate screen after resize

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -3785,6 +3785,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this._console.resize(this.width, this.height)
     this.root.resize(this.width, this.height)
     this.emit(CliRenderEvents.RESIZE, this.width, this.height)
+    if (this._screenMode === "alternate-screen") this.forceFullRepaintRequested = true
     this.requestRender()
   }
 

--- a/packages/core/src/tests/renderer.control.test.ts
+++ b/packages/core/src/tests/renderer.control.test.ts
@@ -144,6 +144,25 @@ test("resume() forces the next alternate-screen render to fully repaint", async 
   await expectStartedResumeForcesNextRender("alternate-screen")
 })
 
+test("resize() forces the next alternate-screen render to fully repaint", async () => {
+  renderer.destroy()
+  ;({ renderer, mockInput, mockMouse, renderOnce } = await createTestRenderer({
+    width: 40,
+    height: 10,
+    screenMode: "alternate-screen",
+  }))
+
+  const renderSpy = spyOn((renderer as any).lib, "render")
+  renderer.resize(80, 20)
+  await renderOnce()
+
+  const lastCall = renderSpy.mock.calls[renderSpy.mock.calls.length - 1]
+  expect(lastCall?.[1]).toBe(true)
+  expect((renderer as any).forceFullRepaintRequested).toBe(false)
+
+  renderSpy.mockRestore()
+})
+
 test("stop() transitions to EXPLICIT_STOPPED and stops rendering", () => {
   renderer.start()
   expect(renderer.isRunning).toBe(true)


### PR DESCRIPTION
## What

Force the first alternate-screen frame after a terminal resize to repaint the full surface, preventing stale cells from surviving rapid window resizes.

Fixes #1110.

## Before / After

**Before:** `processResize()` resized OpenTUI's retained buffers, then the next native render used differential output. If the terminal's physical surface diverged during resize, cells considered unchanged by the new buffer were not emitted and stale content could remain visible.

**After:** an alternate-screen geometry change arms the renderer's existing one-shot full-repaint latch. The next frame emits the complete resized surface, then returns to differential rendering.

## How

- `packages/core/src/renderer.ts` arms `forceFullRepaintRequested` after alternate-screen resize processing.
- `packages/core/src/tests/renderer.control.test.ts` verifies that resize forces exactly the next native render and consumes the latch.

## Scope

This only changes alternate-screen rendering. Main-screen and split-footer resize behavior remain unchanged.

## Testing

- `bun test src/tests/renderer.control.test.ts --timeout 30000`
- `bun test --timeout 30000`
- `bunx oxfmt --check packages/core/src/renderer.ts packages/core/src/tests/renderer.control.test.ts`
- `bunx oxlint packages/core/src/renderer.ts packages/core/src/tests/renderer.control.test.ts`

The renderer-level regression test failed before the fix with `render(..., false)` and passes afterward with `render(..., true)`.

## Demo

The original Ghostty failure is intermittent and did not reproduce under the deterministic PTY resize stress loop. The renderer regression is covered directly at the native render call boundary instead.
