### PR TITLE
fix(core): clip glyphs left of the buffer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -535,6 +535,22 @@
 
     "@opentui/core": ["@opentui/core@workspace:packages/core"],
 
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fGi/RubZIhxcU8+M3GXNaBmEHqf127ZOnKmUTSp4ty2QdQ0kT4RTd+t91a/oyxrLZjjCmry0jXyquT0CZR1Byw=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.5.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ezFpB+5mQTd9BS4VvHOYEgQK6YxiYwVUmFb2sfTbJBnTqbOFP3Z/cdE5qNUHoeLQ01/nOs2dmUPcGyWxtMZIzw=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-9S53zkIkbwRb0iIv2thibK+IofpTCEz/c48rJNaBx3qDylaDcTA11k5oqt1gkFcOLernlqIcow8aMCNDnRYMAA=="],
+
+    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-s2DB6he7jgbBqWOHBAIV/p4X12mj+Hlk1pAEcwK36j2wg+L4nVVdWecUJm1xeJn6LJSRcaJYE29sA45w5b7B2g=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-HO0TWovqxo95hxFoTBx47MTP6pzzTW/QMoOIiD8jw0hkrn1DF8rSVPva0vLQMRer/drO9RpjyroFRNra7710og=="],
+
+    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-zyuJaRGBRbUOABgf3nJ2Jk/NmD+gS2dQpJzC2ikr2OMqclPVk7gFbPTHW2s/A3SJH7D8d0PJ6wL2wzXWMUdrWQ=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-J1QxYJqxyAO49RyocqZSoGWs5uszlYot8sInLasi6nUbjCFg4h7Kvh+64+gxE2i4LASeyvMRpAIYwblI6eMbtg=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-9/F1Q19GdtkZ1jypa0dRP6v9SJHHc91XHs4ZSroamDeqSDyTaGu1bbWnKiC503gpNpQMY0mjOVg4g+WVJLdDig=="],
+
     "@opentui/examples": ["@opentui/examples@workspace:packages/examples"],
 
     "@opentui/keymap": ["@opentui/keymap@workspace:packages/keymap"],

--- a/packages/core/src/zig/buffer.zig
+++ b/packages/core/src/zig/buffer.zig
@@ -1018,6 +1018,9 @@ pub const OptimizedBuffer = struct {
         if (ansi.TextAttributes.getLinkId(attributes) != 0) return false;
         if (gp.isGraphemeChar(char) or gp.isContinuationChar(char)) return false;
 
+        // The caller must clip the glyph before it calculates the index.
+        assert(index < self.buffer.char.len);
+
         const dest_char = self.buffer.char[index];
         const dest_attributes = self.buffer.attributes[index];
         if (ansi.TextAttributes.getLinkId(dest_attributes) != 0) return false;
@@ -1768,7 +1771,12 @@ pub const OptimizedBuffer = struct {
                         break;
                     }
 
-                    if (currentX < -@as(i32, @intCast(g_width))) {
+                    // A glyph occupies columns [currentX, currentX + g_width).
+                    // If this range ends at or before column 0, the glyph is left of the screen.
+                    // Skip the glyph, but advance the counters to put the next glyph in the correct columns.
+                    // This check permits wide glyphs that cross column 0.
+                    // The g_width > 1 check below discards these glyphs before they reach the unchecked fast-path index.
+                    if (currentX + @as(i32, @intCast(g_width)) <= 0) {
                         globalCharPos += g_width;
                         currentX += @as(i32, @intCast(g_width));
                         column_in_line += g_width;

--- a/packages/core/src/zig/tests/buffer_test.zig
+++ b/packages/core/src/zig/tests/buffer_test.zig
@@ -541,6 +541,25 @@ test "OptimizedBuffer text buffer tab clips a negative draw origin" {
     try std.testing.expectEqual(@as(u32, ' '), target.get(0, 0).?.char);
 }
 
+test "OptimizedBuffer text buffer clips width-1 text at a negative draw origin" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+    var text = try TextBuffer.init(std.testing.allocator, pool, &local_link_pool, .unicode);
+    defer text.deinit();
+    try text.setText("AB");
+    var view = try TextBufferView.init(std.testing.allocator, text);
+    defer view.deinit();
+
+    const target = try OptimizedBuffer.init(std.testing.allocator, 1, 1, .{ .pool = pool, .id = "negative-width1-text" });
+    defer target.deinit();
+
+    target.drawTextBuffer(view, -1, 0);
+
+    try std.testing.expectEqual(@as(u32, 'B'), target.get(0, 0).?.char);
+}
+
 test "OptimizedBuffer image-free frame buffer copy does not allocate" {
     var pool = gp.GraphemePool.init(std.testing.allocator);
     defer pool.deinit();


### PR DESCRIPTION
one sentence: check should not be inclusive.

drawTextBufferInternal did not clip a width-1 glyph at currentX == -1.
The transparent text path then calculated an invalid u32 index and read past the cell buffer.
Clip each glyph when its range ends at or before column 0.
Assert that the index is in the cell buffer before direct access.

This fixes the abort in OpenCode issue [#42094](https://github.com/anomalyco/opencode/issues/42094).
The stack includes trySetTransparentTextCellFast and bufferDrawTextBufferView.
