### PR TITLE
fix(core): keep blank rows when assembling selected text

### DIFF
--- a/packages/core/src/Renderable.ts
+++ b/packages/core/src/Renderable.ts
@@ -392,6 +392,16 @@ export abstract class Renderable extends BaseRenderable {
     return ""
   }
 
+  public getSelectedVisualLineSpan(): { first: number; last: number } | null {
+    return null
+  }
+
+  public getSelectedTextSegments(): Array<{ row: number; text: string }> {
+    const text = this.getSelectedText()
+    if (!text) return []
+    return text.split("\n").map((line, index) => ({ row: index, text: line }))
+  }
+
   public shouldStartSelection(x: number, y: number): boolean {
     return false
   }

--- a/packages/core/src/lib/selection.ts
+++ b/packages/core/src/lib/selection.ts
@@ -124,27 +124,45 @@ export class Selection {
       })
       .filter((renderable) => !renderable.isDestroyed)
 
+    const ownersByY = new Map<number, Array<{ first: number; last: number }>>()
     for (const renderable of selectedRenderables) {
-      const text = renderable.getSelectedText()
-      if (!text) continue
-      const lines = text.split("\n")
-      for (let index = 0; index < lines.length; index += 1) {
-        const y = renderable.y + index
+      const segments = renderable.getSelectedTextSegments()
+      if (segments.length === 0) continue
+      const span = renderable.getSelectedVisualLineSpan()
+      const first = span?.first ?? segments[0].row
+      const last = Math.max(span?.last ?? segments[0].row, segments[segments.length - 1].row)
+      const owner = { first: renderable.y + first, last: renderable.y + last }
+      for (const segment of segments) {
+        const y = renderable.y + segment.row
         const line = selectedTextsByLine.get(y) ?? []
-        line.push({ x: renderable.x, text: lines[index] })
+        line.push({ x: renderable.x, text: segment.text })
         selectedTextsByLine.set(y, line)
+        const owners = ownersByY.get(y) ?? []
+        owners.push(owner)
+        ownersByY.set(y, owners)
       }
     }
 
-    return [...selectedTextsByLine.entries()]
-      .sort(([leftY], [rightY]) => leftY - rightY)
-      .map(([, line]) =>
-        line
+    const occupied = [...selectedTextsByLine.entries()].sort(([leftY], [rightY]) => leftY - rightY)
+    if (occupied.length === 0) return ""
+
+    const assembled: string[] = []
+    let previousY = occupied[0][0]
+    for (const [y, segments] of occupied) {
+      const previousOwners = ownersByY.get(previousY) ?? []
+      for (let gap = previousY + 1; gap < y; gap++) {
+        const ownedByPrevious = previousOwners.some((owner) => gap >= owner.first && gap <= owner.last)
+        if (!ownedByPrevious) assembled.push("")
+      }
+      assembled.push(
+        segments
           .sort((left, right) => left.x - right.x)
           .map((segment) => segment.text)
           .join(""),
       )
-      .join("\n")
+      previousY = y
+    }
+    return assembled.join("\n")
   }
 }
 

--- a/packages/core/src/renderables/TextBufferRenderable.ts
+++ b/packages/core/src/renderables/TextBufferRenderable.ts
@@ -445,6 +445,55 @@ export abstract class TextBufferRenderable extends Renderable implements LineInf
     return this.textBufferView.getSelectedText()
   }
 
+  getSelectedVisualLineSpan(): { first: number; last: number } | null {
+    const selection = this.textBufferView.getSelection()
+    if (!selection) return null
+
+    const starts = this.textBufferView.lineInfo.lineStartCols
+    if (starts.length === 0) return null
+
+    let first = -1
+    let last = -1
+    for (let index = 0; index < starts.length; index++) {
+      const lineStart = starts[index]
+      const lineEnd = index + 1 < starts.length ? starts[index + 1] : Number.POSITIVE_INFINITY
+      if (lineStart < selection.end && lineEnd > selection.start) {
+        if (first < 0) first = index
+        last = index
+      }
+    }
+    if (first < 0) return null
+    return { first, last }
+  }
+
+  getSelectedTextSegments(): Array<{ row: number; text: string }> {
+    const text = this.getSelectedText()
+    if (!text) return []
+    const lines = text.split("\n")
+    const span = this.getSelectedVisualLineSpan()
+    const sources = this.textBufferView.lineInfo.lineSources
+    if (!span || sources.length === 0) {
+      return lines.map((line, index) => ({ row: index, text: line }))
+    }
+
+    const segments: Array<{ row: number; text: string }> = []
+    const seen = new Set<number>()
+    let logical = 0
+    for (let index = span.first; index <= span.last; index++) {
+      const source = sources[index]
+      if (seen.has(source)) continue
+      seen.add(source)
+      const piece = lines[logical++]
+      if (piece === undefined) break
+      segments.push({ row: index, text: piece })
+    }
+    let row = span.last + 1
+    while (logical < lines.length) {
+      segments.push({ row: row++, text: lines[logical++] })
+    }
+    return segments
+  }
+
   hasSelection(): boolean {
     return this.textBufferView.hasSelection()
   }

--- a/packages/core/src/renderables/__tests__/Markdown.test.ts
+++ b/packages/core/src/renderables/__tests__/Markdown.test.ts
@@ -1424,6 +1424,28 @@ test("selection across top-level ordered list copies marker and text on same lin
   expect(renderer.getSelection()?.getSelectedText()).toBe(" 9. Nine\n10. Ten")
 })
 
+test("selection across markdown paragraphs preserves the blank line", async () => {
+  const md = createMarkdownRenderable({
+    id: "markdown-paragraph-selection-blank-line",
+    content: `First paragraph.
+
+Second paragraph.`,
+    syntaxStyle,
+  })
+
+  renderer.root.add(md)
+  await renderMarkdownRenderable(md)
+
+  expect(md._blockStates).toHaveLength(1)
+  const block = md._blockStates[0]?.renderable
+  expect(block).toBeDefined()
+
+  await mockMouse.drag(block!.x, block!.y, block!.x + 20, block!.y + 2)
+  await renderer.idle()
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe("First paragraph.\n\nSecond paragraph.")
+})
+
 test("top-level structured lists align nested fenced code under nested content", async () => {
   const md = createMarkdownRenderable({
     id: "markdown-structured-list-code",

--- a/packages/core/src/tests/renderer.selection.test.ts
+++ b/packages/core/src/tests/renderer.selection.test.ts
@@ -82,6 +82,7 @@ test("selected text joins same-row renderables without newlines", () => {
 test("selected text keeps newlines between different rows", () => {
   const top = new TextRenderable(renderer, {
     content: "First row",
+    position: "absolute",
     left: 0,
     top: 0,
     width: 9,
@@ -90,6 +91,7 @@ test("selected text keeps newlines between different rows", () => {
   })
   const bottom = new TextRenderable(renderer, {
     content: "Second row",
+    position: "absolute",
     left: 0,
     top: 1,
     width: 10,
@@ -100,6 +102,8 @@ test("selected text keeps newlines between different rows", () => {
   renderer.root.add(top)
   renderer.root.add(bottom)
   renderOnce()
+
+  expect(bottom.y).toBe(top.y + 1)
 
   renderer.startSelection(top, top.x, top.y)
   renderer.updateSelection(bottom, bottom.x + bottom.width, bottom.y, { finishDragging: true })
@@ -135,4 +139,250 @@ test("selected text merges multiline same-row renderables by visual row", () => 
   renderer.updateSelection(right, right.x + right.width, right.y + 1, { finishDragging: true })
 
   expect(renderer.getSelection()?.getSelectedText()).toBe("A1\nB2")
+})
+
+test("selected text preserves blank rows between vertically gapped renderables", () => {
+  const top = new TextRenderable(renderer, {
+    content: "First paragraph",
+    position: "absolute",
+    left: 0,
+    top: 0,
+    width: 20,
+    height: 1,
+    selectable: true,
+  })
+  const bottom = new TextRenderable(renderer, {
+    content: "Second paragraph",
+    position: "absolute",
+    left: 0,
+    top: 2,
+    width: 20,
+    height: 1,
+    selectable: true,
+  })
+
+  renderer.root.add(top)
+  renderer.root.add(bottom)
+  renderOnce()
+
+  expect(bottom.y).toBe(top.y + 2)
+
+  renderer.startSelection(top, top.x, top.y)
+  renderer.updateSelection(bottom, bottom.x + bottom.width, bottom.y, { finishDragging: true })
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe("First paragraph\n\nSecond paragraph")
+})
+
+test("selected text does not invent blanks for a partial multiline selection", () => {
+  const top = new TextRenderable(renderer, {
+    content: "A\nB\nC",
+    position: "absolute",
+    left: 0,
+    top: 0,
+    width: 3,
+    height: 3,
+    selectable: true,
+  })
+  const bottom = new TextRenderable(renderer, {
+    content: "Next",
+    position: "absolute",
+    left: 0,
+    top: 3,
+    width: 4,
+    height: 1,
+    selectable: true,
+  })
+
+  renderer.root.add(top)
+  renderer.root.add(bottom)
+  renderOnce()
+
+  expect(bottom.y).toBe(top.y + 3)
+
+  renderer.startSelection(top, top.x, top.y + 2)
+  renderer.updateSelection(bottom, bottom.x + bottom.width, bottom.y, { finishDragging: true })
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe("C\nNext")
+})
+
+test("selected text does not invent blanks for a wrapped renderable followed by an adjacent widget", () => {
+  const top = new TextRenderable(renderer, {
+    content: "abcdefghij",
+    position: "absolute",
+    left: 0,
+    top: 0,
+    width: 5,
+    height: 2,
+    wrapMode: "char",
+    selectable: true,
+  })
+  const bottom = new TextRenderable(renderer, {
+    content: "Next",
+    position: "absolute",
+    left: 0,
+    top: 2,
+    width: 4,
+    height: 1,
+    selectable: true,
+  })
+
+  renderer.root.add(top)
+  renderer.root.add(bottom)
+  renderOnce()
+
+  expect(top.height).toBe(2)
+  expect(bottom.y).toBe(top.y + 2)
+
+  renderer.startSelection(top, top.x, top.y)
+  renderer.updateSelection(bottom, bottom.x + bottom.width, bottom.y, { finishDragging: true })
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe("abcdefghij\nNext")
+})
+
+test("selected text keeps a blank row that is empty across columns", () => {
+  const tall = new TextRenderable(renderer, {
+    content: "A",
+    position: "absolute",
+    left: 10,
+    top: 0,
+    width: 1,
+    height: 3,
+    selectable: true,
+  })
+  const mid = new TextRenderable(renderer, {
+    content: "B",
+    position: "absolute",
+    left: 0,
+    top: 1,
+    width: 1,
+    height: 1,
+    selectable: true,
+  })
+  const bottom = new TextRenderable(renderer, {
+    content: "C",
+    position: "absolute",
+    left: 0,
+    top: 3,
+    width: 1,
+    height: 1,
+    selectable: true,
+  })
+
+  renderer.root.add(tall)
+  renderer.root.add(mid)
+  renderer.root.add(bottom)
+  renderOnce()
+
+  expect(mid.y).toBe(1)
+  expect(bottom.y).toBe(3)
+
+  renderer.startSelection(tall, tall.x, tall.y)
+  renderer.updateSelection(bottom, bottom.x + bottom.width, bottom.y, { finishDragging: true })
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe("A\nB\n\nC")
+})
+
+test("selected text keeps a blank row after a tall widget's last text line", () => {
+  const tall = new TextRenderable(renderer, {
+    content: "A\nX",
+    position: "absolute",
+    left: 10,
+    top: 0,
+    width: 1,
+    height: 3,
+    selectable: true,
+  })
+  const mid = new TextRenderable(renderer, {
+    content: "B",
+    position: "absolute",
+    left: 0,
+    top: 1,
+    width: 1,
+    height: 1,
+    selectable: true,
+  })
+  const bottom = new TextRenderable(renderer, {
+    content: "C",
+    position: "absolute",
+    left: 0,
+    top: 3,
+    width: 1,
+    height: 1,
+    selectable: true,
+  })
+
+  renderer.root.add(tall)
+  renderer.root.add(mid)
+  renderer.root.add(bottom)
+  renderOnce()
+
+  renderer.startSelection(tall, tall.x, tall.y)
+  renderer.updateSelection(bottom, bottom.x + bottom.width, bottom.y, { finishDragging: true })
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe("A\nBX\n\nC")
+})
+
+test("selected text joins a wrapped logical line's later visual row with a same-row widget", () => {
+  const top = new TextRenderable(renderer, {
+    content: "aaaaa\nB",
+    position: "absolute",
+    left: 10,
+    top: 0,
+    width: 4,
+    height: 3,
+    wrapMode: "char",
+    selectable: true,
+  })
+  const left = new TextRenderable(renderer, {
+    content: "L",
+    position: "absolute",
+    left: 0,
+    top: 2,
+    width: 1,
+    height: 1,
+    selectable: true,
+  })
+  const bottom = new TextRenderable(renderer, {
+    content: "C",
+    position: "absolute",
+    left: 0,
+    top: 4,
+    width: 1,
+    height: 1,
+    selectable: true,
+  })
+
+  renderer.root.add(top)
+  renderer.root.add(left)
+  renderer.root.add(bottom)
+  renderOnce()
+
+  expect(left.y).toBe(top.y + 2)
+  expect(bottom.y).toBe(top.y + 4)
+
+  renderer.startSelection(top, top.x, top.y)
+  renderer.updateSelection(bottom, bottom.x + bottom.width, bottom.y, { finishDragging: true })
+
+  expect(renderer.getSelection()?.getSelectedText()).toBe("aaaaa\nLB\n\nC")
+})
+
+test("selected text keeps a trailing newline when selection ends on an empty line", () => {
+  const text = new TextRenderable(renderer, {
+    content: "A\n\nX",
+    position: "absolute",
+    left: 0,
+    top: 0,
+    width: 3,
+    height: 3,
+    selectable: true,
+  })
+
+  renderer.root.add(text)
+  renderOnce()
+
+  renderer.startSelection(text, text.x, text.y)
+  renderer.updateSelection(text, text.x + 1, text.y + 1, { finishDragging: true })
+
+  expect(text.getSelectedText()).toBe("A\n")
+  expect(renderer.getSelection()?.getSelectedText()).toBe("A\n")
 })


### PR DESCRIPTION
Mouse-copy across stacked renderables dropped visual blank rows. `Selection.getSelectedText()` joined only occupied y keys, so a gap (markdown margin, absolute `top` offset) became a single newline.

I place each logical line on its first selected visual row and fill a missing y only when the previous line's owner span does not cover it. `TextBufferRenderable` maps the native selection onto visual lines (`lineInfo.lineSources`). Leftover `split("\n")` pieces after a half-open selection (text ending in `\n`) stay.

Tests in `renderer.selection.test.ts`: adjacent rows, gapped paragraphs, partial multiline, wrap, two-column blank row, wrap+newline join, trailing newline on an empty line.

Fixes the OpenCode mouse-copy case in anomalyco/opencode#44056. Related: #1103 (empty logical lines inside one TextBuffer; different path).