### PR TITLE
Restore pre and code syntax highlighting

### DIFF
--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -10,62 +10,6 @@ const copyButtonTransformer = {
   },
 }
 
-// Monochrome highlighting: identifiers plain, keywords bold, literals gray,
-// comments fainter gray italic. Structure through weight and shade, not hue.
-function grayscaleTheme({ name, type, foreground, background, literal, comment }) {
-  return {
-    name,
-    type,
-    colors: {
-      "editor.background": background,
-      "editor.foreground": foreground,
-    },
-    settings: [
-      { settings: { foreground, background } },
-      {
-        scope: ["comment", "punctuation.definition.comment"],
-        settings: { foreground: comment, fontStyle: "italic" },
-      },
-      {
-        scope: ["string", "constant.numeric", "constant.language", "constant.character.escape"],
-        settings: { foreground: literal },
-      },
-      {
-        scope: ["keyword.control", "keyword.other", "keyword.declaration", "storage.type", "storage.modifier"],
-        settings: { fontStyle: "bold" },
-      },
-    ],
-  }
-}
-
-const codeLight = grayscaleTheme({
-  name: "opentui-light",
-  type: "light",
-  foreground: "#000000",
-  background: "#ffffff",
-  literal: "#4a4a4a",
-  comment: "#767676",
-})
-
-const codeDark = grayscaleTheme({
-  name: "opentui-dark",
-  type: "dark",
-  foreground: "#ededed",
-  background: "#000000",
-  literal: "#b0b0b0",
-  comment: "#8a8a8a",
-})
-
-// Blue tint: the grayscale ramp shifted onto the ink hue.
-const codeBlue = grayscaleTheme({
-  name: "opentui-blue",
-  type: "light",
-  foreground: "#1131e9",
-  background: "#ffffff",
-  literal: "#475ac2",
-  comment: "#7783c5",
-})
-
 export default defineConfig({
   integrations: [
     mdx(),
@@ -90,9 +34,8 @@ export default defineConfig({
   markdown: {
     shikiConfig: {
       themes: {
-        light: codeLight,
-        dark: codeDark,
-        blue: codeBlue,
+        light: "min-light",
+        dark: "github-dark",
       },
       transformers: [copyButtonTransformer],
     },


### PR DESCRIPTION
It looks like syntax highlighting was removed back in #1362 with the introduction of grayscale themes. 

This PR restores the syntax highlight themes that were previously in use.

## Before

<img width="648" alt="CleanShot 2026-08-24 at 14 53 58@2x" src="https://github.com/user-attachments/assets/0676caa2-dce6-4259-a4e1-c9e99848701b" />

<img width="648" alt="CleanShot 2026-08-24 at 14 54 06@2x" src="https://github.com/user-attachments/assets/c736f387-01ee-444f-9f1e-10a66f4b72b7" />


## After

<img width="648" alt="CleanShot 2026-08-24 at 14 54 19@2x" src="https://github.com/user-attachments/assets/8f943037-e290-4177-b4c0-f0f8119734cd" />

<img width="648" alt="CleanShot 2026-08-24 at 14 54 15@2x" src="https://github.com/user-attachments/assets/f5f14a90-711f-47d5-9a23-01a30ce2e9bb" />
