### PR TITLE
fix(core): use blocks fallback for forced Sixel placements on Kitty

### DIFF
--- a/packages/core/src/zig/renderer.zig
+++ b/packages/core/src/zig/renderer.zig
@@ -1750,6 +1750,11 @@ pub const CliRenderer = struct {
             .sixel => Terminal.ImageProtocol.sixel,
             .blocks => Terminal.ImageProtocol.blocks,
         };
+        if (configured == .sixel and self.terminal.term_info.from_xtversion and
+            std.ascii.eqlIgnoreCase(self.terminal.getTerminalName(), "kitty") and !self.terminal.getCapabilities().sixel)
+        {
+            return .fallback;
+        }
         switch (configured) {
             .kitty => return .kitty,
             .sixel => return .sixel,

--- a/packages/core/src/zig/tests/renderer_test.zig
+++ b/packages/core/src/zig/tests/renderer_test.zig
@@ -412,6 +412,28 @@ test "renderer honors per-placement protocol overrides" {
     try std.testing.expect(std.mem.find(u8, test_renderer.memory.lastWrite(), "\x1b_Ga=t") == null);
 }
 
+test "renderer does not send forced Sixel to Kitty" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    defer link.deinitGlobalLinkPool();
+    var test_renderer = try TestRenderer.create(std.testing.allocator, 4, 2, pool);
+    defer test_renderer.deinit();
+    const value = try image.createFromRgba(std.testing.allocator, &[_]u8{ 255, 0, 0, 255 }, 1, 1, 4);
+    const image_handle = try handles.insert(.image, @ptrCast(value));
+    defer {
+        const token = handles.beginDestroy(image_handle, .image, image.Image).?;
+        token.ptr.deinit();
+        handles.finishDestroy(token.handle);
+    }
+    test_renderer.renderer.terminal.processCapabilityResponse("\x1bP>|kitty(0.48.2)\x1b\\");
+
+    try std.testing.expect(try test_renderer.renderer.getNextBuffer().drawImage(value, image_handle, 0, 0, 1, 1, 2, 2, 0, 0, 1, 1, .sixel));
+    try std.testing.expectEqual(renderer.RenderStatus.rendered, test_renderer.renderer.render(true));
+    const output = test_renderer.memory.lastWrite();
+    try std.testing.expect(std.mem.find(u8, output, "\x1bP0;1;0q") == null);
+    try std.testing.expect(std.mem.find(u8, output, "█") != null);
+}
+
 test "renderer honors global image protocol override for auto placements" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();


### PR DESCRIPTION
Kitty does not implement Sixel, but an explicit protocol override bypassed
capability detection and emitted the payload anyway. This occurs with a
"sixel" placement or OPENTUI_IMAGE_PROTOCOL=sixel.

Kitty consumes unknown DCS sequences only up to its 1 MiB escape buffer.
Larger Sixel payloads leak the remainder onto the screen as text.
