### PR TITLE
fix(core/tree-sitter): render markdown backslash escapes as the escaped character

### DIFF
--- a/packages/core/src/lib/tree-sitter/client.test.ts
+++ b/packages/core/src/lib/tree-sitter/client.test.ts
@@ -695,6 +695,35 @@ You can use \`const x = 42\` in your code.`
     }
   }, 10000)
 
+  test("should conceal the backslash of markdown backslash escapes", async () => {
+    const client = new TreeSitterClient({ dataPath })
+
+    try {
+      await client.initialize()
+
+      const content = "Escaped \\~ and \\* here"
+      const result = await client.highlightOnce(content, "markdown")
+
+      expect(result.highlights).toBeDefined()
+
+      const escapeHighlights = result.highlights!.filter((hl) => hl[2] === "string.escape")
+      // "Escaped " is 8 bytes: the escapes sit at [8,10) and [15,17).
+      // Each must collapse to a 1-byte conceal covering only the backslash;
+      // no full-range string.escape may remain, so the escaped character
+      // renders unstyled (CommonMark: "\~" renders as "~").
+      expect(escapeHighlights).toHaveLength(2)
+      expect(escapeHighlights.map((hl) => [hl[0], hl[1]])).toEqual([
+        [8, 9],
+        [15, 16],
+      ])
+      for (const hl of escapeHighlights) {
+        expect(hl[3]).toMatchObject({ conceal: "" })
+      }
+    } finally {
+      await client.destroy()
+    }
+  }, 10000)
+
   test("should highlight code blocks in markdown using language-specific injection", async () => {
     const client = new TreeSitterClient({ dataPath })
 

--- a/packages/core/src/lib/tree-sitter/parser.worker.ts
+++ b/packages/core/src/lib/tree-sitter/parser.worker.ts
@@ -495,6 +495,10 @@ class ParserWorker {
                 _injectedQuery: injectedParser.queries.highlights, // Store the correct query reference
                 node: {
                   ...match.node,
+                  // web-tree-sitter node type is a prototype getter, so the
+                  // spread above drops it; carry it explicitly for consumers
+                  // that dispatch on node.type.
+                  type: match.node.type,
                   startPosition: {
                     row: match.node.startPosition.row + injectionNode.startPosition.row,
                     column:
@@ -760,6 +764,23 @@ class ParserWorker {
       }
       if (concealLines !== undefined) {
         meta.concealLines = concealLines
+      }
+
+      // CommonMark: a backslash escape renders as the escaped character, not
+      // the literal "\x". The markdown_inline grammar emits backslash_escape
+      // as one atomic token spanning both characters, so the split cannot be
+      // expressed as a query conceal rule (conceal replaces whole ranges).
+      // Conceal the backslash byte here and drop the escape styling from the
+      // remainder so the escaped punctuation renders as plain text. An
+      // explicit conceal on the node set by a query still wins.
+      if (
+        concealValue === undefined &&
+        node.type === "backslash_escape" &&
+        isInjection &&
+        injectionLang === "markdown_inline"
+      ) {
+        highlights.push([node.startIndex, node.startIndex + 1, match.name, { ...meta, conceal: "" }])
+        continue
       }
 
       if (Object.keys(meta).length > 0) {


### PR DESCRIPTION
Fixes #1369

## Summary

Markdown renderables style paragraph text through the markdown_inline injection with conceal. The bundled highlight query captures `(backslash_escape)` as `@string.escape` with no conceal rule, so CommonMark escapes rendered literally with the backslash visible and escape-styled (`\~` displayed as backslash + tilde in the escape color).

The escape cannot be fixed in the query language: the markdown_inline grammar emits `backslash_escape` as one atomic regex token spanning both characters, so no query can capture the backslash separately, and conceal replaces whole captured ranges with a static literal, so a whole-node conceal rule would remove the escaped character too.

## Fix

Both halves in the worker's one-shot highlight pipeline:

- `processInjections` spreads each injected capture node into a plain pseudo-node; web-tree-sitter's node `type` is a prototype getter, so the spread dropped it. Carry `type` explicitly so downstream consumers can dispatch on it.
- `getSimpleHighlights` splits a `backslash_escape` capture that has no query-configured conceal into a one-byte conceal of the backslash and drops the escape styling from the remainder, so `\~` renders as plain `~`. An explicit `#set! conceal` on the node set by a query still wins.

The marked-based streaming placeholder path already decoded escapes (`renderInlineToken`'s escape case), so the two internal render paths now agree.

## Tests

`client.test.ts` gains a markdown escape test asserting that each `string.escape` highlight on `"Escaped \~ and \* here"` collapses to a one-byte conceal tuple covering only the backslash (`[8,9)` / `[15,16)`, `meta.conceal === ""`), and that no full-range `string.escape` remains, so the escaped character renders unstyled.

tree-sitter suites: 63 pass, 1 pre-existing skip. The only `packages/core` failure (`node-assets` manifest) also fails on the pristine tag without build output and is unrelated.

## Out of scope (deliberately)

- `(hard_line_break)` keeps its current literal rendering; it shares the `@string.escape` capture but involves line-break semantics rather than character decoding.
- `#offset!`-style partial-token conceal (nvim queries use it in commented form) would be a more general engine feature; this fix does not need it.