### PR TITLE
ci: include hidden core dump files

### DIFF
--- a/.github/actions/upload-linux-coredumps/action.yml
+++ b/.github/actions/upload-linux-coredumps/action.yml
@@ -99,3 +99,4 @@ runs:
         if-no-files-found: ignore
         retention-days: 7
         compression-level: 9
+        include-hidden-files: true


### PR DESCRIPTION
Upload dot-prefixed core dump files so crash diagnostics are not
silently omitted from CI artifacts.
