### PR TITLE
renderer: reject forced Sixel for non-hosts

### DIFF
--- a/packages/native/src/renderer.zig
+++ b/packages/native/src/renderer.zig
@@ -1762,9 +1762,7 @@ pub const CliRenderer = struct {
             .sixel => Terminal.ImageProtocol.sixel,
             .blocks => Terminal.ImageProtocol.blocks,
         };
-        if (configured == .sixel and self.terminal.term_info.from_xtversion and
-            std.ascii.eqlIgnoreCase(self.terminal.getTerminalName(), "kitty") and !self.terminal.getCapabilities().sixel)
-        {
+        if (configured == .sixel and self.terminal.refusesForcedSixel()) {
             return .fallback;
         }
         switch (configured) {

--- a/packages/native/src/terminal.zig
+++ b/packages/native/src/terminal.zig
@@ -1761,6 +1761,19 @@ pub fn getTerminalName(self: *Terminal) []const u8 {
     return self.term_info.name[0..self.term_info.name_len];
 }
 
+/// Forced Sixel bypasses detection. Refuse it when identity cannot be a
+/// Sixel host. After XTVERSION, a multiplexer is not the host; DA still
+/// wins if the host reported Sixel through it. Apple Terminal has no
+/// XTVERSION, so TERM_PROGRAM is the only identity.
+pub fn refusesForcedSixel(self: *Terminal) bool {
+    if (self.caps.sixel) return false;
+    if (self.term_info.from_xtversion) {
+        if (self.multiplexer != .none) return true;
+        return std.ascii.eqlIgnoreCase(self.getTerminalName(), "kitty");
+    }
+    return std.ascii.eqlIgnoreCase(self.getTerminalName(), "Apple_Terminal");
+}
+
 pub fn getTerminalVersion(self: *Terminal) []const u8 {
     return self.term_info.version[0..self.term_info.version_len];
 }

--- a/packages/native/src/tests/renderer_test.zig
+++ b/packages/native/src/tests/renderer_test.zig
@@ -412,6 +412,54 @@ test "renderer honors per-placement protocol overrides" {
     try std.testing.expect(std.mem.find(u8, test_renderer.memory.lastWrite(), "\x1b_Ga=t") == null);
 }
 
+test "renderer does not send forced Sixel to Apple Terminal" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    defer link.deinitGlobalLinkPool();
+    var test_renderer = try TestRenderer.createWithEnv(std.testing.allocator, 4, 2, pool, &.{
+        .{ .key = "TERM_PROGRAM", .value = "Apple_Terminal" },
+    });
+    defer test_renderer.deinit();
+    const value = try image.createFromRgba(std.testing.allocator, &[_]u8{ 255, 0, 0, 255 }, 1, 1, 4);
+    const image_handle = try handles.insert(.image, @ptrCast(value));
+    defer {
+        const token = handles.beginDestroy(image_handle, .image, image.Image).?;
+        token.ptr.deinit();
+        handles.finishDestroy(token.handle);
+    }
+
+    try std.testing.expect(try test_renderer.renderer.getNextBuffer().drawImage(value, image_handle, 0, 0, 1, 1, 2, 2, 0, 0, 1, 1, .sixel));
+    try std.testing.expectEqual(renderer.RenderStatus.rendered, test_renderer.renderer.render(true));
+    const output = test_renderer.memory.lastWrite();
+    try std.testing.expect(std.mem.find(u8, output, "\x1bP0;1;0q") == null);
+    try std.testing.expect(std.mem.find(u8, output, "█") != null);
+}
+
+test "renderer does not send forced Sixel through tmux XTVERSION" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    defer link.deinitGlobalLinkPool();
+    var test_renderer = try TestRenderer.createWithEnv(std.testing.allocator, 4, 2, pool, &.{
+        .{ .key = "TERM_PROGRAM", .value = "Apple_Terminal" },
+    });
+    defer test_renderer.deinit();
+    const value = try image.createFromRgba(std.testing.allocator, &[_]u8{ 255, 0, 0, 255 }, 1, 1, 4);
+    const image_handle = try handles.insert(.image, @ptrCast(value));
+    defer {
+        const token = handles.beginDestroy(image_handle, .image, image.Image).?;
+        token.ptr.deinit();
+        handles.finishDestroy(token.handle);
+    }
+    test_renderer.renderer.terminal.processCapabilityResponse("\x1bP>|tmux 3.5a\x1b\\");
+
+    try std.testing.expect(try test_renderer.renderer.getNextBuffer().drawImage(value, image_handle, 0, 0, 1, 1, 2, 2, 0, 0, 1, 1, .sixel));
+    try std.testing.expectEqual(renderer.RenderStatus.rendered, test_renderer.renderer.render(true));
+    const output = test_renderer.memory.lastWrite();
+    try std.testing.expect(std.mem.find(u8, output, "\x1bP0;1;0q") == null);
+    try std.testing.expect(std.mem.find(u8, output, "\x1bPtmux;") == null);
+    try std.testing.expect(std.mem.find(u8, output, "█") != null);
+}
+
 test "renderer does not send forced Sixel to Kitty" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/tests/terminal_test.zig
+++ b/packages/native/src/tests/terminal_test.zig
@@ -227,6 +227,31 @@ test "graphics identity - malformed XTVERSION cannot reuse environment version" 
     try testing.expect(!term.caps.sixel);
 }
 
+test "refusesForcedSixel - XTVERSION replaces leftover Apple Terminal env" {
+    var leftover = std.process.Environ.Map.init(testing.allocator);
+    defer leftover.deinit();
+    try leftover.put("TERM_PROGRAM", "Apple_Terminal");
+    var foot = Terminal.init(.{ .env_map = &leftover });
+    foot.processCapabilityResponse("\x1bP>|foot(1.20.2)\x1b\\");
+    try testing.expect(!foot.refusesForcedSixel());
+
+    var iterm = Terminal.init(.{});
+    iterm.processCapabilityResponse("\x1bP>|iTerm2 3.6.9\x1b\\");
+    try testing.expect(!iterm.refusesForcedSixel());
+}
+
+test "refusesForcedSixel - tmux XTVERSION is not a Sixel endpoint" {
+    var env = std.process.Environ.Map.init(testing.allocator);
+    defer env.deinit();
+    try env.put("TERM_PROGRAM", "Apple_Terminal");
+    var term = Terminal.init(.{ .env_map = &env });
+    term.processCapabilityResponse("\x1bP>|tmux 3.5a\x1b\\");
+    try testing.expect(term.refusesForcedSixel());
+
+    term.processCapabilityResponse("\x1b[?62;4c");
+    try testing.expect(!term.refusesForcedSixel());
+}
+
 test "graphics identity - environment name alone is not authoritative" {
     var env = std.process.Environ.Map.init(testing.allocator);
     defer env.deinit();


### PR DESCRIPTION
Apple Terminal and terminal multiplexers cannot render forced Sixel
output. Fall back to blocks unless the detected host supports Sixel.
