### PR TITLE
fix(core): serialize tree-sitter parse() to avoid Asyncify re-entrancy hang

### DIFF
--- a/packages/core/src/lib/tree-sitter/client.test.ts
+++ b/packages/core/src/lib/tree-sitter/client.test.ts
@@ -621,6 +621,26 @@ describe("TreeSitterClient", () => {
     expect(queryLoadLogs.length).toBeLessThanOrEqual(1)
   }, 15000)
 
+  test("should not hang under many parallel highlightOnce calls (Asyncify re-entrancy regression)", async () => {
+    await client.initialize()
+
+    const md =
+      "# heading\n\n" +
+      Array.from({ length: 20 }, (_, i) => `- item ${i} with \`inline code\`\n`).join("") +
+      "\n```ts\nconst x: number = 1\nfunction f(): string { return `hi` }\n```\n"
+
+    const N = 100
+    const results = await Promise.all(
+      Array.from({ length: N }, (_, i) => client.highlightOnce(md + `\n<!-- ${i} -->`, "markdown")),
+    )
+
+    expect(results).toHaveLength(N)
+    for (const r of results) {
+      expect(r.error).toBeUndefined()
+      expect(r.highlights).toBeDefined()
+    }
+  }, 30000)
+
   test("should reuse canonical parser assets for aliased filetypes", async () => {
     const workerLogs: string[] = []
 

--- a/packages/core/src/lib/tree-sitter/parser.worker.ts
+++ b/packages/core/src/lib/tree-sitter/parser.worker.ts
@@ -54,6 +54,15 @@ interface ReusableParserState {
   }
 }
 
+// Serialize parse(): Asyncify makes it re-entrant and shared C globals corrupt.
+let parseQueue: Promise<unknown> = Promise.resolve()
+function serializeParse<T>(fn: () => T | Promise<T>): Promise<T> {
+  const prev = parseQueue
+  const next = prev.catch(() => {}).then(() => fn())
+  parseQueue = next
+  return next as Promise<T>
+}
+
 class ParserWorker {
   private bufferParsers: Map<number, ParserState> = new Map()
   private filetypeParserOptions: Map<string, FiletypeParserOptions> = new Map()
@@ -345,7 +354,7 @@ class ParserWorker {
 
     const parser = new Parser()
     parser.setLanguage(filetypeParser.language)
-    const tree = parser.parse(content)
+    const tree = await serializeParse(() => parser.parse(content))
     if (!tree) {
       postWorkerMessage({
         type: "PARSER_INIT_RESPONSE",
@@ -480,7 +489,7 @@ class ParserWorker {
           })
 
           const injectionContent = this.getNodeText(injectionNode, content)
-          const tree = parser.parse(injectionContent)
+          const tree = await serializeParse(() => parser.parse(injectionContent))
 
           if (tree) {
             const matches = injectedParser.queries.highlights.captures(tree.rootNode)
@@ -563,7 +572,7 @@ class ParserWorker {
 
     const startParse = performance.now()
 
-    const newTree = parserState.parser.parse(content, parserState.tree)
+    const newTree = await serializeParse(() => parserState.parser.parse(content, parserState.tree))
 
     const endParse = performance.now()
     const parseTime = endParse - startParse
@@ -786,7 +795,7 @@ class ParserWorker {
 
     parserState.content = content
 
-    const newTree = parserState.parser.parse(content)
+    const newTree = await serializeParse(() => parserState.parser.parse(content))
 
     if (!newTree) {
       return { error: "Failed to parse buffer during reset" }
@@ -834,7 +843,7 @@ class ParserWorker {
     // The tree-sitter markdown parser only creates closing delimiter nodes when followed by newline
     const parseContent = filetype === "markdown" && content.endsWith("```") ? content + "\n" : content
 
-    const tree = reusableState.parser.parse(parseContent)
+    const tree = await serializeParse(() => reusableState.parser.parse(parseContent))
 
     if (!tree) {
       postWorkerMessage({


### PR DESCRIPTION
Downstream: [anomalyco/opencode#42896](https://github.com/anomalyco/opencode/issues/42896)

## What

`parser.parse()` in web-tree-sitter is Asyncify: the sync JS call unwinds the stack mid-WASM. Under streaming input, a second `parse()` starts before the first resumes and clobbers shared C globals (`currentParseCallback` etc.), and the first never returns. In opencode this shows up as list items and code blocks freezing partway through the LLM stream.

Fix: a per-worker Promise queue that runs at most one `parse()` at a time. All five `parser.parse()` call sites in `parser.worker.ts` go through it.

## Regression test

The existing 5-parallel `highlightOnce` case in `client.test.ts` never overlapped enough to trigger the race. Added a 100-parallel markdown case in the same file. Unpatched build times out; patched build passes in about 4 seconds together with the file's other 49 tests.

## Evidence

Instrumented `@opentui/core@0.4.5` on opencode `v1.18.18`. JSONL of every `parse.begin` / `parse.done` per worker message.

|                  | before  | after   |
|------------------|---------|---------|
| `parse.begin`    | 8168    | 12272   |
| `parse.done`     | 1369    | 12272   |
| exceptions       | 0       | 0       |
| `worker.onerror` | 0       | 0       |

Before: 6799 parses suspended and never resumed. No exception, no worker crash, just a silent hang. After: fully balanced.
