### PR TITLE
fix(core): normalize embedded terminal keys

### DIFF
--- a/packages/core/src/renderables/EmbeddedTerminal.test.ts
+++ b/packages/core/src/renderables/EmbeddedTerminal.test.ts
@@ -98,6 +98,12 @@ describe("EmbeddedTerminalRenderable", () => {
     )
     expect(new TextDecoder().decode(terminal.encodeKey(keyEvent({ name: "😀", sequence: "😀" })))).toBe("😀")
     expect(new TextDecoder().decode(terminal.encodeKey(keyEvent({ name: "space", sequence: " " })))).toBe(" ")
+    expect(new TextDecoder().decode(terminal.encodeKey(keyEvent({ name: "up", sequence: "\x1b[A", code: "[A" })))).toBe(
+      "\x1b[A",
+    )
+    expect(
+      new TextDecoder().decode(terminal.encodeKey(keyEvent({ name: "down", sequence: "\x1b[B", code: "[B" }))),
+    ).toBe("\x1b[B")
     expect(
       new TextDecoder().decode(terminal.encodeKey(keyEvent({ name: "a", sequence: "A", shift: true, raw: "A" }))),
     ).toBe("A")

--- a/packages/core/src/renderables/EmbeddedTerminal.test.ts
+++ b/packages/core/src/renderables/EmbeddedTerminal.test.ts
@@ -175,6 +175,25 @@ describe("EmbeddedTerminalRenderable", () => {
     expect(new TextDecoder().decode(encoded)).toBe("\x1b[97;9u")
   })
 
+  test("re-encodes Kitty character and escape keys for nested terminals", () => {
+    const terminal = new EmbeddedTerminalRenderable(setup.renderer, { width: 20, height: 4 })
+    setup.renderer.root.add(terminal)
+    terminal.write("\x1b[>3u")
+
+    expect(
+      new TextDecoder().decode(
+        terminal.encodeKey(keyEvent({ name: "c", sequence: "c", raw: "\x1b[99;5u", source: "kitty", ctrl: true })),
+      ),
+    ).toBe("\x1b[99;5u")
+    expect(
+      new TextDecoder().decode(
+        terminal.encodeKey(
+          keyEvent({ name: "escape", sequence: "\x1b[27u", raw: "\x1b[27u", source: "kitty", code: "[27u" }),
+        ),
+      ),
+    ).toBe("\x1b[27u")
+  })
+
   test("drains the preserved response prefix after overflow", () => {
     const lib = resolveRenderLib()
     const handle = lib.createEmbeddedTerminal({ cols: 20, rows: 4 })

--- a/packages/core/src/renderables/EmbeddedTerminal.ts
+++ b/packages/core/src/renderables/EmbeddedTerminal.ts
@@ -371,7 +371,7 @@ function modifiers(input: {
 }
 
 function physicalKey(key: KeyEvent) {
-  if (key.code) return key.code
+  if (key.code && !key.code.startsWith("[")) return key.code
   return (
     {
       backspace: "Backspace",

--- a/packages/core/src/renderables/EmbeddedTerminal.ts
+++ b/packages/core/src/renderables/EmbeddedTerminal.ts
@@ -142,12 +142,13 @@ export class EmbeddedTerminalRenderable extends Renderable {
   public encodeKey(key: KeyEvent): Uint8Array {
     if (!this.handle) return new Uint8Array()
     const text = textualKey(key)
+    const physical = physicalKey(key)
     return this.lib.embeddedTerminalEncodeKey(this.handle, {
       action: key.eventType === "release" ? "release" : key.repeated ? "repeat" : "press",
-      key: physicalKey(key),
+      key: physical,
       mods: modifiers(key),
       text,
-      unshiftedCodepoint: key.baseCode ?? physicalUnshiftedCodepoint(key.code),
+      unshiftedCodepoint: key.baseCode ?? physicalUnshiftedCodepoint(physical),
     })
   }
 
@@ -372,6 +373,8 @@ function modifiers(input: {
 
 function physicalKey(key: KeyEvent) {
   if (key.code && !key.code.startsWith("[")) return key.code
+  if (/^[a-z]$/i.test(key.name)) return `Key${key.name.toUpperCase()}`
+  if (/^[0-9]$/.test(key.name)) return `Digit${key.name}`
   return (
     {
       backspace: "Backspace",


### PR DESCRIPTION
## Summary
- reject parser escape codes such as `[A` and `[27u` as physical key identifiers
- infer Web-style physical identities (`ArrowUp`, `KeyC`, `Digit1`, `Escape`) before calling Ghostty
- derive the unshifted codepoint from that normalized physical identity
- cover raw arrow input and nested Kitty character/escape re-encoding

## Why this is needed
OpenTUI key events use `code` for two different kinds of values. Kitty and raw escape parsing can produce parser codes such as `[A` for Up or `[27u` for Kitty Escape, while other events provide Web-style physical codes such as `KeyA`. Ghostty's key encoder accepts the latter physical identities, not parser escape fragments. Passing `[A` through as the physical key leaves Ghostty unable to encode an arrow key.

Embedded terminals also need to re-encode input when the program inside them enables the Kitty keyboard protocol. In that mode, text alone is insufficient for modified and disambiguated keys: Ghostty needs a normalized physical identity and its unshifted codepoint. Raw character events may not include `code`, so this change infers `KeyA`/`Digit1`; Kitty escape events whose parser code is `[27u` fall back to `Escape`. The regression verifies that Ctrl+C and Escape are re-emitted as Kitty sequences for a nested terminal.

## Testing
- `bun test src/renderables/EmbeddedTerminal.test.ts` (16 passed)
- `oxlint packages/core/src/renderables/EmbeddedTerminal.ts packages/core/src/renderables/EmbeddedTerminal.test.ts`
- `oxfmt --check packages/core/src/renderables/EmbeddedTerminal.ts packages/core/src/renderables/EmbeddedTerminal.test.ts`