### PR TITLE
renderer: clear stale mouse input

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -4322,6 +4322,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       },
       true,
     )
+    if (this.stdin === process.stdin && this._usesProcessStdout) this.disableMouse()
     this._useMouse = false
     this.setCapturedRenderable(undefined)
 
@@ -4449,10 +4450,15 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       }
     }
 
+    const discardInput = this._terminalIsSetup && this._controlState !== RendererControlState.EXPLICIT_SUSPENDED
     try {
-      this.lib.destroyRenderer(this.rendererPtr)
+      this.lib.destroyRenderer(this.rendererPtr, discardInput && this.stdin === process.stdin)
     } catch (e) {
       console.error("Error in lib.destroyRenderer during destroy:", e)
+    }
+    if (discardInput) {
+      const bufferedInput = this.stdin.readableLength
+      if (bufferedInput > 0) this.stdin.read(bufferedInput)
     }
     rendererTracker.renderers.delete(this)
     if (rendererTracker.renderers.size === 0) {

--- a/packages/core/src/tests/renderer.tracker.test.ts
+++ b/packages/core/src/tests/renderer.tracker.test.ts
@@ -160,6 +160,37 @@ test("renderer with custom stdin does not pause process.stdin on destroy", async
   expect(pauseCalled).toBe(false)
 })
 
+test("destroy discards terminal input queued during teardown", async () => {
+  const stdin = createTestStdin()
+  stdin.once("pause", () => {
+    stdin.push("\x1b[<35;125;28M")
+  })
+  const renderer = await createCliRenderer({
+    stdin,
+    stdout: createTestStdout(),
+    bufferedOutput: "memory",
+  })
+
+  renderer.destroy()
+
+  expect(stdin.read()).toBeNull()
+})
+
+test("destroy preserves input queued after suspension", async () => {
+  const stdin = createTestStdin()
+  const renderer = await createCliRenderer({
+    stdin,
+    stdout: createTestStdout(),
+    bufferedOutput: "memory",
+  })
+  renderer.suspend()
+  stdin.push("input after suspend")
+
+  renderer.destroy()
+
+  expect(stdin.read()).toEqual(Buffer.from("input after suspend"))
+})
+
 test("destroying process stdin owner pauses it while a custom renderer remains", async () => {
   const processRenderer = await createCliRenderer({
     stdin: process.stdin,

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -329,7 +329,7 @@ function getOpenTUILib(libPath?: string) {
       returns: "bool",
     },
     destroyRenderer: {
-      args: ["u32"],
+      args: ["u32", "bool"],
       returns: "void",
     },
     setUseThread: {
@@ -2215,7 +2215,7 @@ export interface AudioEngineLib {
 export interface RenderLib extends AudioEngineLib {
   createRenderer: (width: number, height: number, options?: NativeRendererCreateOptions) => RendererHandle | null
   setTerminalEnvVar: (renderer: RendererHandle, key: string, value: string) => boolean
-  destroyRenderer: (renderer: RendererHandle) => void
+  destroyRenderer: (renderer: RendererHandle, flushInput?: boolean) => void
   setUseThread: (renderer: RendererHandle, useThread: boolean) => void
   setClearOnShutdown: (renderer: RendererHandle, clear: boolean) => void
   setBackgroundColor: (renderer: RendererHandle, color: RGBA) => void
@@ -3231,8 +3231,8 @@ class FFIRenderLib implements RenderLib {
     )
   }
 
-  public destroyRenderer(renderer: Pointer): void {
-    this.opentui.symbols.destroyRenderer(renderer)
+  public destroyRenderer(renderer: Pointer, flushInput: boolean = false): void {
+    this.opentui.symbols.destroyRenderer(renderer, ffiBool(flushInput))
   }
 
   public setUseThread(renderer: Pointer, useThread: boolean) {

--- a/packages/core/src/zig/lib.zig
+++ b/packages/core/src/zig/lib.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const build_options = @import("build_options");
 const Allocator = std.mem.Allocator;
 
@@ -846,11 +847,34 @@ export fn setClearOnShutdown(renderer_handle: NativeHandle, clear: bool) void {
     object_ptr.setClearOnShutdown(clear);
 }
 
-export fn destroyRenderer(renderer_handle: NativeHandle) void {
+export fn destroyRenderer(renderer_handle: NativeHandle, flush_input: bool) void {
     const token = handles.beginDestroy(renderer_handle, .renderer, renderer.CliRenderer) orelse return;
     handles.invalidateChildren(token.handle);
     token.ptr.destroy();
+    if (flush_input) flushTerminalInput();
     handles.finishDestroy(token.handle);
+}
+
+fn flushTerminalInput() void {
+    if (builtin.os.tag == .windows) {
+        const WindowsConsole = struct {
+            extern "kernel32" fn GetStdHandle(handle: std.os.windows.DWORD) callconv(.winapi) std.os.windows.HANDLE;
+            extern "kernel32" fn FlushConsoleInputBuffer(handle: std.os.windows.HANDLE) callconv(.winapi) std.os.windows.BOOL;
+        };
+        const stdin_handle = WindowsConsole.GetStdHandle(@bitCast(@as(i32, -10)));
+        _ = WindowsConsole.FlushConsoleInputBuffer(stdin_handle);
+        return;
+    }
+
+    const tciflush = switch (builtin.os.tag) {
+        .linux => 0,
+        .macos => 1,
+        else => return,
+    };
+    const PosixTerminal = struct {
+        extern "c" fn tcflush(fd: c_int, queue_selector: c_int) c_int;
+    };
+    _ = PosixTerminal.tcflush(0, tciflush);
 }
 
 export fn setBackgroundColor(renderer_handle: NativeHandle, color: [*]const u16) void {


### PR DESCRIPTION
The terminal can send mouse reports after OpenTUI releases stdin.
Clear pending input during shutdown. This stops the next app from
reading stale escape sequences.
Keep input received after suspend(). The app owns terminal input then.
