### PR TITLE
feat(core): add scoped viewport preservation

### DIFF
--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -193,8 +193,9 @@ export class ScrollBoxRenderable extends BoxRenderable {
   }
 
   set scrollTop(value: number) {
+    const previous = this.verticalScrollBar.scrollPosition
     this.verticalScrollBar.scrollPosition = value
-    this.updateStickyState()
+    if (this.scrollTop === previous && !this.viewportAnchor) this.updateStickyState()
   }
 
   get scrollLeft(): number {
@@ -202,8 +203,9 @@ export class ScrollBoxRenderable extends BoxRenderable {
   }
 
   set scrollLeft(value: number) {
+    const previous = this.horizontalScrollBar.scrollPosition
     this.horizontalScrollBar.scrollPosition = value
-    this.updateStickyState()
+    if (this.scrollLeft === previous && !this.viewportAnchor) this.updateStickyState()
   }
 
   get scrollWidth(): number {
@@ -248,6 +250,25 @@ export class ScrollBoxRenderable extends BoxRenderable {
     }
 
     this.syncManualScrollState()
+  }
+
+  private handleScrollChange(axis: "vertical" | "horizontal"): void {
+    const isExternal = !this._isApplyingStickyScroll && !this.restoringViewport
+    const hadViewportAnchor = this.viewportAnchor !== undefined
+    if (isExternal) {
+      this.scrollRevision++
+      this.viewportAnchor = undefined
+    }
+
+    const stickyAxis =
+      this._stickyStart === "top" || this._stickyStart === "bottom"
+        ? "vertical"
+        : this._stickyStart === "left" || this._stickyStart === "right"
+          ? "horizontal"
+          : undefined
+    if (isExternal && hadViewportAnchor && stickyAxis && stickyAxis !== axis) return
+
+    this.updateStickyState()
   }
 
   private syncManualScrollState(): void {
@@ -390,8 +411,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
       orientation: "vertical",
       onChange: (position) => {
         this.content.translateY = -position
-        if (!this._isApplyingStickyScroll && !this.restoringViewport) this.scrollRevision++
-        this.updateStickyState()
+        this.handleScrollChange("vertical")
       },
     })
     super.add(this.verticalScrollBar)
@@ -407,8 +427,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
       orientation: "horizontal",
       onChange: (position) => {
         this.content.translateX = -position
-        if (!this._isApplyingStickyScroll && !this.restoringViewport) this.scrollRevision++
-        this.updateStickyState()
+        this.handleScrollChange("horizontal")
       },
     })
     this.wrapper.add(this.horizontalScrollBar)
@@ -477,8 +496,12 @@ export class ScrollBoxRenderable extends BoxRenderable {
   }
 
   private restoreViewport(): void {
+    const hadViewportAnchor = this.viewportAnchor !== undefined
     const anchor = this.resolveViewportAnchor()
-    if (!anchor) return
+    if (!anchor) {
+      if (hadViewportAnchor && !this._hasManualScroll) this.applyStickyScroll()
+      return
+    }
 
     const layout = anchor.child.getLayoutNode().getComputedLayout()
     const x = layout.left - anchor.left
@@ -550,8 +573,6 @@ export class ScrollBoxRenderable extends BoxRenderable {
       this.scrollTop = position.y
       this.scrollLeft = position.x
     }
-    // Note: scrollTo doesn't need to set _hasManualScroll here because
-    // the scrollTop/scrollLeft setters handle it
   }
 
   private isAtStickyPosition(): boolean {
@@ -661,8 +682,6 @@ export class ScrollBoxRenderable extends BoxRenderable {
           this.scrollAccumulatorX -= integerScroll
         }
       }
-
-      this.syncManualScrollState()
     }
 
     if (event.type === "drag" && event.isDragging) {
@@ -674,16 +693,18 @@ export class ScrollBoxRenderable extends BoxRenderable {
 
   public handleKeyPress(key: KeyEvent): boolean {
     // Let scrollbars handle their own acceleration
+    const previousScrollTop = this.scrollTop
     if (this.verticalScrollBar.handleKeyPress(key)) {
       this.scrollAccel.reset()
       this.resetScrollAccumulators()
-      this.syncManualScrollState()
+      if (this.scrollTop === previousScrollTop && !this.viewportAnchor) this.updateStickyState()
       return true
     }
+    const previousScrollLeft = this.scrollLeft
     if (this.horizontalScrollBar.handleKeyPress(key)) {
       this.scrollAccel.reset()
       this.resetScrollAccumulators()
-      this.syncManualScrollState()
+      if (this.scrollLeft === previousScrollLeft && !this.viewportAnchor) this.updateStickyState()
       return true
     }
     return false
@@ -828,9 +849,45 @@ export class ScrollBoxRenderable extends BoxRenderable {
     }
   }
 
-  private recalculateBarProps(): void {
-    const preservingViewport = this.resolveViewportAnchor() !== undefined
+  private applyStickyScroll(): void {
+    if (!this._stickyScroll) return
 
+    const wasApplyingStickyScroll = this._isApplyingStickyScroll
+    this._isApplyingStickyScroll = true
+    try {
+      const newMaxScrollTop = Math.max(0, this.scrollHeight - this.viewport.height)
+      const newMaxScrollLeft = Math.max(0, this.scrollWidth - this.viewport.width)
+      const stickyStart = this._stickyStart
+
+      if (stickyStart && !this._hasManualScroll) {
+        this.applyStickyStart(stickyStart)
+      } else if (
+        stickyStart &&
+        this._hasManualScroll &&
+        this.isAtStickyReengagePoint(stickyStart, newMaxScrollTop, newMaxScrollLeft)
+      ) {
+        // User scrolled back to the sticky edge during streaming; re-engage sticky.
+        this._hasManualScroll = false
+        this.applyStickyStart(stickyStart)
+      } else if (!this._hasManualScroll) {
+        if (this._stickyScrollTop) {
+          this.scrollTop = 0
+        } else if (this._stickyScrollBottom && newMaxScrollTop > 0) {
+          this.scrollTop = newMaxScrollTop
+        }
+
+        if (this._stickyScrollLeft) {
+          this.scrollLeft = 0
+        } else if (this._stickyScrollRight && newMaxScrollLeft > 0) {
+          this.scrollLeft = newMaxScrollLeft
+        }
+      }
+    } finally {
+      this._isApplyingStickyScroll = wasApplyingStickyScroll
+    }
+  }
+
+  private recalculateBarProps(): void {
     // Wrap entire method to prevent scroll changes from being treated as manual
     const wasApplyingStickyScroll = this._isApplyingStickyScroll
     this._isApplyingStickyScroll = true
@@ -841,35 +898,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
       this.horizontalScrollBar.scrollSize = this.content.width
       this.horizontalScrollBar.viewportSize = this.viewport.width
 
-      if (this._stickyScroll && !preservingViewport) {
-        const newMaxScrollTop = Math.max(0, this.scrollHeight - this.viewport.height)
-        const newMaxScrollLeft = Math.max(0, this.scrollWidth - this.viewport.width)
-        const stickyStart = this._stickyStart
-
-        if (stickyStart && !this._hasManualScroll) {
-          this.applyStickyStart(stickyStart)
-        } else if (
-          stickyStart &&
-          this._hasManualScroll &&
-          this.isAtStickyReengagePoint(stickyStart, newMaxScrollTop, newMaxScrollLeft)
-        ) {
-          // User scrolled back to the sticky edge during streaming; re-engage sticky.
-          this._hasManualScroll = false
-          this.applyStickyStart(stickyStart)
-        } else if (!this._hasManualScroll) {
-          if (this._stickyScrollTop) {
-            this.scrollTop = 0
-          } else if (this._stickyScrollBottom && newMaxScrollTop > 0) {
-            this.scrollTop = newMaxScrollTop
-          }
-
-          if (this._stickyScrollLeft) {
-            this.scrollLeft = 0
-          } else if (this._stickyScrollRight && newMaxScrollLeft > 0) {
-            this.scrollLeft = newMaxScrollLeft
-          }
-        }
-      }
+      if (!this.viewportAnchor) this.applyStickyScroll()
     } finally {
       this._isApplyingStickyScroll = wasApplyingStickyScroll
     }

--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -193,11 +193,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
   }
 
   set scrollTop(value: number) {
-    const previous = this.verticalScrollBar.scrollPosition
     this.verticalScrollBar.scrollPosition = value
-    if (!this._isApplyingStickyScroll && !this.restoringViewport && this.scrollTop !== previous) {
-      this.scrollRevision++
-    }
     this.updateStickyState()
   }
 
@@ -206,11 +202,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
   }
 
   set scrollLeft(value: number) {
-    const previous = this.horizontalScrollBar.scrollPosition
     this.horizontalScrollBar.scrollPosition = value
-    if (!this._isApplyingStickyScroll && !this.restoringViewport && this.scrollLeft !== previous) {
-      this.scrollRevision++
-    }
     this.updateStickyState()
   }
 
@@ -398,6 +390,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
       orientation: "vertical",
       onChange: (position) => {
         this.content.translateY = -position
+        if (!this._isApplyingStickyScroll && !this.restoringViewport) this.scrollRevision++
         this.updateStickyState()
       },
     })
@@ -414,6 +407,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
       orientation: "horizontal",
       onChange: (position) => {
         this.content.translateX = -position
+        if (!this._isApplyingStickyScroll && !this.restoringViewport) this.scrollRevision++
         this.updateStickyState()
       },
     })
@@ -445,8 +439,6 @@ export class ScrollBoxRenderable extends BoxRenderable {
       this.verticalScrollBar.scrollBy(delta.y, unit)
       this.horizontalScrollBar.scrollBy(delta.x, unit)
     }
-    // Note: scrollBy doesn't need to set _hasManualScroll here because the scrollbar
-    // change will trigger the scrollTop setter which handles it
   }
 
   public preserveViewport(anchor: Renderable, options: PreserveViewportOptions = {}): ViewportPreservation | undefined {

--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -11,16 +11,24 @@ import { ScrollBarRenderable, type ScrollBarOptions, type ScrollUnit } from "./S
 class ContentRenderable extends BoxRenderable {
   private viewport: BoxRenderable
   private _viewportCulling: boolean
+  private onLayout: () => void
 
   constructor(
     ctx: RenderContext,
     viewport: BoxRenderable,
     viewportCulling: boolean,
+    onLayout: () => void,
     options: RenderableOptions<BoxRenderable>,
   ) {
     super(ctx, options)
     this.viewport = viewport
     this._viewportCulling = viewportCulling
+    this.onLayout = onLayout
+  }
+
+  public override updateFromLayout(): void {
+    super.updateFromLayout()
+    this.onLayout()
   }
 
   get viewportCulling(): boolean {
@@ -71,6 +79,22 @@ export interface ScrollBoxOptions extends BoxOptions<ScrollBoxRenderable> {
   viewportCulling?: boolean
 }
 
+export interface ViewportPreservation {
+  cancel(): void
+}
+
+export interface PreserveViewportOptions {
+  id?: string
+}
+
+interface ViewportAnchor extends ViewportPreservation {
+  child: Renderable
+  id?: string
+  left: number
+  top: number
+  scrollRevision: number
+}
+
 const SCROLLBOX_PADDING_KEYS = [
   "padding",
   "paddingX",
@@ -117,6 +141,9 @@ export class ScrollBoxRenderable extends BoxRenderable {
 
   protected _focusable: boolean = true
   private selectionListener?: () => void
+  private viewportAnchor?: ViewportAnchor
+  private scrollRevision = 0
+  private restoringViewport = false
 
   private autoScrollMouseX: number = 0
   private autoScrollMouseY: number = 0
@@ -166,7 +193,11 @@ export class ScrollBoxRenderable extends BoxRenderable {
   }
 
   set scrollTop(value: number) {
+    const previous = this.verticalScrollBar.scrollPosition
     this.verticalScrollBar.scrollPosition = value
+    if (!this._isApplyingStickyScroll && !this.restoringViewport && this.scrollTop !== previous) {
+      this.scrollRevision++
+    }
     this.updateStickyState()
   }
 
@@ -175,7 +206,11 @@ export class ScrollBoxRenderable extends BoxRenderable {
   }
 
   set scrollLeft(value: number) {
+    const previous = this.horizontalScrollBar.scrollPosition
     this.horizontalScrollBar.scrollPosition = value
+    if (!this._isApplyingStickyScroll && !this.restoringViewport && this.scrollLeft !== previous) {
+      this.scrollRevision++
+    }
     this.updateStickyState()
   }
 
@@ -337,7 +372,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
     })
     this.wrapper.add(this.viewport)
 
-    this.content = new ContentRenderable(ctx, this.viewport, viewportCulling, {
+    this.content = new ContentRenderable(ctx, this.viewport, viewportCulling, () => this.restoreViewport(), {
       alignSelf: "flex-start",
       flexShrink: 0,
       ...(scrollX ? { minWidth: "100%" } : { minWidth: "100%", maxWidth: "100%" }),
@@ -410,6 +445,53 @@ export class ScrollBoxRenderable extends BoxRenderable {
     }
     // Note: scrollBy doesn't need to set _hasManualScroll here because the scrollbar
     // change will trigger the scrollTop setter which handles it
+  }
+
+  public preserveViewport(anchor: Renderable, options: PreserveViewportOptions = {}): ViewportPreservation | undefined {
+    if (anchor.isDestroyed || anchor.parent !== this.content) return
+    const layout = anchor.getLayoutNode().getComputedLayout()
+    const preservation: ViewportAnchor = {
+      child: anchor,
+      id: options.id,
+      left: layout.left,
+      top: layout.top,
+      scrollRevision: this.scrollRevision,
+      cancel: () => {
+        if (this.viewportAnchor === preservation) this.viewportAnchor = undefined
+      },
+    }
+    this.viewportAnchor = preservation
+    return preservation
+  }
+
+  private restoreViewport(): void {
+    const anchor = this.viewportAnchor
+    if (!anchor) return
+    if (anchor.id) {
+      const current = this.content.getRenderable(anchor.id)
+      if (current) anchor.child = current
+    }
+    if (
+      anchor.child.isDestroyed ||
+      anchor.child.parent !== this.content ||
+      this.scrollRevision !== anchor.scrollRevision
+    ) {
+      this.viewportAnchor = undefined
+      return
+    }
+
+    const layout = anchor.child.getLayoutNode().getComputedLayout()
+    const x = layout.left - anchor.left
+    const y = layout.top - anchor.top
+    if (x === 0 && y === 0) return
+    this.restoringViewport = true
+    try {
+      this.scrollBy({ x, y })
+    } finally {
+      this.restoringViewport = false
+    }
+    anchor.left = layout.left
+    anchor.top = layout.top
   }
 
   public scrollChildIntoView(childId: string): void {

--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -223,6 +223,8 @@ export class ScrollBoxRenderable extends BoxRenderable {
   }
 
   private updateStickyState(): void {
+    if (this.restoringViewport) return
+
     if (!this._stickyScroll) {
       this.syncManualScrollState()
       return
@@ -839,7 +841,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
       this.horizontalScrollBar.scrollSize = this.content.width
       this.horizontalScrollBar.viewportSize = this.viewport.width
 
-      if (this._stickyScroll) {
+      if (this._stickyScroll && !this.viewportAnchor) {
         const newMaxScrollTop = Math.max(0, this.scrollHeight - this.viewport.height)
         const newMaxScrollLeft = Math.max(0, this.scrollWidth - this.viewport.width)
         const stickyStart = this._stickyStart

--- a/packages/core/src/renderables/ScrollBox.ts
+++ b/packages/core/src/renderables/ScrollBox.ts
@@ -223,7 +223,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
   }
 
   private updateStickyState(): void {
-    if (this.restoringViewport) return
+    if (this.restoringViewport || (this.viewportAnchor && this._isApplyingStickyScroll)) return
 
     if (!this._stickyScroll) {
       this.syncManualScrollState()
@@ -466,7 +466,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
     return preservation
   }
 
-  private restoreViewport(): void {
+  private resolveViewportAnchor(): ViewportAnchor | undefined {
     const anchor = this.viewportAnchor
     if (!anchor) return
     if (anchor.id) {
@@ -481,6 +481,12 @@ export class ScrollBoxRenderable extends BoxRenderable {
       this.viewportAnchor = undefined
       return
     }
+    return anchor
+  }
+
+  private restoreViewport(): void {
+    const anchor = this.resolveViewportAnchor()
+    if (!anchor) return
 
     const layout = anchor.child.getLayoutNode().getComputedLayout()
     const x = layout.left - anchor.left
@@ -831,6 +837,8 @@ export class ScrollBoxRenderable extends BoxRenderable {
   }
 
   private recalculateBarProps(): void {
+    const preservingViewport = this.resolveViewportAnchor() !== undefined
+
     // Wrap entire method to prevent scroll changes from being treated as manual
     const wasApplyingStickyScroll = this._isApplyingStickyScroll
     this._isApplyingStickyScroll = true
@@ -841,7 +849,7 @@ export class ScrollBoxRenderable extends BoxRenderable {
       this.horizontalScrollBar.scrollSize = this.content.width
       this.horizontalScrollBar.viewportSize = this.viewport.width
 
-      if (this._stickyScroll && !this.viewportAnchor) {
+      if (this._stickyScroll && !preservingViewport) {
         const newMaxScrollTop = Math.max(0, this.scrollHeight - this.viewport.height)
         const newMaxScrollLeft = Math.max(0, this.scrollWidth - this.viewport.width)
         const stickyStart = this._stickyStart

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -186,6 +186,62 @@ describe("ScrollBoxRenderable - child delegation", () => {
     expect(captureCharFrame().split("\n")[0]).toContain("row-4")
   })
 
+  test("stops preserving after explicit cancellation", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, (_, index) => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      row.add(new TextRenderable(testRenderer, { content: `row-${index}` }))
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+    const offset = rows[4].y - scrollbox.viewport.y
+
+    const preservation = scrollbox.preserveViewport(rows[4])
+    preservation?.cancel()
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 2, flexShrink: 0 }), rows[0])
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(4)
+    expect(rows[4].y - scrollbox.viewport.y).toBe(offset + 2)
+  })
+
+  test("preserves a non-top anchor when preceding content resizes", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, (_, index) => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      row.add(new TextRenderable(testRenderer, { content: `row-${index}` }))
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+    const offset = rows[6].y - scrollbox.viewport.y
+
+    const preservation = scrollbox.preserveViewport(rows[6])
+    rows[0].height = 3
+    await renderOnce()
+    preservation?.cancel()
+
+    expect(scrollbox.scrollTop).toBe(6)
+    expect(rows[6].y - scrollbox.viewport.y).toBe(offset)
+  })
+
   test("preserves an explicit viewport anchor replaced by declarative reconciliation", async () => {
     const scrollbox = new ScrollBoxRenderable(testRenderer, {
       id: "scrollbox",
@@ -215,6 +271,62 @@ describe("ScrollBoxRenderable - child delegation", () => {
 
     expect(scrollbox.scrollTop).toBe(6)
     expect(captureCharFrame().split("\n")[0]).toContain("row-4")
+  })
+
+  test("stops preserving after the anchor is removed", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, () => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+
+    scrollbox.preserveViewport(rows[4])
+    scrollbox.remove(rows[4])
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 2, flexShrink: 0 }), rows[0])
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(4)
+
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 }), rows[0])
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(4)
+  })
+
+  test("rejects anchors that are not direct children", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, () => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      scrollbox.add(row)
+      return row
+    })
+    const nested = new BoxRenderable(testRenderer, { height: 1 })
+    rows[4].add(nested)
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+
+    expect(scrollbox.preserveViewport(nested)).toBeUndefined()
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 2, flexShrink: 0 }), rows[0])
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(4)
   })
 
   test("cancels explicit viewport preservation when the user scrolls", async () => {

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -206,7 +206,8 @@ describe("ScrollBoxRenderable - child delegation", () => {
     const offset = rows[4].y - scrollbox.viewport.y
 
     const preservation = scrollbox.preserveViewport(rows[4])
-    preservation?.cancel()
+    expect(preservation).toBeDefined()
+    preservation!.cancel()
     scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 2, flexShrink: 0 }), rows[0])
     await renderOnce()
 
@@ -292,12 +293,12 @@ describe("ScrollBoxRenderable - child delegation", () => {
 
     scrollbox.preserveViewport(rows[4])
     scrollbox.remove(rows[4])
-    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 2, flexShrink: 0 }), rows[0])
     await renderOnce()
 
     expect(scrollbox.scrollTop).toBe(4)
 
-    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 }), rows[0])
+    scrollbox.insertBefore(rows[4], rows[5])
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 2, flexShrink: 0 }), rows[0])
     await renderOnce()
 
     expect(scrollbox.scrollTop).toBe(4)
@@ -353,6 +354,62 @@ describe("ScrollBoxRenderable - child delegation", () => {
     await renderOnce()
 
     expect(scrollbox.scrollTop).toBe(4)
+  })
+
+  test("cancels explicit viewport preservation when scrollBy moves away and back", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, () => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+
+    scrollbox.preserveViewport(rows[4])
+    scrollbox.scrollBy(1)
+    scrollbox.scrollBy(-1)
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 2, flexShrink: 0 }), rows[0])
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(4)
+  })
+
+  test("preserves a horizontal viewport anchor when preceding content resizes", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 4,
+      height: 2,
+      scrollX: true,
+      scrollY: false,
+      viewportCulling: false,
+      contentOptions: { flexDirection: "row" },
+    })
+    testRenderer.root.add(scrollbox)
+    const columns = Array.from({ length: 10 }, () => {
+      const column = new BoxRenderable(testRenderer, { width: 1, flexShrink: 0 })
+      scrollbox.add(column)
+      return column
+    })
+    await renderOnce()
+    scrollbox.scrollLeft = 4
+    await renderOnce()
+    const offset = columns[6].x - scrollbox.viewport.x
+
+    const preservation = scrollbox.preserveViewport(columns[6])
+    columns[0].width = 3
+    await renderOnce()
+    preservation?.cancel()
+
+    expect(scrollbox.scrollLeft).toBe(6)
+    expect(columns[6].x - scrollbox.viewport.x).toBe(offset)
   })
 
   test("explicit viewport preservation pauses sticky top only for its active scope", async () => {

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -573,6 +573,108 @@ describe("ScrollBoxRenderable - child delegation", () => {
     expect(scrollbox.scrollTop).toBe(3)
   })
 
+  test("automatic preservation cancellation keeps sticky manually paused through range clamping", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      stickyScroll: true,
+      stickyStart: "bottom",
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, () => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+
+    scrollbox.preserveViewport(rows[4])
+    scrollbox.remove(rows[4])
+    scrollbox.remove(rows[8])
+    scrollbox.remove(rows[9])
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(3)
+
+    for (let i = 0; i < 5; i++) {
+      scrollbox.add(new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 }))
+    }
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(3)
+  })
+
+  test("same-position scrolling re-engages sticky after preservation clamps the range", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      stickyScroll: true,
+      stickyStart: "bottom",
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, () => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+
+    scrollbox.preserveViewport(rows[4])
+    scrollbox.remove(rows[4])
+    scrollbox.remove(rows[8])
+    scrollbox.remove(rows[9])
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(3)
+
+    scrollbox.scrollTop = 3
+    for (let i = 0; i < 5; i++) {
+      scrollbox.add(new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 }))
+    }
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(8)
+  })
+
+  test("orthogonal scroll cancellation preserves sticky intent", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 4,
+      height: 4,
+      scrollX: true,
+      stickyScroll: true,
+      stickyStart: "bottom",
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, () => {
+      const row = new BoxRenderable(testRenderer, { width: 10, height: 1, flexShrink: 0 })
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+
+    scrollbox.preserveViewport(rows[6])
+    scrollbox.add(new BoxRenderable(testRenderer, { width: 10, height: 2, flexShrink: 0 }))
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(6)
+
+    scrollbox.scrollLeft = 1
+    scrollbox.add(new BoxRenderable(testRenderer, { width: 10, height: 1, flexShrink: 0 }))
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(9)
+  })
+
   test("preserves an explicit viewport anchor with culling enabled", async () => {
     const scrollbox = new ScrollBoxRenderable(testRenderer, {
       id: "scrollbox",

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -430,6 +430,92 @@ describe("ScrollBoxRenderable - child delegation", () => {
     expect(scrollbox.scrollTop).toBe(5)
   })
 
+  test("sticky resumes when anchor removal automatically cancels preservation", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      stickyScroll: true,
+      stickyStart: "bottom",
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, () => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+
+    scrollbox.preserveViewport(rows[6])
+    scrollbox.remove(rows[6])
+    scrollbox.add(new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 }))
+    scrollbox.add(new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 }))
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(7)
+  })
+
+  test("sticky resumes when a scroll revision automatically cancels preservation", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      stickyScroll: true,
+      stickyStart: "bottom",
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, () => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+
+    scrollbox.preserveViewport(rows[6])
+    scrollbox.scrollTop = 5
+    scrollbox.scrollTop = 6
+    scrollbox.add(new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 }))
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(7)
+  })
+
+  test("viewport preservation keeps sticky manually paused through range clamping", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      stickyScroll: true,
+      stickyStart: "bottom",
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, () => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+
+    const preservation = scrollbox.preserveViewport(rows[4])
+    for (const row of rows.slice(7)) scrollbox.remove(row)
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(3)
+
+    preservation?.cancel()
+    for (let i = 0; i < 5; i++) {
+      scrollbox.add(new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 }))
+    }
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(3)
+  })
+
   test("preserves an explicit viewport anchor with culling enabled", async () => {
     const scrollbox = new ScrollBoxRenderable(testRenderer, {
       id: "scrollbox",

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -243,7 +243,7 @@ describe("ScrollBoxRenderable - child delegation", () => {
     expect(scrollbox.scrollTop).toBe(4)
   })
 
-  test("explicit viewport preservation takes precedence over sticky top", async () => {
+  test("explicit viewport preservation pauses sticky top only for its active scope", async () => {
     const scrollbox = new ScrollBoxRenderable(testRenderer, {
       id: "scrollbox",
       width: 20,
@@ -264,10 +264,58 @@ describe("ScrollBoxRenderable - child delegation", () => {
     const preservation = scrollbox.preserveViewport(rows[0])
     scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 2, flexShrink: 0 }), rows[0])
     await renderOnce()
-    preservation?.cancel()
 
     expect(scrollbox.scrollTop).toBe(2)
     expect(captureCharFrame().split("\n")[0]).toContain("row-0")
+
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 }), rows[0])
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(3)
+    expect(captureCharFrame().split("\n")[0]).toContain("row-0")
+
+    preservation?.cancel()
+
+    expect(scrollbox.scrollTop).toBe(3)
+
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 }), rows[0])
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(0)
+  })
+
+  test("explicit viewport preservation keeps a manually paused sticky state", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      stickyScroll: true,
+      stickyStart: "top",
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, (_, index) => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      row.add(new TextRenderable(testRenderer, { content: `row-${index}` }))
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+
+    const preservation = scrollbox.preserveViewport(rows[4])
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 }), rows[0])
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(5)
+    expect(captureCharFrame().split("\n")[0]).toContain("row-4")
+
+    preservation?.cancel()
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 }), rows[0])
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(5)
   })
 
   test("preserves an explicit viewport anchor with culling enabled", async () => {

--- a/packages/core/src/tests/scrollbox.test.ts
+++ b/packages/core/src/tests/scrollbox.test.ts
@@ -128,6 +128,222 @@ describe("ScrollBoxRenderable - child delegation", () => {
 
     expect(scrollbox.verticalScrollBar.parent).toBeNull()
   })
+
+  test("preserves an explicit viewport anchor before drawing prepended content", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, (_, index) => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      row.add(new TextRenderable(testRenderer, { content: `row-${index}` }))
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+
+    scrollbox.preserveViewport(rows[4])
+    const prepended = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+    prepended.add(new TextRenderable(testRenderer, { content: "prepended" }))
+    scrollbox.insertBefore(prepended, rows[0])
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(5)
+    expect(captureCharFrame().split("\n")[0]).toContain("row-4")
+  })
+
+  test("keeps an explicit viewport anchor armed across async no-op frames", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, (_, index) => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      row.add(new TextRenderable(testRenderer, { content: `row-${index}` }))
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+
+    const preservation = scrollbox.preserveViewport(rows[4])
+    await renderOnce()
+    const prepended = new BoxRenderable(testRenderer, { height: 2, flexShrink: 0 })
+    scrollbox.insertBefore(prepended, rows[0])
+    await renderOnce()
+    preservation?.cancel()
+
+    expect(scrollbox.scrollTop).toBe(6)
+    expect(captureCharFrame().split("\n")[0]).toContain("row-4")
+  })
+
+  test("preserves an explicit viewport anchor replaced by declarative reconciliation", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, (_, index) => {
+      const row = new BoxRenderable(testRenderer, { id: `row-${index}`, height: 1, flexShrink: 0 })
+      row.add(new TextRenderable(testRenderer, { content: `row-${index}` }))
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+
+    const preservation = scrollbox.preserveViewport(rows[4], { id: "row-4" })
+    scrollbox.remove(rows[4])
+    const replacement = new BoxRenderable(testRenderer, { id: "row-4", height: 1, flexShrink: 0 })
+    replacement.add(new TextRenderable(testRenderer, { content: "row-4" }))
+    scrollbox.insertBefore(replacement, rows[5])
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 2, flexShrink: 0 }), rows[0])
+    await renderOnce()
+    preservation?.cancel()
+
+    expect(scrollbox.scrollTop).toBe(6)
+    expect(captureCharFrame().split("\n")[0]).toContain("row-4")
+  })
+
+  test("cancels explicit viewport preservation when the user scrolls", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, () => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+
+    scrollbox.preserveViewport(rows[4])
+    scrollbox.scrollTop = 5
+    scrollbox.scrollTop = 4
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 2, flexShrink: 0 }), rows[0])
+    await renderOnce()
+
+    expect(scrollbox.scrollTop).toBe(4)
+  })
+
+  test("explicit viewport preservation takes precedence over sticky top", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      stickyScroll: true,
+      stickyStart: "top",
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, (_, index) => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      row.add(new TextRenderable(testRenderer, { content: `row-${index}` }))
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+
+    const preservation = scrollbox.preserveViewport(rows[0])
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 2, flexShrink: 0 }), rows[0])
+    await renderOnce()
+    preservation?.cancel()
+
+    expect(scrollbox.scrollTop).toBe(2)
+    expect(captureCharFrame().split("\n")[0]).toContain("row-0")
+  })
+
+  test("preserves an explicit viewport anchor with culling enabled", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 20 }, (_, index) => {
+      const row = new BoxRenderable(testRenderer, { id: `row-${index}`, height: 1, flexShrink: 0 })
+      row.add(new TextRenderable(testRenderer, { content: `row-${index}` }))
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+
+    const preservation = scrollbox.preserveViewport(rows[4])
+    scrollbox.insertBefore(new BoxRenderable(testRenderer, { height: 2, flexShrink: 0 }), rows[0])
+    await renderOnce()
+    preservation?.cancel()
+
+    expect(scrollbox.scrollTop).toBe(6)
+    expect(captureCharFrame().split("\n")[0]).toContain("row-4")
+  })
+
+  test("does not resolve child ids when viewport preservation is inactive", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    scrollbox.add(new BoxRenderable(testRenderer, { height: 10, flexShrink: 0 }))
+    const getRenderable = spyOn(scrollbox.content, "getRenderable")
+
+    await renderOnce()
+
+    expect(getRenderable).not.toHaveBeenCalled()
+  })
+
+  test("app-level post-layout compensation exposes an intermediate shifted frame", async () => {
+    const scrollbox = new ScrollBoxRenderable(testRenderer, {
+      id: "scrollbox",
+      width: 20,
+      height: 4,
+      viewportCulling: false,
+    })
+    testRenderer.root.add(scrollbox)
+    const rows = Array.from({ length: 10 }, (_, index) => {
+      const row = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+      row.add(new TextRenderable(testRenderer, { content: `row-${index}` }))
+      scrollbox.add(row)
+      return row
+    })
+    await renderOnce()
+    scrollbox.scrollTop = 4
+    await renderOnce()
+    const before = scrollbox.scrollHeight
+
+    const prepended = new BoxRenderable(testRenderer, { height: 1, flexShrink: 0 })
+    prepended.add(new TextRenderable(testRenderer, { content: "prepended" }))
+    scrollbox.insertBefore(prepended, rows[0])
+    await renderOnce()
+    const shiftedFrame = captureCharFrame()
+
+    scrollbox.scrollBy(scrollbox.scrollHeight - before)
+    await renderOnce()
+    const restoredFrame = captureCharFrame()
+
+    expect(shiftedFrame.split("\n")[0]).toContain("row-3")
+    expect(restoredFrame.split("\n")[0]).toContain("row-4")
+  })
 })
 
 describe("ScrollBoxRenderable - culled content layout freshness", () => {

--- a/packages/web/src/content/docs/components/scrollbox.mdx
+++ b/packages/web/src/content/docs/components/scrollbox.mdx
@@ -38,6 +38,28 @@ for (let i = 0; i < 100; i++) {
 renderer.root.add(scrollbox)
 ```
 
+## Preserve the viewport during content updates
+
+Use `preserveViewport` to keep a visible child at the same viewport-relative position while content is inserted or resized before it. Preservation remains active until it is canceled and stops automatically if the anchor is removed or the scroll position changes.
+
+```typescript
+const anchor = scrollbox.getRenderable("message-20")
+const preservation = anchor ? scrollbox.preserveViewport(anchor) : undefined
+
+try {
+  await prependOlderMessages()
+  await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+} finally {
+  preservation?.cancel()
+}
+```
+
+The anchor must be a direct child of the ScrollBox. If a declarative renderer may replace that child during reconciliation, pass its stable child ID so ScrollBox can follow the replacement. Explicit viewport preservation takes precedence over sticky scrolling while its scope is active.
+
+```typescript
+const preservation = anchor ? scrollbox.preserveViewport(anchor, { id: "message-20" }) : undefined
+```
+
 ### Construct API
 
 ```typescript

--- a/packages/web/src/content/docs/components/scrollbox.mdx
+++ b/packages/web/src/content/docs/components/scrollbox.mdx
@@ -38,28 +38,6 @@ for (let i = 0; i < 100; i++) {
 renderer.root.add(scrollbox)
 ```
 
-## Preserve the viewport during content updates
-
-Use `preserveViewport` to keep a visible child at the same viewport-relative position while content is inserted or resized before it. Preservation remains active until it is canceled and stops automatically if the anchor is removed or the scroll position changes.
-
-```typescript
-const anchor = scrollbox.getRenderable("message-20")
-const preservation = anchor ? scrollbox.preserveViewport(anchor) : undefined
-
-try {
-  await prependOlderMessages()
-  await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
-} finally {
-  preservation?.cancel()
-}
-```
-
-The anchor must be a direct child of the ScrollBox. If a declarative renderer may replace that child during reconciliation, pass its stable child ID so ScrollBox can follow the replacement. Explicit viewport preservation takes precedence over sticky scrolling while its scope is active.
-
-```typescript
-const preservation = anchor ? scrollbox.preserveViewport(anchor, { id: "message-20" }) : undefined
-```
-
 ### Construct API
 
 ```typescript
@@ -81,6 +59,28 @@ renderer.root.add(
     ),
   ),
 )
+```
+
+## Preserve the viewport during content updates
+
+Use `preserveViewport` to keep a visible child at the same viewport-relative position while content is inserted or resized before it. Preservation remains active until it is canceled and stops automatically if the anchor is removed or the scroll position changes.
+
+```typescript
+const anchor = scrollbox.getRenderable("message-20")
+const preservation = anchor ? scrollbox.preserveViewport(anchor) : undefined
+
+try {
+  await prependOlderMessages()
+  await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+} finally {
+  preservation?.cancel()
+}
+```
+
+The anchor must be a direct child of the ScrollBox. If a declarative renderer may replace that child during reconciliation, pass its stable child ID so ScrollBox can follow the replacement. Explicit viewport preservation takes precedence over sticky scrolling while its scope is active.
+
+```typescript
+const preservation = anchor ? scrollbox.preserveViewport(anchor, { id: "message-20" }) : undefined
 ```
 
 ## Sticky scroll


### PR DESCRIPTION
## What

Add an explicit `ScrollBoxRenderable.preserveViewport()` scope that keeps one direct child at the same viewport-relative position while content before it is inserted, resized, or reconciled.

This lets applications preserve a reader's position across asynchronous history pagination without continuously scanning ScrollBox children or emitting an intermediate shifted frame.

## Before / After

**Before:** An application prepends older rows, Yoga lays out and draws them at the current scroll offset, then application-level compensation runs after layout. In the reproduced OpenCode pagination flow, emitted frames changed from messages `2,3` to `0,1`, then back to `2,3` 33 ms later.

**After:** The application scopes preservation around the async prepend. ScrollBox restores the anchor after Yoga layout and before culling/drawing. Messages `2,3` remain visible through pagination; only later explicit page-up inputs move the viewport to `1,2` and `0,1`.

## How

- `packages/core/src/renderables/ScrollBox.ts` stores one explicit child, its layout position, and the current scroll revision.
- Content layout restores the positional delta before culling and drawing.
- Any external scroll change cancels preservation, including scrolling away and back before layout.
- Declarative callers can provide a stable direct-child `id` when reconciliation may replace the renderable instance.
- Explicit preservation takes precedence over sticky scrolling while the scope is active.
- `packages/web/src/content/docs/components/scrollbox.mdx` documents lifecycle, cancellation, and reconciled-child usage.

```ts
const preservation = scrollbox.preserveViewport(anchor, { id: anchor.id })
try {
  await prependContent()
  await layoutSettles()
} finally {
  preservation?.cancel()
}
```

## Scope

This PR adds only app-directed, scoped preservation. It does not add a persistent automatic anchoring mode or heuristics for selecting an anchor. The broader automatic implementation remains preserved in closed PR #1354 for possible future work.

The OpenCode call-site update remains in anomalyco/opencode#39721 and can adopt this API after the corresponding OpenTUI release.

## Testing

- `bun test packages/core/src/tests/scrollbox.test.ts`: 54 passed
- Node.js v26.4.0 `bun run test:js:node`: 4,618 passed, 6 skipped, 0 failed
- `bunx tsc -p packages/core/tsconfig.node-test.json --noEmit`
- `bunx oxfmt --check packages/core/src/renderables/ScrollBox.ts packages/core/src/tests/scrollbox.test.ts packages/web/src/content/docs/components/scrollbox.mdx`
- `bunx oxlint packages/core/src/renderables/ScrollBox.ts packages/core/src/tests/scrollbox.test.ts`
- `git diff --check`
- OpenCode Drive: 12-turn session, fresh reader TUI, initial 20-message window, top pagination, and frame-by-frame terminal recording analysis

## Demo

**Before: post-layout application compensation exposes the prepended rows**

https://github.com/user-attachments/assets/59682010-902e-43b7-98f8-46f7c52338f9

**After: scoped preservation restores before frame emission**

https://github.com/user-attachments/assets/ed46de3e-76ff-4190-b37f-b46f3d662975

## Flow

```mermaid
sequenceDiagram
    participant App
    participant ScrollBox
    participant Yoga
    participant Renderer

    App->>ScrollBox: preserveViewport(anchor, id)
    App->>App: asynchronously prepend content
    Renderer->>Yoga: calculate layout
    Yoga-->>ScrollBox: updated child positions
    ScrollBox->>ScrollBox: restore anchor delta
    ScrollBox-->>Renderer: cull and draw stable viewport
    Renderer-->>App: emit frame
    App->>ScrollBox: cancel preservation
```
