### PR TITLE
image: accept retained NativeImage sources

### DIFF
--- a/packages/core/src/image.ts
+++ b/packages/core/src/image.ts
@@ -559,6 +559,10 @@ export class NativeImage {
     )
   }
 
+  public ensureEncodedPng(): void {
+    checkStatus(this.lib.imageEnsureEncodedPng(this.guard()))
+  }
+
   public raw(format: PixelFormat = "rgba8"): RawImage {
     const stride = this.width * 4
     const data = new Uint8Array(stride * this.height)

--- a/packages/core/src/image.ts
+++ b/packages/core/src/image.ts
@@ -481,6 +481,10 @@ export class NativeImage {
     return this.wrap(this.lib.imageClone(this.guard()))
   }
 
+  public retain(): NativeImage {
+    return this.wrap(this.lib.imageRetain(this.guard()))
+  }
+
   public resize(options: ResizeOptions): NativeImage {
     if (!options || (options.width === undefined && options.height === undefined)) {
       throw new TypeError("resize requires width, height, or both")

--- a/packages/core/src/renderables/Image.ts
+++ b/packages/core/src/renderables/Image.ts
@@ -5,11 +5,12 @@ import { RGBA } from "../lib/RGBA.js"
 import type { ImageRenderProtocol, RenderContext, TerminalCapabilities } from "../types.js"
 
 export type ImageFit = "fit" | "cover" | "fill"
+export type ImageRenderableSource = ImageSource | NativeImage
 
 const TRANSPARENT = RGBA.fromValues(0, 0, 0, 0)
 
 export interface ImageRenderableOptions extends RenderableOptions<ImageRenderable> {
-  source?: ImageSource
+  source?: ImageRenderableSource
   fit?: ImageFit
   protocol?: ImageRenderProtocol
   onLoad?: (image: NativeImage) => void
@@ -38,8 +39,9 @@ function pixelResolution(ctx: RenderContext): { width: number; height: number } 
 }
 
 export class ImageRenderable extends Renderable {
-  private _source: ImageSource | undefined
+  private _source: ImageRenderableSource | undefined
   private _image: NativeImage | null = null
+  private _pendingImage: NativeImage | null = null
   private _loadError: unknown = null
   private _loadController: AbortController | null = null
   public onLoad?: (image: NativeImage) => void
@@ -57,16 +59,18 @@ export class ImageRenderable extends Renderable {
     if (options.source !== undefined) this.source = options.source
   }
 
-  public get source(): ImageSource | undefined {
+  public get source(): ImageRenderableSource | undefined {
     return this._source
   }
 
-  public set source(source: ImageSource | undefined) {
+  public set source(source: ImageRenderableSource | undefined) {
     source ??= undefined
     if (source === this._source) return
     this._source = source
     this._loadController?.abort()
     this._loadController = null
+    this._pendingImage?.dispose()
+    this._pendingImage = null
 
     if (source === undefined) {
       this._loadError = null
@@ -80,7 +84,19 @@ export class ImageRenderable extends Renderable {
     const controller = new AbortController()
     this._loadController = controller
     this._loadError = null
-    this.loadPromise = this.load(source, controller)
+    let imagePromise: Promise<NativeImage>
+    if (source instanceof NativeImage) {
+      try {
+        const image = source.retain()
+        this._pendingImage = image
+        imagePromise = Promise.resolve(image)
+      } catch (error) {
+        imagePromise = Promise.reject(error)
+      }
+    } else {
+      imagePromise = NativeImage.load(source, { signal: controller.signal })
+    }
+    this.loadPromise = this.load(imagePromise, controller)
   }
 
   public get image(): NativeImage | null {
@@ -202,10 +218,10 @@ export class ImageRenderable extends Renderable {
     )
   }
 
-  private async load(source: ImageSource, controller: AbortController): Promise<void> {
+  private async load(imagePromise: Promise<NativeImage>, controller: AbortController): Promise<void> {
     let image: NativeImage
     try {
-      image = await NativeImage.load(source, { signal: controller.signal })
+      image = await imagePromise
     } catch (error) {
       if (controller.signal.aborted || this.isDestroyed || this._loadController !== controller) return
       this._loadController = null
@@ -219,6 +235,7 @@ export class ImageRenderable extends Renderable {
       return
     }
 
+    if (this._pendingImage === image) this._pendingImage = null
     const previous = this._image
     this._image = image
     this._loadController = null
@@ -230,6 +247,8 @@ export class ImageRenderable extends Renderable {
   protected destroySelf(): void {
     this._loadController?.abort()
     this._loadController = null
+    this._pendingImage?.dispose()
+    this._pendingImage = null
     this._image?.dispose()
     this._image = null
     super.destroySelf()

--- a/packages/core/src/tests/ffi-borrowed-pointer-callsites.test.ts
+++ b/packages/core/src/tests/ffi-borrowed-pointer-callsites.test.ts
@@ -661,6 +661,7 @@ describe("borrowed pointer call sites", () => {
       "imageDecode",
       "imageCreateFromRgba",
       "imageGetInfo",
+      "imageRetain",
       "imageClone",
       "imageCopyPixels",
       "imageResize",
@@ -693,6 +694,7 @@ describe("borrowed pointer call sites", () => {
       lib.imageDecode(data)
       lib.imageCreateFromRgba(pixels, 1, 1, 4)
       lib.imageGetInfo(handle)
+      lib.imageRetain(handle)
       lib.imageClone(handle)
       lib.imageCopyPixels(handle, destination, 4, false)
       lib.imageResize(handle, 1, 1, 0)
@@ -720,6 +722,7 @@ describe("borrowed pointer call sites", () => {
       expect(calls.get("imageCreateFromRgba")![0]).toBe(pixels)
       expect(calls.get("imageCreateFromRgba")![5]).toBeInstanceOf(Uint32Array)
       expect(calls.get("imageGetInfo")![1]).toBeInstanceOf(ArrayBuffer)
+      expect(calls.get("imageRetain")![1]).toBeInstanceOf(Uint32Array)
       expect(calls.get("imageClone")![1]).toBeInstanceOf(Uint32Array)
       expect(calls.get("imageCopyPixels")![1]).toBe(destination)
       expect(calls.get("imageResize")![4]).toBeInstanceOf(Uint32Array)

--- a/packages/core/src/tests/image-renderable.test.ts
+++ b/packages/core/src/tests/image-renderable.test.ts
@@ -3,7 +3,7 @@ import { readFile, rm } from "node:fs/promises"
 import { resolve } from "node:path"
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
-import { ImageLoadError } from "../image.js"
+import { ImageLoadError, NativeImage } from "../image.js"
 import { createCliRenderer } from "../renderer.js"
 import { ImageRenderable, resolveImageRenderProtocol } from "../renderables/Image.js"
 import { TextRenderable } from "../renderables/Text.js"
@@ -115,6 +115,60 @@ describe("ImageRenderable image loading", () => {
       renderable.destroy()
     }
     expect(() => image.info()).toThrow("disposed")
+  })
+
+  test("retains native image sources synchronously and loads them asynchronously", async () => {
+    const source = NativeImage.fromRgba(Uint8Array.of(12, 34, 56, 255), 1, 1)
+    let loaded = false
+    const renderable = new ImageRenderable(renderer, {
+      source,
+      onLoad: () => {
+        loaded = true
+      },
+    })
+
+    expect(loaded).toBe(false)
+    expect(() => source.takeRaw()).toThrow("native buffers retain the image")
+    source.dispose()
+    await renderable.loadPromise
+    try {
+      expect(loaded).toBe(true)
+      expect([...renderable.image!.raw().data]).toEqual([12, 34, 56, 255])
+    } finally {
+      renderable.destroy()
+    }
+  })
+
+  test("releases retained native sources on replacement and destruction", async () => {
+    const first = NativeImage.fromRgba(Uint8Array.of(1, 2, 3, 255), 1, 1)
+    const second = NativeImage.fromRgba(Uint8Array.of(4, 5, 6, 255), 1, 1)
+    const renderable = new ImageRenderable(renderer, { source: first })
+    await renderable.loadPromise
+
+    renderable.source = second
+    await renderable.loadPromise
+    const firstRaw = first.takeRaw()
+    firstRaw.dispose()
+    renderable.destroy()
+    const secondRaw = second.takeRaw()
+    secondRaw.dispose()
+  })
+
+  test("reports disposed native image sources asynchronously", async () => {
+    const source = NativeImage.fromRgba(Uint8Array.of(1, 2, 3, 255), 1, 1)
+    source.dispose()
+    const errors: unknown[] = []
+    const renderable = new ImageRenderable(renderer, { source, onError: (error) => errors.push(error) })
+
+    expect(errors).toHaveLength(0)
+    await renderable.loadPromise
+    try {
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toBeInstanceOf(Error)
+      expect(renderable.image).toBeNull()
+    } finally {
+      renderable.destroy()
+    }
   })
 
   test("dumps image cells with their fallback glyphs", async () => {

--- a/packages/core/src/tests/image.test.ts
+++ b/packages/core/src/tests/image.test.ts
@@ -542,7 +542,6 @@ describe("NativeImage", () => {
     const image = NativeImage.fromRgba(Uint8Array.of(1, 2, 3, 255, 4, 5, 6, 128), 2, 1)
     try {
       image.ensureEncodedPng()
-      image.ensureEncodedPng()
       expect(image.info()).toMatchObject({ width: 2, height: 1, format: "raw-rgba", hasAlpha: true })
       expect([...image.raw().data]).toEqual([1, 2, 3, 255, 4, 5, 6, 128])
     } finally {

--- a/packages/core/src/tests/image.test.ts
+++ b/packages/core/src/tests/image.test.ts
@@ -538,6 +538,18 @@ describe("NativeImage", () => {
     }
   })
 
+  test("retains independently disposable references without copying", () => {
+    const image = NativeImage.fromRgba(Uint8Array.of(1, 2, 3, 255), 1, 1)
+    const retained = image.retain()
+    expect(retained.ptr).not.toBe(image.ptr)
+    image.dispose()
+    try {
+      expect([...retained.raw().data]).toEqual([1, 2, 3, 255])
+    } finally {
+      retained.dispose()
+    }
+  })
+
   test("transfers native RGBA pixels without copying", () => {
     const pixels = Uint8Array.of(1, 2, 3, 4, 5, 6, 7, 8)
     const image = NativeImage.fromRgba(pixels, 2, 1)

--- a/packages/core/src/tests/image.test.ts
+++ b/packages/core/src/tests/image.test.ts
@@ -538,6 +538,19 @@ describe("NativeImage", () => {
     }
   })
 
+  test("ensureEncodedPng keeps a raw RGBA image usable and rejects disposed images", () => {
+    const image = NativeImage.fromRgba(Uint8Array.of(1, 2, 3, 255, 4, 5, 6, 128), 2, 1)
+    try {
+      image.ensureEncodedPng()
+      image.ensureEncodedPng()
+      expect(image.info()).toMatchObject({ width: 2, height: 1, format: "raw-rgba", hasAlpha: true })
+      expect([...image.raw().data]).toEqual([1, 2, 3, 255, 4, 5, 6, 128])
+    } finally {
+      image.dispose()
+    }
+    expect(() => image.ensureEncodedPng()).toThrow("disposed")
+  })
+
   test("retains independently disposable references without copying", () => {
     const image = NativeImage.fromRgba(Uint8Array.of(1, 2, 3, 255), 1, 1)
     const retained = image.retain()

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -1265,6 +1265,7 @@ function getOpenTUILib(libPath?: string) {
     imageRetain: { args: ["u32", "ptr"], returns: "u32" },
     imageGetInfo: { args: ["u32", "ptr"], returns: "u32" },
     imageMaterialize: { args: ["u32"], returns: "u32" },
+    imageEnsureEncodedPng: { args: ["u32"], returns: "u32" },
     imageGetPixelsPtr: { args: ["u32"], returns: "ptr" },
     imageClone: { args: ["u32", "ptr"], returns: "u32" },
     imageCopyPixels: { args: ["u32", "ptr", "u64", "u32", "u8"], returns: "u32" },
@@ -2683,6 +2684,7 @@ export interface RenderLib extends AudioEngineLib {
   imageRetain: (image: ImageHandle) => { status: number; handle: ImageHandle | null }
   imageGetInfo: (image: ImageHandle) => { status: number; info: NativeImageInfo }
   imageMaterialize: (image: ImageHandle) => number
+  imageEnsureEncodedPng: (image: ImageHandle) => number
   imageGetPixelsPtr: (image: ImageHandle) => Pointer | null
   imageClone: (image: ImageHandle) => { status: number; handle: ImageHandle | null }
   imageCopyPixels: (image: ImageHandle, destination: Uint8Array, stride: number, bgra: boolean) => number
@@ -5708,6 +5710,10 @@ class FFIRenderLib implements RenderLib {
 
   public imageMaterialize(image: ImageHandle): number {
     return this.opentui.symbols.imageMaterialize(image)
+  }
+
+  public imageEnsureEncodedPng(image: ImageHandle): number {
+    return this.opentui.symbols.imageEnsureEncodedPng(image)
   }
 
   public imageClone(image: ImageHandle): { status: number; handle: ImageHandle | null } {

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -1262,6 +1262,7 @@ function getOpenTUILib(libPath?: string) {
     imageDecode: { args: ["ptr", "u32", "ptr"], returns: "u32" },
     imageCreateFromRgba: { args: ["ptr", "u64", "u32", "u32", "u32", "ptr"], returns: "u32" },
     imageDestroy: { args: ["u32"], returns: "void" },
+    imageRetain: { args: ["u32", "ptr"], returns: "u32" },
     imageGetInfo: { args: ["u32", "ptr"], returns: "u32" },
     imageMaterialize: { args: ["u32"], returns: "u32" },
     imageGetPixelsPtr: { args: ["u32"], returns: "ptr" },
@@ -2679,6 +2680,7 @@ export interface RenderLib extends AudioEngineLib {
     stride: number,
   ) => { status: number; handle: ImageHandle | null }
   imageDestroy: (image: ImageHandle) => void
+  imageRetain: (image: ImageHandle) => { status: number; handle: ImageHandle | null }
   imageGetInfo: (image: ImageHandle) => { status: number; info: NativeImageInfo }
   imageMaterialize: (image: ImageHandle) => number
   imageGetPixelsPtr: (image: ImageHandle) => Pointer | null
@@ -5674,6 +5676,11 @@ class FFIRenderLib implements RenderLib {
 
   public imageDestroy(image: ImageHandle): void {
     this.opentui.symbols.imageDestroy(image)
+  }
+
+  public imageRetain(image: ImageHandle): { status: number; handle: ImageHandle | null } {
+    const output = new Uint32Array(1)
+    return this.imageHandleResult(this.opentui.symbols.imageRetain(image, output), output)
   }
 
   public imageRetainIccCache(): void {

--- a/packages/core/src/zig/image.zig
+++ b/packages/core/src/zig/image.zig
@@ -243,6 +243,19 @@ pub const Image = struct {
         self.pixels = pixels;
         return pixels;
     }
+
+    pub fn ensureEncodedPng(self: *Image) ![]u8 {
+        if (self.encoded_png) |bytes| return bytes;
+        const pixels = try self.ensurePixels();
+        const has_alpha = self.metadata.has_alpha != 0;
+        const encoded = try encodePng(self.allocator, pixels, self.width(), self.height(), has_alpha);
+        self.encoded_png = encoded;
+        // The fresh encoding is plain sRGB, so stale ICC metadata must not describe it.
+        self.png_color_type = if (has_alpha) 6 else 2;
+        self.iccp_compressed_offset = 0;
+        self.iccp_compressed_len = 0;
+        return encoded;
+    }
 };
 
 const png_signature = [_]u8{ 137, 80, 78, 71, 13, 10, 26, 10 };
@@ -911,6 +924,77 @@ fn decodeInternal(allocator: Allocator, data: []const u8, limits: Limits, retain
 
 pub fn decode(allocator: Allocator, data: []const u8, limits: Limits) !*Image {
     return decodeInternal(allocator, data, limits, true);
+}
+
+fn writePngChunk(destination: []u8, kind: *const [4]u8, payload: []const u8) usize {
+    std.mem.writeInt(u32, destination[0..4], @intCast(payload.len), .big);
+    @memcpy(destination[4..8], kind);
+    @memcpy(destination[8..][0..payload.len], payload);
+    const crc = std.hash.Crc32.hash(destination[4 .. 8 + payload.len]);
+    std.mem.writeInt(u32, destination[8 + payload.len ..][0..4], crc, .big);
+    return payload.len + 12;
+}
+
+fn compressPngScanlines(allocator: Allocator, pixels: []const u8, width: u32, height: u32, has_alpha: bool) ![]u8 {
+    var idat: std.Io.Writer.Allocating = try .initCapacity(allocator, 1024);
+    defer idat.deinit();
+    const window = try allocator.alloc(u8, std.compress.flate.max_window_len);
+    defer allocator.free(window);
+    // The compressor state is ~224 KiB, too large for the stack.
+    const compress = try allocator.create(std.compress.flate.Compress);
+    defer allocator.destroy(compress);
+    // Allocating-writer failures surface as WriteFailed; allocation is its only failure mode.
+    compress.* = std.compress.flate.Compress.init(&idat.writer, window, .zlib, .default) catch return error.OutOfMemory;
+
+    const source_stride = @as(usize, width) * 4;
+    if (has_alpha) {
+        for (0..height) |y| {
+            compress.writer.writeByte(0) catch return error.OutOfMemory;
+            compress.writer.writeAll(pixels[y * source_stride ..][0..source_stride]) catch return error.OutOfMemory;
+        }
+    } else {
+        const row = try allocator.alloc(u8, 1 + @as(usize, width) * 3);
+        defer allocator.free(row);
+        row[0] = 0; // Filter type none for every scanline.
+        for (0..height) |y| {
+            const source_row = pixels[y * source_stride ..][0..source_stride];
+            for (0..width) |x| {
+                @memcpy(row[1 + x * 3 ..][0..3], source_row[x * 4 ..][0..3]);
+            }
+            compress.writer.writeAll(row) catch return error.OutOfMemory;
+        }
+    }
+    compress.finish() catch return error.OutOfMemory;
+    return idat.toOwnedSlice();
+}
+
+fn encodePng(allocator: Allocator, pixels: []const u8, width: u32, height: u32, has_alpha: bool) ![]u8 {
+    std.debug.assert(width > 0 and height > 0);
+    std.debug.assert(pixels.len == @as(usize, width) * @as(usize, height) * 4);
+    std.debug.assert(has_alpha or !pixelsHaveTransparency(pixels));
+    const idat = try compressPngScanlines(allocator, pixels, width, height, has_alpha);
+    defer allocator.free(idat);
+
+    var ihdr: [13]u8 = undefined;
+    std.mem.writeInt(u32, ihdr[0..4], width, .big);
+    std.mem.writeInt(u32, ihdr[4..8], height, .big);
+    ihdr[8] = 8; // Bit depth.
+    ihdr[9] = if (has_alpha) 6 else 2; // Color type: RGBA or RGB.
+    ihdr[10] = 0; // Compression method: deflate.
+    ihdr[11] = 0; // Filter method: adaptive.
+    ihdr[12] = 0; // Interlace method: none.
+
+    const limits: Limits = .{};
+    const total = png_signature.len + (ihdr.len + 12) + (idat.len + 12) + 12;
+    if (total > limits.max_encoded_bytes) return error.MemoryLimit;
+    const encoded = try allocator.alloc(u8, total);
+    @memcpy(encoded[0..png_signature.len], &png_signature);
+    var offset: usize = png_signature.len;
+    offset += writePngChunk(encoded[offset..], "IHDR", &ihdr);
+    offset += writePngChunk(encoded[offset..], "IDAT", idat);
+    offset += writePngChunk(encoded[offset..], "IEND", "");
+    std.debug.assert(offset == total);
+    return encoded;
 }
 
 fn pixelOffset(width: u32, x: u32, y: u32) usize {

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -2917,6 +2917,12 @@ export fn imageMaterialize(image_handle: NativeHandle) u32 {
     return @intFromEnum(native_image.Status.ok);
 }
 
+export fn imageEnsureEncodedPng(image_handle: NativeHandle) u32 {
+    const image = acquireImage(image_handle) orelse return @intFromEnum(native_image.Status.invalid_handle);
+    _ = image.ensureEncodedPng() catch |err| return @intFromEnum(native_image.statusFromError(err));
+    return @intFromEnum(native_image.Status.ok);
+}
+
 export fn imageClone(image_handle: NativeHandle, out_handle: ?*NativeHandle) u32 {
     const image = acquireImage(image_handle) orelse return @intFromEnum(native_image.Status.invalid_handle);
     const output = out_handle orelse return @intFromEnum(native_image.Status.invalid_argument);
@@ -2975,6 +2981,27 @@ test "imageGetPixelsPtr requires exclusive ownership and invalidates encoded sta
     try std.testing.expect(imageGetPixelsPtr(handle) != null);
     try std.testing.expectEqual(@as(?[]u8, null), value.encoded_png);
     try std.testing.expectEqual(@as(u32, 1), value.metadata.has_alpha);
+}
+
+test "imageEnsureEncodedPng attaches an encoding that pixel mutation discards" {
+    const pixels = [_]u8{ 1, 2, 3, 255, 4, 5, 6, 255 };
+    var handle: NativeHandle = INVALID_HANDLE;
+    try std.testing.expectEqual(
+        @as(u32, @intFromEnum(native_image.Status.ok)),
+        imageCreateFromRgba(&pixels, pixels.len, 2, 1, 8, &handle),
+    );
+    defer imageDestroy(handle);
+
+    try std.testing.expectEqual(
+        @as(u32, @intFromEnum(native_image.Status.invalid_handle)),
+        imageEnsureEncodedPng(INVALID_HANDLE),
+    );
+    try std.testing.expectEqual(@as(u32, @intFromEnum(native_image.Status.ok)), imageEnsureEncodedPng(handle));
+    const image = acquireImage(handle) orelse return error.TestUnexpectedResult;
+    try std.testing.expect(image.encoded_png != null);
+
+    try std.testing.expect(imageGetPixelsPtr(handle) != null);
+    try std.testing.expectEqual(@as(?[]u8, null), image.encoded_png);
 }
 
 test "imageRetain creates independently disposable handles without copying pixels" {

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -2884,6 +2884,15 @@ export fn imageDestroy(image_handle: NativeHandle) void {
     handles.finishDestroy(token.handle);
 }
 
+export fn imageRetain(image_handle: NativeHandle, out_handle: ?*NativeHandle) u32 {
+    const image = acquireImage(image_handle) orelse return @intFromEnum(native_image.Status.invalid_handle);
+    const output = out_handle orelse return @intFromEnum(native_image.Status.invalid_argument);
+    output.* = INVALID_HANDLE;
+    if (image.ref_count == std.math.maxInt(u32)) return @intFromEnum(native_image.Status.memory_limit);
+    image.retain();
+    return @intFromEnum(insertImage(image, output));
+}
+
 export fn imageGetInfo(image_handle: NativeHandle, out_info: ?*native_image.Info) u32 {
     const image = acquireImage(image_handle) orelse return @intFromEnum(native_image.Status.invalid_handle);
     const output = out_info orelse return @intFromEnum(native_image.Status.invalid_argument);
@@ -2966,6 +2975,30 @@ test "imageGetPixelsPtr requires exclusive ownership and invalidates encoded sta
     try std.testing.expect(imageGetPixelsPtr(handle) != null);
     try std.testing.expectEqual(@as(?[]u8, null), value.encoded_png);
     try std.testing.expectEqual(@as(u32, 1), value.metadata.has_alpha);
+}
+
+test "imageRetain creates independently disposable handles without copying pixels" {
+    const pixels = [_]u8{ 1, 2, 3, 255 };
+    var handle: NativeHandle = INVALID_HANDLE;
+    try std.testing.expectEqual(
+        @as(u32, @intFromEnum(native_image.Status.ok)),
+        imageCreateFromRgba(&pixels, pixels.len, 1, 1, 4, &handle),
+    );
+    defer imageDestroy(handle);
+
+    var retained_handle: NativeHandle = INVALID_HANDLE;
+    try std.testing.expectEqual(
+        @as(u32, @intFromEnum(native_image.Status.ok)),
+        imageRetain(handle, &retained_handle),
+    );
+    defer imageDestroy(retained_handle);
+    try std.testing.expect(handle != retained_handle);
+    const image = acquireImage(handle) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(image, acquireImage(retained_handle));
+
+    imageDestroy(handle);
+    try std.testing.expect(acquireImage(handle) == null);
+    try std.testing.expectEqual(image, acquireImage(retained_handle));
 }
 
 export fn imageResize(image_handle: NativeHandle, width: u32, height: u32, filter: u32, out_handle: ?*NativeHandle) u32 {

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -1377,7 +1377,7 @@ pub const CliRenderer = struct {
         placement: OptimizedBuffer.ImagePlacement,
         image_id: u32,
     ) !void {
-        const transmit = try self.kittyPlacementTransmit(placement);
+        const transmit = try self.kittyPlacementTransmit(placement, .pixels);
         defer if (transmit.owned) transmit.image.deinit();
         try terminal_image.writeKittyTransmit(writer, transmit.image, image_id, self.terminal.isInTmux());
         try terminal_image.writeKittyPlacementAtCursor(
@@ -1995,20 +1995,31 @@ pub const CliRenderer = struct {
         return kittyDownscaleAppliesTo(placement.source_width, placement.source_height, placement.pixel_width, placement.pixel_height);
     }
 
-    fn kittyCropApplies(placement: OptimizedBuffer.ImagePlacement) bool {
-        return placement.source_x != 0 or placement.source_y != 0 or
-            placement.source_width != placement.image.width() or placement.source_height != placement.image.height();
-    }
-
     const KittyTransmit = struct {
         image: *native_image.Image,
         owned: bool,
     };
 
-    fn kittyPlacementTransmit(self: *CliRenderer, placement: OptimizedBuffer.ImagePlacement) !KittyTransmit {
+    // How a placement's source rectangle reaches the terminal: the live render
+    // path selects it in the placement escape so scrolling a clipped image never
+    // retransmits, while scrollback snapshots must bake it into the transmitted
+    // pixels because their placements cannot carry a source rectangle and the
+    // terminal would otherwise retain the full image in its history.
+    const KittyTransmitCrop = enum { escape, pixels };
+
+    fn kittyCropApplies(placement: OptimizedBuffer.ImagePlacement) bool {
+        return placement.source_x != 0 or placement.source_y != 0 or
+            placement.source_width != placement.image.width() or placement.source_height != placement.image.height();
+    }
+
+    fn kittyPlacementTransmit(
+        self: *CliRenderer,
+        placement: OptimizedBuffer.ImagePlacement,
+        crop: KittyTransmitCrop,
+    ) !KittyTransmit {
         const source = placement.image;
         const downscaled = kittyDownscaleApplies(placement);
-        if (downscaled or kittyCropApplies(placement)) {
+        if (downscaled or (crop == .pixels and kittyCropApplies(placement))) {
             const cropped = try native_image.extract(
                 self.allocator,
                 source,
@@ -2065,12 +2076,12 @@ pub const CliRenderer = struct {
                 );
                 const source_changed = committed.source_x != placement.source_x or committed.source_y != placement.source_y or
                     committed.source_width != placement.source_width or committed.source_height != placement.source_height;
-                break :blk committed.opacity != placement.opacity or source_changed or previous_downscaled != downscaled or
-                    (downscaled and (committed.pixel_width != placement.pixel_width or committed.pixel_height != placement.pixel_height));
+                break :blk committed.opacity != placement.opacity or previous_downscaled != downscaled or
+                    (downscaled and (source_changed or committed.pixel_width != placement.pixel_width or committed.pixel_height != placement.pixel_height));
             } else false;
             if (previous == null or retransmit) {
                 if (retransmit) try terminal_image.writeKittyDelete(writer, image_id, null, true, tmux);
-                const transmit = try self.kittyPlacementTransmit(placement);
+                const transmit = try self.kittyPlacementTransmit(placement, .escape);
                 defer if (transmit.owned) transmit.image.deinit();
                 try terminal_image.writeKittyTransmit(writer, transmit.image, image_id, tmux);
             } else if (force_place or previous.?.x != placement.x or previous.?.y != placement.y or previous.?.width != placement.width or previous.?.height != placement.height or
@@ -2080,7 +2091,10 @@ pub const CliRenderer = struct {
                 try terminal_image.writeKittyDelete(writer, image_id, placement.placement_id, false, tmux);
             } else continue;
             if (placement.x < 0 or placement.y < 0) continue;
-            const normalized = downscaled or kittyCropApplies(placement);
+            // A downscaled transmit already contains exactly the placement's
+            // source rectangle; otherwise the full image was transmitted and the
+            // placement escape selects the visible portion.
+            const normalized = downscaled;
             try terminal_image.writeKittyPlacement(
                 writer,
                 image_id,

--- a/packages/core/src/zig/tests/image_test.zig
+++ b/packages/core/src/zig/tests/image_test.zig
@@ -57,6 +57,12 @@ fn resizeWithAllocator(allocator: std.mem.Allocator) !void {
     defer resized.deinit();
 }
 
+fn encodePngWithAllocator(allocator: std.mem.Allocator) !void {
+    const source = try image.createFromRgba(allocator, &[_]u8{ 1, 2, 3, 255 }, 1, 1, 4);
+    defer source.deinit();
+    _ = try source.ensureEncodedPng();
+}
+
 test "image operations release partial allocations on OOM" {
     const png = try decodeBase64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4AWP4z8DwHwAFAAH/e+m+7wAAAABJRU5ErkJggg==");
     defer std.testing.allocator.free(png);
@@ -64,6 +70,7 @@ test "image operations release partial allocations on OOM" {
     try std.testing.checkAllAllocationFailures(std.testing.allocator, decodePngWithAllocator, .{png});
     try std.testing.checkAllAllocationFailures(std.testing.allocator, clonePngWithAllocator, .{png});
     try std.testing.checkAllAllocationFailures(std.testing.allocator, resizeWithAllocator, .{});
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, encodePngWithAllocator, .{});
 }
 
 test "image inspection does not retain encoded PNG bytes" {
@@ -497,6 +504,57 @@ test "image creation rejects invalid stride and short input" {
     const pixels = [_]u8{0} ** 16;
     try std.testing.expectError(error.InvalidArgument, image.createFromRgba(std.testing.allocator, &pixels, 2, 2, 7));
     try std.testing.expectError(error.InvalidArgument, image.createFromRgba(std.testing.allocator, pixels[0..15], 2, 2, 8));
+}
+
+test "ensureEncodedPng round-trips opaque pixels through the RGB path" {
+    const pixels = [_]u8{
+        1, 2, 3, 255, 4,  5,  6,  255,
+        7, 8, 9, 255, 10, 11, 12, 255,
+    };
+    const source = try makeImage(&pixels, 2, 2);
+    defer source.deinit();
+    try std.testing.expectEqual(@as(u32, 0), source.metadata.has_alpha);
+
+    const encoded = try source.ensureEncodedPng();
+    try std.testing.expectEqual(encoded, source.encoded_png.?);
+
+    var info: image.Info = .{};
+    try std.testing.expectEqual(image.Status.ok, image.probe(encoded, .{}, &info));
+    try std.testing.expectEqual(@as(u32, 2), info.width);
+    try std.testing.expectEqual(@as(u32, 2), info.height);
+    try std.testing.expectEqual(@as(u32, 0), info.has_alpha);
+
+    const decoded = try image.decode(std.testing.allocator, encoded, .{});
+    defer decoded.deinit();
+    try std.testing.expectEqualSlices(u8, &pixels, try decoded.ensurePixels());
+}
+
+test "ensureEncodedPng round-trips transparent pixels through the RGBA path" {
+    const pixels = [_]u8{
+        1, 2, 3, 254, 4,  5,  6,  0,
+        7, 8, 9, 128, 10, 11, 12, 255,
+    };
+    const source = try makeImage(&pixels, 2, 2);
+    defer source.deinit();
+    try std.testing.expectEqual(@as(u32, 1), source.metadata.has_alpha);
+
+    const encoded = try source.ensureEncodedPng();
+    var info: image.Info = .{};
+    try std.testing.expectEqual(image.Status.ok, image.probe(encoded, .{}, &info));
+    try std.testing.expectEqual(@as(u32, 1), info.has_alpha);
+
+    const decoded = try image.decode(std.testing.allocator, encoded, .{});
+    defer decoded.deinit();
+    try std.testing.expectEqualSlices(u8, &pixels, try decoded.ensurePixels());
+}
+
+test "ensureEncodedPng is a no-op when an encoding is already attached" {
+    const source = try makeImage(&[_]u8{ 1, 2, 3, 255 }, 1, 1);
+    defer source.deinit();
+    const first = try source.ensureEncodedPng();
+    const second = try source.ensureEncodedPng();
+    try std.testing.expectEqual(first.ptr, second.ptr);
+    try std.testing.expectEqual(first.len, second.len);
 }
 
 test "extract copies the exact requested rectangle" {

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -4227,7 +4227,7 @@ test "renderer transmits small kitty images at native size" {
     try std.testing.expect(std.mem.find(u8, output, "x=0,y=0,w=8,h=8,C=1") != null);
 }
 
-test "renderer transmits only cropped kitty source pixels" {
+test "renderer reuses the kitty transmit across source rectangle changes" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
     defer link.deinitGlobalLinkPool();
@@ -4250,47 +4250,31 @@ test "renderer transmits only cropped kitty source pixels" {
     }
     test_renderer.renderer.terminal.caps.kitty_graphics = true;
 
+    // A clipped placement transmits the full image once; the placement escape
+    // selects the visible source rectangle.
     const next = test_renderer.renderer.getNextBuffer();
     try std.testing.expect(try next.drawImage(value, value_handle, 0, 0, 2, 2, 16, 16, 8, 12, 8, 8, .auto));
     try std.testing.expectEqual(renderer.RenderStatus.rendered, test_renderer.renderer.render(true));
     const output = test_renderer.memory.lastWrite();
 
-    try std.testing.expect(std.mem.find(u8, output, "a=t,f=24,s=8,v=8") != null);
-    try std.testing.expect(std.mem.find(u8, output, "x=0,y=0,w=8,h=8,C=1") != null);
+    try std.testing.expect(std.mem.find(u8, output, "a=t,f=24,s=64,v=64") != null);
+    try std.testing.expect(std.mem.find(u8, output, "x=8,y=12,w=8,h=8,C=1") != null);
     const transmit_start = std.mem.find(u8, output, "\x1b_Ga=t").?;
     const transmit_end = std.mem.findPos(u8, output, transmit_start, "\x1b[").?;
     const transmitted = try terminal_image_test.decodeKittyChunks(output[transmit_start..transmit_end]);
     defer std.testing.allocator.free(transmitted);
-    try std.testing.expectEqual(@as(usize, 8 * 8 * 3), transmitted.len);
-    var expected: [8 * 8 * 3]u8 = undefined;
-    for (0..8) |y| {
-        for (0..8) |x| {
-            const offset = (y * 8 + x) * 3;
-            expected[offset] = @truncate((12 + y) * 64 + 8 + x);
-            expected[offset + 1] = 100;
-            expected[offset + 2] = 200;
-        }
-    }
-    try std.testing.expectEqualSlices(u8, &expected, transmitted);
+    try std.testing.expectEqual(@as(usize, 64 * 64 * 3), transmitted.len);
 
+    // A scroll step changes only the source rectangle: no delete-image, no new
+    // transmit, just a re-placement referencing the retained image.
     const changed = test_renderer.renderer.getNextBuffer();
     try std.testing.expect(try changed.drawImage(value, value_handle, 0, 0, 2, 2, 16, 16, 16, 12, 8, 8, .auto));
     try std.testing.expectEqual(renderer.RenderStatus.rendered, test_renderer.renderer.render(false));
     const changed_output = test_renderer.memory.lastWrite();
-    try std.testing.expect(std.mem.find(u8, changed_output, "a=d,d=I") != null);
-    try std.testing.expect(std.mem.find(u8, changed_output, "a=t,f=24,s=8,v=8") != null);
-    const changed_start = std.mem.find(u8, changed_output, "\x1b_Ga=t").?;
-    const changed_end = std.mem.findPos(u8, changed_output, changed_start, "\x1b[").?;
-    const changed_transmitted = try terminal_image_test.decodeKittyChunks(changed_output[changed_start..changed_end]);
-    defer std.testing.allocator.free(changed_transmitted);
-    for (0..8) |y| {
-        for (0..8) |x| {
-            const offset = (y * 8 + x) * 3;
-            expected[offset] = @truncate((12 + y) * 64 + 16 + x);
-        }
-    }
-    try std.testing.expectEqualSlices(u8, &expected, changed_transmitted);
-    try std.testing.expect(!std.mem.eql(u8, transmitted, changed_transmitted));
+    try std.testing.expect(std.mem.find(u8, changed_output, "a=d,d=I") == null);
+    try std.testing.expect(std.mem.find(u8, changed_output, "a=t") == null);
+    try std.testing.expect(std.mem.find(u8, changed_output, "a=d,d=i") != null);
+    try std.testing.expect(std.mem.find(u8, changed_output, "x=16,y=12,w=8,h=8,C=1") != null);
 }
 
 test "renderer does not publish a frame when image dirty preparation fails" {

--- a/packages/core/src/zig/tests/terminal-image_test.zig
+++ b/packages/core/src/zig/tests/terminal-image_test.zig
@@ -173,6 +173,24 @@ test "kitty transmission uses RGB only when every pixel is opaque" {
     try std.testing.expect(std.mem.find(u8, rgba.written(), ";AQIDBA==\x1b\\") != null);
 }
 
+test "kitty transmission prefers PNG passthrough after ensureEncodedPng" {
+    const value = try image.createFromRgba(std.testing.allocator, &[_]u8{ 1, 2, 3, 255 }, 1, 1, 4);
+    defer value.deinit();
+    var raw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer raw.deinit();
+    try terminal_image.writeKittyTransmit(&raw.writer, value, 5, false);
+    try std.testing.expect(std.mem.find(u8, raw.written(), "f=24") != null);
+
+    const encoded = try value.ensureEncodedPng();
+    var output: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer output.deinit();
+    try terminal_image.writeKittyTransmit(&output.writer, value, 5, false);
+    try std.testing.expect(std.mem.find(u8, output.written(), "a=t,f=100,i=5") != null);
+    const decoded = try decodeKittyChunks(output.written());
+    defer std.testing.allocator.free(decoded);
+    try std.testing.expectEqualSlices(u8, encoded, decoded);
+}
+
 test "kitty transmission sends retained PNG bytes as f=100" {
     const encoded = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4AWP4z8DwHwAFAAH/e+m+7wAAAABJRU5ErkJggg==";
     const png_len = try std.base64.standard.Decoder.calcSizeForSlice(encoded);


### PR DESCRIPTION
Let ImageRenderable take a NativeImage without decoding again.
Retain gives the renderable its own handle so the caller can
dispose immediately; pending refs drop on replace or destroy.
