### PR TITLE
core: test u32 cell attributes on all platforms

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -90,7 +90,6 @@ jobs:
           bun-version: 1.3.14
 
       - name: Setup Node
-        if: runner.os == 'Linux'
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -140,7 +139,6 @@ jobs:
           bun run test:js
 
       - name: Run Node TypeScript tests
-        if: runner.os == 'Linux'
         working-directory: packages/core
         run: bun run test:js:node
 

--- a/packages/core/src/buffer.test.ts
+++ b/packages/core/src/buffer.test.ts
@@ -14,6 +14,18 @@ describe("OptimizedBuffer", () => {
     buffer.destroy()
   })
 
+  it("preserves u32 attributes across per-cell FFI calls", () => {
+    const fg = RGBA.fromInts(255, 255, 255)
+    const bg = RGBA.fromInts(0, 0, 0)
+    const attributes = [0x8000_00ff, 0x4000_01fe, 0x2000_02fd]
+
+    buffer.setCell(0, 0, "S", fg, bg, attributes[0])
+    buffer.setCellWithAlphaBlending(1, 0, "A", fg, bg, attributes[1])
+    buffer.drawChar("D".codePointAt(0)!, 2, 0, fg, bg, attributes[2])
+
+    expect([...buffer.buffers.attributes.slice(0, attributes.length)]).toEqual(attributes)
+  })
+
   it("draws images as reserved cells with resolved fallback glyphs", () => {
     const image = NativeImage.fromRgba(
       Uint8Array.of(255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255),


### PR DESCRIPTION
Node FFI paths can truncate cell attributes when native types differ across
platforms. Exercise every per-cell entry point under Node on all runners.