### PR TITLE
docs: add section-aware documentation search

### DIFF
--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -74,6 +74,11 @@ export default defineConfig({
     }),
   ],
   site: "https://opentui.com",
+  vite: {
+    server: {
+      allowedHosts: true,
+    },
+  },
   redirects: {
     "/docs/getting-started": "/docs",
     "/docs/core-concepts/constructs": "/docs/core-concepts/renderables",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -17,7 +17,7 @@
     "validate:docs:skill": "bun scripts/validate-skill-docs.ts",
     "validate:docs:examples": "bun scripts/verify-doc-examples.ts",
     "validate:docs": "bun run validate:docs:metadata && bun run validate:docs:links && bun run validate:docs:skill && bun run test:docs",
-    "test:docs": "bun test src/lib/docs-index.test.ts scripts/doc-validator.test.ts",
+    "test:docs": "bun test src/lib/docs-index.test.ts src/lib/docs-search.test.ts scripts/doc-validator.test.ts",
     "validate:packages": "bun scripts/validate-packages.ts src/content/packages",
     "test:packages": "bun test src/lib/package-facts.test.ts src/lib/package-schema.test.ts src/lib/remote-package-facts.test.ts"
   },

--- a/packages/web/scripts/validate-doc-links.ts
+++ b/packages/web/scripts/validate-doc-links.ts
@@ -3,6 +3,7 @@
 import { readdir, readFile } from "node:fs/promises"
 import { join } from "node:path"
 
+import { getFenceMarker, closesFence, slugifyHeading } from "../src/lib/docs-headings"
 import { buildDocsIndex } from "../src/lib/docs-index"
 import { parsePackageEntryFile } from "./package-entry-file"
 
@@ -259,31 +260,7 @@ function collectRepositoryPaths(content: string): RepositoryPathInfo[] {
   return paths
 }
 
-export function slugifyHeading(text: string): string {
-  return text
-    .replace(/`([^`]*)`/g, "$1")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .replace(/<([^>]+)>/g, "$1")
-    .replace(/[*~]/g, "")
-    .toLowerCase()
-    .replace(/[^a-z0-9_\s-]/g, "")
-    .trim()
-    .replace(/\s/g, "-")
-}
-
-function getFenceMarker(line: string): { marker: string; length: number } | undefined {
-  const match = line.match(/^(`{3,}|~{3,})/)
-  if (!match) {
-    return undefined
-  }
-
-  return { marker: match[1][0], length: match[1].length }
-}
-
-function closesFence(line: string, fence: { marker: string; length: number }): boolean {
-  const pattern = new RegExp(`^${fence.marker}{${fence.length},}\\s*$`)
-  return pattern.test(line)
-}
+export { slugifyHeading }
 
 function isExternalLink(target: string): boolean {
   return /^(https?:\/\/|mailto:)/.test(target)

--- a/packages/web/src/components/DocsNav.astro
+++ b/packages/web/src/components/DocsNav.astro
@@ -1,5 +1,6 @@
 ---
 import { buildDocsIndex } from "../lib/docs-index"
+import DocsSearch from "./DocsSearch.astro"
 
 const docsIndex = await buildDocsIndex()
 
@@ -7,32 +8,35 @@ const normalize = (path: string) => path.replace(/\/+$/, "") || "/"
 const current = normalize(Astro.url.pathname)
 ---
 
-<nav aria-label="Documentation">
-  <ul>
-    {
-      docsIndex.sections.map((section) => (
-        <li>
-          <span class="section">{section.title}</span>
-          <ul>
-            {section.pages.map((page, index) => (
-              <>
-                {page.group && page.group !== section.pages[index - 1]?.group && <li class="group">{page.group}</li>}
-                <li>
-                  <a href={page.url} aria-current={current === page.url ? "page" : undefined}>
-                    {page.navTitle}
-                  </a>
-                </li>
-              </>
-            ))}
-          </ul>
-        </li>
-      ))
-    }
-  </ul>
-</nav>
+<div class="docs-index">
+  <DocsSearch />
+  <nav aria-label="Documentation" data-docs-nav>
+    <ul>
+      {
+        docsIndex.sections.map((section) => (
+          <li>
+            <span class="section">{section.title}</span>
+            <ul>
+              {section.pages.map((page, index) => (
+                <>
+                  {page.group && page.group !== section.pages[index - 1]?.group && <li class="group">{page.group}</li>}
+                  <li>
+                    <a href={page.url} aria-current={current === page.url ? "page" : undefined}>
+                      {page.navTitle}
+                    </a>
+                  </li>
+                </>
+              ))}
+            </ul>
+          </li>
+        ))
+      }
+    </ul>
+  </nav>
+</div>
 
 <style>
-  nav {
+  .docs-index {
     font-size: 0.875rem;
     line-height: 1.6;
   }
@@ -41,6 +45,10 @@ const current = normalize(Astro.url.pathname)
     list-style: none;
     margin: 0;
     padding: 0;
+  }
+
+  nav[hidden] {
+    display: none;
   }
 
   nav > ul > li + li {

--- a/packages/web/src/components/DocsSearch.astro
+++ b/packages/web/src/components/DocsSearch.astro
@@ -2,7 +2,8 @@
 // Documentation search: a prompt line above the page list. Without the
 // script the row stays reserved but invisible, as on the packages filter.
 // The page renders this twice (sidebar and menu), so each copy needs its
-// own control ids.
+// own control ids. On the sidebar, results overlay the article from
+// the nav's left edge; the overlay is only as large as the hits.
 const searchId = `docs-search-${crypto.randomUUID()}`
 const resultsId = `${searchId}-results`
 ---
@@ -45,6 +46,7 @@ const resultsId = `${searchId}-results`
     const input = root.querySelector("input")
     const results = root.querySelector<HTMLElement>(".results")
     const nav = root.closest(".docs-index")?.querySelector<HTMLElement>("[data-docs-nav]")
+    const sidebar = root.closest(".docs-pages")
     if (!(input instanceof HTMLInputElement) || !results) return
 
     let query = ""
@@ -55,6 +57,7 @@ const resultsId = `${searchId}-results`
 
     input.addEventListener("focus", () => {
       void load()
+      if (input.value.trim()) void run(input.value)
     })
     input.addEventListener("input", () => {
       void run(input.value)
@@ -68,6 +71,13 @@ const resultsId = `${searchId}-results`
       // click lands. The link still navigates, so middle and modifier
       // clicks keep working.
       if (event.target instanceof Element && event.target.closest("a")) event.preventDefault()
+    })
+
+    document.addEventListener("click", (event) => {
+      if (!root.contains(document.activeElement)) return
+      if (event.target instanceof Node && root.contains(event.target)) return
+      close()
+      input.blur()
     })
 
     root.addEventListener("focusout", (event) => {
@@ -154,6 +164,7 @@ const resultsId = `${searchId}-results`
       appendHighlighted(snippet, preview(entry.text, match.pattern), match)
 
       option.append(heading, snippet)
+      option.addEventListener("mouseenter", () => select(index))
       option.addEventListener("click", () => close())
       return option
     }
@@ -183,15 +194,10 @@ const resultsId = `${searchId}-results`
           close()
           window.location.assign(chosen.entry.url)
         }
-      } else if (event.key === "Tab") {
-        close()
       } else if (event.key === "Escape") {
-        // A search input would clear itself on Escape. Close the results
-        // first; a second press clears the query and releases focus.
         event.preventDefault()
         if (results.hidden) {
           input.value = ""
-          close()
           input.blur()
         } else {
           close()
@@ -220,14 +226,16 @@ const resultsId = `${searchId}-results`
 
     function open() {
       results.hidden = false
-      if (nav) nav.hidden = true
+      // The sidebar overlays the article; the menu still swaps the page
+      // list for results because that panel is the only surface.
+      if (nav && !sidebar) nav.hidden = true
       input.setAttribute("aria-expanded", "true")
       input.removeAttribute("aria-activedescendant")
     }
 
     function close() {
       results.hidden = true
-      if (nav) nav.hidden = false
+      if (nav && !sidebar) nav.hidden = false
       matches = []
       active = -1
       input.setAttribute("aria-expanded", "false")
@@ -284,6 +292,7 @@ const resultsId = `${searchId}-results`
 <style>
   /* A terminal prompt line: a ">" cue and bare text, no box. */
   search {
+    position: relative;
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;
@@ -336,31 +345,71 @@ const resultsId = `${searchId}-results`
     display: none;
   }
 
-  /* Result rows are built in the script, so they do not receive this
-   * component's scoped attribute. Style them as descendants. */
-  .results :global(a),
-  .results :global(a:visited) {
-    color: var(--link-color);
-    display: grid;
-    gap: 0.125rem;
+  /* Sidebar: the prompt stays in the column. Results grow it across the
+   * article without moving the page. Body size keeps it off the nav's
+   * 0.875rem measure. */
+  :global(.docs-pages) search {
+    width: 100%;
+    font-size: 1rem;
+    line-height: 1.5;
+    transition: width var(--motion-step) linear;
   }
 
-  .results :global(a[aria-current]) {
+  :global(.docs-pages) search:has(.results:not([hidden])) {
+    width: var(--content-width);
+    margin-inline-end: calc(var(--docs-nav-width) - var(--content-width));
+    padding: 1.5rem;
+    background: var(--page-background);
+    border: 1px solid;
+  }
+
+  /* Result rows are built in the script, so they do not receive this
+   * component's scoped attribute. Style them as descendants.
+   *
+   * Page color throughout: bold titles, plain snippets. A caret marks
+   * the current and hovered row. Links keep no underline so hover is
+   * the caret, not a decoration. */
+  .results :global(a),
+  .results :global(a:visited),
+  .results :global(a:hover),
+  :global(:root[data-theme="blue"]) .results :global(a) {
     color: inherit;
+    text-decoration: none;
+    display: grid;
+    grid-template-columns: 1ch minmax(0, 1fr);
+    column-gap: 1ch;
+    row-gap: 0.125rem;
+    padding-block: 0.375rem;
+  }
+
+  .results :global(a::before) {
+    content: "";
+    grid-column: 1;
+    grid-row: 1 / span 2;
+  }
+
+  .results :global(a[aria-current]::before) {
+    content: ">";
+  }
+
+  .results :global(.heading),
+  .results :global(.preview) {
+    grid-column: 2;
+  }
+
+  .results :global(.title) {
+    font-weight: 700;
   }
 
   .results :global(.heading) {
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;
-    justify-content: space-between;
     gap: 0 1.5ch;
   }
 
-  .results :global(.chapter),
-  .results :global(.preview),
   .results :global(.empty) {
-    color: var(--muted-color);
+    margin: 0;
   }
 
   .results :global(.preview) {
@@ -375,5 +424,11 @@ const resultsId = `${searchId}-results`
     background: none;
     color: inherit;
     font-weight: 700;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :global(.docs-pages) search {
+      transition: none;
+    }
   }
 </style>

--- a/packages/web/src/components/DocsSearch.astro
+++ b/packages/web/src/components/DocsSearch.astro
@@ -1,0 +1,379 @@
+---
+// Documentation search: a prompt line above the page list. Without the
+// script the row stays reserved but invisible, as on the packages filter.
+// The page renders this twice (sidebar and menu), so each copy needs its
+// own control ids.
+const searchId = `docs-search-${crypto.randomUUID()}`
+const resultsId = `${searchId}-results`
+---
+
+<search class="docs-search" hidden>
+  <label for={searchId}>
+    <span aria-hidden="true">&gt;</span>
+    <span class="sr-only">Search the docs</span>
+  </label>
+  <!-- type="text", not "search": the browser draws a clear button in a
+       search field, and this prompt line has no controls. -->
+  <input
+    type="text"
+    id={searchId}
+    placeholder="Search"
+    autocomplete="off"
+    spellcheck="false"
+    role="combobox"
+    aria-expanded="false"
+    aria-autocomplete="list"
+    aria-controls={resultsId}
+  />
+  <div class="results" id={resultsId} role="listbox" aria-label="Search results" hidden></div>
+</search>
+
+<script>
+  import { highlightParts, lookup, preview, type SearchEntry, type SearchMatch } from "../lib/docs-search"
+
+  const INDEX_URL = "/docs/search-index.json"
+  const MAX_RESULTS = 8
+
+  let entries: SearchEntry[] | null = null
+  let loading: Promise<void> | null = null
+
+  for (const root of document.querySelectorAll<HTMLElement>("search.docs-search")) {
+    ready(root)
+  }
+
+  function ready(root: HTMLElement) {
+    const input = root.querySelector("input")
+    const results = root.querySelector<HTMLElement>(".results")
+    const nav = root.closest(".docs-index")?.querySelector<HTMLElement>("[data-docs-nav]")
+    if (!(input instanceof HTMLInputElement) || !results) return
+
+    let query = ""
+    let matches: SearchMatch[] = []
+    let active = -1
+
+    root.hidden = false
+
+    input.addEventListener("focus", () => {
+      void load()
+    })
+    input.addEventListener("input", () => {
+      void run(input.value)
+    })
+    input.addEventListener("keydown", (event) => {
+      navigate(event)
+    })
+
+    results.addEventListener("mousedown", (event) => {
+      // Hold the focus so the blur does not close the results before the
+      // click lands. The link still navigates, so middle and modifier
+      // clicks keep working.
+      if (event.target instanceof Element && event.target.closest("a")) event.preventDefault()
+    })
+
+    root.addEventListener("focusout", (event) => {
+      if (!root.contains(event.relatedTarget as Node | null)) close()
+    })
+
+    async function run(value: string) {
+      query = value.trim()
+      if (!query) {
+        close()
+        return
+      }
+
+      if (!entries) {
+        await load()
+        resume()
+        return
+      }
+
+      matches = lookup(entries, query).slice(0, MAX_RESULTS)
+      active = -1
+      render()
+    }
+
+    function resume() {
+      if (query !== input.value.trim()) return
+      if (entries) void run(input.value)
+      else unavailable()
+    }
+
+    function render() {
+      results.replaceChildren()
+
+      if (matches.length === 0) {
+        const empty = document.createElement("p")
+        empty.className = "empty"
+        empty.textContent = `No results for “${query}”`
+        results.append(empty)
+      } else {
+        for (const [index, match] of matches.entries()) {
+          results.append(result(match, index))
+        }
+      }
+
+      open()
+    }
+
+    function unavailable() {
+      matches = []
+      active = -1
+      results.replaceChildren()
+      const empty = document.createElement("p")
+      empty.className = "empty"
+      empty.textContent = "Search is unavailable right now"
+      results.append(empty)
+      open()
+    }
+
+    function result(match: SearchMatch, index: number) {
+      const entry = match.entry
+      const option = document.createElement("a")
+      option.href = entry.url
+      option.id = `${results.id}-${index}`
+      option.role = "option"
+      option.tabIndex = -1
+      option.setAttribute("aria-selected", "false")
+
+      const heading = document.createElement("span")
+      heading.className = "heading"
+      const title = document.createElement("span")
+      title.className = "title"
+      appendHighlighted(title, entry.title, match)
+      heading.append(title)
+
+      if (entry.title !== entry.chapter) {
+        const chapter = document.createElement("span")
+        chapter.className = "chapter"
+        chapter.textContent = entry.chapter
+        heading.append(chapter)
+      }
+
+      const snippet = document.createElement("span")
+      snippet.className = "preview"
+      appendHighlighted(snippet, preview(entry.text, match.pattern), match)
+
+      option.append(heading, snippet)
+      option.addEventListener("click", () => close())
+      return option
+    }
+
+    function appendHighlighted(target: HTMLElement, text: string, match: SearchMatch) {
+      for (const part of highlightParts(text, match.pattern)) {
+        if (!part.text) continue
+        if (part.mark) {
+          const mark = document.createElement("mark")
+          mark.textContent = part.text
+          target.append(mark)
+        } else {
+          target.append(part.text)
+        }
+      }
+    }
+
+    function navigate(event: KeyboardEvent) {
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault()
+        if (results.hidden) void run(input.value)
+        else select(active + (event.key === "ArrowDown" ? 1 : -1))
+      } else if (event.key === "Enter" && !results.hidden) {
+        const chosen = active >= 0 ? matches[active] : matches[0]
+        if (chosen) {
+          event.preventDefault()
+          close()
+          window.location.assign(chosen.entry.url)
+        }
+      } else if (event.key === "Tab") {
+        close()
+      } else if (event.key === "Escape") {
+        // A search input would clear itself on Escape. Close the results
+        // first; a second press clears the query and releases focus.
+        event.preventDefault()
+        if (results.hidden) {
+          input.value = ""
+          close()
+          input.blur()
+        } else {
+          close()
+        }
+      }
+    }
+
+    function select(index: number) {
+      const options = results.querySelectorAll("a")
+      if (options.length === 0) return
+
+      if (index < 0) index = options.length - 1
+      if (index >= options.length) index = 0
+
+      for (const option of options) {
+        option.removeAttribute("aria-current")
+        option.setAttribute("aria-selected", "false")
+      }
+
+      active = index
+      options[active].setAttribute("aria-current", "true")
+      options[active].setAttribute("aria-selected", "true")
+      options[active].scrollIntoView({ block: "nearest" })
+      input.setAttribute("aria-activedescendant", options[active].id)
+    }
+
+    function open() {
+      results.hidden = false
+      if (nav) nav.hidden = true
+      input.setAttribute("aria-expanded", "true")
+      input.removeAttribute("aria-activedescendant")
+    }
+
+    function close() {
+      results.hidden = true
+      if (nav) nav.hidden = false
+      matches = []
+      active = -1
+      input.setAttribute("aria-expanded", "false")
+      input.removeAttribute("aria-activedescendant")
+    }
+  }
+
+  document.addEventListener("keydown", (event) => {
+    if (!shortcut(event)) return
+
+    const inputs = [...document.querySelectorAll<HTMLInputElement>("search.docs-search input")]
+    const visible = inputs.find((candidate) => candidate.offsetParent)
+    if (visible) {
+      event.preventDefault()
+      visible.focus()
+      visible.select()
+      return
+    }
+
+    // Below the docs breakpoint the sidebar is gone, so `/` opens Menu
+    // and focuses the copy inside it.
+    const menuInput = inputs.find((candidate) => candidate.closest("details.menu"))
+    const menu = menuInput?.closest("details.menu")
+    if (!(menu instanceof HTMLDetailsElement) || !menuInput) return
+
+    event.preventDefault()
+    menu.open = true
+    menuInput.focus()
+    menuInput.select()
+  })
+
+  function shortcut(event: KeyboardEvent) {
+    if (event.metaKey || event.ctrlKey || event.altKey) return false
+    if (event.target instanceof Element && event.target.closest("input, textarea, select, [contenteditable]")) {
+      return false
+    }
+    return event.key === "/"
+  }
+
+  function load() {
+    loading ||= fetch(INDEX_URL)
+      .then((response) => (response.ok ? response.json() : Promise.reject(response.status)))
+      .then((index: SearchEntry[]) => {
+        entries = index
+      })
+      .catch(() => {
+        loading = null
+      })
+
+    return loading
+  }
+</script>
+
+<style>
+  /* A terminal prompt line: a ">" cue and bare text, no box. */
+  search {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    column-gap: 1ch;
+    row-gap: 0.75rem;
+    margin-block-end: 1.5rem;
+  }
+
+  /* Reserve the row before the script reveals it, so the list does not
+   * shift on the first paint. Without the script the row stays invisible. */
+  search[hidden] {
+    display: flex;
+    visibility: hidden;
+  }
+
+  label {
+    color: var(--muted-color);
+  }
+
+  search:focus-within label {
+    color: inherit;
+  }
+
+  input {
+    flex: 1;
+    min-width: 0;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    background: none;
+    border: none;
+    outline: none;
+    caret-color: currentColor;
+  }
+
+  input::placeholder {
+    color: var(--muted-color);
+    opacity: 1;
+  }
+
+  .results {
+    flex: 1 0 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    overflow-wrap: anywhere;
+  }
+
+  .results[hidden] {
+    display: none;
+  }
+
+  /* Result rows are built in the script, so they do not receive this
+   * component's scoped attribute. Style them as descendants. */
+  .results :global(a),
+  .results :global(a:visited) {
+    color: var(--link-color);
+    display: grid;
+    gap: 0.125rem;
+  }
+
+  .results :global(a[aria-current]) {
+    color: inherit;
+  }
+
+  .results :global(.heading) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0 1.5ch;
+  }
+
+  .results :global(.chapter),
+  .results :global(.preview),
+  .results :global(.empty) {
+    color: var(--muted-color);
+  }
+
+  .results :global(.preview) {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+  }
+
+  .results :global(mark) {
+    background: none;
+    color: inherit;
+    font-weight: 700;
+  }
+</style>

--- a/packages/web/src/components/DocsSearch.astro
+++ b/packages/web/src/components/DocsSearch.astro
@@ -123,6 +123,7 @@ const resultsId = `${searchId}-results`
       }
 
       open()
+      if (matches.length > 0) select(0)
     }
 
     function unavailable() {
@@ -366,9 +367,8 @@ const resultsId = `${searchId}-results`
   /* Result rows are built in the script, so they do not receive this
    * component's scoped attribute. Style them as descendants.
    *
-   * Page color throughout: bold titles, plain snippets. A caret marks
-   * the current and hovered row. Links keep no underline so hover is
-   * the caret, not a decoration. */
+   * Page color throughout: bold titles, plain snippets. Underline marks
+   * the current row. */
   .results :global(a),
   .results :global(a:visited),
   .results :global(a:hover),
@@ -376,25 +376,12 @@ const resultsId = `${searchId}-results`
     color: inherit;
     text-decoration: none;
     display: grid;
-    grid-template-columns: 1ch minmax(0, 1fr);
-    column-gap: 1ch;
-    row-gap: 0.125rem;
+    gap: 0.125rem;
     padding-block: 0.375rem;
   }
 
-  .results :global(a::before) {
-    content: "";
-    grid-column: 1;
-    grid-row: 1 / span 2;
-  }
-
-  .results :global(a[aria-current]::before) {
-    content: ">";
-  }
-
-  .results :global(.heading),
-  .results :global(.preview) {
-    grid-column: 2;
+  .results :global(a[aria-current] .title) {
+    text-decoration: underline;
   }
 
   .results :global(.title) {

--- a/packages/web/src/layouts/Docs.astro
+++ b/packages/web/src/layouts/Docs.astro
@@ -138,22 +138,49 @@ const hasSections = headings.some((heading) => heading.depth === 2)
   }
 
   .docs {
+    --docs-nav-width: 13rem;
+    --docs-gap: 3rem;
     --subnav-height: 0rem;
+    isolation: isolate;
     position: relative;
     display: grid;
-    grid-template-columns: 13rem minmax(0, 48rem);
-    column-gap: 3rem;
-    align-items: start;
+    grid-template-columns:
+      var(--docs-nav-width)
+      minmax(0, calc(var(--frame-width) - var(--docs-nav-width) - var(--docs-gap)));
+    column-gap: var(--docs-gap);
     margin-block: 3rem;
   }
 
+  /* The column stretches with the article so the page list can stick
+   * for the whole page. Search stays in flow and scrolls away. Overflow
+   * stays visible so results can grow across the article. */
   .docs-pages {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow: visible;
+  }
+
+  .docs-pages :global(.docs-index) {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .docs-pages :global([data-docs-nav]) {
     position: sticky;
     top: calc(var(--site-nav-height) + var(--subnav-height));
     max-height: calc(100vh - var(--site-nav-height) - var(--subnav-height));
     overflow-y: auto;
     scrollbar-width: thin;
     padding-block-end: 2rem;
+  }
+
+  /* Results overlay the article from the nav's left edge. Isolation on
+   * .docs keeps this above in-page code frames and below the header. */
+  .docs-pages:has(.docs-search .results:not([hidden])) {
+    z-index: 1;
   }
 
   main {
@@ -295,14 +322,14 @@ const hasSections = headings.some((heading) => heading.depth === 2)
 </style>
 
 <script>
-  // Keep the current page visible inside the sidebar's own scroll area
+  // Keep the current page visible inside the page list's own scroll area
   // without moving the document.
-  const aside = document.querySelector(".docs-pages")
-  const link = aside?.querySelector("a[aria-current='page']")
-  if (aside instanceof HTMLElement && link instanceof HTMLElement) {
-    const linkTop = link.getBoundingClientRect().top - aside.getBoundingClientRect().top
-    if (linkTop < 0 || linkTop > aside.clientHeight - 48) {
-      aside.scrollTop += linkTop - aside.clientHeight / 3
+  const nav = document.querySelector(".docs-pages [data-docs-nav]")
+  const link = nav?.querySelector("a[aria-current='page']")
+  if (nav instanceof HTMLElement && link instanceof HTMLElement) {
+    const linkTop = link.getBoundingClientRect().top - nav.getBoundingClientRect().top
+    if (linkTop < 0 || linkTop > nav.clientHeight - 48) {
+      nav.scrollTop += linkTop - nav.clientHeight / 3
     }
   }
 

--- a/packages/web/src/lib/docs-headings.ts
+++ b/packages/web/src/lib/docs-headings.ts
@@ -1,0 +1,25 @@
+export function slugifyHeading(text: string): string {
+  return text
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/<([^>]+)>/g, "$1")
+    .replace(/[*~]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9_\s-]/g, "")
+    .trim()
+    .replace(/\s/g, "-")
+}
+
+export function getFenceMarker(line: string): { marker: string; length: number } | undefined {
+  const match = line.match(/^(`{3,}|~{3,})/)
+  if (!match) {
+    return undefined
+  }
+
+  return { marker: match[1][0], length: match[1].length }
+}
+
+export function closesFence(line: string, fence: { marker: string; length: number }): boolean {
+  const pattern = new RegExp(`^${fence.marker}{${fence.length},}\\s*$`)
+  return pattern.test(line)
+}

--- a/packages/web/src/lib/docs-search-index.ts
+++ b/packages/web/src/lib/docs-search-index.ts
@@ -21,7 +21,7 @@ export async function buildDocsSearchIndex(): Promise<SearchEntry[]> {
 }
 
 export function searchEntriesForPage(
-  page: Pick<DocPage, "title" | "url" | "description" | "searchSymbols">,
+  page: Pick<DocPage, "title" | "navTitle" | "url" | "description" | "searchSymbols">,
   content: string,
 ): SearchEntry[] {
   const sections = splitSections(page.title, content)
@@ -30,8 +30,10 @@ export function searchEntriesForPage(
   return sections.map((section, index) => ({
     chapter: page.title,
     title: section.title,
+    navTitle: section.anchor ? "" : page.navTitle,
     url: section.anchor ? `${page.url}#${section.anchor}` : page.url,
     text: index === 0 && extra ? joinText(section.text, extra) : section.text,
+    symbols: section.anchor ? [] : [...page.searchSymbols],
   }))
 }
 

--- a/packages/web/src/lib/docs-search-index.ts
+++ b/packages/web/src/lib/docs-search-index.ts
@@ -1,0 +1,229 @@
+import { readFile } from "node:fs/promises"
+import { basename, dirname, join } from "node:path"
+
+import { closesFence, getFenceMarker, slugifyHeading } from "./docs-headings"
+import { buildDocsIndex, type DocPage } from "./docs-index"
+import type { SearchEntry } from "./docs-search"
+
+const WORKING_DIRECTORY = process.cwd()
+const REPO_ROOT =
+  basename(WORKING_DIRECTORY) === "web" && basename(dirname(WORKING_DIRECTORY)) === "packages"
+    ? join(WORKING_DIRECTORY, "../..")
+    : WORKING_DIRECTORY
+
+let searchIndexPromise: Promise<SearchEntry[]> | undefined
+
+export async function buildDocsSearchIndex(): Promise<SearchEntry[]> {
+  if (import.meta.env.DEV) return loadDocsSearchIndex()
+
+  searchIndexPromise ??= loadDocsSearchIndex()
+  return searchIndexPromise
+}
+
+export function searchEntriesForPage(
+  page: Pick<DocPage, "title" | "url" | "description" | "searchSymbols">,
+  content: string,
+): SearchEntry[] {
+  const sections = splitSections(page.title, content)
+  const extra = extraSearchText(page)
+
+  return sections.map((section, index) => ({
+    chapter: page.title,
+    title: section.title,
+    url: section.anchor ? `${page.url}#${section.anchor}` : page.url,
+    text: index === 0 && extra ? joinText(section.text, extra) : section.text,
+  }))
+}
+
+async function loadDocsSearchIndex(): Promise<SearchEntry[]> {
+  const index = await buildDocsIndex()
+  const entries: SearchEntry[] = []
+
+  for (const page of index.pages) {
+    const source = await readFile(join(REPO_ROOT, page.sourcePath), "utf8")
+    entries.push(...searchEntriesForPage(page, stripFrontmatter(source)))
+  }
+
+  return entries
+}
+
+interface Section {
+  title: string
+  anchor: string
+  text: string
+}
+
+function splitSections(pageTitle: string, content: string): Section[] {
+  const sections: Section[] = []
+  const anchorCounts = new Map<string, number>()
+  let current: { title: string; anchor: string; lines: string[] } | undefined
+  let fence: { marker: string; length: number } | undefined
+  let jsx = 0
+
+  const flush = () => {
+    if (!current) return
+    const text = toSearchText(current.lines.join("\n"))
+    // Drop an empty preamble before the first heading. The page title
+    // still gets an entry after the loop if none remains.
+    if (text || current.anchor) {
+      sections.push({ title: current.title, anchor: current.anchor, text })
+    }
+    current = undefined
+  }
+
+  for (const rawLine of content.replace(/\r\n/g, "\n").split("\n")) {
+    const trimmed = rawLine.trim()
+    if (!trimmed && !fence && jsx === 0) continue
+
+    const fenceMarker = getFenceMarker(trimmed)
+
+    if (!fence && fenceMarker) {
+      fence = fenceMarker
+      current?.lines.push(rawLine)
+      continue
+    }
+
+    if (fence && closesFence(trimmed, fence)) {
+      fence = undefined
+      current?.lines.push(rawLine)
+      continue
+    }
+
+    if (fence) {
+      current?.lines.push(rawLine)
+      continue
+    }
+
+    if (jsx > 0) {
+      jsx += jsxDelta(rawLine)
+      continue
+    }
+
+    if (isSkippedLine(trimmed)) {
+      continue
+    }
+
+    if (/^<[A-Z]/.test(trimmed)) {
+      jsx = Math.max(0, jsx + jsxDelta(rawLine))
+      continue
+    }
+
+    const heading = trimmed.match(/^(#{1,6})\s+(.*)$/)
+    if (heading) {
+      const depth = heading[1].length
+      const title = headingText(heading[2])
+      if (!title) continue
+
+      flush()
+
+      if (depth === 1) {
+        current = { title: pageTitle, anchor: "", lines: [] }
+        continue
+      }
+
+      const baseAnchor = slugifyHeading(heading[2])
+      const duplicateIndex = anchorCounts.get(baseAnchor) ?? 0
+      anchorCounts.set(baseAnchor, duplicateIndex + 1)
+
+      current = {
+        title,
+        anchor: duplicateIndex === 0 ? baseAnchor : `${baseAnchor}-${duplicateIndex}`,
+        lines: [],
+      }
+      continue
+    }
+
+    current ??= { title: pageTitle, anchor: "", lines: [] }
+    current.lines.push(rawLine)
+  }
+
+  flush()
+  if (sections.length === 0 || sections[0].anchor) {
+    sections.unshift({ title: pageTitle, anchor: "", text: "" })
+  }
+  return sections
+}
+
+function toSearchText(source: string): string {
+  const lines: string[] = []
+  let fence: { marker: string; length: number } | undefined
+
+  for (const rawLine of source.split("\n")) {
+    const trimmed = rawLine.trim()
+    const fenceMarker = getFenceMarker(trimmed)
+
+    if (!fence && fenceMarker) {
+      fence = fenceMarker
+      continue
+    }
+
+    if (fence && closesFence(trimmed, fence)) {
+      fence = undefined
+      continue
+    }
+
+    if (fence) {
+      if (trimmed) lines.push(trimmed)
+      continue
+    }
+
+    if (!trimmed || isSkippedLine(trimmed) || isTableRule(trimmed)) {
+      continue
+    }
+
+    const stripped = stripMarkup(trimmed)
+    if (stripped) lines.push(stripped)
+  }
+
+  return joinText(...lines)
+}
+
+function stripMarkup(line: string): string {
+  return line
+    .replace(/^\s*[-*+]\s+/, "")
+    .replace(/^\s*\d+\.\s+/, "")
+    .replace(/^\s*\|/, "")
+    .replace(/\|\s*$/, "")
+    .replace(/\|/g, " ")
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    .replace(/~~([^~]+)~~/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function headingText(raw: string): string {
+  return stripMarkup(raw.replace(/\s*\{#[^}]+\}\s*$/, ""))
+}
+
+function extraSearchText(page: Pick<DocPage, "description" | "searchSymbols">): string {
+  return joinText(page.description ?? "", ...page.searchSymbols)
+}
+
+function joinText(...parts: string[]): string {
+  return parts.join(" ").replace(/\s+/g, " ").trim()
+}
+
+function stripFrontmatter(source: string): string {
+  return source.replace(/\r\n/g, "\n").replace(/^---\n[\s\S]*?\n---\n?/, "")
+}
+
+function isSkippedLine(line: string): boolean {
+  return /^import\s/.test(line) || /^export\s/.test(line) || /^\{[\s/*]/.test(line)
+}
+
+function isTableRule(line: string): boolean {
+  return /^\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?$/.test(line)
+}
+
+function jsxDelta(line: string): number {
+  const open = line.match(/<[A-Z][A-Za-z0-9.]*/g)?.length ?? 0
+  const selfClose = line.match(/\/>/g)?.length ?? 0
+  const close = line.match(/<\/[A-Z][A-Za-z0-9.]*>/g)?.length ?? 0
+  return open - selfClose - close
+}

--- a/packages/web/src/lib/docs-search.test.ts
+++ b/packages/web/src/lib/docs-search.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, test } from "bun:test"
+import { beforeAll, describe, expect, test } from "bun:test"
 
 import { buildDocsSearchIndex, searchEntriesForPage } from "./docs-search-index"
-import { highlightParts, lookup, preview } from "./docs-search"
+import { highlightParts, lookup, preview, score, type SearchEntry } from "./docs-search"
 
 const rendererPage = {
   title: "Renderer",
+  navTitle: "Renderer",
   url: "/docs/core-concepts/renderer" as const,
   description: "Create a CliRenderer, attach its root, and choose a render schedule",
   searchSymbols: ["CliRenderer", "createCliRenderer"],
@@ -51,6 +52,10 @@ describe("documentation search index", () => {
 
     expect(entries[0].text).toContain("CliRenderer owns one terminal session")
     expect(entries[0].text).toContain("createCliRenderer")
+    expect(entries[0].navTitle).toBe("Renderer")
+    expect(entries[0].symbols).toEqual(["CliRenderer", "createCliRenderer"])
+    expect(entries[1].navTitle).toBe("")
+    expect(entries[1].symbols).toEqual([])
     expect(entries[1].text).toContain("const renderer = await createCliRenderer()")
     expect(entries.some((entry) => entry.text.includes("Foo from"))).toBe(false)
     expect(entries.some((entry) => entry.text.includes("should not be indexed"))).toBe(false)
@@ -60,6 +65,7 @@ describe("documentation search index", () => {
     const entries = searchEntriesForPage(
       {
         title: "Input",
+        navTitle: "Input",
         url: "/docs/components/input",
         description: "One line of text",
         searchSymbols: ["InputRenderable"],
@@ -70,8 +76,10 @@ describe("documentation search index", () => {
     expect(entries[0]).toEqual({
       chapter: "Input",
       title: "Input",
+      navTitle: "Input",
       url: "/docs/components/input",
       text: "One line of text InputRenderable",
+      symbols: ["InputRenderable"],
     })
     expect(entries[1]?.url).toBe("/docs/components/input#availability")
   })
@@ -116,3 +124,149 @@ describe("documentation search matching", () => {
     )
   })
 })
+
+describe("documentation search ranking", () => {
+  const pattern = (query: string) => {
+    const [match] = lookup(
+      [entry({ title: "Probe", url: "/docs/probe", text: query, navTitle: query, symbols: [query] })],
+      query,
+    )
+    if (!match) throw new Error(`expected a pattern for ${query}`)
+    return match.pattern
+  }
+
+  test("identity bands cannot be crossed by body frequency", () => {
+    const react = pattern("react")
+    const page = entry({
+      title: "React bindings",
+      navTitle: "React",
+      url: "/docs/bindings/react",
+      text: "React",
+    })
+    const heading = entry({
+      title: "What React adds",
+      url: "/docs/plugins/react#what-react-adds",
+      text: "React ".repeat(50),
+    })
+    const noisy = entry({
+      title: "Unrelated",
+      url: "/docs/unrelated",
+      text: "React ".repeat(50),
+    })
+
+    expect(score(page, react)).toBeGreaterThan(score(heading, react))
+    expect(score(heading, react)).toBeGreaterThan(score(noisy, react))
+  })
+
+  test("an exact page title beats an exact heading title", () => {
+    const input = pattern("input")
+    const page = entry({ title: "Input", url: "/docs/components/input" })
+    const heading = entry({ title: "Input", url: "/docs/core-concepts/keyboard#input" })
+
+    expect(score(page, input)).toBeGreaterThan(score(heading, input))
+  })
+
+  test("among pages with the same nav title, the shorter page title wins", () => {
+    const react = pattern("react")
+    const nav = entry({ title: "React bindings", navTitle: "React", url: "/docs/bindings/react" })
+    const longer = entry({ title: "React keymap integration", navTitle: "React", url: "/docs/keymap/react" })
+
+    expect(score(nav, react)).toBeGreaterThan(score(longer, react))
+  })
+
+  test("an exact symbol beats a body mention of that symbol", () => {
+    const query = pattern("createCliRenderer")
+    const page = entry({
+      title: "Renderer",
+      url: "/docs/core-concepts/renderer",
+      symbols: ["createCliRenderer"],
+    })
+    const other = entry({
+      title: "Getting started",
+      url: "/docs",
+      symbols: ["createCliRenderer"],
+    })
+    const mention = entry({
+      title: "Quick start",
+      url: "/docs/bindings/react#quick-start",
+      text: "createCliRenderer ".repeat(20),
+    })
+
+    expect(score(page, query)).toBeGreaterThan(score(other, query))
+    expect(score(other, query)).toBeGreaterThan(score(mention, query))
+  })
+
+  test("a shorter title that still contains every term ranks above a longer one", () => {
+    const create = pattern("create")
+    const short = entry({ title: "Create a renderer", url: "/docs/core-concepts/renderer#create-a-renderer" })
+    const long = entry({
+      title: "Create a renderer with extra options",
+      url: "/docs/core-concepts/renderer#create-a-renderer-with-extra-options",
+    })
+
+    expect(score(short, create)).toBeGreaterThan(score(long, create))
+  })
+
+  test("a prefix of a page title beats a one-word heading with the same prefix", () => {
+    const rea = pattern("rea")
+    const page = entry({ title: "React bindings", navTitle: "React", url: "/docs/bindings/react" })
+    const heading = entry({ title: "React", url: "/docs/components/image#react" })
+    const farther = entry({ title: "Reading", url: "/docs/core-concepts/clipboard#reading" })
+
+    expect(score(page, rea)).toBeGreaterThan(score(heading, rea))
+    expect(score(heading, rea)).toBeGreaterThan(score(farther, rea))
+  })
+})
+
+describe("documentation search ranking against the published index", () => {
+  let entries: SearchEntry[]
+
+  beforeAll(async () => {
+    entries = await buildDocsSearchIndex()
+  })
+
+  test("react prefers the React bindings page over sections that repeat the word", () => {
+    const urls = lookup(entries, "react")
+      .slice(0, 8)
+      .map((match) => match.entry.url)
+
+    expect(urls[0]).toBe("/docs/bindings/react")
+    expect(urls).toContain("/docs/keymap/react")
+    expect(urls).toContain("/docs/plugins/react")
+    expect(urls.indexOf("/docs/keymap/react")).toBeGreaterThan(0)
+    expect(urls.findIndex((url) => url.includes("#"))).toBeGreaterThan(urls.indexOf("/docs/bindings/react"))
+  })
+
+  test("topic queries prefer the canonical page over a heading of the same name", () => {
+    expect(lookup(entries, "input")[0]?.entry.url).toBe("/docs/components/input")
+    expect(lookup(entries, "renderer")[0]?.entry.url).toBe("/docs/core-concepts/renderer")
+    expect(lookup(entries, "keymap")[0]?.entry.url).toBe("/docs/keymap/overview")
+    expect(lookup(entries, "solid")[0]?.entry.url).toBe("/docs/bindings/solid")
+  })
+
+  test("symbol queries prefer the page that owns the symbol", () => {
+    expect(lookup(entries, "createCliRenderer")[0]?.entry.url).toBe("/docs/core-concepts/renderer")
+    expect(lookup(entries, "InputRenderable")[0]?.entry.url).toBe("/docs/components/input")
+  })
+
+  test("multi-word queries prefer the heading that names the phrase", () => {
+    expect(lookup(entries, "react bindings")[0]?.entry.url).toBe("/docs/bindings/react")
+    expect(lookup(entries, "react keymap")[0]?.entry.url).toBe("/docs/keymap/react")
+    expect(lookup(entries, "create renderer")[0]?.entry.url).toBe("/docs/core-concepts/renderer#create-a-renderer")
+  })
+
+  test("partial queries prefer the nearest page title over a one-word heading", () => {
+    expect(lookup(entries, "rea")[0]?.entry.url).toBe("/docs/bindings/react")
+    expect(lookup(entries, "reac")[0]?.entry.url).toBe("/docs/bindings/react")
+  })
+})
+
+function entry(partial: Partial<SearchEntry> & Pick<SearchEntry, "title" | "url">): SearchEntry {
+  return {
+    chapter: partial.chapter ?? partial.title,
+    navTitle: partial.navTitle ?? "",
+    text: partial.text ?? "",
+    symbols: partial.symbols ?? [],
+    ...partial,
+  }
+}

--- a/packages/web/src/lib/docs-search.test.ts
+++ b/packages/web/src/lib/docs-search.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test"
+
+import { buildDocsSearchIndex, searchEntriesForPage } from "./docs-search-index"
+import { highlightParts, lookup, preview } from "./docs-search"
+
+const rendererPage = {
+  title: "Renderer",
+  url: "/docs/core-concepts/renderer" as const,
+  description: "Create a CliRenderer, attach its root, and choose a render schedule",
+  searchSymbols: ["CliRenderer", "createCliRenderer"],
+}
+
+const rendererSource = `
+import Foo from "bar"
+
+# Renderer
+
+\`CliRenderer\` owns one terminal session.
+
+## Create a renderer
+
+\`createCliRenderer()\` runs asynchronous terminal setup.
+
+\`\`\`typescript
+const renderer = await createCliRenderer()
+\`\`\`
+
+### Nested details
+
+The root always tracks the render width.
+
+<ScrollbackRecording
+  label="should not be indexed"
+/>
+
+## Choose a screen mode
+
+\`screenMode\` controls which terminal area OpenTUI owns. \`split-footer\` uses a footer.
+`.trim()
+
+describe("documentation search index", () => {
+  test("splits pages on headings and strips markup, imports, and components", () => {
+    const entries = searchEntriesForPage(rendererPage, rendererSource)
+
+    expect(entries.map((entry) => ({ title: entry.title, url: entry.url }))).toEqual([
+      { title: "Renderer", url: "/docs/core-concepts/renderer" },
+      { title: "Create a renderer", url: "/docs/core-concepts/renderer#create-a-renderer" },
+      { title: "Nested details", url: "/docs/core-concepts/renderer#nested-details" },
+      { title: "Choose a screen mode", url: "/docs/core-concepts/renderer#choose-a-screen-mode" },
+    ])
+
+    expect(entries[0].text).toContain("CliRenderer owns one terminal session")
+    expect(entries[0].text).toContain("createCliRenderer")
+    expect(entries[1].text).toContain("const renderer = await createCliRenderer()")
+    expect(entries.some((entry) => entry.text.includes("Foo from"))).toBe(false)
+    expect(entries.some((entry) => entry.text.includes("should not be indexed"))).toBe(false)
+  })
+
+  test("keeps a page-level entry when the title has no body of its own", () => {
+    const entries = searchEntriesForPage(
+      {
+        title: "Input",
+        url: "/docs/components/input",
+        description: "One line of text",
+        searchSymbols: ["InputRenderable"],
+      },
+      "# Input\n\n## Availability\n\n`InputRenderable` is built in.\n",
+    )
+
+    expect(entries[0]).toEqual({
+      chapter: "Input",
+      title: "Input",
+      url: "/docs/components/input",
+      text: "One line of text InputRenderable",
+    })
+    expect(entries[1]?.url).toBe("/docs/components/input#availability")
+  })
+
+  test("indexes published documentation pages", async () => {
+    const entries = await buildDocsSearchIndex()
+    expect(entries.length).toBeGreaterThan(100)
+    expect(entries.some((entry) => entry.url === "/docs" && entry.title === "Getting started")).toBe(true)
+    expect(entries.some((entry) => entry.url.startsWith("/docs/core-concepts/renderer#"))).toBe(true)
+  })
+})
+
+describe("documentation search matching", () => {
+  const entries = searchEntriesForPage(rendererPage, rendererSource)
+
+  test("matches from the start of a word and ranks headings above body text", () => {
+    const [first] = lookup(entries, "create")
+
+    expect(first?.entry.title).toBe("Create a renderer")
+    expect(lookup(entries, "ender")).toEqual([])
+  })
+
+  test("treats hyphens in the text as optional", () => {
+    expect(lookup(entries, "splitfooter")[0]?.entry.title).toBe("Choose a screen mode")
+  })
+
+  test("requires every term and prefers a contiguous phrase", () => {
+    const matches = lookup(entries, "create renderer")
+
+    expect(matches[0]?.entry.title).toBe("Create a renderer")
+    expect(lookup(entries, "create missing")).toEqual([])
+  })
+
+  test("builds a preview around the first match and marks the hit", () => {
+    const [match] = lookup(entries, "screenMode")
+    if (!match) throw new Error("expected a match")
+
+    const snippet = preview(match.entry.text, match.pattern)
+    expect(snippet).toContain("screenMode")
+    expect(highlightParts(snippet, match.pattern).some((part) => part.mark && part.text.startsWith("screenMode"))).toBe(
+      true,
+    )
+  })
+})

--- a/packages/web/src/lib/docs-search.ts
+++ b/packages/web/src/lib/docs-search.ts
@@ -1,0 +1,118 @@
+export interface SearchEntry {
+  chapter: string
+  title: string
+  url: string
+  text: string
+}
+
+export interface SearchTerm {
+  anywhere: RegExp
+  whole: RegExp
+}
+
+export interface SearchPattern {
+  terms: SearchTerm[]
+  phrase: string
+  first: RegExp
+  words: RegExp
+}
+
+export interface SearchMatch {
+  entry: SearchEntry
+  pattern: SearchPattern
+  score: number
+}
+
+export interface HighlightPart {
+  text: string
+  mark: boolean
+}
+
+const PREVIEW_LENGTH = 160
+
+export function lookup(entries: SearchEntry[], query: string): SearchMatch[] {
+  const pattern = compile(query)
+  if (!pattern) return []
+
+  return entries
+    .map((entry) => ({ entry, pattern, score: score(entry, pattern) }))
+    .filter((match) => match.score > 0)
+    .sort((a, b) => b.score - a.score || a.entry.url.localeCompare(b.entry.url))
+}
+
+export function compile(query: string): SearchPattern | null {
+  const sources = tokenize(query).map(quote)
+  if (!sources.length) return null
+
+  return {
+    terms: sources.map((source) => ({
+      anywhere: matcher(source, "giu"),
+      whole: matcher(`${source}(?![\\p{L}\\p{N}])`, "iu"),
+    })),
+    phrase: query.toLowerCase(),
+    first: matcher(`(?:${sources.join("|")})`, "iu"),
+    words: matcher(`(${sources.map((source) => `${source}[\\p{L}\\p{N}]*`).join("|")})`, "giu"),
+  }
+}
+
+export function tokenize(query: string): string[] {
+  return query
+    .toLowerCase()
+    .split(/[^\p{L}\p{N}+#_-]+/u)
+    .filter(Boolean)
+}
+
+export function preview(text: string, pattern: SearchPattern): string {
+  const at = text.search(pattern.first)
+  const start = Math.max(0, at - PREVIEW_LENGTH / 3)
+  let snippet = text.slice(start, start + PREVIEW_LENGTH)
+
+  if (start > 0) snippet = `…${snippet.replace(/^\S*\s/, "")}`
+  if (start + PREVIEW_LENGTH < text.length) snippet = `${snippet.replace(/\s\S*$/, "")}…`
+
+  return snippet
+}
+
+export function highlightParts(text: string, pattern: SearchPattern): HighlightPart[] {
+  return text.split(pattern.words).map((part, index) => ({
+    text: part,
+    mark: index % 2 === 1,
+  }))
+}
+
+function score(entry: SearchEntry, pattern: SearchPattern): number {
+  let total = 0
+
+  for (const term of pattern.terms) {
+    const inTitle = occurrences(entry.title, term.anywhere)
+    const inText = occurrences(entry.text, term.anywhere)
+
+    if (!inTitle && !inText) return 0
+
+    total += inTitle * 30 + Math.min(inText, 5) * 2 + occurrences(entry.chapter, term.anywhere) * 10
+
+    term.whole.lastIndex = 0
+    if (term.whole.test(entry.title)) total += 20
+  }
+
+  if (pattern.terms.length > 1 && phrased(entry, pattern.phrase)) total += 40
+
+  return total
+}
+
+function occurrences(text: string, term: RegExp): number {
+  term.lastIndex = 0
+  return (text.match(term) || []).length
+}
+
+function phrased(entry: SearchEntry, phrase: string): boolean {
+  return `${entry.title} ${entry.chapter} ${entry.text}`.toLowerCase().includes(phrase)
+}
+
+function matcher(source: string, flags: string): RegExp {
+  return new RegExp(`(?<![\\p{L}\\p{N}])${source}`, flags)
+}
+
+function quote(term: string): string {
+  return [...term].map((character) => character.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("-?")
+}

--- a/packages/web/src/lib/docs-search.ts
+++ b/packages/web/src/lib/docs-search.ts
@@ -1,20 +1,17 @@
 export interface SearchEntry {
   chapter: string
   title: string
+  navTitle: string
   url: string
   text: string
-}
-
-export interface SearchTerm {
-  anywhere: RegExp
-  whole: RegExp
+  symbols: string[]
 }
 
 export interface SearchPattern {
-  terms: SearchTerm[]
-  phrase: string
+  tokens: string[]
   first: RegExp
   words: RegExp
+  anywhere: RegExp[]
 }
 
 export interface SearchMatch {
@@ -30,6 +27,19 @@ export interface HighlightPart {
 
 const PREVIEW_LENGTH = 160
 
+// Identity bands. A lower band cannot outrank a higher one by repeating a
+// term in the body. Prefix matches keep pages above headings, so "rea"
+// prefers React bindings over a one-word React heading.
+const KIND_EXACT_PAGE_TITLE = 9
+const KIND_EXACT_PAGE_NAV = 8
+const KIND_EXACT_HEADING_TITLE = 7
+const KIND_EXACT_PAGE_SYMBOL = 6
+const KIND_WHOLE_PAGE_TITLE = 5
+const KIND_WHOLE_HEADING_TITLE = 4
+const KIND_PREFIX_PAGE_TITLE = 3
+const KIND_PREFIX_HEADING_TITLE = 2
+const KIND_BODY = 1
+
 export function lookup(entries: SearchEntry[], query: string): SearchMatch[] {
   const pattern = compile(query)
   if (!pattern) return []
@@ -41,15 +51,13 @@ export function lookup(entries: SearchEntry[], query: string): SearchMatch[] {
 }
 
 export function compile(query: string): SearchPattern | null {
-  const sources = tokenize(query).map(quote)
+  const tokens = tokenize(query)
+  const sources = tokens.map(quote)
   if (!sources.length) return null
 
   return {
-    terms: sources.map((source) => ({
-      anywhere: matcher(source, "giu"),
-      whole: matcher(`${source}(?![\\p{L}\\p{N}])`, "iu"),
-    })),
-    phrase: query.toLowerCase(),
+    tokens,
+    anywhere: sources.map((source) => matcher(source, "giu")),
     first: matcher(`(?:${sources.join("|")})`, "iu"),
     words: matcher(`(${sources.map((source) => `${source}[\\p{L}\\p{N}]*`).join("|")})`, "giu"),
   }
@@ -80,33 +88,132 @@ export function highlightParts(text: string, pattern: SearchPattern): HighlightP
   }))
 }
 
-function score(entry: SearchEntry, pattern: SearchPattern): number {
-  let total = 0
+export function score(entry: SearchEntry, pattern: SearchPattern): number {
+  if (!covers(entry, pattern)) return 0
 
-  for (const term of pattern.terms) {
-    const inTitle = occurrences(entry.title, term.anywhere)
-    const inText = occurrences(entry.text, term.anywhere)
-
-    if (!inTitle && !inText) return 0
-
-    total += inTitle * 30 + Math.min(inText, 5) * 2 + occurrences(entry.chapter, term.anywhere) * 10
-
-    term.whole.lastIndex = 0
-    if (term.whole.test(entry.title)) total += 20
+  const page = isPage(entry)
+  const title = tokenize(entry.title)
+  const nav = tokenize(entry.navTitle)
+  const titleRemainder = prefixRemainder(pattern.tokens, title)
+  const navRemainder = page ? prefixRemainder(pattern.tokens, nav) : undefined
+  const kind = matchKind(entry, pattern, page, title, nav, titleRemainder, navRemainder)
+  let tightness = 0
+  if (titleRemainder !== undefined) tightness = 4000 - titleRemainder * 20 - title.length
+  else if (navRemainder !== undefined) tightness = 3800 - navRemainder * 20 - nav.length
+  else if (page && exactSymbol(pattern.tokens, entry.symbols)) {
+    tightness = symbolAffinity(entry.title, entry.navTitle, pattern.tokens)
   }
 
-  if (pattern.terms.length > 1 && phrased(entry, pattern.phrase)) total += 40
+  return kind * 1_000_000 + tightness * 1_000
+}
+
+function covers(entry: SearchEntry, pattern: SearchPattern): boolean {
+  const page = isPage(entry)
+
+  for (const term of pattern.anywhere) {
+    if (hit(entry.title, term)) continue
+    if (hit(entry.text, term)) continue
+    if (page && hit(entry.navTitle, term)) continue
+    if (page && entry.symbols.some((symbol) => hit(symbol, term))) continue
+    return false
+  }
+
+  return true
+}
+
+function matchKind(
+  entry: SearchEntry,
+  pattern: SearchPattern,
+  page: boolean,
+  title: string[],
+  nav: string[],
+  titleRemainder: number | undefined,
+  navRemainder: number | undefined,
+): number {
+  if (sameTokens(pattern.tokens, title)) {
+    return page ? KIND_EXACT_PAGE_TITLE : KIND_EXACT_HEADING_TITLE
+  }
+
+  if (page && sameTokens(pattern.tokens, nav)) {
+    return KIND_EXACT_PAGE_NAV
+  }
+
+  if (page && exactSymbol(pattern.tokens, entry.symbols)) {
+    return KIND_EXACT_PAGE_SYMBOL
+  }
+
+  if (allWholeTokens(pattern.tokens, title) || (page && allWholeTokens(pattern.tokens, nav))) {
+    return page ? KIND_WHOLE_PAGE_TITLE : KIND_WHOLE_HEADING_TITLE
+  }
+
+  if (titleRemainder !== undefined || navRemainder !== undefined) {
+    return page ? KIND_PREFIX_PAGE_TITLE : KIND_PREFIX_HEADING_TITLE
+  }
+
+  return KIND_BODY
+}
+
+function symbolAffinity(title: string, navTitle: string, query: string[]): number {
+  const foldedQuery = query.map(normalizeToken).join("")
+  const titleFolded = tokenize(title).map(normalizeToken).join("")
+  const navFolded = tokenize(navTitle).map(normalizeToken).join("")
+
+  if (titleFolded && foldedQuery.includes(titleFolded)) return 800 - titleFolded.length
+  if (navFolded && foldedQuery.includes(navFolded)) return 700 - navFolded.length
+  return 0
+}
+
+function isPage(entry: SearchEntry): boolean {
+  return !entry.url.includes("#")
+}
+
+function hit(text: string, term: RegExp): boolean {
+  term.lastIndex = 0
+  return term.test(text)
+}
+
+function sameTokens(left: string[], right: string[]): boolean {
+  return (
+    left.length === right.length && left.every((token, index) => normalizeToken(token) === normalizeToken(right[index]))
+  )
+}
+
+function allWholeTokens(query: string[], field: string[]): boolean {
+  const haystack = new Set(field.map(normalizeToken))
+  return query.every((token) => haystack.has(normalizeToken(token)))
+}
+
+function prefixRemainder(query: string[], field: string[]): number | undefined {
+  const haystack = field.map(normalizeToken)
+  let total = 0
+
+  for (const token of query) {
+    const needle = normalizeToken(token)
+    let best: number | undefined
+
+    for (const candidate of haystack) {
+      if (!candidate.startsWith(needle)) continue
+      const remainder = candidate.length - needle.length
+      if (best === undefined || remainder < best) best = remainder
+    }
+
+    if (best === undefined) return undefined
+    total += best
+  }
 
   return total
 }
 
-function occurrences(text: string, term: RegExp): number {
-  term.lastIndex = 0
-  return (text.match(term) || []).length
+function exactSymbol(query: string[], symbols: string[]): boolean {
+  const foldedQuery = query.map(normalizeToken).join("")
+
+  return symbols.some((symbol) => {
+    return sameTokens(query, tokenize(symbol)) || normalizeToken(symbol) === foldedQuery
+  })
 }
 
-function phrased(entry: SearchEntry, phrase: string): boolean {
-  return `${entry.title} ${entry.chapter} ${entry.text}`.toLowerCase().includes(phrase)
+function normalizeToken(token: string): string {
+  return token.toLowerCase().replace(/-/g, "")
 }
 
 function matcher(source: string, flags: string): RegExp {

--- a/packages/web/src/pages/docs/search-index.json.ts
+++ b/packages/web/src/pages/docs/search-index.json.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro"
+
+import { buildDocsSearchIndex } from "../../lib/docs-search-index"
+
+export const GET: APIRoute = async () => {
+  const entries = await buildDocsSearchIndex()
+  return new Response(JSON.stringify(entries), {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+    },
+  })
+}


### PR DESCRIPTION
Let readers find relevant API details without manually scanning the
documentation tree. Return ranked section links with matching context.
