### PR TITLE
fix(core): selection no longer collapses with y below, x left of text

### DIFF
--- a/packages/core/src/renderables/__tests__/Textarea.selection.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.selection.test.ts
@@ -1099,8 +1099,8 @@ describe("Textarea - Selection Tests", () => {
       expect(codeText2.hasSelection()).toBe(true)
       const codeText2Selected = codeText2.getSelectedText()
       const codeText2Content = "  const selected = getText()"
-      // Inclusive selection: the cell under the pointer (15) is selected too.
-      expect(codeText2Selected).toBe(codeText2Content.substring(0, 16))
+      // The below-left anchor clamps to the text end, so selection runs back to the focus.
+      expect(codeText2Selected).toBe(codeText2Content.substring(15))
 
       bottomText.destroy()
       rightBox.destroy()

--- a/packages/native/src/tests/text-buffer-selection_test.zig
+++ b/packages/native/src/tests/text-buffer-selection_test.zig
@@ -1426,3 +1426,38 @@ test "occupancy - offset selection clears stored endpoints" {
     view.setSelectionOccupancy(.boundary);
     try std.testing.expectEqualStrings("H", occupancySelected(view, &out));
 }
+
+test "Selection - vertical bounds take precedence over negative x" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    try tb.setText("Line 1\nLine 2\nLine 3");
+
+    _ = view.setLocalSelection(2, 0, -3, 5, null, null);
+    var range = occupancyPacked(view);
+    try std.testing.expectEqual(@as(u32, 2), range.start);
+    try std.testing.expectEqual(@as(u32, 20), range.end);
+
+    _ = view.setLocalSelection(-3, 5, 2, 0, null, null);
+    range = occupancyPacked(view);
+    try std.testing.expectEqual(@as(u32, 2), range.start);
+    try std.testing.expectEqual(@as(u32, 20), range.end);
+
+    _ = view.setLocalSelection(2, 0, 2, 0, null, null);
+    _ = view.updateLocalSelection(2, 0, -3, 5, null, null);
+    range = occupancyPacked(view);
+    try std.testing.expectEqual(@as(u32, 2), range.start);
+    try std.testing.expectEqual(@as(u32, 20), range.end);
+
+    _ = view.setLocalSelection(5, 1, -2, 1, null, null);
+    range = occupancyPacked(view);
+    try std.testing.expectEqual(@as(u32, 0), range.start);
+    try std.testing.expectEqual(@as(u32, 13), range.end);
+}

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -679,10 +679,14 @@ pub const UnifiedTextBufferView = struct {
 
         const text_end_offset = self.getTextEndOffset();
 
-        const anchor_offset = if (anchor_above or anchorX < 0)
+        // Vertical clamping must win over the x check: a point below this view
+        // maps to the text end even when its x is left of the view.
+        const anchor_offset = if (anchor_above)
             0
         else if (anchor_below)
             text_end_offset
+        else if (anchorX < 0)
+            0
         else
             self.coordsToCharOffset(anchorX, anchorY) orelse {
                 const had_selection = self.selection != null;
@@ -690,10 +694,12 @@ pub const UnifiedTextBufferView = struct {
                 return had_selection;
             };
 
-        const focus_offset = if (focus_above or focusX < 0)
+        const focus_offset = if (focus_above)
             0
         else if (focus_below)
             text_end_offset
+        else if (focusX < 0)
+            0
         else
             self.coordsToCharOffset(focusX, focusY) orelse {
                 const had_selection = self.selection != null;
@@ -744,10 +750,13 @@ pub const UnifiedTextBufferView = struct {
 
         const text_end_offset = self.getTextEndOffset();
 
-        const focus_col_offset = if (focus_above or focusX < 0)
+        // Same ordering as setLocalSelectionStyle: below beats x < 0.
+        const focus_col_offset = if (focus_above)
             0
         else if (focus_below)
             text_end_offset
+        else if (focusX < 0)
+            0
         else
             self.coordsToCharOffset(focusX, focusY) orelse return false;
 

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -679,13 +679,10 @@ pub const UnifiedTextBufferView = struct {
 
         const text_end_offset = self.getTextEndOffset();
 
-        // Vertical clamping must win over the x check: a point below this view
-        // maps to the text end even when its x is left of the view.
-        const anchor_offset = if (anchor_above)
-            0
-        else if (anchor_below)
+        // Vertical clamping takes precedence when a point is below and left.
+        const anchor_offset = if (anchor_below)
             text_end_offset
-        else if (anchorX < 0)
+        else if (anchor_above or anchorX < 0)
             0
         else
             self.coordsToCharOffset(anchorX, anchorY) orelse {
@@ -694,11 +691,9 @@ pub const UnifiedTextBufferView = struct {
                 return had_selection;
             };
 
-        const focus_offset = if (focus_above)
-            0
-        else if (focus_below)
+        const focus_offset = if (focus_below)
             text_end_offset
-        else if (focusX < 0)
+        else if (focus_above or focusX < 0)
             0
         else
             self.coordsToCharOffset(focusX, focusY) orelse {
@@ -750,12 +745,9 @@ pub const UnifiedTextBufferView = struct {
 
         const text_end_offset = self.getTextEndOffset();
 
-        // Same ordering as setLocalSelectionStyle: below beats x < 0.
-        const focus_col_offset = if (focus_above)
-            0
-        else if (focus_below)
+        const focus_col_offset = if (focus_below)
             text_end_offset
-        else if (focusX < 0)
+        else if (focus_above or focusX < 0)
             0
         else
             self.coordsToCharOffset(focusX, focusY) orelse return false;


### PR DESCRIPTION
This fixes the selection breaking when `x` is before the text, but `y` below it. Without the fix, the show selection is flipped.