### PR TITLE
ci: save Linux core dumps from failed tests

### DIFF
--- a/.github/actions/enable-linux-coredumps/action.yml
+++ b/.github/actions/enable-linux-coredumps/action.yml
@@ -1,0 +1,32 @@
+name: Enable Linux core dumps
+description: Point Linux core dumps at the workspace so a later step can upload them.
+
+runs:
+  using: composite
+  steps:
+    - name: Enable Linux core dumps
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -eu
+        dump_dir="${GITHUB_WORKSPACE}/.crash-dumps"
+        mkdir -p "$dump_dir"
+
+        echo "core_pattern=$(cat /proc/sys/kernel/core_pattern)"
+        echo "core_uses_pid=$(cat /proc/sys/kernel/core_uses_pid 2>/dev/null || true)"
+        ulimit -c || true
+
+        if ! sudo -n true 2>/dev/null; then
+          echo "No passwordless sudo; test steps must still raise ulimit -c."
+          echo "Existing core handlers will be scanned after a crash."
+          exit 0
+        fi
+
+        # A path pattern writes into the workspace. A piped handler (apport /
+        # systemd-coredump) can still produce a dump, but the file is not ours
+        # unless we collect it later. Some hosted runners refuse this sysctl.
+        if printf '%s\n' "${dump_dir}/core.%e.%p.%s.%t" | sudo tee /proc/sys/kernel/core_pattern >/dev/null; then
+          echo "core_pattern now=$(cat /proc/sys/kernel/core_pattern)"
+        else
+          echo "Could not replace core_pattern; will collect from the existing handler after a crash."
+        fi

--- a/.github/actions/upload-linux-coredumps/action.yml
+++ b/.github/actions/upload-linux-coredumps/action.yml
@@ -1,0 +1,101 @@
+name: Upload Linux core dumps
+description: Collect Linux core dumps after a failed job and upload them as an artifact.
+
+inputs:
+  name:
+    description: Artifact name
+    required: false
+    default: crash-dumps-${{ github.job }}-${{ runner.os }}-${{ github.run_attempt }}
+
+runs:
+  using: composite
+  steps:
+    - name: Collect Linux core dumps
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -eu
+        dump_dir="${GITHUB_WORKSPACE}/.crash-dumps"
+        mkdir -p "$dump_dir"
+        bun_path="$(command -v bun || true)"
+
+        {
+          echo "bun=$(${bun_path:-true} --revision 2>/dev/null || true)"
+          echo "bun_path=${bun_path}"
+          echo "core_pattern=$(cat /proc/sys/kernel/core_pattern)"
+          echo "ulimit_c=$(ulimit -c)"
+          echo "uname=$(uname -a)"
+        } | tee "${dump_dir}/crash-env.txt"
+
+        if [ -n "$bun_path" ]; then
+          cp -L "$bun_path" "${dump_dir}/bun" || true
+        fi
+
+        native_lib="$(find "${GITHUB_WORKSPACE}/packages/core/node_modules/@opentui" \
+          -name 'libopentui.so' -print -quit 2>/dev/null || true)"
+        if [ -n "$native_lib" ]; then
+          cp -L "$native_lib" "${dump_dir}/libopentui.so" || true
+        fi
+
+        copy_if_present() {
+          local source="$1"
+          if [ -e "$source" ]; then
+            echo "copying ${source}"
+            sudo -n cp -a "$source" "$dump_dir/" 2>/dev/null || cp -a "$source" "$dump_dir/" || true
+          fi
+        }
+
+        shopt -s nullglob
+        for source in \
+          "${dump_dir}"/core.* \
+          "${GITHUB_WORKSPACE}"/core \
+          "${GITHUB_WORKSPACE}"/core.* \
+          /var/lib/systemd/coredump/* \
+          /var/crash/* \
+          /tmp/core.* \
+          /cores/core.*
+        do
+          copy_if_present "$source"
+        done
+
+        if command -v coredumpctl >/dev/null; then
+          coredumpctl list --no-pager > "${dump_dir}/coredumpctl-list.txt" 2>&1 || true
+          # Extract the newest bun dump if systemd kept one.
+          if sudo -n coredumpctl dump bun --output="${dump_dir}/bun.systemd.core" >/dev/null 2>>"${dump_dir}/coredumpctl-dump.txt"; then
+            echo "extracted systemd bun core"
+          else
+            echo "no systemd bun core" >> "${dump_dir}/coredumpctl-dump.txt"
+          fi
+        fi
+
+        # A backtrace in the job log is enough to start; the artifact is for gdb.
+        if command -v gdb >/dev/null && [ -n "$bun_path" ]; then
+          newest_core=""
+          for candidate in "${dump_dir}"/core.* "${dump_dir}"/*.core "${dump_dir}"/bun.systemd.core; do
+            [ -f "$candidate" ] || continue
+            newest_core="$candidate"
+          done
+          if [ -n "$newest_core" ]; then
+            echo "gdb backtrace from ${newest_core}"
+            gdb -batch -nx \
+              -ex "set pagination off" \
+              -ex "thread apply all bt" \
+              "$bun_path" "$newest_core" \
+              > "${dump_dir}/gdb-bt.txt" 2>&1 || true
+            sed -n '1,200p' "${dump_dir}/gdb-bt.txt" || true
+          fi
+        fi
+
+        sudo -n chmod -R a+rX "$dump_dir" 2>/dev/null || chmod -R a+rX "$dump_dir" || true
+        echo "collected files:"
+        ls -lah "$dump_dir" || true
+
+    - name: Upload Linux core dumps
+      if: runner.os == 'Linux'
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ github.workspace }}/.crash-dumps
+        if-no-files-found: ignore
+        retention-days: 7
+        compression-level: 9

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -124,9 +124,15 @@ jobs:
           ls -la packages/core/node_modules/@opentui/
           ls -la packages/core/node_modules/@opentui/core-${{ matrix.platform }}/
 
+      - name: Enable Linux core dumps
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/enable-linux-coredumps
+
       - name: Run native tests
         working-directory: packages/core
-        run: bun run test:native
+        run: |
+          if [ "$(uname -s)" = Linux ]; then ulimit -c unlimited; fi
+          bun run test:native
 
       - name: Build TypeScript library
         run: |
@@ -135,23 +141,36 @@ jobs:
 
       - name: Run TypeScript tests
         run: |
+          if [ "$(uname -s)" = Linux ]; then ulimit -c unlimited; fi
           cd packages/core
           export OTUI_TREE_SITTER_WORKER_PATH="$(bun -e 'import { resolve } from "node:path"; console.log(resolve("dist/parser.worker.js"))')"
           bun run test:js
 
       - name: Run Node TypeScript tests
         working-directory: packages/core
-        run: bun run test:js:node
+        run: |
+          if [ "$(uname -s)" = Linux ]; then ulimit -c unlimited; fi
+          bun run test:js:node
 
       - name: Test packed distribution
         if: runner.os == 'Linux'
         working-directory: packages/core
-        run: bun run test:dist --skip-build
+        run: |
+          if [ "$(uname -s)" = Linux ]; then ulimit -c unlimited; fi
+          bun run test:dist --skip-build
 
       - name: Test Node SEA executable
         if: runner.os == 'Linux'
         working-directory: packages/core
-        run: bun run test:standalone --skip-build
+        run: |
+          if [ "$(uname -s)" = Linux ]; then ulimit -c unlimited; fi
+          bun run test:standalone --skip-build
+
+      - name: Upload Linux core dumps
+        if: failure() && runner.os == 'Linux'
+        uses: ./.github/actions/upload-linux-coredumps
+        with:
+          name: crash-dumps-core-${{ matrix.os }}-${{ github.run_attempt }}
 
   # Gate job for branch protection
   build-complete:

--- a/.github/workflows/build-keymap.yml
+++ b/.github/workflows/build-keymap.yml
@@ -64,10 +64,21 @@ jobs:
           cd packages/keymap
           bun run build --ci
 
+      - name: Enable Linux core dumps
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/enable-linux-coredumps
+
       - name: Run tests
         run: |
+          if [ "$(uname -s)" = Linux ]; then ulimit -c unlimited; fi
           cd packages/keymap
           bun run test
+
+      - name: Upload Linux core dumps
+        if: failure() && runner.os == 'Linux'
+        uses: ./.github/actions/upload-linux-coredumps
+        with:
+          name: crash-dumps-keymap-${{ matrix.os }}-${{ github.run_attempt }}
 
   packed-consumer:
     name: Packed Consumer Smoke

--- a/.github/workflows/build-qrcode.yml
+++ b/.github/workflows/build-qrcode.yml
@@ -62,10 +62,21 @@ jobs:
           cd packages/qrcode
           bun run build
 
+      - name: Enable Linux core dumps
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/enable-linux-coredumps
+
       - name: Run tests
         run: |
+          if [ "$(uname -s)" = Linux ]; then ulimit -c unlimited; fi
           cd packages/qrcode
           bun run test
+
+      - name: Upload Linux core dumps
+        if: failure() && runner.os == 'Linux'
+        uses: ./.github/actions/upload-linux-coredumps
+        with:
+          name: crash-dumps-qrcode-${{ matrix.os }}-${{ github.run_attempt }}
 
   build-complete:
     name: QRCode - Build and Test

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -63,10 +63,21 @@ jobs:
           cd packages/react
           bun run build --ci
 
+      - name: Enable Linux core dumps
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/enable-linux-coredumps
+
       - name: Run tests
         run: |
+          if [ "$(uname -s)" = Linux ]; then ulimit -c unlimited; fi
           cd packages/react
           bun run test
+
+      - name: Upload Linux core dumps
+        if: failure() && runner.os == 'Linux'
+        uses: ./.github/actions/upload-linux-coredumps
+        with:
+          name: crash-dumps-react-${{ matrix.os }}-${{ github.run_attempt }}
 
   # Gate job for branch protection
   build-complete:

--- a/.github/workflows/build-solid.yml
+++ b/.github/workflows/build-solid.yml
@@ -62,9 +62,21 @@ jobs:
         working-directory: packages/solid
         run: bun run build --ci
 
+      - name: Enable Linux core dumps
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/enable-linux-coredumps
+
       - name: Run tests
         working-directory: packages/solid
-        run: bun run test
+        run: |
+          if [ "$(uname -s)" = Linux ]; then ulimit -c unlimited; fi
+          bun run test
+
+      - name: Upload Linux core dumps
+        if: failure() && runner.os == 'Linux'
+        uses: ./.github/actions/upload-linux-coredumps
+        with:
+          name: crash-dumps-solid-${{ matrix.os }}-${{ github.run_attempt }}
 
   node-source:
     name: Node Source Lane

--- a/.github/workflows/build-ssh.yml
+++ b/.github/workflows/build-ssh.yml
@@ -71,10 +71,21 @@ jobs:
           cd packages/ssh
           bun run typecheck
 
+      - name: Enable Linux core dumps
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/enable-linux-coredumps
+
       - name: Run tests
         run: |
+          if [ "$(uname -s)" = Linux ]; then ulimit -c unlimited; fi
           cd packages/ssh
           bun run test
+
+      - name: Upload Linux core dumps
+        if: failure() && runner.os == 'Linux'
+        uses: ./.github/actions/upload-linux-coredumps
+        with:
+          name: crash-dumps-ssh-${{ matrix.os }}-${{ github.run_attempt }}
 
   packed-consumer:
     name: Packed Node Consumer

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,12 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 screenshot-*.png
 
+# CI / local crash dumps. Anchor to the repo root so this does not hide
+# untracked files under packages/core/.
+.crash-dumps/
+/core
+/core.*
+
 # SSH host keys — never commit private keys. @opentui/ssh examples write a
 # `host_key` relative to the cwd, so a run from the repo root drops one here.
 host_key

--- a/bun.lock
+++ b/bun.lock
@@ -544,6 +544,22 @@
 
     "@opentui/core": ["@opentui/core@workspace:packages/core"],
 
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.5.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-75TDJgFD6hDoCElIX35Yg3TIRF/jhrtVQO/9snhjGuTsZ7bd0W88jUlvSXSNhqB3CX431rwgi47B+asWPDI1lQ=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.5.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-j+Dwu2yV8zahBFjnVIssYdPrHz/+pkd7xWxI+nHjV41V3c+scvH6vJY1U85VCVaoQs/zCH5xAJbmAAn7Sgeh8g=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.5.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-gWO9NWaivXRPc0XhEbxehj3ApyC1SW8Bf1cnHnME1zhw/EZNCNE3TQHgKwOnnNKtvlbhzLQjOI4OqyPYV8UcEQ=="],
+
+    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.5.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RumSHTasIAWU7jPBKiTuEZG/m+prfQKCHhL3JAQnBLgp7eAB20XZGfSLVWDBgxkyKq1rHCUgLtZktC5ZAyKfTA=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.5.7", "", { "os": "linux", "cpu": "x64" }, "sha512-fXDmrIlfp9xaoVkk3BNn3yUO/b7plBSOfUh2oWOezRA6E/g5z+hTO1alGFQCy+VV+1kfA6iuYadAww0xNtfACg=="],
+
+    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.5.7", "", { "os": "linux", "cpu": "x64" }, "sha512-1opDV+W7C1F4iWivCNKuYl5Hen+IeFXAuUPm3hVyN0UtdcP8LESpFJTr8QRwHpGSE9Jz1K2g2S2ipzI3u5mhgw=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.5.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-gbiZUyttjq8s+bsnsaopygWN7LTS/RyzD6GOmpgOB2TVitvo0P6mxM+AebBGuu/7xri17Rqaxf3uqrgdKiJAeg=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.5.7", "", { "os": "win32", "cpu": "x64" }, "sha512-bDwon45lUxbV3rMcekTCg4mXcBu9uhdG6HLeLK5TVZf05/h+Ibkf2UeZ8A2jjQt+MK6jpYmxWwDCVCTzZ7EU7Q=="],
+
     "@opentui/examples": ["@opentui/examples@workspace:packages/examples"],
 
     "@opentui/keymap": ["@opentui/keymap@workspace:packages/keymap"],


### PR DESCRIPTION
Linux test crashes left no data to investigate after the runner stopped.
The CI system now saves core dumps and program files to help find the
cause.
