### PR TITLE
ci: limit native artifact upload to platform packages

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -60,7 +60,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: native-libraries
-          path: packages/core/node_modules/@opentui/
+          path: packages/core/node_modules/@opentui/core-*/**
+          if-no-files-found: error
           retention-days: 1
 
   test:


### PR DESCRIPTION
Avoid following unrelated workspace symlinks under the @opentui scope,
which caused the native artifact to include over 183,000 files.
