### PR TITLE
fix(core): align unavailable terminal init

### DIFF
--- a/packages/core/src/zig/embedded-terminal/unavailable.zig
+++ b/packages/core/src/zig/embedded-terminal/unavailable.zig
@@ -20,7 +20,7 @@ pub const Cursor = struct {
 };
 
 pub const EmbeddedTerminal = struct {
-    pub fn init(_: anytype, _: anytype) Error!*EmbeddedTerminal {
+    pub fn init(_: anytype, _: anytype, _: anytype) Error!*EmbeddedTerminal {
         return error.Unsupported;
     }
 


### PR DESCRIPTION
## Summary
- align the no-Ghostty embedded terminal fallback constructor with the available implementation
- restore custom-target builds after the IO argument was added

## Verification
- `zig build -Dtarget=x86_64-freebsd -Doptimize=ReleaseFast`

This is an isolated fix on top of #1340 because `unavailable.zig` is introduced by that PR and is not present on `main`.