### PR TITLE
fix: disable OSC 66 for Ghostty

### DIFF
--- a/packages/core/docs/development.md
+++ b/packages/core/docs/development.md
@@ -151,4 +151,4 @@ OPENTUI_FORCE_EXPLICIT_WIDTH=false
 - Falls back to standard width calculation
 - No visual artifacts on unsupported terminals
 
-**Modern Terminals:** If your terminal supports OSC 66 (Kitty, Ghostty, WezTerm, Alacritty, iTerm2), you don't need this setting - they work correctly by default.
+**Modern Terminals:** If your terminal supports OSC 66 (Kitty, WezTerm, Alacritty, iTerm2), you don't need this setting - they work correctly by default. OpenTUI automatically disables OSC 66 for Ghostty versions that parse the sequence but do not yet apply its sizing metadata.

--- a/packages/native/src/terminal.zig
+++ b/packages/native/src/terminal.zig
@@ -1332,6 +1332,23 @@ pub fn processCapabilityResponse(self: *Terminal, response: []const u8) void {
     if (!self.caps.hyperlinks and isHyperlinkTerm(response)) {
         self.caps.hyperlinks = true;
     }
+
+    // Ghostty currently parses OSC 66 but does not apply its width metadata.
+    // The probe's plain space still advances the cursor, producing a false
+    // positive that causes later graphemes to be wrapped in unsupported OSC 66.
+    // Keep the explicit force-on escape hatch available for future releases.
+    if (self.term_info.from_xtversion and
+        std.ascii.eqlIgnoreCase(self.getTerminalName(), "ghostty") and
+        !self.isExplicitWidthForcedOn())
+    {
+        self.caps.explicit_width = false;
+    }
+}
+
+fn isExplicitWidthForcedOn(self: *Terminal) bool {
+    const env_map = self.opts.env_map orelse return false;
+    const value = env_map.get("OPENTUI_FORCE_EXPLICIT_WIDTH") orelse return false;
+    return std.mem.eql(u8, value, "true") or std.mem.eql(u8, value, "1");
 }
 
 fn parseXtgettcapMs(self: *Terminal, response: []const u8) void {

--- a/packages/native/src/tests/terminal_test.zig
+++ b/packages/native/src/tests/terminal_test.zig
@@ -341,6 +341,30 @@ test "parseXtversion - full ghostty response" {
     try testing.expect(term.term_info.from_xtversion);
 }
 
+test "Ghostty OSC 66 probe does not enable explicit width" {
+    var term = Terminal.init(.{});
+
+    // Ghostty parses OSC 66 but does not yet apply its width metadata. The
+    // probe's plain space therefore advances the cursor and looks supported.
+    term.processCapabilityResponse("\x1b[1;2R\x1bP>|ghostty 1.3.1\x1b\\");
+    try testing.expect(!term.caps.explicit_width);
+
+    // A CPR delivered after XTVERSION must not re-enable the false positive.
+    term.processCapabilityResponse("\x1b[1;2R");
+    try testing.expect(!term.caps.explicit_width);
+}
+
+test "Ghostty explicit width force-on overrides identity guard" {
+    var env = std.process.Environ.Map.init(testing.allocator);
+    defer env.deinit();
+    try env.put("OPENTUI_FORCE_EXPLICIT_WIDTH", "true");
+
+    var term = Terminal.init(.{ .env_map = &env });
+    term.processCapabilityResponse("\x1b[1;2R\x1bP>|ghostty 1.3.1\x1b\\");
+
+    try testing.expect(term.caps.explicit_width);
+}
+
 test "notifications - OSC99 query response enables OSC99 protocol" {
     var term = Terminal.init(.{});
 


### PR DESCRIPTION
## Summary

- ignore OSC 66 width-probe false positives when XTVERSION identifies Ghostty
- preserve `OPENTUI_FORCE_EXPLICIT_WIDTH=true` as an explicit escape hatch
- document the Ghostty compatibility behavior

## Why

OpenTUI's buffer places the reported Malayalam graphemes contiguously, but Ghostty currently parses OSC 66 without applying its sizing metadata (ghostty-org/ghostty#10333). The probe's plain space therefore advances the cursor to column 2 and incorrectly enables explicit-width output. Subsequent graphemes are wrapped in OSC 66 even though Ghostty does not implement the rendering side of the protocol.

This assumes Ghostty should remain on standard Unicode-width output until its open implementation issue is completed. The exact XTVERSION identity guard is small and reversible, and the force-on environment override remains available for testing future releases.

Fixes #1401.

## Validation

- regression test failed before the fix and passes after it
- `bun run test:native` (1988 passed, 53 skipped)
- `bun run build`
- `bun run fmt:check`
- `bun run lint`