### PR TITLE
fix(core): delete virtual extmark blocks atomically on word deletion

### DIFF
--- a/packages/core/src/lib/extmarks.test.ts
+++ b/packages/core/src/lib/extmarks.test.ts
@@ -1387,6 +1387,89 @@ Press ESC to return to main menu.`
     })
   })
 
+  describe("Virtual Extmark - Word Deletion (Atomic Blocks)", () => {
+    it("should delete the whole virtual extmark block when deleteWordBackward intersects it", async () => {
+      await setup("[Pasted ~3 lines] ")
+
+      const id = extmarks.create({
+        start: 0,
+        end: 18,
+        virtual: true,
+      })
+
+      textarea.focus()
+      textarea.cursorOffset = 18
+
+      textarea.deleteWordBackward()
+
+      expect(extmarks.get(id)).toBeNull()
+      expect(textarea.plainText).toBe("")
+    })
+
+    it("should delete the whole virtual extmark block when deleteWordForward intersects it", async () => {
+      await setup("[Pasted ~3 lines] ")
+
+      const id = extmarks.create({
+        start: 0,
+        end: 18,
+        virtual: true,
+      })
+
+      textarea.focus()
+      textarea.cursorOffset = 0
+
+      textarea.deleteWordForward()
+
+      expect(extmarks.get(id)).toBeNull()
+      expect(textarea.plainText).toBe("")
+    })
+
+    it("should not delete the virtual extmark block when deleting the word before it", async () => {
+      await setup("hello [Pasted ~3 lines] ")
+
+      const id = extmarks.create({
+        start: 6,
+        end: 24,
+        virtual: true,
+      })
+
+      textarea.focus()
+      textarea.cursorOffset = 5
+
+      textarea.deleteWordBackward()
+
+      const extmark = extmarks.get(id)
+      expect(extmark).not.toBeNull()
+      expect(extmark?.start).toBe(1)
+      expect(extmark?.end).toBe(19)
+      expect(textarea.plainText).toBe(" [Pasted ~3 lines] ")
+    })
+
+    it("should delete all intersected virtual extmark blocks in one gesture", async () => {
+      await setup("[Image 1] [Pasted ~3 lines] ")
+
+      const id1 = extmarks.create({
+        start: 0,
+        end: 9,
+        virtual: true,
+      })
+      const id2 = extmarks.create({
+        start: 10,
+        end: 27,
+        virtual: true,
+      })
+
+      textarea.focus()
+      textarea.cursorOffset = 28
+
+      textarea.deleteToLineStart()
+
+      expect(extmarks.get(id1)).toBeNull()
+      expect(extmarks.get(id2)).toBeNull()
+      expect(textarea.plainText).toBe("")
+    })
+  })
+
   describe("deleteToLineEnd() Operations", () => {
     it("should remove extmark when deleteToLineEnd covers it", async () => {
       await setup("Hello World")

--- a/packages/core/src/lib/extmarks.ts
+++ b/packages/core/src/lib/extmarks.ts
@@ -357,6 +357,23 @@ export class ExtmarksController {
       const endOffset = this.positionToOffset(endLine, endCol)
       const length = endOffset - startOffset
 
+      const virtualExtmarks = this.findVirtualExtmarksIntersecting(startOffset, endOffset)
+      if (virtualExtmarks.length > 0) {
+        const start = Math.min(startOffset, ...virtualExtmarks.map((extmark) => extmark.start))
+        const end = Math.max(endOffset, ...virtualExtmarks.map((extmark) => extmark.end))
+        for (const extmark of virtualExtmarks) {
+          this.deleteExtmarkById(extmark.id)
+        }
+
+        const startCursor = this.offsetToPosition(start)
+        const endCursor = this.offsetToPosition(end)
+        this.originalDeleteRange(startCursor.row, startCursor.col, endCursor.row, endCursor.col)
+        this.adjustExtmarksAfterDeletion(start, end - start)
+        this.updateHighlights()
+
+        return
+      }
+
       this.originalDeleteRange(startLine, startCol, endLine, endCol)
       this.adjustExtmarksAfterDeletion(startOffset, length)
     }
@@ -524,6 +541,12 @@ export class ExtmarksController {
       }
     }
     return null
+  }
+
+  private findVirtualExtmarksIntersecting(start: number, end: number): Extmark[] {
+    return Array.from(this.extmarks.values()).filter(
+      (extmark) => extmark.virtual && extmark.start < end && extmark.end > start,
+    )
   }
 
   private adjustExtmarksAfterInsertion(insertOffset: number, length: number): void {


### PR DESCRIPTION
Same fix as #1227 (expand the deletion range over intersecting virtual extmarks in the wrapped `editBuffer.deleteRange`), with extra regression tests.

The tests cover:

- `deleteWordBackward` / `deleteWordForward` intersecting a virtual extmark, the block is removed atomically and the extmark is dropped, so ctrl+w no longer deletes the placeholder word by word
- `deleteToLineStart` over multiple adjacent blocks, all intersected blocks are removed in one gesture, not just the first
- the non-intersecting case (deleting the word before a block), the block stays intact and the extmark shifts with the remaining text