### PR TITLE
fix(native): silence standard library logs

### DIFF
--- a/packages/native/src/lib.zig
+++ b/packages/native/src/lib.zig
@@ -3,6 +3,22 @@ const builtin = @import("builtin");
 const build_options = @import("build_options");
 const Allocator = std.mem.Allocator;
 
+pub const std_options: std.Options = .{
+    .logFn = discardStdLog,
+};
+
+fn discardStdLog(
+    comptime message_level: std.log.Level,
+    comptime scope: @EnumLiteral(),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    _ = message_level;
+    _ = scope;
+    _ = format;
+    _ = args;
+}
+
 var io_threaded: std.Io.Threaded = .init_single_threaded;
 pub const io = io_threaded.io();
 


### PR DESCRIPTION
## Summary
- install a root `std_options.logFn` that discards `std.log` output
- leave Zig's default compile-time log level unchanged
- keep explicit OpenTUI `logger.logMessage` output flowing through the existing JavaScript callback

## Why
OpenTUI imports native dependencies such as Ghostty into its Zig root module. Their `std.log` calls otherwise use Zig's default stderr logger, bypass the renderer, and can corrupt the terminal display. OpenTUI already has a separate explicit logger for messages intended for JavaScript and file logging, so standard-library logs should not write directly to the host terminal.

## Testing
- `zig fmt --check packages/native/src/lib.zig`
- release `bun run build` from `packages/core`
- `bun run test:native` from `packages/core` (2066 passed, 8 skipped)