### PR TITLE
utf8: count Thai spacing marks in widths

### DIFF
--- a/packages/native/src/tests/utf8_test.zig
+++ b/packages/native/src/tests/utf8_test.zig
@@ -4028,9 +4028,14 @@ test "Thai: mixed Thai and emoji" {
     try testing.expectEqual(@as(u32, 11), utf8.calculateTextWidth(text, 4, false, .unicode));
 }
 
-test "Thai: คำว่า width should be 3" {
+test "Thai: คำว่า width should be 4" {
     const text = "คำว่า";
-    try testing.expectEqual(@as(u32, 3), utf8.calculateTextWidth(text, 4, false, .unicode));
+    try testing.expectEqual(@as(u32, 4), utf8.calculateTextWidth(text, 4, false, .unicode));
+}
+
+test "Thai: น้ำ width should be 2" {
+    const text = "น้ำ";
+    try testing.expectEqual(@as(u32, 2), utf8.calculateTextWidth(text, 4, false, .unicode));
 }
 
 test "Thai: ว่ width should be 1" {

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -853,6 +853,7 @@ const GraphemeWidthState = struct {
 
         const gc = uucode.get(.general_category, cp);
         const is_virama = gc == .mark_nonspacing;
+        const is_spacing_mark = uucode.get(.grapheme_break, cp) == .spacing_mark;
 
         const is_devanagari_ra = (cp == 0x0930);
 
@@ -877,6 +878,8 @@ const GraphemeWidthState = struct {
         } else if (!self.has_width and cp_width > 0) {
             self.width = cp_width;
             self.has_width = true;
+        } else if (self.has_width and is_spacing_mark and cp_width > 0) {
+            self.width = @max(self.width, 2);
         } else if (self.has_width and self.has_indic_virama and is_devanagari_base and cp_width > 0) {
             if (!is_devanagari_ra) {
                 self.width += cp_width;


### PR DESCRIPTION
Thai SARA AM occupies an additional cell within a grapheme. Count
positive-width spacing marks to keep output coordinates aligned with
terminals.

Fix #479
