### PR TITLE
fix(core): use boundary semantics for backward selection in edit buffers

### DIFF
--- a/packages/core/src/editor-view.test.ts
+++ b/packages/core/src/editor-view.test.ts
@@ -275,6 +275,16 @@ describe("EditorView", () => {
       expect(view.getSelectedText()).toBe("World")
     })
 
+    it("should not include the anchor character in backward selection (boundary semantics)", () => {
+      buffer.setText("Hello World")
+
+      view.setLocalSelection(8, 0, 8, 0)
+      const changed = view.updateLocalSelection(8, 0, 6, 0)
+      expect(changed).toBe(true)
+      expect(view.getSelection()).toEqual({ start: 6, end: 8 })
+      expect(view.getSelectedText()).toBe("Wo")
+    })
+
     it("should handle wrapped lines with updateLocalSelection", () => {
       buffer.setText("ABCDEFGHIJKLMNOPQRST")
 

--- a/packages/core/src/renderables/EditBufferRenderable.ts
+++ b/packages/core/src/renderables/EditBufferRenderable.ts
@@ -714,8 +714,7 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
 
     if (!select && this.hasSelection()) {
       const selection = this.getSelection()!
-      const targetOffset = this.cursorOffset === selection.start ? selection.end - 1 : selection.end
-      this.editBuffer.setCursorByOffset(targetOffset)
+      this.editBuffer.setCursorByOffset(selection.end)
       this._ctx.clearSelection()
       this.requestRender()
       return true

--- a/packages/core/src/renderables/__tests__/Textarea.editing.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.editing.test.ts
@@ -1417,10 +1417,9 @@ describe("Textarea - Editing Tests", () => {
       const selection = editor.getSelection()
       expect(selection).not.toBeNull()
       expect(selection!.start).toBe(0) // Selection starts at buffer start
-      // Selection should include everything from buffer start to original cursor position
+      // Selection covers everything from buffer start to the cursor boundary:
       // gotoLine(1) positions at end of line, moveCursorRight 3 times goes to col 3 of next line
-      // Selection from buffer start to cursor includes "Line 1\nLine" (one more than "Lin" due to cursor position)
-      expect(editor.getSelectedText()).toBe("Line 1\nLine")
+      expect(editor.getSelectedText()).toBe("Line 1\nLin")
     })
 
     it("should select from cursor to buffer end with End+Shift", async () => {

--- a/packages/core/src/renderables/__tests__/Textarea.keybinding.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.keybinding.test.ts
@@ -2974,7 +2974,7 @@ describe("Textarea - Keybinding Tests", () => {
       kittyMockInput.pressKey("a", { ctrl: true, shift: true })
 
       expect(editor.hasSelection()).toBe(true)
-      expect(editor.getSelectedText()).toBe("Hello W")
+      expect(editor.getSelectedText()).toBe("Hello ")
     })
 
     it("should select to line end from middle with ctrl+shift+e", async () => {
@@ -3005,7 +3005,7 @@ describe("Textarea - Keybinding Tests", () => {
 
       // Select to start of line 2
       kittyMockInput.pressKey("a", { ctrl: true, shift: true })
-      expect(editor.getSelectedText()).toBe("Line ")
+      expect(editor.getSelectedText()).toBe("Line")
 
       // Clear selection and move to same position
       editor.editBuffer.setCursor(1, 4)
@@ -3026,9 +3026,9 @@ describe("Textarea - Keybinding Tests", () => {
       // At end of line 1
       editor.editBuffer.setCursor(0, 6)
 
-      // First ctrl+shift+a from EOL selects through the line break at EOL
+      // ctrl+shift+a from EOL selects the whole line up to the cursor boundary
       kittyMockInput.pressKey("a", { ctrl: true, shift: true })
-      expect(editor.getSelectedText()).toBe("Line 1\n")
+      expect(editor.getSelectedText()).toBe("Line 1")
 
       // Reset
       editor.editBuffer.setCursor(0, 0)
@@ -3205,7 +3205,7 @@ describe("Textarea - Keybinding Tests", () => {
 
       expect(editor.hasSelection()).toBe(true)
       const selectedText = editor.getSelectedText()
-      expect(selectedText.length).toBe(6) // From col 20 to 26 (includes char at 25)
+      expect(selectedText.length).toBe(5) // From col 20 to the cursor boundary at 25
     })
 
     it("should select to visual line end with meta+shift+e", async () => {
@@ -3238,7 +3238,7 @@ describe("Textarea - Keybinding Tests", () => {
       editor.editBuffer.setCursor(0, 6)
 
       kittyMockInput.pressKey("a", { meta: true, shift: true })
-      expect(editor.getSelectedText()).toBe("Hello W")
+      expect(editor.getSelectedText()).toBe("Hello ")
 
       editor.editBuffer.setCursor(0, 6)
       kittyMockInput.pressKey("e", { meta: true, shift: true })
@@ -3259,7 +3259,7 @@ describe("Textarea - Keybinding Tests", () => {
       // meta+shift+a selects to visual line start
       kittyMockInput.pressKey("a", { meta: true, shift: true })
       const visualSelection = editor.getSelectedText()
-      expect(visualSelection.length).toBe(6) // From 20 to 26
+      expect(visualSelection.length).toBe(5) // From 20 to the cursor boundary at 25
 
       // Reset
       editor.editBuffer.setCursor(0, 25)
@@ -3267,7 +3267,7 @@ describe("Textarea - Keybinding Tests", () => {
       // ctrl+shift+a selects to logical line start
       kittyMockInput.pressKey("a", { ctrl: true, shift: true })
       const logicalSelection = editor.getSelectedText()
-      expect(logicalSelection.length).toBe(26) // From 0 to 26
+      expect(logicalSelection.length).toBe(25) // From 0 to the cursor boundary at 25
 
       expect(visualSelection).not.toBe(logicalSelection)
     })

--- a/packages/core/src/renderables/__tests__/Textarea.selection.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.selection.test.ts
@@ -189,6 +189,25 @@ describe("Textarea - Selection Tests", () => {
       expect(editor.getSelectedText()).toBe("World")
     })
 
+    it("should not extend a backward mouse drag past the press boundary", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "Hello World",
+        width: 40,
+        height: 10,
+        selectable: true,
+      })
+
+      // Press at boundary 9 (between 'r' and 'l'), drag left to 6.
+      await currentMouse.drag(editor.x + 9, editor.y, editor.x + 6, editor.y)
+      await renderOnce()
+
+      const sel = editor.getSelection()
+      expect(sel).not.toBe(null)
+      expect(sel!.start).toBe(6)
+      expect(sel!.end).toBe(9)
+      expect(editor.getSelectedText()).toBe("Wor")
+    })
+
     it("should render selection properly when drawing to buffer", async () => {
       const buffer = OptimizedBuffer.create(80, 24, "wcwidth")
 
@@ -564,6 +583,43 @@ describe("Textarea - Selection Tests", () => {
       expect(editor.getSelectedText()).toBe("World")
     })
 
+    it("should select exactly one character with shift+left from mid-line", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "Hello World",
+        width: 40,
+        height: 10,
+        selectable: true,
+      })
+
+      editor.focus()
+      editor.editBuffer.setCursorToLineCol(0, 5)
+
+      currentMockInput.pressArrow("left", { shift: true })
+
+      expect(editor.hasSelection()).toBe(true)
+      expect(editor.getSelectedText()).toBe("o")
+    })
+
+    it("should collapse a backward selection to the press boundary with right arrow", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "Hello World",
+        width: 40,
+        height: 10,
+        selectable: true,
+      })
+
+      editor.focus()
+      await currentMouse.drag(editor.x + 9, editor.y, editor.x + 6, editor.y)
+      await renderOnce()
+
+      expect(editor.getSelectedText()).toBe("Wor")
+
+      currentMockInput.pressArrow("right")
+
+      expect(editor.hasSelection()).toBe(false)
+      expect(editor.logicalCursor.col).toBe(9)
+    })
+
     it("should select with shift+down", async () => {
       const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
         initialValue: "Line 1\nLine 2\nLine 3",
@@ -615,7 +671,7 @@ describe("Textarea - Selection Tests", () => {
       currentMockInput.pressKey("HOME", { shift: true })
 
       expect(editor.hasSelection()).toBe(true)
-      expect(editor.getSelectedText()).toBe("Hello W")
+      expect(editor.getSelectedText()).toBe("Hello ")
     })
 
     it("should select to line end with shift+end", async () => {

--- a/packages/core/src/text-buffer-view.test.ts
+++ b/packages/core/src/text-buffer-view.test.ts
@@ -368,6 +368,15 @@ describe("TextBufferView", () => {
       expect(changed).toBe(true)
       expect(view.getSelectedText()).toBe("World")
     })
+
+    it("should keep the anchor cell selected in backward selection (cell semantics)", () => {
+      const styledText = stringToStyledText("Hello World")
+      buffer.setStyledText(styledText)
+
+      view.setLocalSelection(8, 0, 8, 0)
+      view.updateLocalSelection(8, 0, 6, 0)
+      expect(view.getSelectedText()).toBe("Wor")
+    })
   })
 
   describe("getPlainText", () => {

--- a/packages/core/src/zig/editor-view.zig
+++ b/packages/core/src/zig/editor-view.zig
@@ -67,6 +67,10 @@ pub const EditorView = struct {
         const text_buffer = edit_buffer.getTextBuffer();
         const text_buffer_view = UnifiedTextBufferView.init(global_allocator, text_buffer) catch return EditorViewError.OutOfMemory;
         errdefer text_buffer_view.deinit();
+        // Edit buffers use boundary (caret) selection semantics: a press places
+        // the cursor at a column boundary, so a backward extension selects
+        // [focus, anchor) rather than including the anchor cell.
+        text_buffer_view.cell_selection = false;
 
         self.* = .{
             .text_buffer_view = text_buffer_view,

--- a/packages/core/src/zig/tests/editor-view_test.zig
+++ b/packages/core/src/zig/tests/editor-view_test.zig
@@ -3451,3 +3451,58 @@ test "EditorView - mouse selection focus outside buffer bounds clamps correctly"
     // Cursor should be clamped to last line (line 9)
     try std.testing.expectEqual(@as(u32, 9), cursor.row);
 }
+
+test "EditorView - backward local selection uses boundary semantics" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    try eb.setText("Hello World");
+
+    // Press at boundary 8, extend left to boundary 6: the press placed the
+    // caret at 8, so the selection is [6, 8) = "Wo", not [6, 9) = "Wor".
+    _ = ev.setLocalSelection(8, 0, 8, 0, null, null, false);
+    _ = ev.updateLocalSelection(8, 0, 6, 0, null, null, false);
+
+    const packed_info = ev.packSelectionInfo();
+    try std.testing.expect(packed_info != 0xFFFFFFFF_FFFFFFFF);
+
+    const start = @as(u32, @intCast(packed_info >> 32));
+    const end = @as(u32, @intCast(packed_info & 0xFFFFFFFF));
+    try std.testing.expectEqual(@as(u32, 6), start);
+    try std.testing.expectEqual(@as(u32, 8), end);
+
+    var out_buffer: [100]u8 = undefined;
+    const len = ev.getSelectedTextIntoBuffer(&out_buffer);
+    try std.testing.expectEqualStrings("Wo", out_buffer[0..len]);
+}
+
+test "EditorView - single-step backward selection selects exactly one char" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    try eb.setText("Hello World");
+
+    // Click at column 5 then shift+left: exactly "o" [4, 5), not "o " [4, 6).
+    _ = ev.setLocalSelection(5, 0, 5, 0, null, null, false);
+    _ = ev.updateLocalSelection(5, 0, 4, 0, null, null, false);
+
+    var out_buffer: [100]u8 = undefined;
+    const len = ev.getSelectedTextIntoBuffer(&out_buffer);
+    try std.testing.expectEqualStrings("o", out_buffer[0..len]);
+}

--- a/packages/core/src/zig/tests/text-buffer-selection_test.zig
+++ b/packages/core/src/zig/tests/text-buffer-selection_test.zig
@@ -943,7 +943,7 @@ test "Selection - updateLocalSelection backward selection" {
     _ = view.setLocalSelection(11, 0, 11, 0, null, null);
 
     // Move focus backward to (6, 0) - start of "World"
-    // Backward selection adds +1 to make it inclusive, so [6, 12) = "World!"
+    // Cell selection semantics add +1 so the anchor cell stays selected: [6, 12) = "World!"
     const changed = view.updateLocalSelection(11, 0, 6, 0, null, null);
     try std.testing.expect(changed);
 
@@ -957,6 +957,38 @@ test "Selection - updateLocalSelection backward selection" {
     const len = view.getSelectedTextIntoBuffer(&out_buffer);
     const text = out_buffer[0..len];
     try std.testing.expectEqualStrings("World!", text);
+}
+
+test "Selection - updateLocalSelection backward with clamped focus keeps anchor cell" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    try tb.setText("Hello World");
+
+    // Anchor on the 'W' cell (col 6). The drag continues into a renderable
+    // above this view, so the focus arrives clamped (focusY < 0). Cell
+    // semantics must keep the anchor cell selected: [0, 7) = "Hello W".
+    _ = view.setLocalSelection(6, 0, 6, 0, null, null);
+    const changed = view.updateLocalSelection(6, 0, 0, -1, null, null);
+    try std.testing.expect(changed);
+
+    const packed_info = view.packSelectionInfo();
+    const start = @as(u32, @intCast(packed_info >> 32));
+    const end = @as(u32, @intCast(packed_info & 0xFFFFFFFF));
+    try std.testing.expectEqual(@as(u32, 0), start);
+    try std.testing.expectEqual(@as(u32, 7), end);
+
+    var out_buffer: [100]u8 = undefined;
+    const len = view.getSelectedTextIntoBuffer(&out_buffer);
+    try std.testing.expectEqualStrings("Hello W", out_buffer[0..len]);
 }
 
 test "Selection - updateLocalSelection with wrapped lines" {

--- a/packages/core/src/zig/text-buffer-view.zig
+++ b/packages/core/src/zig/text-buffer-view.zig
@@ -130,6 +130,18 @@ pub const UnifiedTextBufferView = struct {
     view_id: u32,
     selection: ?TextSelection,
     selection_anchor_offset: ?u32,
+    /// Backward-selection (focus < anchor) semantics for focus-only selection
+    /// updates (updateLocalSelectionFocusOnly; setLocalSelectionStyle always
+    /// stores plain [min, max) in either mode).
+    /// true  = cell semantics (xterm-style copy selection): the pressed cell
+    ///         stays highlighted when dragging left of it, so the selection end
+    ///         is extended one column past the anchor.
+    /// false = boundary semantics (editor caret selection): a press lands on a
+    ///         column boundary, so a backward extension selects exactly
+    ///         [focus, anchor).
+    /// Static text views default to cell semantics; EditorView opts into
+    /// boundary semantics at construction.
+    cell_selection: bool,
     viewport: ?Viewport,
     wrap_width: ?u32,
     wrap_mode: WrapMode,
@@ -188,6 +200,7 @@ pub const UnifiedTextBufferView = struct {
             .view_id = view_id,
             .selection = null,
             .selection_anchor_offset = null,
+            .cell_selection = true,
             .viewport = null,
             .wrap_width = null,
             .wrap_mode = .none,
@@ -672,7 +685,12 @@ pub const UnifiedTextBufferView = struct {
         const new_start = @min(anchor_offset, focus_col_offset);
         var new_end = @max(anchor_offset, focus_col_offset);
 
-        if (focus_col_offset < anchor_offset) {
+        // Cell semantics: keep the pressed cell highlighted when dragging left
+        // of it. This intentionally also applies when the focus arrived clamped
+        // (above/left of this view) so multi-renderable reverse drags keep the
+        // anchor cell selected in the anchor renderable. Boundary-semantics
+        // views (edit buffers) select exactly [focus, anchor) instead.
+        if (self.cell_selection and focus_col_offset < anchor_offset) {
             new_end = @min(new_end + 1, text_end_offset);
         }
 


### PR DESCRIPTION
When selecting backwards using shift+left with a thin cursor placed after character in position `n`, the next character, position `n+1`, is also selected.

The fix is not entirely clear here since some product decisions discretion is required. Please see if  it's to your liking