### PR TITLE
feat(core): add static retained layers

### DIFF
--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events"
 import Yoga, { Direction, Display, Edge, FlexDirection, type Node as YogaNode } from "./yoga.js"
 import { OptimizedBuffer } from "./buffer.js"
+import { RGBA } from "./lib/RGBA.js"
 import type { KeyEvent, PasteEvent } from "./lib/KeyHandler.js"
 import type { MouseEventType } from "./lib/parse.mouse.js"
 import type { Selection } from "./lib/selection.js"
@@ -100,6 +101,8 @@ export interface RenderableOptions<T extends BaseRenderable = BaseRenderable> ex
   zIndex?: number
   visible?: boolean
   buffered?: boolean
+  /** Cache this subtree between frames. Descendants must update through normal renderable setters or requestRender(). */
+  retained?: "static"
   live?: boolean
   opacity?: number
 
@@ -243,6 +246,9 @@ export abstract class Renderable extends BaseRenderable {
   public selectable: boolean = false
   protected buffered: boolean
   protected frameBuffer: OptimizedBuffer | null = null
+  private retained: boolean
+  private retainedBuffer: OptimizedBuffer | null = null
+  private retainedHitGrid: Uint32Array | null = null
 
   protected _focusable: boolean = false
   protected _focused: boolean = false
@@ -307,6 +313,7 @@ export abstract class Renderable extends BaseRenderable {
     this._zIndex = options.zIndex ?? 0
     this._visible = options.visible !== false
     this.buffered = options.buffered ?? false
+    this.retained = options.retained === "static"
     this._live = options.live ?? false
     this._liveCount = this._live && this._visible ? 1 : 0
     this._opacity = options.opacity !== undefined ? Math.max(0, Math.min(1, options.opacity)) : 1.0
@@ -488,6 +495,7 @@ export abstract class Renderable extends BaseRenderable {
       const delta = value ? 1 : -1
       this.propagateLiveCount(delta)
     }
+    this.requestRender()
   }
 
   protected propagateLiveCount(delta: number): void {
@@ -511,7 +519,47 @@ export abstract class Renderable extends BaseRenderable {
 
   public requestRender() {
     this.markDirty()
+    let retainedInvalidated = this.retained
+    let parent = this.parent
+    while (parent) {
+      if (parent.retained) {
+        parent.markDirty()
+        retainedInvalidated = true
+      }
+      parent = parent.parent
+    }
+    if (retainedInvalidated) bumpRenderListRevision(this._ctx)
     this._ctx.requestRender()
+  }
+
+  public invalidateRetainedDescendants(): void {
+    let invalidated = false
+    const pending = [...this._childrenInLayoutOrder]
+    while (pending.length > 0) {
+      const child = pending.pop()
+      if (!child) continue
+      if (child.retained) {
+        child.markDirty()
+        invalidated = true
+      }
+      pending.push(...child._childrenInLayoutOrder)
+    }
+    if (invalidated) bumpRenderListRevision(this._ctx)
+  }
+
+  private getRetainedBuffer(): OptimizedBuffer {
+    if (!this.retainedBuffer) {
+      this.retainedBuffer = OptimizedBuffer.create(this._ctx.width, this._ctx.height, this._ctx.widthMethod, {
+        respectAlpha: true,
+        id: `retained-${this.id}`,
+      })
+      return this.retainedBuffer
+    }
+    if (this.retainedBuffer.width !== this._ctx.width || this.retainedBuffer.height !== this._ctx.height) {
+      this.retainedBuffer.resize(this._ctx.width, this._ctx.height)
+      this.markDirty()
+    }
+    return this.retainedBuffer
   }
 
   public get translateX(): number {
@@ -1097,6 +1145,8 @@ export abstract class Renderable extends BaseRenderable {
 
     const oldX = this._x
     const oldY = this._y
+    const oldScreenX = this._screenX
+    const oldScreenY = this._screenY
     const oldWidth = this._widthValue
     const oldHeight = this._heightValue
 
@@ -1124,6 +1174,8 @@ export abstract class Renderable extends BaseRenderable {
     if (positionChanged) {
       if (this.parent) this.parent.childrenPrimarySortDirty = true
     }
+    if (this.retained && (!Object.is(oldScreenX, this._screenX) || !Object.is(oldScreenY, this._screenY)))
+      this.markDirty()
   }
 
   protected onLayoutResize(width: number, height: number): void {
@@ -1410,6 +1462,14 @@ export abstract class Renderable extends BaseRenderable {
     // Check again after updateFromLayout, which calls onResize/onSizeChange
     if (this._isDestroyed) return
 
+    if (this.retained && this.retainedBuffer && !this.isDirty && this.liveCount === 0 && !this.hasFocusedDescendant) {
+      renderList.push({ action: "beginRetained", renderable: this })
+      renderList.push({ action: "endRetained", renderable: this })
+      return
+    }
+
+    if (this.retained) renderList.push({ action: "beginRetained", renderable: this })
+
     // Push opacity BEFORE rendering this element so it affects this element and all children
     const shouldPushOpacity = this._opacity < 1.0
     if (shouldPushOpacity) {
@@ -1462,9 +1522,10 @@ export abstract class Renderable extends BaseRenderable {
     if (shouldPushOpacity) {
       renderList.push({ action: "popOpacity" })
     }
+    if (this.retained) renderList.push({ action: "endRetained", renderable: this })
   }
 
-  public render(buffer: OptimizedBuffer, deltaTime: number): void {
+  public render(buffer: OptimizedBuffer, deltaTime: number, draw: boolean = true): void {
     let renderBuffer = buffer
     if (this.buffered && this.frameBuffer) {
       renderBuffer = this.frameBuffer
@@ -1472,13 +1533,13 @@ export abstract class Renderable extends BaseRenderable {
 
     // Layout and culling are already finalized for this frame. These hooks are
     // only safe for drawing into the buffer; avoid renderable/reactive mutations.
-    if (this.renderBefore) {
+    if (draw && this.renderBefore) {
       this.renderBefore.call(this, renderBuffer, deltaTime)
     }
 
-    this.renderSelf(renderBuffer, deltaTime)
+    if (draw) this.renderSelf(renderBuffer, deltaTime)
 
-    if (this.renderAfter) {
+    if (draw && this.renderAfter) {
       this.renderAfter.call(this, renderBuffer, deltaTime)
     }
 
@@ -1487,12 +1548,37 @@ export abstract class Renderable extends BaseRenderable {
     const screenX = this._screenX
     const screenY = this._screenY
 
-    this.markClean()
+    if (draw) this.markClean()
     this._ctx.addToHitGrid(screenX, screenY, this.width, this.height, this.num)
 
-    if (this.buffered && this.frameBuffer) {
+    if (draw && this.buffered && this.frameBuffer) {
       buffer.drawFrameBuffer(screenX, screenY, this.frameBuffer)
     }
+  }
+
+  public beginRetainedFrame(): { buffer: OptimizedBuffer; draw: boolean } {
+    const buffer = this.getRetainedBuffer()
+    const draw = this.isDirty || this.liveCount > 0 || this.hasFocusedDescendant
+    if (draw) {
+      buffer.clearScissorRects()
+      buffer.clearOpacity()
+      buffer.clear(RGBA.fromValues(0, 0, 0, 0))
+    }
+    return { buffer, draw }
+  }
+
+  public getRetainedHitGrid(): Uint32Array {
+    if (!this.retainedHitGrid || this.retainedHitGrid.length !== this._ctx.width * this._ctx.height) {
+      this.retainedHitGrid = this._ctx.createHitGridLayer()
+      this.markDirty()
+    }
+    return this.retainedHitGrid
+  }
+
+  public endRetainedFrame(buffer: OptimizedBuffer, composite: boolean): void {
+    if (!this.retainedBuffer) return
+    if (composite) buffer.drawFrameBuffer(0, 0, this.retainedBuffer)
+    this.markClean()
   }
 
   protected _hasVisibleChildFilter(): boolean {
@@ -1557,6 +1643,8 @@ export abstract class Renderable extends BaseRenderable {
       this.frameBuffer.destroy()
       this.frameBuffer = null
     }
+    this.retainedBuffer?.destroy()
+    this.retainedBuffer = null
 
     for (const child of [...this._childrenInLayoutOrder]) {
       this.remove(child)
@@ -1700,7 +1788,14 @@ export abstract class Renderable extends BaseRenderable {
 }
 
 interface RenderCommandBase {
-  action: "render" | "pushScissorRect" | "popScissorRect" | "pushOpacity" | "popOpacity"
+  action:
+    | "render"
+    | "pushScissorRect"
+    | "popScissorRect"
+    | "pushOpacity"
+    | "popOpacity"
+    | "beginRetained"
+    | "endRetained"
 }
 
 interface RenderCommandPushScissorRect extends RenderCommandBase {
@@ -1731,12 +1826,19 @@ interface RenderCommandPopOpacity extends RenderCommandBase {
   action: "popOpacity"
 }
 
+interface RenderCommandRetained extends RenderCommandBase {
+  action: "beginRetained" | "endRetained"
+  renderable: Renderable
+  endIndex?: number
+}
+
 export type RenderCommand =
   | RenderCommandPushScissorRect
   | RenderCommandPopScissorRect
   | RenderCommandRender
   | RenderCommandPushOpacity
   | RenderCommandPopOpacity
+  | RenderCommandRetained
 
 export class RootRenderable extends Renderable {
   private renderList: RenderCommand[] = []
@@ -1816,10 +1918,22 @@ export class RootRenderable extends Renderable {
       this.appliedLayoutGeneration = layoutGeneration
       this.appliedRenderListRevision = getRenderListRevision(this._ctx)
       this.renderListReusable = this.canReuseCurrentRenderList()
+      const retainedCommands: RenderCommandRetained[] = []
+      for (let index = 0; index < this.renderList.length; index++) {
+        const command = this.renderList[index]
+        if (command.action === "beginRetained") retainedCommands.push(command)
+        if (command.action !== "endRetained") continue
+        const begin = retainedCommands.pop()
+        if (!begin) throw new Error("Unbalanced retained render commands")
+        begin.endIndex = index
+      }
     }
 
     // 3. Render all collected renderables
     this._ctx.clearHitGridScissorRects()
+    let renderBuffer = buffer
+    let draw = true
+    const retainedFrames: Array<{ buffer: OptimizedBuffer; draw: boolean }> = []
     for (let i = 1; i < this.renderList.length; i++) {
       const command = this.renderList[i]
       switch (command.action) {
@@ -1827,24 +1941,49 @@ export class RootRenderable extends Renderable {
           // Skip if renderable was destroyed during a previous render callback
           if (!command.renderable.isDestroyed) {
             this._currentRenderable = command.renderable
-            command.renderable.render(buffer, deltaTime)
+            command.renderable.render(renderBuffer, deltaTime, draw)
             this._currentRenderable = undefined
           }
           break
         case "pushScissorRect":
-          buffer.pushScissorRect(command.x, command.y, command.width, command.height)
+          if (draw) renderBuffer.pushScissorRect(command.x, command.y, command.width, command.height)
           this._ctx.pushHitGridScissorRect(command.screenX, command.screenY, command.width, command.height)
           break
         case "popScissorRect":
-          buffer.popScissorRect()
+          if (draw) renderBuffer.popScissorRect()
           this._ctx.popHitGridScissorRect()
           break
         case "pushOpacity":
-          buffer.pushOpacity(command.opacity)
+          if (draw) renderBuffer.pushOpacity(command.opacity)
           break
         case "popOpacity":
-          buffer.popOpacity()
+          if (draw) renderBuffer.popOpacity()
           break
+        case "beginRetained": {
+          const frame = command.renderable.beginRetainedFrame()
+          const hitGrid = command.renderable.getRetainedHitGrid()
+          if (!frame.draw) {
+            command.renderable.endRetainedFrame(renderBuffer, draw)
+            this._ctx.drawHitGridLayer(hitGrid)
+            if (command.endIndex === undefined) throw new Error("Missing retained end command")
+            i = command.endIndex
+            break
+          }
+          this._ctx.beginHitGridLayer(hitGrid)
+          retainedFrames.push({ buffer: renderBuffer, draw })
+          renderBuffer = frame.buffer
+          draw = frame.draw
+          break
+        }
+        case "endRetained": {
+          const parent = retainedFrames.pop()
+          if (!parent) throw new Error("Unbalanced retained render commands")
+          command.renderable.endRetainedFrame(parent.buffer, parent.draw)
+          this._ctx.endHitGridLayer()
+          renderBuffer = parent.buffer
+          draw = parent.draw
+          break
+        }
       }
     }
   }

--- a/packages/core/src/renderables/EditBufferRenderable.ts
+++ b/packages/core/src/renderables/EditBufferRenderable.ts
@@ -953,7 +953,7 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
     this.nativeRenderable = nativeRenderable
   }
 
-  render(buffer: OptimizedBuffer, deltaTime: number): void {
+  render(buffer: OptimizedBuffer, deltaTime: number, draw: boolean = true): void {
     if (!this.visible) return
     if (this.isDestroyed) return
     // Editor rendering/cursor placement reads absolute coordinates multiple
@@ -964,6 +964,10 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
     this.markClean()
     this._ctx.addToHitGrid(screenX, screenY, this.width, this.height, this.num)
 
+    if (!draw) {
+      this.renderCursor(buffer)
+      return
+    }
     this.renderSelf(buffer)
     this.renderCursor(buffer)
   }

--- a/packages/core/src/renderables/Image.ts
+++ b/packages/core/src/renderables/Image.ts
@@ -166,9 +166,9 @@ export class ImageRenderable extends Renderable {
     return this._loadError
   }
 
-  public override render(buffer: OptimizedBuffer, deltaTime: number): void {
-    if (this.buffered) this.frameBuffer?.clear(TRANSPARENT)
-    super.render(buffer, deltaTime)
+  public override render(buffer: OptimizedBuffer, deltaTime: number, draw: boolean = true): void {
+    if (draw && this.buffered) this.frameBuffer?.clear(TRANSPARENT)
+    super.render(buffer, deltaTime, draw)
   }
 
   protected renderSelf(buffer: OptimizedBuffer): void {

--- a/packages/core/src/renderables/TextBufferRenderable.ts
+++ b/packages/core/src/renderables/TextBufferRenderable.ts
@@ -453,7 +453,7 @@ export abstract class TextBufferRenderable extends Renderable implements LineInf
     return this.textBufferView.getSelection()
   }
 
-  render(buffer: OptimizedBuffer, deltaTime: number): void {
+  render(buffer: OptimizedBuffer, deltaTime: number, draw: boolean = true): void {
     if (!this.visible) return
     // Text views do enough per-frame work that avoiding recursive x/y lookups is
     // measurable; use the layout cache for hit-grid and draw entry points.
@@ -463,6 +463,7 @@ export abstract class TextBufferRenderable extends Renderable implements LineInf
     this.markClean()
     this._ctx.addToHitGrid(screenX, screenY, this.width, this.height, this.num)
 
+    if (!draw) return
     this.renderSelf(buffer)
 
     if (this.buffered && this.frameBuffer) {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -483,6 +483,13 @@ class ScrollbackSnapshotRenderContext extends EventEmitter implements RenderCont
   public pushHitGridScissorRect(_x: number, _y: number, _width: number, _height: number): void {}
   public popHitGridScissorRect(): void {}
   public clearHitGridScissorRects(): void {}
+  public createHitGridLayer(): Uint32Array {
+    return new Uint32Array(this.width * this.height)
+  }
+  public beginHitGridLayer(_layer: Uint32Array): void {}
+  public endHitGridLayer(): void {}
+  public drawHitGridLayer(_layer: Uint32Array): void {}
+  public resetHitGridLayers(): void {}
   public requestRender(): void {}
   public setCursorPosition(_x: number, _y: number, _visible: boolean): void {}
   public setCursorStyle(_options: CursorStyleOptions): void {}
@@ -1413,24 +1420,81 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       return
     }
     this.capturedRenderable = renderable
+    this.root.invalidateRetainedDescendants()
+    this.root.requestRender()
   }
 
   public addToHitGrid(x: number, y: number, width: number, height: number, id: number) {
-    if (!this._useMouse) return
-    if (id !== this.capturedRenderable?.num) {
+    const captured = id === this.capturedRenderable?.num
+    if (!captured && this.hitGridLayers.length > 0) {
+      const scissor = this.hitGridScissors.at(-1)
+      const startX = Math.max(0, x, scissor?.x ?? 0)
+      const startY = Math.max(0, y, scissor?.y ?? 0)
+      const endX = Math.min(this.width, x + width, scissor ? scissor.x + scissor.width : this.width)
+      const endY = Math.min(this.height, y + height, scissor ? scissor.y + scissor.height : this.height)
+      for (let row = startY; row < endY; row++) {
+        for (const layer of this.hitGridLayers) layer.fill(id, row * this.width + startX, row * this.width + endX)
+      }
+    }
+    if (this._useMouse && !captured) {
       this.lib.addToHitGrid(this.rendererPtr, x, y, width, height, id)
     }
   }
 
+  private hitGridLayers: Uint32Array[] = []
+  private hitGridScissors: Array<{ x: number; y: number; width: number; height: number }> = []
+
+  public createHitGridLayer(): Uint32Array {
+    return new Uint32Array(this.width * this.height)
+  }
+
+  public beginHitGridLayer(layer: Uint32Array): void {
+    layer.fill(0)
+    this.hitGridLayers.push(layer)
+  }
+
+  public endHitGridLayer(): void {
+    this.hitGridLayers.pop()
+  }
+
+  public drawHitGridLayer(layer: Uint32Array): void {
+    for (const parent of this.hitGridLayers) {
+      for (let index = 0; index < layer.length; index++) {
+        if (layer[index] !== 0) parent[index] = layer[index]
+      }
+    }
+    if (!this._useMouse) return
+    this.lib.drawHitGridLayer(this.rendererPtr, layer, this.capturedRenderable?.num ?? 0)
+  }
+
+  public resetHitGridLayers(): void {
+    this.hitGridLayers.length = 0
+    this.hitGridScissors.length = 0
+    this.lib.hitGridClearScissorRects(this.rendererPtr)
+  }
+
   public pushHitGridScissorRect(x: number, y: number, width: number, height: number): void {
+    const parent = this.hitGridScissors.at(-1)
+    const startX = Math.max(x, parent?.x ?? x)
+    const startY = Math.max(y, parent?.y ?? y)
+    const endX = Math.min(x + width, parent ? parent.x + parent.width : x + width)
+    const endY = Math.min(y + height, parent ? parent.y + parent.height : y + height)
+    this.hitGridScissors.push({
+      x: startX,
+      y: startY,
+      width: Math.max(0, endX - startX),
+      height: Math.max(0, endY - startY),
+    })
     this.lib.hitGridPushScissorRect(this.rendererPtr, x, y, width, height)
   }
 
   public popHitGridScissorRect(): void {
+    this.hitGridScissors.pop()
     this.lib.hitGridPopScissorRect(this.rendererPtr)
   }
 
   public clearHitGridScissorRects(): void {
+    this.hitGridScissors.length = 0
     this.lib.hitGridClearScissorRects(this.rendererPtr)
   }
 
@@ -2333,6 +2397,9 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       })
     } catch (error) {
       renderFailed = true
+      this.nextRenderBuffer.clearScissorRects()
+      this.nextRenderBuffer.clearOpacity()
+      this.resetHitGridLayers()
       snapshotBuffer?.destroy()
       throw error
     } finally {

--- a/packages/core/src/tests/ffi-borrowed-pointer-callsites.test.ts
+++ b/packages/core/src/tests/ffi-borrowed-pointer-callsites.test.ts
@@ -666,6 +666,19 @@ describe("borrowed pointer call sites", () => {
     })
   })
 
+  test("drawHitGridLayer passes the typed array owner as an object value", () => {
+    withStubbedSymbol("drawHitGridLayer", (calls) => {
+      const layer = new Uint32Array([0, 1, 2])
+
+      lib.drawHitGridLayer(0 as any, layer, 2)
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0]![1]).toBe(layer)
+      expect(calls[0]![2]).toBe(layer.length)
+      expect(calls[0]![3]).toBe(2)
+    })
+  })
+
   test("image calls pass transient buffer owners directly", () => {
     const names = [
       "bufferDrawImage",

--- a/packages/core/src/tests/renderable.test.ts
+++ b/packages/core/src/tests/renderable.test.ts
@@ -607,6 +607,193 @@ describe("Renderable - Child Management", () => {
     expect(call[1]).toBe(renderable.screenY)
   })
 
+  test("retained subtrees replay semantics without redrawing clean descendants", async () => {
+    const hitGridSpy = spyOn(testRenderer, "drawHitGridLayer")
+    const layer = new TestRenderable(testRenderer, { id: "layer", retained: "static", width: 10, height: 2 })
+    const child = new CountingRenderable(testRenderer, { id: "child", width: 10, height: 1 })
+    layer.add(child)
+    testRenderer.root.add(layer)
+
+    await renderOnce()
+    expect(child.renderCount).toBe(1)
+
+    hitGridSpy.mockClear()
+    testRenderer.requestRender()
+    await renderOnce()
+
+    expect(child.renderCount).toBe(1)
+    expect(hitGridSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test("stable undefined-axis coordinates do not invalidate retained subtrees", async () => {
+    const layer = new TestRenderable(testRenderer, { id: "layer", retained: "static", width: 10, height: 2 })
+    const child = new CountingRenderable(testRenderer, { id: "child", width: 10, height: 1 })
+    layer.add(child)
+    testRenderer.root.add(layer)
+
+    await renderOnce()
+    testRenderer.requestRender()
+    await renderOnce()
+
+    expect(child.renderCount).toBe(1)
+  })
+
+  test("dirty descendants invalidate retained subtrees", async () => {
+    const layer = new TestRenderable(testRenderer, { id: "layer", retained: "static", width: 10, height: 2 })
+    const child = new CountingRenderable(testRenderer, { id: "child", width: 10, height: 1 })
+    layer.add(child)
+    testRenderer.root.add(layer)
+
+    await renderOnce()
+    child.requestRender()
+    await renderOnce()
+
+    expect(child.renderCount).toBe(2)
+  })
+
+  test("dirty descendants expand compact retained command lists", async () => {
+    const layer = new TestRenderable(testRenderer, { id: "layer", retained: "static", width: 10, height: 2 })
+    const child = new CountingRenderable(testRenderer, { id: "child", width: 10, height: 1 })
+    layer.add(child)
+    testRenderer.root.add(layer)
+
+    await renderOnce()
+    testRenderer.root.add(new TestRenderable(testRenderer, { id: "sibling", width: 1, height: 1 }))
+    await renderOnce()
+    const compacted = child.renderCount
+    child.requestRender()
+    await renderOnce()
+
+    expect(child.renderCount).toBe(compacted + 1)
+  })
+
+  test("live descendants redraw retained subtrees", async () => {
+    const layer = new TestRenderable(testRenderer, { id: "layer", retained: "static", width: 10, height: 2 })
+    const child = new CountingRenderable(testRenderer, { id: "child", live: true, width: 10, height: 1 })
+    layer.add(child)
+    testRenderer.root.add(layer)
+
+    await renderOnce()
+    const initial = child.renderCount
+    await renderOnce()
+
+    expect(child.renderCount).toBeGreaterThan(initial)
+  })
+
+  test("activating live descendants expands compact retained command lists", async () => {
+    const layer = new TestRenderable(testRenderer, { id: "layer", retained: "static", width: 10, height: 2 })
+    const child = new CountingRenderable(testRenderer, { id: "child", width: 10, height: 1 })
+    layer.add(child)
+    testRenderer.root.add(layer)
+
+    await renderOnce()
+    testRenderer.root.add(new TestRenderable(testRenderer, { id: "sibling", width: 1, height: 1 }))
+    await renderOnce()
+    const compacted = child.renderCount
+    child.live = true
+    await renderOnce()
+
+    expect(child.renderCount).toBeGreaterThan(compacted)
+  })
+
+  test("moving an ancestor redraws retained descendants at their new screen position", async () => {
+    const parent = new TestRenderable(testRenderer, {
+      id: "parent",
+      position: "absolute",
+      left: 0,
+      width: 10,
+      height: 2,
+    })
+    const layer = new TestRenderable(testRenderer, { id: "layer", retained: "static", width: 10, height: 2 })
+    const child = new CountingRenderable(testRenderer, { id: "child", width: 10, height: 1 })
+    layer.add(child)
+    parent.add(layer)
+    testRenderer.root.add(parent)
+
+    await renderOnce()
+    parent.left = 2
+    await renderOnce()
+
+    expect(child.renderCount).toBe(2)
+    expect(child.getScreenPosition().x).toBe(2)
+  })
+
+  test("enabling mouse after caching retains descendant hit targets", async () => {
+    const layer = new TestRenderable(testRenderer, { id: "layer", retained: "static", width: 10, height: 2 })
+    const child = new CountingRenderable(testRenderer, { id: "child", width: 10, height: 1 })
+    layer.add(child)
+    testRenderer.root.add(layer)
+
+    testRenderer.useMouse = false
+    await renderOnce()
+    testRenderer.useMouse = true
+    await renderOnce()
+
+    expect(testRenderer.hitTest(0, 0)).toBe(child.num)
+  })
+
+  test("capturing a retained target reveals the target beneath it", async () => {
+    const layer = new TestRenderable(testRenderer, { id: "layer", retained: "static", width: 10, height: 2 })
+    const lower = new CountingRenderable(testRenderer, {
+      id: "lower",
+      position: "absolute",
+      width: 10,
+      height: 1,
+    })
+    const upper = new CountingRenderable(testRenderer, {
+      id: "upper",
+      position: "absolute",
+      width: 10,
+      height: 1,
+      zIndex: 1,
+    })
+    layer.add(lower)
+    layer.add(upper)
+    testRenderer.root.add(layer)
+
+    await renderOnce()
+    expect(testRenderer.hitTest(0, 0)).toBe(upper.num)
+
+    ;(testRenderer as any).setCapturedRenderable(upper)
+    await renderOnce()
+
+    expect(testRenderer.hitTest(0, 0)).toBe(lower.num)
+  })
+
+  test("nested retained layers preserve hit targets while mouse tracking is disabled", async () => {
+    const outer = new TestRenderable(testRenderer, { id: "outer", retained: "static", width: 10, height: 2 })
+    const inner = new TestRenderable(testRenderer, { id: "inner", retained: "static", width: 10, height: 1 })
+    const target = new CountingRenderable(testRenderer, { id: "target", width: 10, height: 1 })
+    inner.add(target)
+    outer.add(inner)
+    testRenderer.root.add(outer)
+
+    await renderOnce()
+    testRenderer.useMouse = false
+    outer.requestRender()
+    await renderOnce()
+    testRenderer.useMouse = true
+    await renderOnce()
+
+    expect(testRenderer.hitTest(0, 0)).toBe(target.num)
+  })
+
+  test("focused descendants keep retained subtrees dynamic", async () => {
+    const layer = new TestRenderable(testRenderer, { id: "layer", retained: "static", width: 10, height: 2 })
+    const child = new TestFocusableRenderable(testRenderer, { id: "child", width: 10, height: 1 })
+    const renderSpy = spyOn(child, "render")
+    layer.add(child)
+    testRenderer.root.add(layer)
+
+    child.focus()
+    await renderOnce()
+    const initial = renderSpy.mock.calls.length
+    testRenderer.requestRender()
+    await renderOnce()
+
+    expect(renderSpy.mock.calls.length).toBeGreaterThan(initial)
+  })
+
   test("can insert child at specific index", () => {
     const parent = new TestRenderable(testRenderer, { id: "parent" })
     const child1 = new TestRenderable(testRenderer, { id: "child1" })

--- a/packages/core/src/tests/renderer.render-error.test.ts
+++ b/packages/core/src/tests/renderer.render-error.test.ts
@@ -73,6 +73,29 @@ test("a one-shot render can request recovery from an error listener", async () =
   }
 })
 
+test("retained render errors reset semantic layer state", async () => {
+  const { renderer, waitFor } = await createTestRenderer({ useMouse: true })
+  const layer = new ThrowingRenderable(renderer, { retained: "static", width: 2, height: 1 })
+  const child = new ThrowingRenderable(renderer, { width: 1, height: 1 })
+  child.shouldThrow = false
+  const errors: CliRendererErrorEvent[] = []
+
+  try {
+    layer.add(child)
+    renderer.root.add(layer)
+    renderer.on(CliRenderEvents.RENDER_ERROR, (event) => {
+      errors.push(event)
+      layer.shouldThrow = false
+      renderer.requestRender()
+    })
+
+    renderer.requestRender()
+    await waitFor(() => errors.length === 1 && renderer.hitTest(0, 0) === child.num)
+  } finally {
+    renderer.destroy()
+  }
+})
+
 test("reports an unobserved render error", async () => {
   const { renderer, waitFor } = await createTestRenderer({ openConsoleOnError: false })
   const target = new ThrowingRenderable(renderer, { width: 1, height: 1 }, "render failed")

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -108,6 +108,11 @@ export interface RenderContext extends EventEmitter {
   pushHitGridScissorRect: (x: number, y: number, width: number, height: number) => void
   popHitGridScissorRect: () => void
   clearHitGridScissorRects: () => void
+  createHitGridLayer: () => Uint32Array
+  beginHitGridLayer: (layer: Uint32Array) => void
+  endHitGridLayer: () => void
+  drawHitGridLayer: (layer: Uint32Array) => void
+  resetHitGridLayers: () => void
   width: number
   height: number
   terminalWidth?: number

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -712,6 +712,10 @@ function getOpenTUILib(libPath?: string) {
       args: ["u32", "i32", "i32", "u32", "u32", "u32"],
       returns: "void",
     },
+    drawHitGridLayer: {
+      args: ["u32", "ptr", "u32", "u32"],
+      returns: "void",
+    },
     clearCurrentHitGrid: {
       args: ["u32"],
       returns: "void",
@@ -2494,6 +2498,7 @@ export interface RenderLib extends AudioEngineLib {
   clipboardOperationDestroy: (operation: ClipboardOperationHandle) => NativeClipboardDestroyStatus
   triggerNotification: (renderer: RendererHandle, message: string, title?: string) => boolean
   addToHitGrid: (renderer: RendererHandle, x: number, y: number, width: number, height: number, id: number) => void
+  drawHitGridLayer: (renderer: RendererHandle, layer: Uint32Array, excludedId: number) => void
   clearCurrentHitGrid: (renderer: RendererHandle) => void
   hitGridPushScissorRect: (renderer: RendererHandle, x: number, y: number, width: number, height: number) => void
   hitGridPopScissorRect: (renderer: RendererHandle) => void
@@ -4088,6 +4093,10 @@ class FFIRenderLib implements RenderLib {
 
   public addToHitGrid(renderer: Pointer, x: number, y: number, width: number, height: number, id: number) {
     this.opentui.symbols.addToHitGrid(renderer, x, y, width, height, id)
+  }
+
+  public drawHitGridLayer(renderer: Pointer, layer: Uint32Array, excludedId: number) {
+    this.opentui.symbols.drawHitGridLayer(renderer, layer, layer.length, excludedId)
   }
 
   public clearCurrentHitGrid(renderer: Pointer) {

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -1632,6 +1632,11 @@ export fn addToHitGrid(renderer_handle: NativeHandle, x: i32, y: i32, width: u32
     object_ptr.addToHitGrid(x, y, width, height, id);
 }
 
+export fn drawHitGridLayer(renderer_handle: NativeHandle, layer: [*]const u32, length: u32, excluded_id: u32) void {
+    const object_ptr = acquireRenderer(renderer_handle) orelse return;
+    object_ptr.drawHitGridLayer(layer, length, excluded_id);
+}
+
 export fn clearCurrentHitGrid(renderer_handle: NativeHandle) void {
     const object_ptr = acquireRenderer(renderer_handle) orelse return;
     object_ptr.clearCurrentHitGrid();

--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -2832,6 +2832,13 @@ pub const CliRenderer = struct {
         }
     }
 
+    pub fn drawHitGridLayer(self: *CliRenderer, layer: [*]const u32, length: u32, excluded_id: u32) void {
+        const size = @min(self.nextHitGrid.len, length);
+        for (0..size) |index| {
+            if (layer[index] != 0 and layer[index] != excluded_id) self.nextHitGrid[index] = layer[index];
+        }
+    }
+
     /// Clear currentHitGrid before an immediate rebuild.
     ///
     /// Used by syncHitGridIfNeeded in TypeScript when scroll/translate changes


### PR DESCRIPTION
## What

Add opt-in `retained: "static"` renderable layers for large stable subtrees that share a frame with small live regions.

OpenTUI normally replays the root render command list whenever any descendant is live. A static retained layer captures its visual cells and hit-grid semantics once, then composites those cached results on later frames without traversing or redrawing clean descendants.

The mode is deliberately explicit: descendants must update through normal renderable setters or `requestRender()`. Live and focused descendants keep the layer dynamic.

## How

- `Renderable.ts` adds the static retained-layer lifecycle, ancestor invalidation, compact command-list reuse, resize/position handling, and native-buffer cleanup.
- `renderer.ts` captures and replays retained hit-grid layers, including nested scissors, mouse enable/disable transitions, drag capture, and render-error recovery.
- `zig.ts` and the Zig renderer add one portable bulk hit-grid overlay call. The typed-array owner is borrowed directly for Node/Bun FFI safety.
- Text, editor, and image renderables honor semantic-only passes without redrawing cached visual content.
- Focused tests cover dirty/live transitions, compact-list expansion, ancestor movement, stable undefined-axis layout, nested layers, drag capture, mouse toggles, FFI ownership, and render exceptions.

```mermaid
flowchart LR
  Frame[Live frame] --> Layer{Static layer dirty?}
  Layer -->|yes| Traverse[Traverse descendants]
  Traverse --> Capture[Capture visual buffer + hit grid]
  Layer -->|no| Replay[Replay cached visual buffer + hit grid]
  Capture --> Composite[Composite through current opacity and scissors]
  Replay --> Composite
  Composite --> Pulse[Draw live sibling]
```

## Scope

- This does not make arbitrary dynamic subtrees retained automatically.
- Custom descendant state must invalidate through normal OpenTUI mutation APIs; `"static"` is an explicit lifecycle promise.
- This does not change the default immediate-mode renderer.
- Bun runtime upgrades and allocator-retention fixes are separate concerns.

## Performance

30-second native-backed benchmark: 1,200 static transcript rows inside a scrollbox plus a live 60 FPS pulse.

| Runtime | Immediate CPU | Retained CPU | Immediate FPS | Retained FPS | Immediate RSS delta | Retained RSS delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Bun 1.3.14 | 30.4% | 10.0% | 55.0 | 52.5 | +30.2 MB | +4.3 MB |
| Bun 1.4 canary | 18.4% | 3.7% | 57.0 | 55.8 | +14.2 MB | +7.6 MB |

## Testing

- `bun run test:js`: 5,380 passed, 23 skipped
- `bun run test:native`: 1,982 passed, 31 skipped
- `bunx tsc --noEmit --project tsconfig.build.json`
- `bun run build`
- `bun run fmt:check`
- `bun run lint`
- `bun run test:js:node`: 4,652 passed, 6 skipped with Node 26.4.0
- `bun run test:dist`: packed Node and Bun consumer smoke tests passed
