### PR TITLE
ci: run all matrix tests after failures

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -68,6 +68,7 @@ jobs:
     name: Test (${{ matrix.os }})
     needs: build
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: blacksmith-12vcpu-macos-15

--- a/.github/workflows/build-keymap.yml
+++ b/.github/workflows/build-keymap.yml
@@ -21,6 +21,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         os: [blacksmith-8vcpu-ubuntu-2404, blacksmith-8vcpu-windows-2025]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-qrcode.yml
+++ b/.github/workflows/build-qrcode.yml
@@ -20,6 +20,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         os: [blacksmith-8vcpu-ubuntu-2404, blacksmith-8vcpu-windows-2025]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -20,6 +20,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         os: [blacksmith-8vcpu-ubuntu-2404, blacksmith-8vcpu-windows-2025]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-solid.yml
+++ b/.github/workflows/build-solid.yml
@@ -21,6 +21,7 @@ jobs:
   bun-test:
     name: Bun Test (${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         os: [blacksmith-8vcpu-ubuntu-2404, blacksmith-8vcpu-windows-2025]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-ssh.yml
+++ b/.github/workflows/build-ssh.yml
@@ -21,6 +21,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         os: [blacksmith-12vcpu-macos-15, blacksmith-8vcpu-ubuntu-2404, blacksmith-8vcpu-windows-2025]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Preserve results from every supported platform when one matrix job fails.

Trying to avoid it cancelling all jobs when one thing fails.