### PR TITLE
core: add double/triple click support

### DIFF
--- a/packages/core/src/editor-view.test.ts
+++ b/packages/core/src/editor-view.test.ts
@@ -289,6 +289,14 @@ describe("EditorView", () => {
       expect(view.getSelectedText()).toBe("ABCDEFGHIJKLMNOP")
     })
 
+    it("should select a word with word behavior on the same cell", () => {
+      buffer.setText("alpha beta gamma")
+
+      const changed = view.setLocalSelection(6, 0, 6, 0, undefined, undefined, false, false, "word")
+      expect(changed).toBe(true)
+      expect(view.getSelectedText()).toBe("beta")
+    })
+
     it("should return null bytes for zero-length selected-text output buffer", () => {
       buffer.setText("Hello World")
       view.setSelection(0, 5)

--- a/packages/core/src/editor-view.ts
+++ b/packages/core/src/editor-view.ts
@@ -166,6 +166,11 @@ export class EditorView {
     this.lib.editorViewResetLocalSelection(this.viewPtr)
   }
 
+  public convertSelectionToCell(): boolean {
+    this.guard()
+    return this.lib.editorViewConvertSelectionToCell(this.viewPtr)
+  }
+
   public setSelectionOccupancy(occupancy: SelectionOccupancy): void {
     this.guard()
     this.lib.editorViewSetSelectionOccupancy(this.viewPtr, occupancy)

--- a/packages/core/src/editor-view.ts
+++ b/packages/core/src/editor-view.ts
@@ -9,7 +9,7 @@ import {
 } from "./zig.js"
 import type { EditBuffer } from "./edit-buffer.js"
 import { createExtmarksController } from "./lib/index.js"
-import type { SelectionOccupancy } from "./types.js"
+import type { SelectionBehavior, SelectionOccupancy } from "./types.js"
 
 export interface Viewport {
   offsetY: number
@@ -118,6 +118,7 @@ export class EditorView {
     fgColor?: RGBA,
     updateCursor?: boolean,
     followCursor?: boolean,
+    behavior: SelectionBehavior = "cell",
   ): boolean {
     this.guard()
     return this.lib.editorViewSetLocalSelection(
@@ -130,6 +131,7 @@ export class EditorView {
       fgColor || null,
       updateCursor ?? false,
       followCursor ?? false,
+      behavior,
     )
   }
 
@@ -142,6 +144,7 @@ export class EditorView {
     fgColor?: RGBA,
     updateCursor?: boolean,
     followCursor?: boolean,
+    behavior: SelectionBehavior = "cell",
   ): boolean {
     this.guard()
     return this.lib.editorViewUpdateLocalSelection(
@@ -154,6 +157,7 @@ export class EditorView {
       fgColor || null,
       updateCursor ?? false,
       followCursor ?? false,
+      behavior,
     )
   }
 

--- a/packages/core/src/lib/selection.ascii-font.test.ts
+++ b/packages/core/src/lib/selection.ascii-font.test.ts
@@ -17,6 +17,7 @@ function bounds(anchorX: number, focusX: number, anchorY = 0, focusY = 0): Local
     focusX,
     focusY,
     isActive: true,
+    behavior: "cell",
   }
 }
 

--- a/packages/core/src/lib/selection.ts
+++ b/packages/core/src/lib/selection.ts
@@ -1,5 +1,5 @@
 import { Renderable } from "../Renderable.js"
-import type { ViewportBounds } from "../types.js"
+import type { SelectionBehavior, ViewportBounds } from "../types.js"
 import { coordinateToCharacterIndex, fonts, getCharacterPositions } from "./ascii.font.js"
 
 class SelectionAnchor {
@@ -32,10 +32,17 @@ export class Selection {
   private _isActive: boolean = true
   private _isDragging: boolean = true
   private _isStart: boolean = false
+  readonly behavior: SelectionBehavior
 
-  constructor(anchorRenderable: Renderable, anchor: { x: number; y: number }, focus: { x: number; y: number }) {
+  constructor(
+    anchorRenderable: Renderable,
+    anchor: { x: number; y: number },
+    focus: { x: number; y: number },
+    behavior: SelectionBehavior = "cell",
+  ) {
     this._anchor = new SelectionAnchor(anchorRenderable, anchor.x, anchor.y)
     this._focus = { ...focus }
+    this.behavior = behavior
   }
 
   get isStart(): boolean {
@@ -154,6 +161,7 @@ export interface LocalSelectionBounds {
   focusX: number
   focusY: number
   isActive: boolean
+  behavior: SelectionBehavior
 }
 
 export function convertGlobalToLocalSelection(
@@ -171,6 +179,7 @@ export function convertGlobalToLocalSelection(
     focusX: globalSelection.focus.x - localX,
     focusY: globalSelection.focus.y - localY,
     isActive: true,
+    behavior: globalSelection.behavior,
   }
 }
 

--- a/packages/core/src/lib/selection.ts
+++ b/packages/core/src/lib/selection.ts
@@ -32,7 +32,7 @@ export class Selection {
   private _isActive: boolean = true
   private _isDragging: boolean = true
   private _isStart: boolean = false
-  readonly behavior: SelectionBehavior
+  behavior: SelectionBehavior
 
   constructor(
     anchorRenderable: Renderable,

--- a/packages/core/src/renderables/EditBufferRenderable.ts
+++ b/packages/core/src/renderables/EditBufferRenderable.ts
@@ -493,6 +493,8 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
       this._selectionBg,
       this._selectionFg,
       false,
+      false,
+      localSelection.behavior,
     )
   }
 
@@ -527,6 +529,7 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
         this._selectionFg,
         updateCursor,
         followCursor,
+        selection.behavior,
       )
     } else {
       changed = this.editorView.updateLocalSelection(
@@ -538,6 +541,7 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
         this._selectionFg,
         updateCursor,
         followCursor,
+        selection.behavior,
       )
     }
 
@@ -1147,6 +1151,19 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
     return this.editBuffer.getTextRangeByCoords(startRow, startCol, endRow, endCol)
   }
 
+  private convertGestureSelectionToCell(): void {
+    const range = this.getSelection()
+    if (!range) return
+
+    this.editorView.setCursorByOffset(range.start)
+    const start = this.editorView.getVisualCursor()
+    this.editorView.setCursorByOffset(range.end > range.start ? range.end - 1 : range.start)
+    const end = this.editorView.getVisualCursor()
+
+    this._ctx.startSelection(this, this.x + start.visualCol, this.y + start.visualRow)
+    this._ctx.updateSelection(this, this.x + end.visualCol, this.y + end.visualRow, { finishDragging: true })
+  }
+
   protected updateSelectionForMovement(shiftPressed: boolean, isBeforeMovement: boolean): void {
     if (!shiftPressed) {
       this._keyboardSelectionActive = false
@@ -1165,6 +1182,8 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
     if (isBeforeMovement) {
       if (!this._ctx.hasSelection || !this.hasSelection()) {
         this._ctx.startSelection(this, cursorX, cursorY)
+      } else if (this._ctx.getSelection()?.behavior !== "cell") {
+        this.convertGestureSelectionToCell()
       }
       return
     }

--- a/packages/core/src/renderables/EditBufferRenderable.ts
+++ b/packages/core/src/renderables/EditBufferRenderable.ts
@@ -529,7 +529,7 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
         this._selectionFg,
         updateCursor,
         followCursor,
-        selection.behavior,
+        localSelection.behavior,
       )
     } else {
       changed = this.editorView.updateLocalSelection(
@@ -541,7 +541,7 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
         this._selectionFg,
         updateCursor,
         followCursor,
-        selection.behavior,
+        localSelection.behavior,
       )
     }
 

--- a/packages/core/src/renderables/EditBufferRenderable.ts
+++ b/packages/core/src/renderables/EditBufferRenderable.ts
@@ -1151,19 +1151,6 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
     return this.editBuffer.getTextRangeByCoords(startRow, startCol, endRow, endCol)
   }
 
-  private convertGestureSelectionToCell(): void {
-    const range = this.getSelection()
-    if (!range) return
-
-    this.editorView.setCursorByOffset(range.start)
-    const start = this.editorView.getVisualCursor()
-    this.editorView.setCursorByOffset(range.end > range.start ? range.end - 1 : range.start)
-    const end = this.editorView.getVisualCursor()
-
-    this._ctx.startSelection(this, this.x + start.visualCol, this.y + start.visualRow)
-    this._ctx.updateSelection(this, this.x + end.visualCol, this.y + end.visualRow, { finishDragging: true })
-  }
-
   protected updateSelectionForMovement(shiftPressed: boolean, isBeforeMovement: boolean): void {
     if (!shiftPressed) {
       this._keyboardSelectionActive = false
@@ -1183,7 +1170,10 @@ export abstract class EditBufferRenderable extends Renderable implements LineInf
       if (!this._ctx.hasSelection || !this.hasSelection()) {
         this._ctx.startSelection(this, cursorX, cursorY)
       } else if (this._ctx.getSelection()?.behavior !== "cell") {
-        this.convertGestureSelectionToCell()
+        if (this.editorView.convertSelectionToCell()) {
+          const selection = this._ctx.getSelection()
+          if (selection) selection.behavior = "cell"
+        }
       }
       return
     }

--- a/packages/core/src/renderables/TextBufferRenderable.ts
+++ b/packages/core/src/renderables/TextBufferRenderable.ts
@@ -360,6 +360,7 @@ export abstract class TextBufferRenderable extends Renderable implements LineInf
       localSelection.focusY,
       this._selectionBg,
       this._selectionFg,
+      localSelection.behavior,
     )
   }
 
@@ -422,6 +423,7 @@ export abstract class TextBufferRenderable extends Renderable implements LineInf
         localSelection.focusY,
         this._selectionBg,
         this._selectionFg,
+        selection.behavior,
       )
     } else {
       changed = this.textBufferView.updateLocalSelection(
@@ -431,6 +433,7 @@ export abstract class TextBufferRenderable extends Renderable implements LineInf
         localSelection.focusY,
         this._selectionBg,
         this._selectionFg,
+        selection.behavior,
       )
     }
 

--- a/packages/core/src/renderables/TextBufferRenderable.ts
+++ b/packages/core/src/renderables/TextBufferRenderable.ts
@@ -423,7 +423,7 @@ export abstract class TextBufferRenderable extends Renderable implements LineInf
         localSelection.focusY,
         this._selectionBg,
         this._selectionFg,
-        selection.behavior,
+        localSelection.behavior,
       )
     } else {
       changed = this.textBufferView.updateLocalSelection(
@@ -433,7 +433,7 @@ export abstract class TextBufferRenderable extends Renderable implements LineInf
         localSelection.focusY,
         this._selectionBg,
         this._selectionFg,
-        selection.behavior,
+        localSelection.behavior,
       )
     }
 

--- a/packages/core/src/renderables/__tests__/Textarea.selection.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.selection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach } from "bun:test"
 import { createTestRenderer, type TestRenderer, type MockMouse, type MockInput } from "../../testing/test-renderer.js"
+import { ManualClock } from "../../testing/manual-clock.js"
 import { createTextareaRenderable } from "./renderable-test-utils.js"
 import { RGBA } from "../../lib/RGBA.js"
 import { OptimizedBuffer } from "../../buffer.js"
@@ -21,6 +22,7 @@ describe("Textarea - Selection Tests", () => {
     } = await createTestRenderer({
       width: 80,
       height: 24,
+      clock: new ManualClock(),
     }))
   })
 

--- a/packages/core/src/renderables/__tests__/Textarea.selection.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.selection.test.ts
@@ -2005,6 +2005,41 @@ describe("Textarea - Selection Tests", () => {
       expect(editor.visualCursor.visualCol).toBe(14)
     })
 
+    it("double-click selects the word and keeps the cursor on that grapheme", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "alpha beta gamma",
+        width: 40,
+        height: 10,
+        selectable: true,
+      })
+
+      await currentMouse.doubleClick(editor.x + 6, editor.y)
+      await renderOnce()
+
+      expect(editor.getSelectedText()).toBe("beta")
+      expect(editor.logicalCursor.row).toBe(0)
+      expect(editor.logicalCursor.col).toBe(6)
+    })
+
+    it("shift+right after a word click extends by cell not by word", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "alpha beta gamma",
+        width: 40,
+        height: 10,
+        selectable: true,
+      })
+
+      await currentMouse.doubleClick(editor.x + 6, editor.y)
+      await renderOnce()
+      expect(editor.getSelectedText()).toBe("beta")
+
+      editor.focus()
+      currentMockInput.pressArrow("right", { shift: true })
+      await renderOnce()
+
+      expect(editor.getSelectedText()).toBe("beta ")
+    })
+
     it("keeps cell visual End on a grapheme boundary", async () => {
       const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
         initialValue: "ab你cd",

--- a/packages/core/src/renderables/__tests__/Textarea.selection.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.selection.test.ts
@@ -2040,6 +2040,51 @@ describe("Textarea - Selection Tests", () => {
       expect(editor.getSelectedText()).toBe("beta ")
     })
 
+    it("shift+right after a word click extends by cell in boundary occupancy", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "alpha beta gamma",
+        width: 40,
+        height: 10,
+        selectable: true,
+        selectionOccupancy: "boundary",
+      })
+
+      await currentMouse.doubleClick(editor.x + 6, editor.y)
+      await renderOnce()
+      expect(editor.getSelectedText()).toBe("beta")
+
+      editor.focus()
+      currentMockInput.pressArrow("right", { shift: true })
+      await renderOnce()
+
+      expect(editor.getSelectedText()).toBe("beta ")
+    })
+
+    it("shift+right after a line click keeps an off-screen line start", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        initialValue: "hello world",
+        width: 5,
+        height: 1,
+        wrapMode: "char",
+        selectable: true,
+      })
+
+      editor.focus()
+      editor.cursorOffset = editor.plainText.length
+      await renderOnce()
+
+      await currentMouse.click(editor.x, editor.y)
+      await currentMouse.click(editor.x, editor.y)
+      await currentMouse.click(editor.x, editor.y)
+      await renderOnce()
+      expect(editor.getSelectedText()).toBe("hello world")
+
+      currentMockInput.pressArrow("right", { shift: true })
+      await renderOnce()
+
+      expect(editor.getSelectedText()).toBe("hello world")
+    })
+
     it("keeps cell visual End on a grapheme boundary", async () => {
       const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
         initialValue: "ab你cd",

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -11,6 +11,7 @@ import {
   type RenderContext,
   type TerminalCapabilities,
   type ThemeMode,
+  type SelectionBehavior,
   type ViewportBounds,
   type WidthMethod,
 } from "./types.js"
@@ -517,7 +518,7 @@ class ScrollbackSnapshotRenderContext extends EventEmitter implements RenderCont
     return this.lifecyclePasses
   }
   public clearSelection(): void {}
-  public startSelection(_renderable: Renderable, _x: number, _y: number): void {}
+  public startSelection(_renderable: Renderable, _x: number, _y: number, _behavior?: SelectionBehavior): void {}
   public updateSelection(
     _currentRenderable: Renderable | undefined,
     _x: number,
@@ -757,6 +758,8 @@ export enum RendererControlState {
   EXPLICIT_STOPPED = "explicit_stopped",
 }
 
+const CLICK_REPEAT_INTERVAL_MS = 500
+
 export class CliRenderer extends EventEmitter implements RenderContext {
   private static animationFrameId = 0
   private lib: RenderLib
@@ -869,6 +872,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private currentSelection: Selection | null = null
   private selectionContainers: Renderable[] = []
+  private lastClick: { count: number; time: number; x: number; y: number; renderableId: number } | null = null
   private clipboard: Clipboard
 
   private _splitHeight: number = 0
@@ -3601,7 +3605,12 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       )
 
       if (canStartSelection && maybeRenderable) {
-        this.startSelection(maybeRenderable, mouseEvent.x, mouseEvent.y)
+        this.startSelection(
+          maybeRenderable,
+          mouseEvent.x,
+          mouseEvent.y,
+          this.nextClickBehavior(maybeRenderable, mouseEvent.x, mouseEvent.y),
+        )
         this.dispatchMouseEvent(maybeRenderable, mouseEvent)
         return true
       }
@@ -4768,6 +4777,11 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   public clearSelection(): void {
+    this.clearSelectionState()
+    this.lastClick = null
+  }
+
+  private clearSelectionState(): void {
     if (this.currentSelection) {
       for (const renderable of this.currentSelection.touchedRenderables) {
         if (renderable.selectable && !renderable.isDestroyed) {
@@ -4783,15 +4797,28 @@ export class CliRenderer extends EventEmitter implements RenderContext {
    * Start a new selection at the given coordinates.
    * Used by both mouse and keyboard selection.
    */
-  public startSelection(renderable: Renderable, x: number, y: number): void {
+  public startSelection(renderable: Renderable, x: number, y: number, behavior: SelectionBehavior = "cell"): void {
     if (!renderable.selectable) return
 
-    this.clearSelection()
+    this.clearSelectionState()
     this.selectionContainers.push(renderable.parent || this.root)
-    this.currentSelection = new Selection(renderable, { x, y }, { x, y })
+    this.currentSelection = new Selection(renderable, { x, y }, { x, y }, behavior)
     this.currentSelection.isStart = true
 
     this.notifySelectablesOfSelectionChange()
+  }
+
+  private nextClickBehavior(renderable: Renderable, x: number, y: number): SelectionBehavior {
+    const now = Date.now()
+    const last = this.lastClick
+    const continued =
+      last !== null &&
+      renderable.num === last.renderableId &&
+      now - last.time <= CLICK_REPEAT_INTERVAL_MS &&
+      Math.max(Math.abs(x - last.x), Math.abs(y - last.y)) <= 1
+    const count = continued ? Math.min(last.count + 1, 3) : 1
+    this.lastClick = { count, time: now, x, y, renderableId: renderable.num }
+    return count === 1 ? "cell" : count === 2 ? "word" : "line"
   }
 
   public updateSelection(

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -4809,7 +4809,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   private nextClickBehavior(renderable: Renderable, x: number, y: number): SelectionBehavior {
-    const now = Date.now()
+    const now = this.clock.now()
     const last = this.lastClick
     const continued =
       last !== null &&

--- a/packages/core/src/tests/renderer.selection.test.ts
+++ b/packages/core/src/tests/renderer.selection.test.ts
@@ -1,13 +1,14 @@
 import { test, expect, beforeEach, afterEach } from "bun:test"
-import { createTestRenderer, type TestRenderer } from "../testing/test-renderer.js"
+import { createTestRenderer, type MockMouse, type TestRenderer } from "../testing/test-renderer.js"
 import { BoxRenderable } from "../renderables/Box.js"
 import { TextRenderable } from "../renderables/Text.js"
 
 let renderer: TestRenderer
-let renderOnce: () => void
+let renderOnce: () => Promise<void>
+let mockMouse: MockMouse
 
 beforeEach(async () => {
-  ;({ renderer, renderOnce } = await createTestRenderer({}))
+  ;({ renderer, renderOnce, mockMouse } = await createTestRenderer({}))
 })
 
 afterEach(() => {
@@ -135,4 +136,57 @@ test("selected text merges multiline same-row renderables by visual row", () => 
   renderer.updateSelection(right, right.x + right.width, right.y + 1, { finishDragging: true })
 
   expect(renderer.getSelection()?.getSelectedText()).toBe("A1\nB2")
+})
+
+async function addSelectableText(): Promise<TextRenderable> {
+  const text = new TextRenderable(renderer, {
+    content: "alpha beta gamma",
+    width: 20,
+    height: 1,
+    selectable: true,
+  })
+  renderer.root.add(text)
+  await renderOnce()
+  return text
+}
+
+test("double-click on beta selects the word", async () => {
+  const text = await addSelectableText()
+  await mockMouse.doubleClick(text.x + 6, text.y)
+  await renderOnce()
+  expect(text.getSelectedText()).toBe("beta")
+})
+
+test("triple-click selects the line", async () => {
+  const text = await addSelectableText()
+  await mockMouse.click(text.x + 6, text.y)
+  await mockMouse.click(text.x + 6, text.y)
+  await mockMouse.click(text.x + 6, text.y)
+  await renderOnce()
+  expect(text.getSelectedText()).toBe("alpha beta gamma")
+})
+
+test("two clicks 600ms apart stay a cell press", async () => {
+  const text = await addSelectableText()
+  await mockMouse.click(text.x + 6, text.y)
+  await new Promise((resolve) => setTimeout(resolve, 600))
+  await mockMouse.click(text.x + 6, text.y)
+  await renderOnce()
+  expect(text.getSelectedText()).toBe("")
+})
+
+test("two clicks one cell apart start a new sequence", async () => {
+  const text = await addSelectableText()
+  await mockMouse.click(text.x + 6, text.y)
+  await mockMouse.click(text.x + 8, text.y)
+  await renderOnce()
+  expect(text.getSelectedText()).toBe("")
+})
+
+test("double-click then drag onto the next word selects both", async () => {
+  const text = await addSelectableText()
+  await mockMouse.click(text.x + 6, text.y)
+  await mockMouse.drag(text.x + 6, text.y, text.x + 12, text.y)
+  await renderOnce()
+  expect(text.getSelectedText()).toBe("beta gamma")
 })

--- a/packages/core/src/tests/renderer.selection.test.ts
+++ b/packages/core/src/tests/renderer.selection.test.ts
@@ -1,14 +1,17 @@
 import { test, expect, beforeEach, afterEach } from "bun:test"
 import { createTestRenderer, type MockMouse, type TestRenderer } from "../testing/test-renderer.js"
+import { ManualClock } from "../testing/manual-clock.js"
 import { BoxRenderable } from "../renderables/Box.js"
 import { TextRenderable } from "../renderables/Text.js"
 
 let renderer: TestRenderer
 let renderOnce: () => Promise<void>
 let mockMouse: MockMouse
+let clock: ManualClock
 
 beforeEach(async () => {
-  ;({ renderer, renderOnce, mockMouse } = await createTestRenderer({}))
+  clock = new ManualClock()
+  ;({ renderer, renderOnce, mockMouse } = await createTestRenderer({ clock }))
 })
 
 afterEach(() => {
@@ -169,7 +172,7 @@ test("triple-click selects the line", async () => {
 test("two clicks 600ms apart stay a cell press", async () => {
   const text = await addSelectableText()
   await mockMouse.click(text.x + 6, text.y)
-  await new Promise((resolve) => setTimeout(resolve, 600))
+  clock.advance(600)
   await mockMouse.click(text.x + 6, text.y)
   await renderOnce()
   expect(text.getSelectedText()).toBe("")

--- a/packages/core/src/text-buffer-view.test.ts
+++ b/packages/core/src/text-buffer-view.test.ts
@@ -369,6 +369,24 @@ describe("TextBufferView", () => {
       expect(changed).toBe(true)
       expect(view.getSelectedText()).toBe("World")
     })
+
+    it("should select a word with word behavior on the same cell", () => {
+      const styledText = stringToStyledText("alpha beta gamma")
+      buffer.setStyledText(styledText)
+
+      const changed = view.setLocalSelection(6, 0, 6, 0, undefined, undefined, "word")
+      expect(changed).toBe(true)
+      expect(view.getSelectedText()).toBe("beta")
+    })
+
+    it("should keep a cell press zero-width", () => {
+      const styledText = stringToStyledText("alpha beta")
+      buffer.setStyledText(styledText)
+
+      view.setLocalSelection(6, 0, 6, 0)
+      expect(view.getSelectedText()).toBe("")
+      expect(view.hasSelection()).toBe(false)
+    })
   })
 
   describe("getPlainText", () => {

--- a/packages/core/src/text-buffer-view.ts
+++ b/packages/core/src/text-buffer-view.ts
@@ -7,7 +7,7 @@ import {
   type TextBufferViewHandle,
 } from "./zig.js"
 import type { TextBuffer } from "./text-buffer.js"
-import type { SelectionOccupancy } from "./types.js"
+import type { SelectionBehavior, SelectionOccupancy } from "./types.js"
 
 export class TextBufferView {
   private lib: RenderLib
@@ -69,6 +69,7 @@ export class TextBufferView {
     focusY: number,
     bgColor?: RGBA,
     fgColor?: RGBA,
+    behavior: SelectionBehavior = "cell",
   ): boolean {
     this.guard()
     return this.lib.textBufferViewSetLocalSelection(
@@ -79,6 +80,7 @@ export class TextBufferView {
       focusY,
       bgColor || null,
       fgColor || null,
+      behavior,
     )
   }
 
@@ -89,6 +91,7 @@ export class TextBufferView {
     focusY: number,
     bgColor?: RGBA,
     fgColor?: RGBA,
+    behavior: SelectionBehavior = "cell",
   ): boolean {
     this.guard()
     return this.lib.textBufferViewUpdateLocalSelection(
@@ -99,6 +102,7 @@ export class TextBufferView {
       focusY,
       bgColor || null,
       fgColor || null,
+      behavior,
     )
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -149,7 +149,7 @@ export interface RenderContext extends EventEmitter {
   keyInput: KeyHandler
   _internalKeyInput: InternalKeyHandler
   clearSelection: () => void
-  startSelection: (renderable: Renderable, x: number, y: number) => void
+  startSelection: (renderable: Renderable, x: number, y: number, behavior?: SelectionBehavior) => void
   updateSelection: (
     currentRenderable: Renderable | undefined,
     x: number,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,6 +39,11 @@ export type CursorStyle = "block" | "line" | "underline" | "default"
  * range `[min, max)`. */
 export type SelectionOccupancy = "cell" | "boundary"
 
+/** How local cell coordinates expand into a highlight range.
+ * `cell` is the current inclusive press/drag. `word` and `line` expand
+ * each endpoint through native selectWord / selectLine. */
+export type SelectionBehavior = "cell" | "word" | "line"
+
 export type MousePointerStyle = "default" | "pointer" | "text" | "crosshair" | "move" | "not-allowed"
 
 export interface CursorStyleOptions {

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -16,6 +16,7 @@ import {
   type CursorStyle,
   type CursorStyleOptions,
   type SelectionOccupancy,
+  type SelectionBehavior,
   type TargetChannel,
   type DebugOverlayCorner,
   type WidthMethod,
@@ -353,6 +354,10 @@ function rgbaBuffer(value: RGBA): Uint16Array {
 
 function optionalRgbaBuffer(value: RGBA | null | undefined): Uint16Array | null {
   return value ? rgbaBuffer(value) : null
+}
+
+function selectionBehaviorByte(behavior?: SelectionBehavior): number {
+  return behavior === "word" ? 1 : behavior === "line" ? 2 : 0
 }
 
 function getOpenTUILib(libPath?: string) {
@@ -1109,7 +1114,7 @@ function getOpenTUILib(libPath?: string) {
       returns: "u64",
     },
     textBufferViewSetLocalSelection: {
-      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr"],
+      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "u8"],
       returns: "bool",
     },
     textBufferViewUpdateSelection: {
@@ -1117,7 +1122,7 @@ function getOpenTUILib(libPath?: string) {
       returns: "void",
     },
     textBufferViewUpdateLocalSelection: {
-      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr"],
+      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "u8"],
       returns: "bool",
     },
     textBufferViewResetLocalSelection: {
@@ -1423,7 +1428,7 @@ function getOpenTUILib(libPath?: string) {
       returns: "u64",
     },
     editorViewSetLocalSelection: {
-      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "bool", "bool"],
+      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "bool", "bool", "u8"],
       returns: "bool",
     },
     editorViewUpdateSelection: {
@@ -1431,7 +1436,7 @@ function getOpenTUILib(libPath?: string) {
       returns: "void",
     },
     editorViewUpdateLocalSelection: {
-      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "bool", "bool"],
+      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "bool", "bool", "u8"],
       returns: "bool",
     },
     editorViewResetLocalSelection: {
@@ -2820,6 +2825,7 @@ export interface RenderLib extends AudioEngineLib {
     focusY: number,
     bgColor: RGBA | null,
     fgColor: RGBA | null,
+    behavior?: SelectionBehavior,
   ) => boolean
   textBufferViewUpdateSelection: (
     view: TextBufferViewHandle,
@@ -2835,6 +2841,7 @@ export interface RenderLib extends AudioEngineLib {
     focusY: number,
     bgColor: RGBA | null,
     fgColor: RGBA | null,
+    behavior?: SelectionBehavior,
   ) => boolean
   textBufferViewResetLocalSelection: (view: TextBufferViewHandle) => void
   textBufferViewSetSelectionOccupancy: (view: TextBufferViewHandle, occupancy: SelectionOccupancy) => void
@@ -2963,6 +2970,7 @@ export interface RenderLib extends AudioEngineLib {
     fgColor: RGBA | null,
     updateCursor: boolean,
     followCursor: boolean,
+    behavior?: SelectionBehavior,
   ) => boolean
 
   editorViewUpdateSelection: (view: EditorViewHandle, end: number, bgColor: RGBA | null, fgColor: RGBA | null) => void
@@ -2976,6 +2984,7 @@ export interface RenderLib extends AudioEngineLib {
     fgColor: RGBA | null,
     updateCursor: boolean,
     followCursor: boolean,
+    behavior?: SelectionBehavior,
   ) => boolean
 
   editorViewResetLocalSelection: (view: EditorViewHandle) => void
@@ -5119,10 +5128,22 @@ class FFIRenderLib implements RenderLib {
     focusY: number,
     bgColor: RGBA | null,
     fgColor: RGBA | null,
+    behavior?: SelectionBehavior,
   ): boolean {
     const bg = optionalRgbaBuffer(bgColor)
     const fg = optionalRgbaBuffer(fgColor)
-    return Boolean(this.opentui.symbols.textBufferViewSetLocalSelection(view, anchorX, anchorY, focusX, focusY, bg, fg))
+    return Boolean(
+      this.opentui.symbols.textBufferViewSetLocalSelection(
+        view,
+        anchorX,
+        anchorY,
+        focusX,
+        focusY,
+        bg,
+        fg,
+        selectionBehaviorByte(behavior),
+      ),
+    )
   }
 
   public textBufferViewUpdateSelection(view: Pointer, end: number, bgColor: RGBA | null, fgColor: RGBA | null): void {
@@ -5139,11 +5160,21 @@ class FFIRenderLib implements RenderLib {
     focusY: number,
     bgColor: RGBA | null,
     fgColor: RGBA | null,
+    behavior?: SelectionBehavior,
   ): boolean {
     const bg = optionalRgbaBuffer(bgColor)
     const fg = optionalRgbaBuffer(fgColor)
     return Boolean(
-      this.opentui.symbols.textBufferViewUpdateLocalSelection(view, anchorX, anchorY, focusX, focusY, bg, fg),
+      this.opentui.symbols.textBufferViewUpdateLocalSelection(
+        view,
+        anchorX,
+        anchorY,
+        focusX,
+        focusY,
+        bg,
+        fg,
+        selectionBehaviorByte(behavior),
+      ),
     )
   }
 
@@ -5754,6 +5785,7 @@ class FFIRenderLib implements RenderLib {
     fgColor: RGBA | null,
     updateCursor: boolean,
     followCursor: boolean,
+    behavior?: SelectionBehavior,
   ): boolean {
     const bg = optionalRgbaBuffer(bgColor)
     const fg = optionalRgbaBuffer(fgColor)
@@ -5768,6 +5800,7 @@ class FFIRenderLib implements RenderLib {
         fg,
         ffiBool(updateCursor),
         ffiBool(followCursor),
+        selectionBehaviorByte(behavior),
       ),
     )
   }
@@ -5788,6 +5821,7 @@ class FFIRenderLib implements RenderLib {
     fgColor: RGBA | null,
     updateCursor: boolean,
     followCursor: boolean,
+    behavior?: SelectionBehavior,
   ): boolean {
     const bg = optionalRgbaBuffer(bgColor)
     const fg = optionalRgbaBuffer(fgColor)
@@ -5802,6 +5836,7 @@ class FFIRenderLib implements RenderLib {
         fg,
         ffiBool(updateCursor),
         ffiBool(followCursor),
+        selectionBehaviorByte(behavior),
       ),
     )
   }

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -1443,6 +1443,10 @@ function getOpenTUILib(libPath?: string) {
       args: ["u32"],
       returns: "void",
     },
+    editorViewConvertSelectionToCell: {
+      args: ["u32"],
+      returns: "bool",
+    },
     editorViewSetSelectionOccupancy: {
       args: ["u32", "u8"],
       returns: "void",
@@ -2988,6 +2992,7 @@ export interface RenderLib extends AudioEngineLib {
   ) => boolean
 
   editorViewResetLocalSelection: (view: EditorViewHandle) => void
+  editorViewConvertSelectionToCell: (view: EditorViewHandle) => boolean
   editorViewSetSelectionOccupancy: (view: EditorViewHandle, occupancy: SelectionOccupancy) => void
   editorViewSetSelectionInclusive: (
     view: EditorViewHandle,
@@ -5843,6 +5848,10 @@ class FFIRenderLib implements RenderLib {
 
   public editorViewResetLocalSelection(view: Pointer): void {
     this.opentui.symbols.editorViewResetLocalSelection(view)
+  }
+
+  public editorViewConvertSelectionToCell(view: Pointer): boolean {
+    return Boolean(this.opentui.symbols.editorViewConvertSelectionToCell(view))
   }
 
   public editorViewSetSelectionOccupancy(view: Pointer, occupancy: SelectionOccupancy): void {

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -360,11 +360,7 @@ function selectionBehaviorByte(behavior?: SelectionBehavior): number {
   return behavior === "word" ? 1 : behavior === "line" ? 2 : 0
 }
 
-function editorLocalSelectionFlags(
-  updateCursor: boolean,
-  followCursor: boolean,
-  behavior?: SelectionBehavior,
-): number {
+function editorLocalSelectionFlags(updateCursor: boolean, followCursor: boolean, behavior?: SelectionBehavior): number {
   return ffiBool(updateCursor) | (ffiBool(followCursor) << 1) | (selectionBehaviorByte(behavior) << 2)
 }
 

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -1428,7 +1428,7 @@ function getOpenTUILib(libPath?: string) {
       returns: "u64",
     },
     editorViewSetLocalSelection: {
-      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "bool", "bool", "u8"],
+      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "u8", "u8", "u8"],
       returns: "bool",
     },
     editorViewUpdateSelection: {
@@ -1436,7 +1436,7 @@ function getOpenTUILib(libPath?: string) {
       returns: "void",
     },
     editorViewUpdateLocalSelection: {
-      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "bool", "bool", "u8"],
+      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "u8", "u8", "u8"],
       returns: "bool",
     },
     editorViewResetLocalSelection: {

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -360,6 +360,14 @@ function selectionBehaviorByte(behavior?: SelectionBehavior): number {
   return behavior === "word" ? 1 : behavior === "line" ? 2 : 0
 }
 
+function editorLocalSelectionFlags(
+  updateCursor: boolean,
+  followCursor: boolean,
+  behavior?: SelectionBehavior,
+): number {
+  return ffiBool(updateCursor) | (ffiBool(followCursor) << 1) | (selectionBehaviorByte(behavior) << 2)
+}
+
 function getOpenTUILib(libPath?: string) {
   const resolvedLibPath = libPath || targetLibPath
   if (!resolvedLibPath) {
@@ -1428,7 +1436,7 @@ function getOpenTUILib(libPath?: string) {
       returns: "u64",
     },
     editorViewSetLocalSelection: {
-      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "u8", "u8", "u8"],
+      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "u8"],
       returns: "bool",
     },
     editorViewUpdateSelection: {
@@ -1436,7 +1444,7 @@ function getOpenTUILib(libPath?: string) {
       returns: "void",
     },
     editorViewUpdateLocalSelection: {
-      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "u8", "u8", "u8"],
+      args: ["u32", "i32", "i32", "i32", "i32", "ptr", "ptr", "u8"],
       returns: "bool",
     },
     editorViewResetLocalSelection: {
@@ -5803,9 +5811,7 @@ class FFIRenderLib implements RenderLib {
         focusY,
         bg,
         fg,
-        ffiBool(updateCursor),
-        ffiBool(followCursor),
-        selectionBehaviorByte(behavior),
+        editorLocalSelectionFlags(updateCursor, followCursor, behavior),
       ),
     )
   }
@@ -5839,9 +5845,7 @@ class FFIRenderLib implements RenderLib {
         focusY,
         bg,
         fg,
-        ffiBool(updateCursor),
-        ffiBool(followCursor),
-        selectionBehaviorByte(behavior),
+        editorLocalSelectionFlags(updateCursor, followCursor, behavior),
       ),
     )
   }

--- a/packages/native/src/editor-view.zig
+++ b/packages/native/src/editor-view.zig
@@ -371,6 +371,13 @@ pub const EditorView = struct {
         return changed;
     }
 
+    pub fn convertSelectionToCell(self: *EditorView) bool {
+        if (!self.text_buffer_view.convertSelectionToCell()) return false;
+        self.selection_updates_cursor = true;
+        self.syncCursorToSelectionFocus();
+        return true;
+    }
+
     pub fn resetLocalSelection(self: *EditorView) void {
         self.selection_updates_cursor = false;
         self.text_buffer_view.resetLocalSelection();

--- a/packages/native/src/editor-view.zig
+++ b/packages/native/src/editor-view.zig
@@ -335,7 +335,11 @@ pub const EditorView = struct {
     }
 
     pub fn setLocalSelection(self: *EditorView, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?tb.RGBA, fgColor: ?tb.RGBA, updateCursor: bool) bool {
-        const changed = self.text_buffer_view.setLocalSelection(anchorX, anchorY, focusX, focusY, bgColor, fgColor);
+        return self.setLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, bgColor, fgColor, updateCursor, .cell);
+    }
+
+    pub fn setLocalSelectionBehavior(self: *EditorView, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?tb.RGBA, fgColor: ?tb.RGBA, updateCursor: bool, behavior: tbv.SelectionBehavior) bool {
+        const changed = self.text_buffer_view.setLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, bgColor, fgColor, behavior);
         self.selection_updates_cursor = updateCursor;
 
         if (updateCursor and self.text_buffer_view.selection_endpoints != null) {
@@ -347,8 +351,12 @@ pub const EditorView = struct {
     }
 
     pub fn updateLocalSelection(self: *EditorView, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?tb.RGBA, fgColor: ?tb.RGBA, updateCursor: bool) bool {
+        return self.updateLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, bgColor, fgColor, updateCursor, .cell);
+    }
+
+    pub fn updateLocalSelectionBehavior(self: *EditorView, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?tb.RGBA, fgColor: ?tb.RGBA, updateCursor: bool, behavior: tbv.SelectionBehavior) bool {
         const had_endpoints = self.text_buffer_view.selection_endpoints != null;
-        const changed = self.text_buffer_view.updateLocalSelection(anchorX, anchorY, focusX, focusY, bgColor, fgColor);
+        const changed = self.text_buffer_view.updateLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, bgColor, fgColor, behavior);
         if (!had_endpoints) {
             self.selection_updates_cursor = updateCursor;
         } else if (updateCursor) {

--- a/packages/native/src/lib.zig
+++ b/packages/native/src/lib.zig
@@ -198,6 +198,14 @@ inline fn selectionOccupancy(value: u8) text_buffer_view.SelectionOccupancy {
     return if (value == 1) .boundary else .cell;
 }
 
+inline fn selectionBehavior(value: u8) text_buffer_view.SelectionBehavior {
+    return switch (value) {
+        1 => .word,
+        2 => .line,
+        else => .cell,
+    };
+}
+
 comptime {
     std.debug.assert(@sizeOf(ExternalEmbeddedTerminalCursor) == 14);
     std.debug.assert(@sizeOf(ExternalEmbeddedTerminalKeyOptions) == 12);
@@ -2265,9 +2273,9 @@ export fn textBufferViewGetSelectionInfo(view_handle: NativeHandle) u64 {
     return object_ptr.packSelectionInfo();
 }
 
-export fn textBufferViewSetLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16) bool {
+export fn textBufferViewSetLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, behavior: u8) bool {
     const object_ptr = acquireTextBufferView(view_handle) orelse return false;
-    return object_ptr.setLocalSelectionStyle(anchorX, anchorY, focusX, focusY, selectionStyle(optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor)), .cell);
+    return object_ptr.setLocalSelectionStyle(anchorX, anchorY, focusX, focusY, selectionStyle(optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor)), selectionBehavior(behavior));
 }
 
 export fn textBufferViewUpdateSelection(view_handle: NativeHandle, end: u32, bgColor: ?[*]const u16, fgColor: ?[*]const u16) void {
@@ -2275,9 +2283,9 @@ export fn textBufferViewUpdateSelection(view_handle: NativeHandle, end: u32, bgC
     object_ptr.updateSelectionStyle(end, selectionStyle(optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor)));
 }
 
-export fn textBufferViewUpdateLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16) bool {
+export fn textBufferViewUpdateLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, behavior: u8) bool {
     const object_ptr = acquireTextBufferView(view_handle) orelse return false;
-    return object_ptr.updateLocalSelectionStyle(anchorX, anchorY, focusX, focusY, selectionStyle(optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor)), .cell);
+    return object_ptr.updateLocalSelectionStyle(anchorX, anchorY, focusX, focusY, selectionStyle(optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor)), selectionBehavior(behavior));
 }
 
 export fn textBufferViewResetLocalSelection(view_handle: NativeHandle) void {
@@ -2893,10 +2901,10 @@ export fn editorViewGetSelection(view_handle: NativeHandle) u64 {
     return object_ptr.text_buffer_view.packSelectionInfo();
 }
 
-export fn editorViewSetLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, updateCursor: bool, followCursor: bool) bool {
+export fn editorViewSetLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, updateCursor: bool, followCursor: bool, behavior: u8) bool {
     const object_ptr = acquireEditorView(view_handle) orelse return false;
     object_ptr.setSelectionFollowCursor(followCursor);
-    return object_ptr.setLocalSelection(anchorX, anchorY, focusX, focusY, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor), updateCursor);
+    return object_ptr.setLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor), updateCursor, selectionBehavior(behavior));
 }
 
 export fn editorViewUpdateSelection(view_handle: NativeHandle, end: u32, bgColor: ?[*]const u16, fgColor: ?[*]const u16) void {
@@ -2904,10 +2912,10 @@ export fn editorViewUpdateSelection(view_handle: NativeHandle, end: u32, bgColor
     object_ptr.updateSelection(end, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor));
 }
 
-export fn editorViewUpdateLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, updateCursor: bool, followCursor: bool) bool {
+export fn editorViewUpdateLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, updateCursor: bool, followCursor: bool, behavior: u8) bool {
     const object_ptr = acquireEditorView(view_handle) orelse return false;
     object_ptr.setSelectionFollowCursor(followCursor);
-    return object_ptr.updateLocalSelection(anchorX, anchorY, focusX, focusY, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor), updateCursor);
+    return object_ptr.updateLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor), updateCursor, selectionBehavior(behavior));
 }
 
 export fn editorViewResetLocalSelection(view_handle: NativeHandle) void {

--- a/packages/native/src/lib.zig
+++ b/packages/native/src/lib.zig
@@ -2924,6 +2924,11 @@ export fn editorViewResetLocalSelection(view_handle: NativeHandle) void {
     object_ptr.resetLocalSelection();
 }
 
+export fn editorViewConvertSelectionToCell(view_handle: NativeHandle) bool {
+    const object_ptr = acquireEditorView(view_handle) orelse return false;
+    return object_ptr.convertSelectionToCell();
+}
+
 export fn editorViewSetSelectionOccupancy(view_handle: NativeHandle, occupancy: u8) void {
     const object_ptr = acquireEditorView(view_handle) orelse return;
     object_ptr.setSelectionOccupancy(selectionOccupancy(occupancy));

--- a/packages/native/src/lib.zig
+++ b/packages/native/src/lib.zig
@@ -2267,7 +2267,7 @@ export fn textBufferViewGetSelectionInfo(view_handle: NativeHandle) u64 {
 
 export fn textBufferViewSetLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16) bool {
     const object_ptr = acquireTextBufferView(view_handle) orelse return false;
-    return object_ptr.setLocalSelectionStyle(anchorX, anchorY, focusX, focusY, selectionStyle(optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor)));
+    return object_ptr.setLocalSelectionStyle(anchorX, anchorY, focusX, focusY, selectionStyle(optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor)), .cell);
 }
 
 export fn textBufferViewUpdateSelection(view_handle: NativeHandle, end: u32, bgColor: ?[*]const u16, fgColor: ?[*]const u16) void {
@@ -2277,7 +2277,7 @@ export fn textBufferViewUpdateSelection(view_handle: NativeHandle, end: u32, bgC
 
 export fn textBufferViewUpdateLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16) bool {
     const object_ptr = acquireTextBufferView(view_handle) orelse return false;
-    return object_ptr.updateLocalSelectionStyle(anchorX, anchorY, focusX, focusY, selectionStyle(optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor)));
+    return object_ptr.updateLocalSelectionStyle(anchorX, anchorY, focusX, focusY, selectionStyle(optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor)), .cell);
 }
 
 export fn textBufferViewResetLocalSelection(view_handle: NativeHandle) void {

--- a/packages/native/src/lib.zig
+++ b/packages/native/src/lib.zig
@@ -2901,10 +2901,10 @@ export fn editorViewGetSelection(view_handle: NativeHandle) u64 {
     return object_ptr.text_buffer_view.packSelectionInfo();
 }
 
-export fn editorViewSetLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, updateCursor: bool, followCursor: bool, behavior: u8) bool {
+export fn editorViewSetLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, updateCursor: u8, followCursor: u8, behavior: u8) bool {
     const object_ptr = acquireEditorView(view_handle) orelse return false;
-    object_ptr.setSelectionFollowCursor(followCursor);
-    return object_ptr.setLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor), updateCursor, selectionBehavior(behavior));
+    object_ptr.setSelectionFollowCursor(followCursor == 1);
+    return object_ptr.setLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor), updateCursor == 1, selectionBehavior(behavior));
 }
 
 export fn editorViewUpdateSelection(view_handle: NativeHandle, end: u32, bgColor: ?[*]const u16, fgColor: ?[*]const u16) void {
@@ -2912,10 +2912,10 @@ export fn editorViewUpdateSelection(view_handle: NativeHandle, end: u32, bgColor
     object_ptr.updateSelection(end, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor));
 }
 
-export fn editorViewUpdateLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, updateCursor: bool, followCursor: bool, behavior: u8) bool {
+export fn editorViewUpdateLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, updateCursor: u8, followCursor: u8, behavior: u8) bool {
     const object_ptr = acquireEditorView(view_handle) orelse return false;
-    object_ptr.setSelectionFollowCursor(followCursor);
-    return object_ptr.updateLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor), updateCursor, selectionBehavior(behavior));
+    object_ptr.setSelectionFollowCursor(followCursor == 1);
+    return object_ptr.updateLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor), updateCursor == 1, selectionBehavior(behavior));
 }
 
 export fn editorViewResetLocalSelection(view_handle: NativeHandle) void {

--- a/packages/native/src/lib.zig
+++ b/packages/native/src/lib.zig
@@ -2901,10 +2901,10 @@ export fn editorViewGetSelection(view_handle: NativeHandle) u64 {
     return object_ptr.text_buffer_view.packSelectionInfo();
 }
 
-export fn editorViewSetLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, updateCursor: u8, followCursor: u8, behavior: u8) bool {
+export fn editorViewSetLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, flags: u8) bool {
     const object_ptr = acquireEditorView(view_handle) orelse return false;
-    object_ptr.setSelectionFollowCursor(followCursor == 1);
-    return object_ptr.setLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor), updateCursor == 1, selectionBehavior(behavior));
+    object_ptr.setSelectionFollowCursor(flags & 2 != 0);
+    return object_ptr.setLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor), flags & 1 != 0, selectionBehavior(flags >> 2));
 }
 
 export fn editorViewUpdateSelection(view_handle: NativeHandle, end: u32, bgColor: ?[*]const u16, fgColor: ?[*]const u16) void {
@@ -2912,10 +2912,10 @@ export fn editorViewUpdateSelection(view_handle: NativeHandle, end: u32, bgColor
     object_ptr.updateSelection(end, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor));
 }
 
-export fn editorViewUpdateLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, updateCursor: u8, followCursor: u8, behavior: u8) bool {
+export fn editorViewUpdateLocalSelection(view_handle: NativeHandle, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?[*]const u16, fgColor: ?[*]const u16, flags: u8) bool {
     const object_ptr = acquireEditorView(view_handle) orelse return false;
-    object_ptr.setSelectionFollowCursor(followCursor == 1);
-    return object_ptr.updateLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor), updateCursor == 1, selectionBehavior(behavior));
+    object_ptr.setSelectionFollowCursor(flags & 2 != 0);
+    return object_ptr.updateLocalSelectionBehavior(anchorX, anchorY, focusX, focusY, optionalPtrToRGBA(bgColor), optionalPtrToRGBA(fgColor), flags & 1 != 0, selectionBehavior(flags >> 2));
 }
 
 export fn editorViewResetLocalSelection(view_handle: NativeHandle) void {

--- a/packages/native/src/test.zig
+++ b/packages/native/src/test.zig
@@ -3,6 +3,7 @@ const text_buffer_tests = @import("tests/text-buffer_test.zig");
 const text_buffer_highlights_tests = @import("tests/text-buffer-highlights_test.zig");
 const text_buffer_view_tests = @import("tests/text-buffer-view_test.zig");
 const text_buffer_selection_tests = @import("tests/text-buffer-selection_test.zig");
+const text_buffer_selection_gesture_tests = @import("tests/text-buffer-selection-gesture_test.zig");
 const text_buffer_drawing_tests = @import("tests/text-buffer-drawing_test.zig");
 const text_buffer_segment_tests = @import("tests/text-buffer-segment_test.zig");
 const text_buffer_iterators_tests = @import("tests/text-buffer-iterators_test.zig");
@@ -51,6 +52,7 @@ comptime {
     _ = text_buffer_highlights_tests;
     _ = text_buffer_view_tests;
     _ = text_buffer_selection_tests;
+    _ = text_buffer_selection_gesture_tests;
     _ = text_buffer_drawing_tests;
     _ = text_buffer_segment_tests;
     _ = text_buffer_iterators_tests;

--- a/packages/native/src/tests/editor-view_test.zig
+++ b/packages/native/src/tests/editor-view_test.zig
@@ -3600,3 +3600,84 @@ test "occupancy - EditorView forwards occupancy and replays stored endpoints" {
     ev.gotoVisualLineEnd();
     try std.testing.expectEqual(@as(u32, 2), ev.getPrimaryCursor().offset);
 }
+
+test "EditorView - word press keeps cursor on the clicked grapheme" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    try eb.insertText("alpha beta");
+    try eb.setCursor(0, 0);
+    _ = ev.getVirtualLines();
+
+    _ = ev.setLocalSelectionBehavior(6, 0, 6, 0, null, null, true, .word);
+
+    var out: [32]u8 = undefined;
+    const len = ev.getSelectedTextIntoBuffer(&out);
+    try std.testing.expectEqualStrings("beta", out[0..len]);
+
+    const cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 0), cursor.row);
+    try std.testing.expectEqual(@as(u32, 6), cursor.col);
+}
+
+test "EditorView - line press keeps cursor on the clicked grapheme" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    try eb.insertText("  hello world  ");
+    try eb.setCursor(0, 0);
+    _ = ev.getVirtualLines();
+
+    _ = ev.setLocalSelectionBehavior(4, 0, 4, 0, null, null, true, .line);
+
+    var out: [32]u8 = undefined;
+    const len = ev.getSelectedTextIntoBuffer(&out);
+    try std.testing.expectEqualStrings("hello world", out[0..len]);
+
+    const cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 0), cursor.row);
+    try std.testing.expectEqual(@as(u32, 4), cursor.col);
+}
+
+test "EditorView - cell press still syncs cursor without selecting" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    try eb.insertText("alpha beta");
+    try eb.setCursor(0, 0);
+    _ = ev.getVirtualLines();
+
+    _ = ev.setLocalSelection(6, 0, 6, 0, null, null, true);
+
+    var out: [32]u8 = undefined;
+    const len = ev.getSelectedTextIntoBuffer(&out);
+    try std.testing.expectEqualStrings("", out[0..len]);
+
+    const cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 0), cursor.row);
+    try std.testing.expectEqual(@as(u32, 6), cursor.col);
+}

--- a/packages/native/src/tests/editor-view_test.zig
+++ b/packages/native/src/tests/editor-view_test.zig
@@ -3681,3 +3681,31 @@ test "EditorView - cell press still syncs cursor without selecting" {
     try std.testing.expectEqual(@as(u32, 0), cursor.row);
     try std.testing.expectEqual(@as(u32, 6), cursor.col);
 }
+
+test "EditorView - convert word selection to cell keeps the range and moves focus to the last cell" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
+    defer ev.deinit();
+
+    try eb.insertText("alpha beta");
+    try eb.setCursor(0, 0);
+    _ = ev.getVirtualLines();
+
+    _ = ev.setLocalSelectionBehavior(6, 0, 6, 0, null, null, true, .word);
+    try std.testing.expect(ev.convertSelectionToCell());
+
+    var converted: [32]u8 = undefined;
+    const converted_len = ev.getSelectedTextIntoBuffer(&converted);
+    try std.testing.expectEqualStrings("beta", converted[0..converted_len]);
+
+    const converted_cursor = ev.getPrimaryCursor();
+    try std.testing.expectEqual(@as(u32, 0), converted_cursor.row);
+    try std.testing.expectEqual(@as(u32, 9), converted_cursor.col);
+}

--- a/packages/native/src/tests/text-buffer-selection-gesture_test.zig
+++ b/packages/native/src/tests/text-buffer-selection-gesture_test.zig
@@ -33,11 +33,6 @@ fn deinitView(pair: ViewPair) void {
     link.deinitGlobalLinkPool();
 }
 
-fn selected(view: *TextBufferView, range: text_buffer_view.SelectionRange, out: []u8) []const u8 {
-    const len = view.getTextBuffer().getTextRange(range.start, range.end, out);
-    return out[0..len];
-}
-
 fn expectSelected(
     view: *TextBufferView,
     range: ?text_buffer_view.SelectionRange,
@@ -45,7 +40,8 @@ fn expectSelected(
 ) !void {
     const found = range orelse return error.TestUnexpectedResult;
     var out: [128]u8 = undefined;
-    try std.testing.expectEqualStrings(expected, selected(view, found, &out));
+    const len = view.getTextBuffer().getTextRange(found.start, found.end, &out);
+    try std.testing.expectEqualStrings(expected, out[0..len]);
 }
 
 test "selectWord - alpha beta click on b selects beta" {

--- a/packages/native/src/tests/text-buffer-selection-gesture_test.zig
+++ b/packages/native/src/tests/text-buffer-selection-gesture_test.zig
@@ -239,3 +239,43 @@ test "behavior - set and update agree for word and line" {
     try std.testing.expectEqualStrings(set_out[0..line_set_len], update_out[0..line_update_len]);
     try std.testing.expectEqualStrings("alpha beta gamma\nnext", set_out[0..line_set_len]);
 }
+
+test "behavior - convert word range to cell keeps text and later drag is cell-granular" {
+    const pair = try initView("alpha beta gamma");
+    defer deinitView(pair);
+
+    _ = pair.view.setLocalSelectionBehavior(6, 0, 6, 0, null, null, .word);
+    try expectViewSelected(pair.view, "beta");
+    try std.testing.expect(pair.view.convertSelectionToCell());
+    try expectViewSelected(pair.view, "beta");
+
+    _ = pair.view.updateLocalSelectionBehavior(6, 0, 10, 0, null, null, .cell);
+    try expectViewSelected(pair.view, "beta ");
+}
+
+test "behavior - convert word range keeps exclusive end under boundary occupancy" {
+    const pair = try initView("alpha beta gamma");
+    defer deinitView(pair);
+    pair.view.setSelectionOccupancy(.boundary);
+
+    _ = pair.view.setLocalSelectionBehavior(6, 0, 6, 0, null, null, .word);
+    try expectViewSelected(pair.view, "beta");
+    try std.testing.expect(pair.view.convertSelectionToCell());
+    try expectViewSelected(pair.view, "beta");
+
+    _ = pair.view.updateLocalSelectionBehavior(6, 0, 11, 0, null, null, .cell);
+    try expectViewSelected(pair.view, "beta ");
+}
+
+test "behavior - convert line range keeps text when the start is above the viewport" {
+    const pair = try initView("hello world");
+    defer deinitView(pair);
+    pair.view.setWrapMode(.char);
+    pair.view.setWrapWidth(5);
+    pair.view.setViewport(.{ .x = 0, .y = 1, .width = 5, .height = 1 });
+
+    _ = pair.view.setLocalSelectionBehavior(1, 0, 1, 0, null, null, .line);
+    try expectViewSelected(pair.view, "hello world");
+    try std.testing.expect(pair.view.convertSelectionToCell());
+    try expectViewSelected(pair.view, "hello world");
+}

--- a/packages/native/src/tests/text-buffer-selection-gesture_test.zig
+++ b/packages/native/src/tests/text-buffer-selection-gesture_test.zig
@@ -141,3 +141,93 @@ test "selectLine - selected bytes match a whole visual-line drag" {
 
     try expectSelected(pair.view, pair.view.selectLine(0), "hello");
 }
+
+fn expectViewSelected(view: *TextBufferView, expected: []const u8) !void {
+    var out: [128]u8 = undefined;
+    const len = view.getSelectedTextIntoBuffer(&out);
+    try std.testing.expectEqualStrings(expected, out[0..len]);
+}
+
+test "behavior - word press on one cell produces a non-empty range" {
+    const pair = try initView("alpha beta gamma");
+    defer deinitView(pair);
+
+    _ = pair.view.setLocalSelectionBehavior(6, 0, 6, 0, null, null, .word);
+    try expectViewSelected(pair.view, "beta");
+}
+
+test "behavior - word press on padding produces zero-width" {
+    const pair = try initView("alpha beta");
+    defer deinitView(pair);
+
+    _ = pair.view.setLocalSelectionBehavior(10, 0, 10, 0, null, null, .word);
+    try expectViewSelected(pair.view, "");
+    try std.testing.expectEqual(@as(u64, 0xFFFFFFFF_FFFFFFFF), pair.view.packSelectionInfo());
+}
+
+test "behavior - word drag beta to gamma selects both words" {
+    const pair = try initView("alpha beta gamma");
+    defer deinitView(pair);
+
+    _ = pair.view.setLocalSelectionBehavior(6, 0, 6, 0, null, null, .word);
+    _ = pair.view.updateLocalSelectionBehavior(6, 0, 12, 0, null, null, .word);
+    try expectViewSelected(pair.view, "beta gamma");
+}
+
+test "behavior - word drag backward matches forward" {
+    const pair = try initView("alpha beta gamma");
+    defer deinitView(pair);
+
+    _ = pair.view.setLocalSelectionBehavior(6, 0, 12, 0, null, null, .word);
+    try expectViewSelected(pair.view, "beta gamma");
+
+    pair.view.resetLocalSelection();
+    _ = pair.view.setLocalSelectionBehavior(12, 0, 6, 0, null, null, .word);
+    try expectViewSelected(pair.view, "beta gamma");
+}
+
+test "behavior - line drag across two source lines unions them" {
+    const pair = try initView("hello\nworld");
+    defer deinitView(pair);
+
+    _ = pair.view.setLocalSelectionBehavior(0, 0, 0, 0, null, null, .line);
+    _ = pair.view.updateLocalSelectionBehavior(0, 0, 0, 1, null, null, .line);
+    try expectViewSelected(pair.view, "hello\nworld");
+}
+
+test "behavior - cell press still zero-width" {
+    const pair = try initView("alpha beta");
+    defer deinitView(pair);
+
+    _ = pair.view.setLocalSelection(6, 0, 6, 0, null, null);
+    try expectViewSelected(pair.view, "");
+    try std.testing.expectEqual(@as(u64, 0xFFFFFFFF_FFFFFFFF), pair.view.packSelectionInfo());
+}
+
+test "behavior - set and update agree for word and line" {
+    const pair = try initView("alpha beta gamma\nnext");
+    defer deinitView(pair);
+
+    _ = pair.view.setLocalSelectionBehavior(6, 0, 12, 0, null, null, .word);
+    var set_out: [128]u8 = undefined;
+    const set_len = pair.view.getSelectedTextIntoBuffer(&set_out);
+
+    pair.view.resetLocalSelection();
+    _ = pair.view.setLocalSelectionBehavior(6, 0, 6, 0, null, null, .word);
+    _ = pair.view.updateLocalSelectionBehavior(6, 0, 12, 0, null, null, .word);
+    var update_out: [128]u8 = undefined;
+    const update_len = pair.view.getSelectedTextIntoBuffer(&update_out);
+    try std.testing.expectEqualStrings(set_out[0..set_len], update_out[0..update_len]);
+    try std.testing.expectEqualStrings("beta gamma", set_out[0..set_len]);
+
+    pair.view.resetLocalSelection();
+    _ = pair.view.setLocalSelectionBehavior(0, 0, 0, 1, null, null, .line);
+    const line_set_len = pair.view.getSelectedTextIntoBuffer(&set_out);
+
+    pair.view.resetLocalSelection();
+    _ = pair.view.setLocalSelectionBehavior(0, 0, 0, 0, null, null, .line);
+    _ = pair.view.updateLocalSelectionBehavior(0, 0, 0, 1, null, null, .line);
+    const line_update_len = pair.view.getSelectedTextIntoBuffer(&update_out);
+    try std.testing.expectEqualStrings(set_out[0..line_set_len], update_out[0..line_update_len]);
+    try std.testing.expectEqualStrings("alpha beta gamma\nnext", set_out[0..line_set_len]);
+}

--- a/packages/native/src/tests/text-buffer-selection-gesture_test.zig
+++ b/packages/native/src/tests/text-buffer-selection-gesture_test.zig
@@ -1,0 +1,143 @@
+const std = @import("std");
+const text_buffer = @import("../text-buffer.zig");
+const text_buffer_view = @import("../text-buffer-view.zig");
+const gp = @import("../grapheme.zig");
+const link = @import("../link.zig");
+
+const TextBuffer = text_buffer.TextBuffer;
+const TextBufferView = text_buffer_view.TextBufferView;
+
+const ViewPair = struct {
+    tb: *TextBuffer,
+    view: *TextBufferView,
+};
+
+fn initView(text: []const u8) !ViewPair {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    errdefer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    errdefer link.deinitGlobalLinkPool();
+
+    const tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    errdefer tb.deinit();
+    const view = try TextBufferView.init(std.testing.allocator, tb);
+    errdefer view.deinit();
+    try tb.setText(text);
+    return .{ .tb = tb, .view = view };
+}
+
+fn deinitView(pair: ViewPair) void {
+    pair.view.deinit();
+    pair.tb.deinit();
+    gp.deinitGlobalPool();
+    link.deinitGlobalLinkPool();
+}
+
+fn selected(view: *TextBufferView, range: text_buffer_view.SelectionRange, out: []u8) []const u8 {
+    const len = view.getTextBuffer().getTextRange(range.start, range.end, out);
+    return out[0..len];
+}
+
+fn expectSelected(
+    view: *TextBufferView,
+    range: ?text_buffer_view.SelectionRange,
+    expected: []const u8,
+) !void {
+    const found = range orelse return error.TestUnexpectedResult;
+    var out: [128]u8 = undefined;
+    try std.testing.expectEqualStrings(expected, selected(view, found, &out));
+}
+
+test "selectWord - alpha beta click on b selects beta" {
+    const pair = try initView("alpha beta");
+    defer deinitView(pair);
+
+    try expectSelected(pair.view, pair.view.selectWord(6), "beta");
+}
+
+test "selectWord - click on space selects one space" {
+    const pair = try initView("alpha beta");
+    defer deinitView(pair);
+
+    try expectSelected(pair.view, pair.view.selectWord(5), " ");
+}
+
+test "selectWord - empty padding past the line returns no range" {
+    const pair = try initView("alpha beta");
+    defer deinitView(pair);
+
+    try std.testing.expect(pair.view.selectWord(10) == null);
+    try std.testing.expect(pair.view.selectWord(11) == null);
+}
+
+test "selectWord - newline returns no range" {
+    const pair = try initView("alpha\nbeta");
+    defer deinitView(pair);
+
+    try std.testing.expect(pair.view.selectWord(5) == null);
+}
+
+test "selectWord - wide glyph 日本語abc is one word" {
+    const pair = try initView("日本語abc");
+    defer deinitView(pair);
+
+    // 日=2, 本=2, 語=2, a=1, b=1, c=1. Click either cell of 本 (offsets 2 or 3).
+    try expectSelected(pair.view, pair.view.selectWord(2), "日本語abc");
+    try expectSelected(pair.view, pair.view.selectWord(3), "日本語abc");
+}
+
+test "selectWord - slash is not a boundary unlike wrap breaks" {
+    const pair = try initView("foo/bar");
+    defer deinitView(pair);
+
+    try expectSelected(pair.view, pair.view.selectWord(0), "foo/bar");
+    try expectSelected(pair.view, pair.view.selectWord(3), "foo/bar");
+}
+
+test "selectWord - wrapped hello world still selects world" {
+    const pair = try initView("hello world");
+    defer deinitView(pair);
+    pair.view.setWrapMode(.char);
+    pair.view.setWrapWidth(5);
+
+    try expectSelected(pair.view, pair.view.selectWord(6), "world");
+}
+
+test "selectWordBetween - from alpha across spaces onto padding past beta" {
+    const pair = try initView("alpha beta");
+    defer deinitView(pair);
+
+    try expectSelected(pair.view, pair.view.selectWordBetween(0, 10), "alpha");
+    try expectSelected(pair.view, pair.view.selectWordBetween(10, 0), "beta");
+}
+
+test "selectLine - hello world keeps interior spaces and trims ends" {
+    const pair = try initView("  hello world  ");
+    defer deinitView(pair);
+
+    try expectSelected(pair.view, pair.view.selectLine(4), "hello world");
+}
+
+test "selectLine - wrapped source line selected as one line" {
+    const pair = try initView("hello world");
+    defer deinitView(pair);
+    pair.view.setWrapMode(.char);
+    pair.view.setWrapWidth(5);
+
+    try expectSelected(pair.view, pair.view.selectLine(0), "hello world");
+    try expectSelected(pair.view, pair.view.selectLine(6), "hello world");
+}
+
+test "selectLine - blank line selected in full" {
+    const pair = try initView("alpha\n   \nbeta");
+    defer deinitView(pair);
+
+    try expectSelected(pair.view, pair.view.selectLine(6), "   ");
+}
+
+test "selectLine - selected bytes match a whole visual-line drag" {
+    const pair = try initView("hello\nworld");
+    defer deinitView(pair);
+
+    try expectSelected(pair.view, pair.view.selectLine(0), "hello");
+}

--- a/packages/native/src/tests/text-buffer-selection-gesture_test.zig
+++ b/packages/native/src/tests/text-buffer-selection-gesture_test.zig
@@ -86,6 +86,14 @@ test "selectWord - wide glyph 日本語abc is one word" {
     try expectSelected(pair.view, pair.view.selectWord(3), "日本語abc");
 }
 
+test "selectWord - zero-width prefix does not hang" {
+    const pair = try initView("\u{200B}hello");
+    defer deinitView(pair);
+
+    try expectSelected(pair.view, pair.view.selectWord(0), "\u{200B}hello");
+    try expectSelected(pair.view, pair.view.selectLine(0), "\u{200B}hello");
+}
+
 test "selectWord - slash is not a boundary unlike wrap breaks" {
     const pair = try initView("foo/bar");
     defer deinitView(pair);

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -814,6 +814,26 @@ pub const UnifiedTextBufferView = struct {
         return true;
     }
 
+    /// Keep the exclusive highlight and store cell endpoints so a later
+    /// cell drag or shift-extend does not re-expand by word or line.
+    /// Cell occupancy pins focus on the last occupied grapheme; boundary
+    /// occupancy pins it on the exclusive end.
+    pub fn convertSelectionToCell(self: *Self) bool {
+        const selection = self.selection orelse return false;
+        if (selection.start == selection.end) return false;
+
+        const focus = if (self.selection_occupancy == .boundary)
+            selection.end
+        else if (self.text_buffer.graphemeBoundsAtOffset(selection.end - 1)) |bounds|
+            bounds.start
+        else
+            selection.end - 1;
+
+        self.selection_endpoints = .{ .anchor = selection.start, .focus = focus };
+        self.selection_behavior = .cell;
+        return true;
+    }
+
     fn expandSelectionRange(
         self: *Self,
         anchor_offset: u32,

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -41,6 +41,15 @@ pub const SelectionOccupancy = enum(u8) {
     boundary = 1,
 };
 
+/// How local cell coordinates expand into a highlight range.
+/// `cell` is the current inclusive press/drag. `word` and `line` expand
+/// each endpoint through selectWord / selectLine.
+pub const SelectionBehavior = enum(u8) {
+    cell = 0,
+    word = 1,
+    line = 2,
+};
+
 /// Half-open display-offset range used by word/line click expansion.
 pub const SelectionRange = struct {
     start: u32,
@@ -177,6 +186,7 @@ pub const UnifiedTextBufferView = struct {
     /// cell occupancy can extend `selection.end` past the focus grapheme.
     selection_endpoints: ?SelectionEndpoints,
     selection_occupancy: SelectionOccupancy,
+    selection_behavior: SelectionBehavior,
     viewport: ?Viewport,
     wrap_width: ?u32,
     wrap_mode: WrapMode,
@@ -236,6 +246,7 @@ pub const UnifiedTextBufferView = struct {
             .selection = null,
             .selection_endpoints = null,
             .selection_occupancy = .cell,
+            .selection_behavior = .cell,
             .viewport = null,
             .wrap_width = null,
             .wrap_mode = .none,
@@ -634,6 +645,7 @@ pub const UnifiedTextBufferView = struct {
     pub fn resetSelection(self: *Self) void {
         self.selection = null;
         self.clearSelectionEndpoints();
+        self.selection_behavior = .cell;
     }
 
     pub fn setSelectionOccupancy(self: *Self, occupancy: SelectionOccupancy) void {
@@ -643,7 +655,8 @@ pub const UnifiedTextBufferView = struct {
         const text_end = self.getTextEndOffset();
         endpoints.anchor = @min(endpoints.anchor, text_end);
         endpoints.focus = @min(endpoints.focus, text_end);
-        const range = self.selectionRange(endpoints.anchor, endpoints.focus, text_end);
+        const range = self.expandSelectionRange(endpoints.anchor, endpoints.focus, text_end, self.selection_behavior) orelse
+            self.selectionRange(endpoints.anchor, endpoints.focus, text_end);
         selection.start = range.start;
         selection.end = range.end;
     }
@@ -686,10 +699,14 @@ pub const UnifiedTextBufferView = struct {
     }
 
     pub fn setLocalSelection(self: *Self, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?RGBA, fgColor: ?RGBA) bool {
-        return self.setLocalSelectionStyle(anchorX, anchorY, focusX, focusY, SelectionStyle.rgb(bgColor, fgColor));
+        return self.setLocalSelectionStyle(anchorX, anchorY, focusX, focusY, SelectionStyle.rgb(bgColor, fgColor), .cell);
     }
 
-    pub fn setLocalSelectionStyle(self: *Self, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, style: SelectionStyle) bool {
+    pub fn setLocalSelectionBehavior(self: *Self, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?RGBA, fgColor: ?RGBA, behavior: SelectionBehavior) bool {
+        return self.setLocalSelectionStyle(anchorX, anchorY, focusX, focusY, SelectionStyle.rgb(bgColor, fgColor), behavior);
+    }
+
+    pub fn setLocalSelectionStyle(self: *Self, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, style: SelectionStyle, behavior: SelectionBehavior) bool {
         self.updateVirtualLines();
         if (self.truncate and self.viewport != null) {
             self.ensureTruncation();
@@ -733,8 +750,10 @@ pub const UnifiedTextBufferView = struct {
             };
 
         self.selection_endpoints = .{ .anchor = anchor_offset, .focus = focus_offset };
+        self.selection_behavior = behavior;
 
-        const range = self.selectionRange(anchor_offset, focus_offset, text_end_offset);
+        const range = self.expandSelectionRange(anchor_offset, focus_offset, text_end_offset, behavior) orelse
+            self.selectionRange(anchor_offset, focus_offset, text_end_offset);
 
         // Always store selection, even if zero-width, to preserve anchor for updateLocalSelection
         const new_selection = selectionFromStyle(range.start, range.end, style);
@@ -749,18 +768,22 @@ pub const UnifiedTextBufferView = struct {
     }
 
     pub fn updateLocalSelection(self: *Self, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?RGBA, fgColor: ?RGBA) bool {
-        return self.updateLocalSelectionStyle(anchorX, anchorY, focusX, focusY, SelectionStyle.rgb(bgColor, fgColor));
+        return self.updateLocalSelectionStyle(anchorX, anchorY, focusX, focusY, SelectionStyle.rgb(bgColor, fgColor), .cell);
     }
 
-    pub fn updateLocalSelectionStyle(self: *Self, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, style: SelectionStyle) bool {
+    pub fn updateLocalSelectionBehavior(self: *Self, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, bgColor: ?RGBA, fgColor: ?RGBA, behavior: SelectionBehavior) bool {
+        return self.updateLocalSelectionStyle(anchorX, anchorY, focusX, focusY, SelectionStyle.rgb(bgColor, fgColor), behavior);
+    }
+
+    pub fn updateLocalSelectionStyle(self: *Self, anchorX: i32, anchorY: i32, focusX: i32, focusY: i32, style: SelectionStyle, behavior: SelectionBehavior) bool {
         if (self.selection_endpoints != null) {
-            return self.updateLocalSelectionFocusOnly(focusX, focusY, style);
+            return self.updateLocalSelectionFocusOnly(focusX, focusY, style, behavior);
         } else {
-            return self.setLocalSelectionStyle(anchorX, anchorY, focusX, focusY, style);
+            return self.setLocalSelectionStyle(anchorX, anchorY, focusX, focusY, style, behavior);
         }
     }
 
-    fn updateLocalSelectionFocusOnly(self: *Self, focusX: i32, focusY: i32, style: SelectionStyle) bool {
+    fn updateLocalSelectionFocusOnly(self: *Self, focusX: i32, focusY: i32, style: SelectionStyle, behavior: SelectionBehavior) bool {
         const endpoints = self.selection_endpoints orelse return false;
         const anchor_offset = endpoints.anchor;
 
@@ -783,11 +806,44 @@ pub const UnifiedTextBufferView = struct {
             self.coordsToCharOffset(focusX, focusY) orelse return false;
 
         self.selection_endpoints.?.focus = focus_col_offset;
+        self.selection_behavior = behavior;
 
-        const range = self.selectionRange(anchor_offset, focus_col_offset, text_end_offset);
+        const range = self.expandSelectionRange(anchor_offset, focus_col_offset, text_end_offset, behavior) orelse return false;
         self.selection = selectionFromStyle(range.start, range.end, style);
 
         return true;
+    }
+
+    fn expandSelectionRange(
+        self: *Self,
+        anchor_offset: u32,
+        focus_offset: u32,
+        text_end_offset: u32,
+        behavior: SelectionBehavior,
+    ) ?SelectionRange {
+        switch (behavior) {
+            .cell => return self.selectionRange(anchor_offset, focus_offset, text_end_offset),
+            .word => {
+                const a = self.selectWordBetween(anchor_offset, focus_offset);
+                const b = self.selectWordBetween(focus_offset, anchor_offset);
+                return unionRanges(a, b);
+            },
+            .line => {
+                const a = self.selectLine(anchor_offset);
+                const b = self.selectLine(focus_offset);
+                return unionRanges(a, b);
+            },
+        }
+    }
+
+    fn unionRanges(a: ?SelectionRange, b: ?SelectionRange) ?SelectionRange {
+        if (a == null and b == null) return null;
+        if (a == null) return b;
+        if (b == null) return a;
+        return .{
+            .start = @min(a.?.start, b.?.start),
+            .end = @max(a.?.end, b.?.end),
+        };
     }
 
     /// Word at `offset`. Null on newline or end-of-buffer. `/` is not a boundary.
@@ -951,7 +1007,7 @@ pub const UnifiedTextBufferView = struct {
     /// `boundary`: `[min, max)` — the insert range the caret swept.
     /// Zero extent (`anchor == focus`) stays empty in both modes: a press is
     /// not a cell to occupy.
-    fn selectionRange(self: *Self, anchor_offset: u32, focus_offset: u32, text_end_offset: u32) struct { start: u32, end: u32 } {
+    fn selectionRange(self: *Self, anchor_offset: u32, focus_offset: u32, text_end_offset: u32) SelectionRange {
         var start = @min(anchor_offset, focus_offset);
         var end = @max(anchor_offset, focus_offset);
         if (anchor_offset == focus_offset) {

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -56,8 +56,12 @@ pub const SelectionRange = struct {
     end: u32,
 };
 
-/// Ghostty-style boundary codepoints, without NUL. A run of these is a word.
-/// Space and tab are included so a double-click on whitespace selects the run.
+/// Ghostty-style boundaries for double-click selection. NUL is omitted because
+/// OpenTUI text buffers do not use it for unwritten terminal cells.
+/// Keep this policy separate from `utf8.findWrapBreaks`: wrap and editor motion
+/// split on `/`, `-`, and CJK/ASCII transitions, but selection does not.
+/// Selection groups consecutive graphemes by this class, so space and tab runs
+/// are selectable instead of mapping to an adjacent word.
 const default_word_boundaries = [_]u21{
     ' ',
     '\t',

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -858,12 +858,14 @@ pub const UnifiedTextBufferView = struct {
         while (self.prevSelectionGrapheme(start)) |prev| {
             if (prev.is_break) break;
             if (isWordBoundary(prev.first_cp) != expect_boundary) break;
+            if (prev.start >= start) break;
             start = prev.start;
         }
 
         while (self.selectionGraphemeAt(end)) |next| {
             if (next.is_break) break;
             if (isWordBoundary(next.first_cp) != expect_boundary) break;
+            if (next.end <= end) break;
             end = next.end;
         }
 
@@ -880,6 +882,7 @@ pub const UnifiedTextBufferView = struct {
             while (offset <= limit) {
                 if (self.selectWord(offset)) |range| return range;
                 const next = self.selectionGraphemeAt(offset) orelse return null;
+                if (next.end <= offset) return null;
                 offset = next.end;
             }
             return null;
@@ -889,6 +892,7 @@ pub const UnifiedTextBufferView = struct {
             if (self.selectWord(offset)) |range| return range;
             if (offset <= limit) return null;
             const prev = self.prevSelectionGrapheme(offset) orelse return null;
+            if (prev.start >= offset) return null;
             offset = prev.start;
         }
     }
@@ -922,6 +926,7 @@ pub const UnifiedTextBufferView = struct {
                 end = grapheme.end;
                 saw_content = true;
             }
+            if (grapheme.end <= offset) break;
             offset = grapheme.end;
         }
 
@@ -978,7 +983,20 @@ pub const UnifiedTextBufferView = struct {
                     width_method,
                 );
                 if (pos.byte_offset >= bytes.len) return null;
-                const width = utf8.getGraphemeWidthAt(bytes, pos.byte_offset, tab_width, width_method);
+                var width = utf8.getGraphemeWidthAt(bytes, pos.byte_offset, tab_width, width_method);
+                if (width == 0) {
+                    const next = utf8.findGraphemePosByWidth(
+                        bytes,
+                        pos.columns_used + 1,
+                        tab_width,
+                        is_ascii,
+                        false,
+                        width_method,
+                    );
+                    if (next.byte_offset < bytes.len) {
+                        width = utf8.getGraphemeWidthAt(bytes, next.byte_offset, tab_width, width_method);
+                    }
+                }
                 const first_cp = utf8.decodeUtf8Unchecked(bytes, pos.byte_offset).cp;
                 const start = line_start + cols_before + pos.columns_used;
                 return .{

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -857,12 +857,11 @@ pub const UnifiedTextBufferView = struct {
     }
 
     fn unionRanges(a: ?SelectionRange, b: ?SelectionRange) ?SelectionRange {
-        if (a == null and b == null) return null;
-        if (a == null) return b;
-        if (b == null) return a;
+        const left = a orelse return b;
+        const right = b orelse return a;
         return .{
-            .start = @min(a.?.start, b.?.start),
-            .end = @max(a.?.end, b.?.end),
+            .start = @min(left.start, right.start),
+            .end = @max(left.end, right.end),
         };
     }
 

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -41,6 +41,36 @@ pub const SelectionOccupancy = enum(u8) {
     boundary = 1,
 };
 
+/// Half-open display-offset range used by word/line click expansion.
+pub const SelectionRange = struct {
+    start: u32,
+    end: u32,
+};
+
+/// Ghostty-style boundary codepoints, without NUL. A run of these is a word.
+/// Space and tab are included so a double-click on whitespace selects the run.
+const default_word_boundaries = [_]u21{
+    ' ',
+    '\t',
+    '\'',
+    '"',
+    '│',
+    '`',
+    '|',
+    ':',
+    ';',
+    ',',
+    '(',
+    ')',
+    '[',
+    ']',
+    '{',
+    '}',
+    '<',
+    '>',
+    '$',
+};
+
 const SelectionEndpoints = struct {
     anchor: u32,
     focus: u32,
@@ -758,6 +788,162 @@ pub const UnifiedTextBufferView = struct {
         self.selection = selectionFromStyle(range.start, range.end, style);
 
         return true;
+    }
+
+    /// Word at `offset`. Null on newline or end-of-buffer. `/` is not a boundary.
+    pub fn selectWord(self: *Self, offset: u32) ?SelectionRange {
+        const grapheme = self.selectionGraphemeAt(offset) orelse return null;
+        if (grapheme.is_break) return null;
+
+        const expect_boundary = isWordBoundary(grapheme.first_cp);
+        var start = grapheme.start;
+        var end = grapheme.end;
+
+        while (self.prevSelectionGrapheme(start)) |prev| {
+            if (prev.is_break) break;
+            if (isWordBoundary(prev.first_cp) != expect_boundary) break;
+            start = prev.start;
+        }
+
+        while (self.selectionGraphemeAt(end)) |next| {
+            if (next.is_break) break;
+            if (isWordBoundary(next.first_cp) != expect_boundary) break;
+            end = next.end;
+        }
+
+        return .{ .start = start, .end = end };
+    }
+
+    /// First non-null `selectWord` walking from `from` toward `toward`, inclusive.
+    pub fn selectWordBetween(self: *Self, from: u32, toward: u32) ?SelectionRange {
+        const text_end = self.text_buffer.textEndOffset();
+        var offset = @min(from, text_end);
+        const limit = @min(toward, text_end);
+
+        if (offset <= limit) {
+            while (offset <= limit) {
+                if (self.selectWord(offset)) |range| return range;
+                const next = self.selectionGraphemeAt(offset) orelse return null;
+                offset = next.end;
+            }
+            return null;
+        }
+
+        while (true) {
+            if (self.selectWord(offset)) |range| return range;
+            if (offset <= limit) return null;
+            const prev = self.prevSelectionGrapheme(offset) orelse return null;
+            offset = prev.start;
+        }
+    }
+
+    /// Logical line at `offset`, ASCII space/tab trimmed. All-whitespace keeps
+    /// the full source line so a blank line is still selected.
+    pub fn selectLine(self: *Self, offset: u32) ?SelectionRange {
+        return self.trimLineWhitespace(self.sourceLineRangeAt(offset) orelse return null);
+    }
+
+    fn sourceLineRangeAt(self: *Self, offset: u32) ?SelectionRange {
+        const rope = self.text_buffer.rope();
+        const text_end = self.text_buffer.textEndOffset();
+        if (offset > text_end) return null;
+        const coords = iter_mod.offsetToCoords(rope, offset) orelse return null;
+        const start = offset - coords.col;
+        return .{ .start = start, .end = start + iter_mod.lineWidthAt(rope, coords.row) };
+    }
+
+    fn trimLineWhitespace(self: *Self, range: SelectionRange) SelectionRange {
+        var start = range.start;
+        var end = range.end;
+        var saw_content = false;
+
+        var offset = range.start;
+        while (offset < range.end) {
+            const grapheme = self.selectionGraphemeAt(offset) orelse break;
+            if (grapheme.is_break) break;
+            if (grapheme.first_cp != ' ' and grapheme.first_cp != '\t') {
+                if (!saw_content) start = grapheme.start;
+                end = grapheme.end;
+                saw_content = true;
+            }
+            offset = grapheme.end;
+        }
+
+        if (!saw_content) return range;
+        return .{ .start = start, .end = end };
+    }
+
+    const SelectionGrapheme = struct {
+        start: u32,
+        end: u32,
+        first_cp: u21,
+        is_break: bool,
+    };
+
+    fn selectionGraphemeAt(self: *Self, offset: u32) ?SelectionGrapheme {
+        const text_end = self.text_buffer.textEndOffset();
+        if (offset >= text_end) return null;
+
+        const rope = self.text_buffer.rope();
+        const coords = iter_mod.offsetToCoords(rope, offset) orelse return null;
+        const line_width = iter_mod.lineWidthAt(rope, coords.row);
+        const line_start = offset - coords.col;
+
+        if (coords.col >= line_width) {
+            return .{
+                .start = line_start + line_width,
+                .end = line_start + line_width + 1,
+                .first_cp = '\n',
+                .is_break = true,
+            };
+        }
+
+        const linestart = rope.getMarker(.linestart, coords.row) orelse return null;
+        var seg_idx = linestart.leaf_index + 1;
+        var cols_before: u32 = 0;
+        const mem_registry = self.text_buffer.memRegistry();
+        const tab_width = self.text_buffer.tabWidth();
+        const width_method = self.text_buffer.widthMethod();
+
+        while (seg_idx < rope.count()) : (seg_idx += 1) {
+            const seg = rope.get(seg_idx) orelse break;
+            if (seg.isBreak() or seg.isLineStart()) break;
+            const chunk = seg.asText() orelse continue;
+            const next_cols = cols_before + chunk.width;
+            if (coords.col < next_cols) {
+                const bytes = chunk.getBytes(mem_registry);
+                const is_ascii = (chunk.flags & TextChunk.Flags.ASCII_ONLY) != 0;
+                const pos = utf8.findGraphemePosByWidth(
+                    bytes,
+                    coords.col - cols_before,
+                    tab_width,
+                    is_ascii,
+                    false,
+                    width_method,
+                );
+                if (pos.byte_offset >= bytes.len) return null;
+                const width = utf8.getGraphemeWidthAt(bytes, pos.byte_offset, tab_width, width_method);
+                const first_cp = utf8.decodeUtf8Unchecked(bytes, pos.byte_offset).cp;
+                const start = line_start + cols_before + pos.columns_used;
+                return .{
+                    .start = start,
+                    .end = start + width,
+                    .first_cp = first_cp,
+                    .is_break = first_cp == '\n' or first_cp == '\r',
+                };
+            }
+            cols_before = next_cols;
+        }
+        return null;
+    }
+
+    fn prevSelectionGrapheme(self: *Self, offset: u32) ?SelectionGrapheme {
+        if (offset == 0) return null;
+        return self.selectionGraphemeAt(offset - 1);
+    }
+
+    fn isWordBoundary(cp: u21) bool {
+        return std.mem.indexOfScalar(u21, &default_word_boundaries, cp) != null;
     }
 
     /// Derive the exclusive highlight/copy/delete range from stored endpoints.

--- a/packages/web/src/content/docs/components/textarea.mdx
+++ b/packages/web/src/content/docs/components/textarea.mdx
@@ -139,6 +139,10 @@ textarea.gotoBufferEnd({ select: true })
 
 ### Selection
 
+Textarea uses the repeated-click behavior from [Text selection](/docs/core-concepts/interaction#text-selection). After a
+double-click or triple-click, the cursor stays on the clicked grapheme. A later Shift+Arrow keeps the selected text and
+continues the selection by cells, not by words or lines.
+
 ```typescript
 textarea.setSelection(start, end) // half-open [start, end) in both occupancy modes
 textarea.setSelectionInclusive(start, end) // also selects the grapheme at end in cell mode

--- a/packages/web/src/content/docs/core-concepts/interaction.mdx
+++ b/packages/web/src/content/docs/core-concepts/interaction.mdx
@@ -28,6 +28,8 @@ Renderable options accept a catch-all `onMouse` handler and these specific handl
 | `onMouseScroll`  | `"scroll"`   | The terminal reported wheel input.                |
 
 OpenTUI does not synthesize a `click` event. A click produces `down` and `up`. A double click produces two such pairs.
+Mouse handlers receive these raw pairs. Text selection also counts repeated left-button downs, but `MouseEvent` has no
+click-count field.
 
 `MouseButton.LEFT`, `MIDDLE`, and `RIGHT` are `0`, `1`, and `2`. For wheel input, read `event.scroll.direction` and `event.scroll.delta` instead of `event.button`.
 
@@ -111,7 +113,40 @@ Use `focused_renderable` for renderable focus changes. See [Terminal capabilitie
 
 Text-buffer renderables are selectable by default. Set `selectable: false` on [Text](/docs/components/text) or related content to disable selection.
 
-A left-button down on selectable content starts a global selection. Dragging extends it across selectable descendants in the active container.
+A left-button down on selectable content starts a global selection. Dragging updates its endpoints and extends the
+selection across selectable descendants in the active container.
+
+Text-buffer renderables, including Text, Code, Input, and Textarea, use repeated left-button presses for these selection
+behaviors:
+
+| Gesture                     | Result                                                       |
+| --------------------------- | ------------------------------------------------------------ |
+| First press and drag        | Start at zero width, then select by cells                    |
+| Second press                | Select the word at the pointer                               |
+| Third press                 | Select the logical source line, including its soft wraps     |
+| Drag after the second press | Extend by words and include the text between the outer words |
+| Drag after the third press  | Extend by logical source lines                               |
+
+Each repeated press must hit the same renderable within 500 ms. Its x and y coordinates can each differ by at most one
+cell from the prior press. OpenTUI does not expose options for this interval or for the selection-word boundary set.
+
+OpenTUI groups adjacent graphemes by whether their first code point is in this boundary set:
+
+```text
+space tab ' " │ ` | : ; , ( ) [ ] { } < > $
+```
+
+Adjacent boundary graphemes form one selectable run. Adjacent non-boundary graphemes form another. Thus, double-clicking
+a run of spaces or tabs selects that run. `/`, `\`, `-`, and `.` are not boundaries, so `foo/bar` is one selection word.
+The same rule treats `日本語abc` as one selection word. A hard line break ends a word, but a soft wrap does not.
+
+These boundaries apply only to pointer selection. Textarea word movement and word deletion use editor boundaries, so
+they can stop at different positions.
+
+Line selection excludes the line break. It trims leading and trailing ASCII spaces and tabs, unless the complete line
+contains only spaces and tabs.
+
+ASCII Font, TextTable, and Embedded Terminal keep their component-specific cell selection behavior.
 
 The active container expands to an ancestor when the pointer leaves its current subtree.
 
@@ -125,9 +160,13 @@ Use these public values:
 
 - `renderer.hasSelection` reports whether a global selection object exists.
 - `renderer.getSelection()` returns that `Selection` or `null`.
-- `Selection.anchor`, `focus`, and `bounds` use global renderer cells. The rectangular `bounds` includes both endpoint cells.
+- `Selection.behavior` is `"cell"`, `"word"`, or `"line"` and records how the selection expands its endpoints.
+- `Selection.anchor`, `focus`, and `bounds` use global gesture cells. The rectangular `bounds` includes both endpoint cells.
 - `Selection.selectedRenderables` lists renderables with selected text.
 - `Selection.getSelectedText()` joins selected text in top-to-bottom, left-to-right order.
+
+A word or line selection can extend beyond `Selection.bounds`. The bounds describe the pointer gesture, not the expanded
+text range.
 
 Each text buffer converts the global cell rectangle to local coordinates. `TextBufferRenderable.getSelection()` then returns `{ start, end }`.
 


### PR DESCRIPTION
Fix https://github.com/anomalyco/opentui/issues/74 

Double-click selects a word. Triple-click selects the line. A first click still selects nothing.

Renderer counts left presses. A second press on the same cell within 500 ms asks for a word. A third press asks for a line.

Drag after a word click keeps the spaces between words. Shift+arrow after a multi-click extends by cell, not by word.

ASCII font and tables stay cell-only. The click interval and the word-character set are hard-coded for now.