### PR TITLE
fix(core): clip transparent box borders to scissor

### DIFF
--- a/packages/core/src/zig/buffer.zig
+++ b/packages/core/src/zig/buffer.zig
@@ -2341,6 +2341,7 @@ pub const OptimizedBuffer = struct {
             if (borderSides.top and isAtActualTop) {
                 var drawX = startX;
                 while (drawX <= endX) : (drawX += 1) {
+                    if (!self.isPointInScissor(drawX, startY)) continue;
                     if (startY >= 0 and startY < @as(i32, @intCast(self.height))) {
                         if (titleLayout.shouldDraw and drawX >= titleLayout.startX and drawX <= titleLayout.endX) {
                             continue;
@@ -2377,6 +2378,7 @@ pub const OptimizedBuffer = struct {
             if (borderSides.bottom and isAtActualBottom) {
                 var drawX = startX;
                 while (drawX <= endX) : (drawX += 1) {
+                    if (!self.isPointInScissor(drawX, endY)) continue;
                     if (endY >= 0 and endY < @as(i32, @intCast(self.height))) {
                         if (bottomTitleLayout.shouldDraw and drawX >= bottomTitleLayout.startX and drawX <= bottomTitleLayout.endX) {
                             continue;
@@ -2418,7 +2420,7 @@ pub const OptimizedBuffer = struct {
             var drawY = verticalStartY;
             while (drawY <= verticalEndY) : (drawY += 1) {
                 // Left border
-                if (borderSides.left and isAtActualLeft and startX >= 0 and startX < @as(i32, @intCast(self.width))) {
+                if (borderSides.left and isAtActualLeft and self.isPointInScissor(startX, drawY) and startX >= 0 and startX < @as(i32, @intCast(self.width))) {
                     if (useTransparentBorderFastPath) {
                         const index = self.coordsToIndex(@intCast(startX), @intCast(drawY));
                         self.buffer.char[index] = borderChars[@intFromEnum(BorderCharIndex.vertical)];
@@ -2440,7 +2442,7 @@ pub const OptimizedBuffer = struct {
                 }
 
                 // Right border
-                if (borderSides.right and isAtActualRight and endX >= 0 and endX < @as(i32, @intCast(self.width))) {
+                if (borderSides.right and isAtActualRight and self.isPointInScissor(endX, drawY) and endX >= 0 and endX < @as(i32, @intCast(self.width))) {
                     if (useTransparentBorderFastPath) {
                         const index = self.coordsToIndex(@intCast(endX), @intCast(drawY));
                         self.buffer.char[index] = borderChars[@intFromEnum(BorderCharIndex.vertical)];

--- a/packages/core/src/zig/tests/buffer_test.zig
+++ b/packages/core/src/zig/tests/buffer_test.zig
@@ -2559,6 +2559,36 @@ test "OptimizedBuffer - drawBox transparent border preserves destination backgro
     try std.testing.expectEqual(@as(u32, 0), cell.attributes);
 }
 
+test "OptimizedBuffer - drawBox respects scissor clipping" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+
+    var buf = try OptimizedBuffer.init(
+        std.testing.allocator,
+        6,
+        4,
+        .{ .pool = pool, .id = "test-buffer" },
+    );
+    defer buf.deinit();
+
+    const background = ansi.rgbColor(1, 2, 3, 255);
+    const border = ansi.rgbColor(4, 5, 6, 255);
+    const transparent_background = ansi.rgbaFromFloats(0.0, 0.0, 0.0, 0.0);
+    const border_chars = [_]u32{ 0x250c, 0x2510, 0x2514, 0x2518, 0x2500, 0x2502, 0, 0, 0, 0, 0 };
+    buf.clear(background, null);
+    try buf.pushScissorRect(1, 0, 4, 4);
+    defer buf.popScissorRect();
+
+    try buf.drawBox(0, 0, 6, 4, &border_chars, .{ .top = true, .right = true, .bottom = true, .left = true }, border, transparent_background, border, false, null, 0, null, 0);
+
+    try std.testing.expectEqual(@as(u32, ' '), buf.get(0, 0).?.char);
+    try std.testing.expectEqual(@as(u32, ' '), buf.get(5, 0).?.char);
+    try std.testing.expectEqual(@as(u32, ' '), buf.get(0, 1).?.char);
+    try std.testing.expectEqual(@as(u32, ' '), buf.get(5, 1).?.char);
+    try std.testing.expectEqual(@as(u32, 0x2500), buf.get(1, 0).?.char);
+    try std.testing.expectEqual(@as(u32, 0x2500), buf.get(4, 3).?.char);
+}
+
 test "OptimizedBuffer - drawBox transparent border foreground blends against box background" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();


### PR DESCRIPTION
Fixes #1311

## Problem

A bordered box that is only partially visible inside a scrollbox can overlap the active scissor rectangle. Most drawing paths are clipped through `validateAndIndex`, but the transparent border fast path writes directly to the backing character, foreground, and attribute buffers. Those direct writes bypass the scissor check, allowing border cells to overwrite neighboring UI outside the scrollbox viewport.

## Change

Check the active scissor rectangle for every top, bottom, left, and right border cell before entering the rendering path. This makes the transparent fast path follow the same clipping contract as opaque and blended border rendering, while retaining the fast path for visible cells.

## Regression Coverage

Adds a native buffer regression using a transparent box background so the direct-write path is exercised. It clips the box horizontally and verifies that clipped border cells preserve the existing content while visible border segments still render. Before this change, the test fails because a clipped corner is written as `0x250c` instead of the original space.

## Validation

- `zig build test -Dtest-filter="OptimizedBuffer - drawBox respects scissor clipping"`
- `zig build test` (`1,860` passed, `22` skipped)
- `bun run fmt:check`
- `bun run lint:ci`