### PR TITLE
refactor(core): make wrapped layout byte-accurate

### DIFF
--- a/packages/core/src/renderables/Text.test.ts
+++ b/packages/core/src/renderables/Text.test.ts
@@ -1659,9 +1659,9 @@ describe("TextRenderable Selection", () => {
       const finalFrame = captureFrame()
       expect(finalFrame).toMatchSnapshot()
 
-      expect(firstText.height).toEqual(5)
-      expect(secondText.y).toEqual(5)
-      expect(thirdText.y).toEqual(6)
+      expect(firstText.height).toEqual(4)
+      expect(secondText.y).toEqual(4)
+      expect(thirdText.y).toEqual(5)
     })
   })
 

--- a/packages/core/src/renderables/__snapshots__/Diff.test.ts.snap
+++ b/packages/core/src/renderables/__snapshots__/Diff.test.ts.snap
@@ -530,12 +530,12 @@ exports[`DiffRenderable - back-to-back change blocks without context lines in sp
 
 exports[`DiffRenderable - very long lines wrapping multiple times in split view: split view multi-wrap lines 1`] = `
 " 1   short line                          1   short line                         
- 2 - This is an extremely long line      2 + This is an extremely long line     
-     that will definitely wrap multiple      that has been modified and will    
-     times when rendered in a split          definitely wrap multiple times     
-     view with word wrapping enabled         when rendered in a split view with 
-     because it contains so many words       word wrapping enabled because it   
-     and characters                          contains so many words and         
+ 2 - This is an extremely long line that 2 + This is an extremely long line that
+     will definitely wrap multiple times     has been modified and will         
+     when rendered in a split view with      definitely wrap multiple times when
+     word wrapping enabled because it        rendered in a split view with word 
+     contains so many words and              wrapping enabled because it        
+     characters                              contains so many words and         
                                              characters and even more content   
  3   another short line                  3   another short line                 
                                                                                 

--- a/packages/core/src/renderables/__snapshots__/Text.test.ts.snap
+++ b/packages/core/src/renderables/__snapshots__/Text.test.ts.snap
@@ -132,13 +132,13 @@ Bottom text
 `;
 
 exports[`TextRenderable Selection Text Node Dimension Updates should handle multiple text node updates with complex layout changes 2`] = `
-"First of            
-a                   
+"First of a          
 sentence            
 partthat            
 will wrap           
 Middle text         
 Bottom text         
+                    
                     
                     
                     
@@ -286,9 +286,9 @@ exports[`TextRenderable Selection Absolute Positioned Box with Text should handl
                                                                       
                                                                       
                                                                       
-             This is an extremely long piece of text                  
-             that needs to wrap multiple times within                 
-             the constrained width of the absolutely                  
+             This is an extremely long piece of text that             
+             needs to wrap multiple times within the                  
+             constrained width of the absolutely                      
              positioned container box with significant                
              padding on all sides.                                    
                                                                       
@@ -322,10 +322,10 @@ exports[`TextRenderable Selection Absolute Positioned Box with Text should rende
 `;
 
 exports[`TextRenderable Selection Word Wrapping should wrap at word boundaries when using word mode 1`] = `
-"The quick           
-brown fox           
-jumps over the      
-lazy dog            
+"The quick brown     
+fox jumps over      
+the lazy dog        
+                    
                     
 "
 `;

--- a/packages/core/src/renderables/__snapshots__/TextTable.test.ts.snap
+++ b/packages/core/src/renderables/__snapshots__/TextTable.test.ts.snap
@@ -46,17 +46,17 @@ exports[`TextTableRenderable balanced fitter keeps constrained columns visually 
 │der  │Services   │Solutions│Model    │        │         │  
 ├─────┼───────────┼─────────┼─────────┼────────┼─────────┤  
 │Amazo│EC2        │S3 tiers,│Pay as   │Global  │Enterpris│  
-│n Web│instances  │ EBS,    │you go,  │regions │e migrati│  
-│ Serv│with       │EFS, and │reserved │and     │on, analy│  
-│ices │extensive  │archive  │terms,   │many    │tics, ML,│  
-│     │options    │classes  │and      │edge    │ and back│  
-│     │for        │for long │discounte│location│end servi│  
-│     │general,   │retention│d spot ca│s       │ces      │  
-│     │memory,    │         │pacity   │        │         │  
-│     │and        │         │         │        │         │  
-│     │accelerated│         │         │        │         │  
-│     │ workloads │         │         │        │         │  
+│n Web│instances  │EBS, EFS,│you go,  │regions │e        │  
+│Servi│with       │and      │reserved │and many│migration│  
+│ces  │extensive  │archive  │terms,   │edge    │,        │  
+│     │options for│classes  │and      │location│analytics│  
+│     │general,   │for long │discounte│s       │, ML, and│  
+│     │memory, and│retention│d spot   │        │backend  │  
+│     │accelerated│         │capacity │        │services │  
+│     │workloads  │         │         │        │         │  
 └─────┴───────────┴─────────┴─────────┴────────┴─────────┘  
+                                                            
+                                                            
 "
 `;
 
@@ -66,17 +66,17 @@ exports[`TextTableRenderable balanced fitter keeps constrained columns visually 
 │        │Services│Solutions│Model    │        │         │  
 ├────────┼────────┼─────────┼─────────┼────────┼─────────┤  
 │Amazon  │EC2     │S3 tiers,│Pay as   │Global  │Enterpris│  
-│Web     │instance│ EBS,    │you go,  │regions │e migrati│  
-│Services│s with e│EFS, and │reserved │and     │on, analy│  
-│        │xtensive│archive  │terms,   │many    │tics, ML,│  
-│        │ options│classes  │and      │edge    │ and back│  
-│        │ for gen│for long │discounte│location│end servi│  
-│        │eral, me│retention│d spot ca│s       │ces      │  
-│        │mory, an│         │pacity   │        │         │  
-│        │d accele│         │         │        │         │  
-│        │rated wo│         │         │        │         │  
-│        │rkloads │         │         │        │         │  
-└────────┴────────┴─────────┴─────────┴────────┴─────────┘  
+│Web     │instance│EBS, EFS,│you go,  │regions │e        │  
+│Services│s with  │and      │reserved │and many│migration│  
+│        │extensiv│archive  │terms,   │edge    │,        │  
+│        │e       │classes  │and      │location│analytics│  
+│        │options │for long │discounte│s       │, ML, and│  
+│        │for     │retention│d spot   │        │backend  │  
+│        │general,│         │capacity │        │services │  
+│        │memory, │         │         │        │         │  
+│        │and     │         │         │        │         │  
+│        │accelera│         │         │        │         │  
+│        │ted     │         │         │        │         │  
 "
 `;
 
@@ -126,8 +126,8 @@ exports[`TextTableRenderable wraps CJK and emoji without grapheme duplication: u
 ├─────┼──────────────────────┤                              
 │mixed│東京界 🌍 emoji       │                              
 │     │wrapping continues    │                              
-│     │across lines for      │                              
-│     │width checks          │                              
+│     │across lines for width│                              
+│     │checks                │                              
 ├─────┼──────────────────────┤                              
 │emoji│Faces 😀😃😄 should   │                              
 │     │remain stable         │                              
@@ -144,22 +144,22 @@ exports[`TextTableRenderable keeps full wrapped table layouts after a wide-to-na
 "┌────────────────────────┬─────────────────┬─────────────────────────┐
 │Task                    │Owner            │ETA                      │
 ├────────────────────────┼─────────────────┼─────────────────────────┤
-│Wrap regression in      │core platform    │done after validating    │
-│operational status      │and runtime      │none, word, and char     │
-│dashboard with dynamic  │reliability squad│wrap modes across narrow,│
-│row heights and         │                 │ medium, wide, and ultra-│
+│Wrap regression in      │core platform and│done after validating    │
+│operational status      │runtime          │none, word, and char wrap│
+│dashboard with dynamic  │reliability squad│modes across narrow,     │
+│row heights and         │                 │medium, wide, and ultra- │
 │constrained layout      │                 │wide terminal widths     │
 │validation              │                 │                         │
 ├────────────────────────┼─────────────────┼─────────────────────────┤
 │Unicode layout          │render pipeline  │in review with follow-up │
 │stabilization for mixed │maintainers with │checks for border style  │
-│Latin, punctuation,     │fallback shaping │transitions, cell        │
-│symbols, and long       │support          │padding variants, and    │
-│identifiers in adjacent │                 │selection range          │
-│columns                 │                 │consistency              │
+│Latin, punctuation,     │fallback shaping │transitions, cell padding│
+│symbols, and long       │support          │variants, and selection  │
+│identifiers in adjacent │                 │range consistency        │
+│columns                 │                 │                         │
 ├────────────────────────┼─────────────────┼─────────────────────────┤
-│Snapshot pass for table │qa automation    │today pending final      │
-│rendering in content    │and visual diff  │baseline updates for     │
+│Snapshot pass for table │qa automation and│today pending final      │
+│rendering in content    │visual diff      │baseline updates for     │
 │mode and full mode with │triage group     │oversized fixtures that  │
 │heavy and double border │                 │intentionally stress     │
 │combinations            │                 │wrapping behavior on     │
@@ -167,14 +167,14 @@ exports[`TextTableRenderable keeps full wrapped table layouts after a wide-to-na
 ├────────────────────────┼─────────────────┼─────────────────────────┤
 │Document edge cases     │developer        │planned for this sprint  │
 │where long tokens       │experience and   │once final reproducible  │
-│without spaces force    │docs tooling     │examples are captured    │
-│char wrapping and       │                 │and linked to regression │
-│reveal per-cell         │                 │tracking tickets         │
-│clipping regressions    │                 │                         │
+│without spaces force    │docs tooling     │examples are captured and│
+│char wrapping and reveal│                 │linked to regression     │
+│per-cell clipping       │                 │tracking tickets         │
+│regressions             │                 │                         │
 ├────────────────────────┼─────────────────┼─────────────────────────┤
 │Performance sweep of    │runtime          │scheduled after review,  │
-│wrapping algorithm      │performance task │with benchmark runs on   │
-│under large datasets to │force            │laptop and desktop       │
+│wrapping algorithm under│performance task │with benchmark runs on   │
+│large datasets to       │force            │laptop and desktop       │
 │confirm stable frame    │                 │terminals at 200-plus    │
 │times during rapid key  │                 │column widths            │
 │toggling                │                 │                         │
@@ -186,24 +186,24 @@ exports[`TextTableRenderable keeps full wrapped table layouts after a wide-to-na
 "┌─────────────┬──────────────────────────────────────────────────────┐
 │Column       │Wrapped Text                                          │
 ├─────────────┼──────────────────────────────────────────────────────┤
-│mixed-       │CJK and emoji wrapping stress case: こんにちは世界    │
-│languages    │and 안녕하세요 세계 and 你好，世界 followed by long   │
+│mixed-       │CJK and emoji wrapping stress case: こんにちは世界 and│
+│languages    │안녕하세요 세계 and 你好，世界 followed by long       │
 │             │English prose that keeps flowing to test whether each │
 │             │cell wraps naturally even when the terminal is        │
-│             │extremely wide and the row still needs multiple       │
-│             │visual lines for readability 🌍🚀                     │
+│             │extremely wide and the row still needs multiple visual│
+│             │lines for readability 🌍🚀                            │
 ├─────────────┼──────────────────────────────────────────────────────┤
 │emoji-and-   │Faces 😀😃😄😁😆 plus symbols 🧪📦🛰️🔧📊 mixed with   │
 │symbols      │version tags like release-candidate-build-2026-02-    │
-│             │very-long-token-without-breaks to ensure char         │
-│             │wrapping remains stable and no glyph alignment issues │
-│             │appear at column boundaries                           │
+│             │very-long-token-without-breaks to ensure char wrapping│
+│             │remains stable and no glyph alignment issues appear at│
+│             │column boundaries                                     │
 ├─────────────┼──────────────────────────────────────────────────────┤
 │long-cjk-    │長文の日本語テキストと中文段落和한국어문장을連続して配│
-│phrase       │置し、その後に additional English context describing r│
-│             │enderer behavior, border intersection handling, and se│
-│             │lection extraction so that this single cell remains a │
-│             │reliable wrapping torture test.                       │
+│phrase       │置し、その後に additional English context describing  │
+│             │renderer behavior, border intersection handling, and  │
+│             │selection extraction so that this single cell remains │
+│             │a reliable wrapping torture test.                     │
 ├─────────────┼──────────────────────────────────────────────────────┤
 │mixed-       │Wrap behavior with punctuation-heavy content: [alpha]{│
 │punctuation  │beta}(gamma)<delta>|epsilon| then repeated fragments, │

--- a/packages/core/src/renderables/__tests__/__snapshots__/Textarea.rendering.test.ts.snap
+++ b/packages/core/src/renderables/__tests__/__snapshots__/Textarea.rendering.test.ts.snap
@@ -115,11 +115,11 @@ abled
 exports[`Textarea - Rendering Tests Textarea Content Snapshots should render text with word wrapping and punctuation 1`] = `
 "Hello,World.                                                                    
 Test-                                                                           
-Example/                                                                        
-Path with                                                                       
-various                                                                         
+Example/Path                                                                    
+with various                                                                    
 punctuation                                                                     
 marks!                                                                          
+                                                                                
                                                                                 
                                                                                 
                                                                                 
@@ -351,9 +351,9 @@ exports[`Textarea - Rendering Tests Absolute Positioned Box with Textarea should
                                                                       
                                                                       
                                                                       
-             This is an extremely long piece of text                  
-             that needs to wrap multiple times within                 
-             the constrained width of the absolutely                  
+             This is an extremely long piece of text that             
+             needs to wrap multiple times within the                  
+             constrained width of the absolutely                      
              positioned container box with significant                
              padding on all sides.                                    
                                                                       

--- a/packages/core/src/text-buffer.test.ts
+++ b/packages/core/src/text-buffer.test.ts
@@ -133,6 +133,16 @@ describe("TextBuffer", () => {
     })
   })
 
+  describe("tab width", () => {
+    it("clamps 255 to the largest representable even width", () => {
+      buffer.setText("a\tb")
+      buffer.setTabWidth(255)
+
+      expect(buffer.getTabWidth()).toBe(254)
+      expect(buffer.length).toBe(256)
+    })
+  })
+
   describe("getTextRange", () => {
     it("should return null bytes for zero-length range output buffers", () => {
       buffer.setText("Hello World")

--- a/packages/core/src/text-buffer.ts
+++ b/packages/core/src/text-buffer.ts
@@ -213,6 +213,7 @@ export class TextBuffer {
   public setTabWidth(width: number): void {
     this.guard()
     this.lib.textBufferSetTabWidth(this.bufferPtr, width)
+    this._length = this.lib.textBufferGetLength(this.bufferPtr)
   }
 
   public getTabWidth(): number {

--- a/packages/core/src/text-buffer.ts
+++ b/packages/core/src/text-buffer.ts
@@ -1,6 +1,6 @@
 import type { StyledText } from "./lib/styled-text.js"
 import { RGBA } from "./lib/RGBA.js"
-import { resolveRenderLib, type LineInfo, type RenderLib, type TextBufferHandle } from "./zig.js"
+import { resolveRenderLib, type RenderLib, type TextBufferHandle } from "./zig.js"
 import { type WidthMethod, type Highlight } from "./types.js"
 import type { SyntaxStyle } from "./syntax-style.js"
 
@@ -18,7 +18,6 @@ export class TextBuffer {
   private bufferPtr: TextBufferHandle
   private _length: number = 0
   private _byteSize: number = 0
-  private _lineInfo?: LineInfo
   private _destroyed: boolean = false
   private _syntaxStyle?: SyntaxStyle
   private _textBytes?: Uint8Array
@@ -55,7 +54,6 @@ export class TextBuffer {
     this.lib.textBufferSetTextFromMem(this.bufferPtr, this._memId)
     this._length = this.lib.textBufferGetLength(this.bufferPtr)
     this._byteSize = this.lib.textBufferGetByteSize(this.bufferPtr)
-    this._lineInfo = undefined
     this._appendedChunks = [] // Clear any previously appended chunks
   }
 
@@ -67,7 +65,6 @@ export class TextBuffer {
     this.lib.textBufferAppend(this.bufferPtr, textBytes)
     this._length = this.lib.textBufferGetLength(this.bufferPtr)
     this._byteSize = this.lib.textBufferGetByteSize(this.bufferPtr)
-    this._lineInfo = undefined
   }
 
   public loadFile(path: string): void {
@@ -78,7 +75,6 @@ export class TextBuffer {
     }
     this._length = this.lib.textBufferGetLength(this.bufferPtr)
     this._byteSize = this.lib.textBufferGetByteSize(this.bufferPtr)
-    this._lineInfo = undefined
     this._textBytes = undefined
   }
 
@@ -89,7 +85,6 @@ export class TextBuffer {
 
     this._length = this.lib.textBufferGetLength(this.bufferPtr)
     this._byteSize = this.lib.textBufferGetByteSize(this.bufferPtr)
-    this._lineInfo = undefined
   }
 
   public setDefaultFg(fg: RGBA | null): void {
@@ -226,7 +221,6 @@ export class TextBuffer {
     this.lib.textBufferClear(this.bufferPtr)
     this._length = 0
     this._byteSize = 0
-    this._lineInfo = undefined
     this._textBytes = undefined
     this._appendedChunks = []
     // Note: _memId is NOT cleared - it can be reused for next setText
@@ -237,7 +231,6 @@ export class TextBuffer {
     this.lib.textBufferReset(this.bufferPtr)
     this._length = 0
     this._byteSize = 0
-    this._lineInfo = undefined
     this._textBytes = undefined
     this._memId = undefined // Reset clears the registry, so clear our ID
     this._appendedChunks = []

--- a/packages/core/src/text-buffer.ts
+++ b/packages/core/src/text-buffer.ts
@@ -208,6 +208,7 @@ export class TextBuffer {
   public setTabWidth(width: number): void {
     this.guard()
     this.lib.textBufferSetTabWidth(this.bufferPtr, width)
+    // Native length is display-cell width, so tab metrics can change it without changing bytes.
     this._length = this.lib.textBufferGetLength(this.bufferPtr)
   }
 

--- a/packages/native/src/bench/text-buffer-view_bench.zig
+++ b/packages/native/src/bench/text-buffer-view_bench.zig
@@ -25,7 +25,8 @@ const large_text_patterns = [_][]const u8{
     "Tab\tseparated\tvalues\there\tfor\ttesting\twrapping. ",
 };
 
-const matched_single_chunk_text = "word-" ** 12_800; // 64,000 bytes and display columns.
+const matched_single_chunk_text = "word-" ** 12_800;
+const matched_single_chunk_width: u32 = 64_000;
 
 pub fn generateLargeText(allocator: std.mem.Allocator, lines: u32, target_bytes: usize) ![]u8 {
     var buffer: std.ArrayList(u8) = .empty;
@@ -50,23 +51,6 @@ pub fn generateLargeText(allocator: std.mem.Allocator, lines: u32, target_bytes:
     return buffer.toOwnedSlice(allocator);
 }
 
-pub fn generateLargeTextSingleLine(allocator: std.mem.Allocator, target_bytes: usize) ![]u8 {
-    var buffer: std.ArrayList(u8) = .empty;
-    errdefer buffer.deinit(allocator);
-
-    var current_bytes: usize = 0;
-    var pattern_idx: usize = 0;
-
-    while (current_bytes < target_bytes) {
-        const pattern = large_text_patterns[pattern_idx % large_text_patterns.len];
-        try buffer.appendSlice(allocator, pattern);
-        current_bytes += pattern.len;
-        pattern_idx += 1;
-    }
-
-    return buffer.toOwnedSlice(allocator);
-}
-
 fn computeLargeTextStats(lines: u32, target_bytes: usize) struct { bytes: usize, line_count: usize } {
     var current_bytes: usize = 0;
     var line_idx: u32 = 0;
@@ -78,19 +62,6 @@ fn computeLargeTextStats(lines: u32, target_bytes: usize) struct { bytes: usize,
     }
 
     return .{ .bytes = current_bytes, .line_count = line_idx };
-}
-
-fn computeSingleLineTextSize(target_bytes: usize) usize {
-    var current_bytes: usize = 0;
-    var pattern_idx: usize = 0;
-
-    while (current_bytes < target_bytes) {
-        const pattern = large_text_patterns[pattern_idx % large_text_patterns.len];
-        current_bytes += pattern.len;
-        pattern_idx += 1;
-    }
-
-    return current_bytes;
 }
 
 fn benchSetText(
@@ -107,7 +78,7 @@ fn benchSetText(
 
     // Small text
     {
-        const name = "TextBuffer setText small (3 lines, 40 bytes)";
+        const name = "TextBuffer setText small (3 lines, 36 bytes)";
         if (bench_utils.matchesBenchFilter(name, bench_filter)) {
             const text = "Hello, world!\nSecond line\nThird line";
             var stats: BenchStats = .{};
@@ -206,7 +177,7 @@ fn benchWrap(
     wrap_mode: WrapMode,
     iterations: usize,
     show_mem: bool,
-    expected_line_count: ?u32,
+    expected_total_width: ?u32,
 ) !BenchResult {
     var stats: BenchStats = .{};
     var final_tb_mem: usize = 0;
@@ -231,13 +202,16 @@ fn benchWrap(
 
         // Validate outside the timed interval so both revisions must produce the
         // same complete layout before their timings are compared.
-        if (expected_line_count) |expected| {
+        if (expected_total_width) |expected_width| {
             const lines = view.getVirtualLines();
-            if (tb.getLineCount() != 1 or count != expected or lines.len != @as(usize, @intCast(expected))) {
+            const expected_count = (expected_width + wrap_width - 1) / wrap_width;
+            if (tb.getLineCount() != 1 or count != expected_count or lines.len != @as(usize, @intCast(expected_count))) {
                 return error.InvalidBenchmarkOutput;
             }
-            for (lines) |line| {
-                if (line.width_cols != wrap_width) return error.InvalidBenchmarkOutput;
+            for (lines, 0..) |line, line_idx| {
+                const remainder = expected_width % wrap_width;
+                const expected_line_width = if (line_idx + 1 == lines.len and remainder != 0) remainder else wrap_width;
+                if (line.width_cols != expected_line_width) return error.InvalidBenchmarkOutput;
             }
         }
 
@@ -365,27 +339,8 @@ pub fn run(
 
     var text_multiline: ?[]u8 = null;
     defer if (text_multiline) |text| allocator.free(text);
-    var text_singleline: ?[]u8 = null;
-    defer if (text_singleline) |text| allocator.free(text);
     const multiline_stats = computeLargeTextStats(5000, 1 * 1024 * 1024);
     const multiline_mb = @as(f64, @floatFromInt(multiline_stats.bytes)) / (1024.0 * 1024.0);
-
-    const matched_name = "TextBufferView wrap (word, width=80, validated 62.5 KiB single chunk)";
-    if (bench_utils.matchesBenchFilter(matched_name, bench_filter)) {
-        var bench_result = try benchWrap(
-            io,
-            allocator,
-            pool,
-            matched_single_chunk_text,
-            80,
-            .word,
-            iterations,
-            show_mem,
-            800,
-        );
-        bench_result.name = matched_name;
-        try all_results.append(allocator, bench_result);
-    }
 
     // Run measureForDimensions benchmarks
     const layout_passes: usize = 3;
@@ -454,28 +409,26 @@ pub fn run(
     };
 
     for (scenarios) |scenario| {
-        if (scenario.single_line) {
-            if (text_singleline == null) {
-                text_singleline = try generateLargeTextSingleLine(allocator, 2 * 1024 * 1024);
-            }
-        } else {
-            if (text_multiline == null) {
-                text_multiline = try generateLargeText(allocator, 5000, 1 * 1024 * 1024);
-            }
-        }
-        const text = if (scenario.single_line) text_singleline.? else text_multiline.?;
-        const line_type = if (scenario.single_line) "single" else "multi";
-
-        const bench_name = try std.fmt.allocPrint(allocator, "TextBufferView wrap ({s}, width={d}, {s}-line)", .{
-            scenario.mode_str,
-            scenario.width,
-            line_type,
-        });
+        const bench_name = if (scenario.single_line)
+            try std.fmt.allocPrint(allocator, "TextBufferView wrap ({s}, width={d}, validated 62.5 KiB single chunk)", .{
+                scenario.mode_str,
+                scenario.width,
+            })
+        else
+            try std.fmt.allocPrint(allocator, "TextBufferView wrap ({s}, width={d}, multi-line)", .{
+                scenario.mode_str,
+                scenario.width,
+            });
 
         if (!bench_utils.matchesBenchFilter(bench_name, bench_filter)) {
             allocator.free(bench_name);
             continue;
         }
+
+        if (!scenario.single_line and text_multiline == null) {
+            text_multiline = try generateLargeText(allocator, 5000, 1 * 1024 * 1024);
+        }
+        const text = if (scenario.single_line) matched_single_chunk_text else text_multiline.?;
 
         var bench_result = try benchWrap(
             io,
@@ -486,7 +439,7 @@ pub fn run(
             scenario.mode,
             iterations,
             show_mem,
-            null,
+            if (scenario.single_line) matched_single_chunk_width else null,
         );
         bench_result.name = bench_name;
 

--- a/packages/native/src/bench/text-buffer-view_bench.zig
+++ b/packages/native/src/bench/text-buffer-view_bench.zig
@@ -25,6 +25,8 @@ const large_text_patterns = [_][]const u8{
     "Tab\tseparated\tvalues\there\tfor\ttesting\twrapping. ",
 };
 
+const matched_single_chunk_text = "word-" ** 12_800; // 64,000 bytes and display columns.
+
 pub fn generateLargeText(allocator: std.mem.Allocator, lines: u32, target_bytes: usize) ![]u8 {
     var buffer: std.ArrayList(u8) = .empty;
     errdefer buffer.deinit(allocator);
@@ -204,6 +206,7 @@ fn benchWrap(
     wrap_mode: WrapMode,
     iterations: usize,
     show_mem: bool,
+    expected_line_count: ?u32,
 ) !BenchResult {
     var stats: BenchStats = .{};
     var final_tb_mem: usize = 0;
@@ -225,7 +228,18 @@ fn benchWrap(
         view.setWrapWidth(wrap_width);
         const count = view.getVirtualLineCount();
         stats.record(timer.read());
-        _ = count;
+
+        // Validate outside the timed interval so both revisions must produce the
+        // same complete layout before their timings are compared.
+        if (expected_line_count) |expected| {
+            const lines = view.getVirtualLines();
+            if (tb.getLineCount() != 1 or count != expected or lines.len != @as(usize, @intCast(expected))) {
+                return error.InvalidBenchmarkOutput;
+            }
+            for (lines) |line| {
+                if (line.width_cols != wrap_width) return error.InvalidBenchmarkOutput;
+            }
+        }
 
         if (i == iterations - 1 and show_mem) {
             final_tb_mem = tb.getArenaAllocatedBytes();
@@ -356,6 +370,23 @@ pub fn run(
     const multiline_stats = computeLargeTextStats(5000, 1 * 1024 * 1024);
     const multiline_mb = @as(f64, @floatFromInt(multiline_stats.bytes)) / (1024.0 * 1024.0);
 
+    const matched_name = "TextBufferView wrap (word, width=80, validated 62.5 KiB single chunk)";
+    if (bench_utils.matchesBenchFilter(matched_name, bench_filter)) {
+        var bench_result = try benchWrap(
+            io,
+            allocator,
+            pool,
+            matched_single_chunk_text,
+            80,
+            .word,
+            iterations,
+            show_mem,
+            800,
+        );
+        bench_result.name = matched_name;
+        try all_results.append(allocator, bench_result);
+    }
+
     // Run measureForDimensions benchmarks
     const layout_passes: usize = 3;
     const wrap_width: u32 = 80;
@@ -455,6 +486,7 @@ pub fn run(
             scenario.mode,
             iterations,
             show_mem,
+            null,
         );
         bench_result.name = bench_name;
 

--- a/packages/native/src/bench/text-buffer-view_bench.zig
+++ b/packages/native/src/bench/text-buffer-view_bench.zig
@@ -395,15 +395,15 @@ pub fn run(
         streaming: bool,
         width: u32,
     }{
-        .{ .label = "layout streaming wrap", .streaming = true, .width = wrap_width },
-        .{ .label = "layout streaming intrinsic", .streaming = true, .width = 0 },
-        .{ .label = "layout static wrap", .streaming = false, .width = wrap_width },
+        .{ .label = "incremental append wrap", .streaming = true, .width = wrap_width },
+        .{ .label = "incremental append intrinsic", .streaming = true, .width = 0 },
+        .{ .label = "repeated cached wrap", .streaming = false, .width = wrap_width },
     };
 
     for (measure_scenarios) |scenario| {
         const bench_name = try std.fmt.allocPrint(
             allocator,
-            "TextBufferView measureForDimensions ({s}, {d:.2} MiB)",
+            "TextBufferView measureForDimensions ({s}, {d:.2} MiB initial text)",
             .{ scenario.label, multiline_mb },
         );
 

--- a/packages/native/src/bench/text-chunk-graphemes_bench.zig
+++ b/packages/native/src/bench/text-chunk-graphemes_bench.zig
@@ -103,14 +103,6 @@ fn benchGetGraphemes(
     // Create TextChunk
     // Width is approximate - clamped to u16 max
     const approx_width: u32 = @intCast(@min(text.len, std.math.maxInt(u32)));
-    var chunk: TextChunk = .{
-        .mem_id = mem_id,
-        .byte_start = 0,
-        .byte_end = @intCast(text.len),
-        .width = approx_width,
-        .flags = if (is_ascii) TextChunk.Flags.ASCII_ONLY else 0,
-    };
-
     var stats: BenchStats = .{};
     var grapheme_count: usize = 0;
     var final_mem: usize = 0;
@@ -121,9 +113,13 @@ fn benchGetGraphemes(
         defer arena.deinit();
         const arena_alloc = arena.allocator();
 
-        // Clear cached graphemes
-        // Each iteration owns a fresh arena, so do not retain its sidecar pointer.
-        chunk.resetCaches();
+        const chunk: TextChunk = .{
+            .mem_id = mem_id,
+            .byte_start = 0,
+            .byte_end = @intCast(text.len),
+            .width = approx_width,
+            .flags = if (is_ascii) TextChunk.Flags.ASCII_ONLY else 0,
+        };
 
         const timer = bench_utils.BenchTimer.start(io);
         const graphemes = try chunk.getGraphemes(

--- a/packages/native/src/bench/text-chunk-graphemes_bench.zig
+++ b/packages/native/src/bench/text-chunk-graphemes_bench.zig
@@ -102,7 +102,7 @@ fn benchGetGraphemes(
 
     // Create TextChunk
     // Width is approximate - clamped to u16 max
-    const approx_width: u16 = @intCast(@min(text.len, std.math.maxInt(u16)));
+    const approx_width: u32 = @intCast(@min(text.len, std.math.maxInt(u32)));
     var chunk: TextChunk = .{
         .mem_id = mem_id,
         .byte_start = 0,
@@ -122,7 +122,8 @@ fn benchGetGraphemes(
         const arena_alloc = arena.allocator();
 
         // Clear cached graphemes
-        chunk.graphemes = null;
+        // Each iteration owns a fresh arena, so do not retain its sidecar pointer.
+        chunk.resetCaches();
 
         const timer = bench_utils.BenchTimer.start(io);
         const graphemes = try chunk.getGraphemes(
@@ -187,7 +188,7 @@ fn computeBenchName(allocator: std.mem.Allocator, size: usize, text_type: TextTy
         .ascii => true,
         else => false,
     };
-    const approx_width: u16 = @intCast(@min(text.len, std.math.maxInt(u16)));
+    const approx_width: u32 = @intCast(@min(text.len, std.math.maxInt(u32)));
     var chunk: TextChunk = .{
         .mem_id = mem_id,
         .byte_start = 0,

--- a/packages/native/src/bench/utf8_bench.zig
+++ b/packages/native/src/bench/utf8_bench.zig
@@ -291,6 +291,49 @@ fn benchFindLineBreaks(
     return results.toOwnedSlice(results_alloc);
 }
 
+fn benchFindChunkLayoutInfo(
+    io: std.Io,
+    results_alloc: std.mem.Allocator,
+    iterations: usize,
+    bench_filter: ?[]const u8,
+) ![]BenchResult {
+    var results: std.ArrayList(BenchResult) = .empty;
+    errdefer results.deinit(results_alloc);
+
+    const name = "findChunkLayoutInfo: ASCII punctuation (62.5 KiB)";
+    if (bench_utils.matchesBenchFilter(name, bench_filter)) {
+        const text = "word-" ** 12_800;
+        var temp = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer temp.deinit();
+        const alloc = temp.allocator();
+        var wrap_breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;
+        defer wrap_breaks.deinit(alloc);
+
+        var stats: BenchStats = .{};
+        for (0..iterations) |_| {
+            const timer = bench_utils.BenchTimer.start(io);
+            const word_classes = try utf8.findChunkLayoutInfo(alloc, text, 4, true, .unicode, &wrap_breaks);
+            stats.record(timer.read());
+
+            if (wrap_breaks.items.len != 12_800 or word_classes.first != .ascii_word or word_classes.last != .other) {
+                return error.InvalidBenchmarkOutput;
+            }
+        }
+
+        try results.append(results_alloc, .{
+            .name = name,
+            .min_ns = stats.min_ns,
+            .avg_ns = stats.avg(),
+            .max_ns = stats.max_ns,
+            .total_ns = stats.total_ns,
+            .iterations = iterations,
+            .mem_stats = null,
+        });
+    }
+
+    return results.toOwnedSlice(results_alloc);
+}
+
 // Benchmark findWrapPosByWidth
 fn benchFindWrapPosByWidth(
     io: std.Io,
@@ -710,6 +753,10 @@ pub fn run(
     // findLineBreaks benchmarks
     const line_breaks_results = try benchFindLineBreaks(io, allocator, iterations, bench_filter);
     try all_results.appendSlice(allocator, line_breaks_results);
+
+    // Direct benchmark for the retained word-layout scanner.
+    const chunk_layout_results = try benchFindChunkLayoutInfo(io, allocator, iterations, bench_filter);
+    try all_results.appendSlice(allocator, chunk_layout_results);
 
     // findWrapPosByWidth benchmarks
     const wrap_pos_results = try benchFindWrapPosByWidth(io, allocator, iterations, bench_filter);

--- a/packages/native/src/bench/utf8_bench.zig
+++ b/packages/native/src/bench/utf8_bench.zig
@@ -291,81 +291,6 @@ fn benchFindLineBreaks(
     return results.toOwnedSlice(results_alloc);
 }
 
-// Benchmark findWrapBreaks
-fn benchFindWrapBreaks(
-    io: std.Io,
-    results_alloc: std.mem.Allocator,
-    iterations: usize,
-    bench_filter: ?[]const u8,
-) ![]BenchResult {
-    var results: std.ArrayList(BenchResult) = .empty;
-    errdefer results.deinit(results_alloc);
-
-    // ASCII text
-    {
-        const name = "findWrapBreaks: ASCII (10KB)";
-        if (bench_utils.matchesBenchFilter(name, bench_filter)) {
-            var temp = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-            defer temp.deinit();
-            const alloc = temp.allocator();
-            const text = try generateAsciiText(alloc, 10 * 1024);
-
-            var wrap_result = utf8.WrapBreakResult.init(alloc);
-            defer wrap_result.deinit();
-
-            var stats: BenchStats = .{};
-            for (0..iterations) |_| {
-                const timer = bench_utils.BenchTimer.start(io);
-                try utf8.findWrapBreaks(text, &wrap_result, .unicode);
-                stats.record(timer.read());
-            }
-
-            try results.append(results_alloc, .{
-                .name = name,
-                .min_ns = stats.min_ns,
-                .avg_ns = stats.avg(),
-                .max_ns = stats.max_ns,
-                .total_ns = stats.total_ns,
-                .iterations = iterations,
-                .mem_stats = null,
-            });
-        }
-    }
-
-    // Mixed text
-    {
-        const name = "findWrapBreaks: Mixed (10KB)";
-        if (bench_utils.matchesBenchFilter(name, bench_filter)) {
-            var temp = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-            defer temp.deinit();
-            const alloc = temp.allocator();
-            const text = try generateMixedText(alloc, 10 * 1024);
-
-            var wrap_result = utf8.WrapBreakResult.init(alloc);
-            defer wrap_result.deinit();
-
-            var stats: BenchStats = .{};
-            for (0..iterations) |_| {
-                const timer = bench_utils.BenchTimer.start(io);
-                try utf8.findWrapBreaks(text, &wrap_result, .unicode);
-                stats.record(timer.read());
-            }
-
-            try results.append(results_alloc, .{
-                .name = name,
-                .min_ns = stats.min_ns,
-                .avg_ns = stats.avg(),
-                .max_ns = stats.max_ns,
-                .total_ns = stats.total_ns,
-                .iterations = iterations,
-                .mem_stats = null,
-            });
-        }
-    }
-
-    return results.toOwnedSlice(results_alloc);
-}
-
 // Benchmark findWrapPosByWidth
 fn benchFindWrapPosByWidth(
     io: std.Io,
@@ -785,10 +710,6 @@ pub fn run(
     // findLineBreaks benchmarks
     const line_breaks_results = try benchFindLineBreaks(io, allocator, iterations, bench_filter);
     try all_results.appendSlice(allocator, line_breaks_results);
-
-    // findWrapBreaks benchmarks
-    const wrap_breaks_results = try benchFindWrapBreaks(io, allocator, iterations, bench_filter);
-    try all_results.appendSlice(allocator, wrap_breaks_results);
 
     // findWrapPosByWidth benchmarks
     const wrap_pos_results = try benchFindWrapPosByWidth(io, allocator, iterations, bench_filter);

--- a/packages/native/src/buffer.zig
+++ b/packages/native/src/buffer.zig
@@ -1314,7 +1314,7 @@ pub const OptimizedBuffer = struct {
             const at_special = special_idx < specials.len and specials[special_idx].col_offset == col;
 
             var grapheme_bytes: []const u8 = undefined;
-            var g_width: u8 = undefined;
+            var g_width: u32 = undefined;
 
             if (at_special) {
                 const g = specials[special_idx];
@@ -1736,50 +1736,37 @@ pub const OptimizedBuffer = struct {
                 const line_col_offset = vline.col_offset;
 
                 if (currentX >= @as(i32, @intCast(self.width))) {
-                    globalCharPos += vchunk.width;
-                    currentX += @intCast(vchunk.width);
+                    globalCharPos += vchunk.width_cols;
+                    currentX += @intCast(vchunk.width_cols);
                     continue;
                 }
-                const col_end = vchunk.grapheme_start + vchunk.width;
-                var col = vchunk.grapheme_start;
+                const col_end = vchunk.col_start_in_chunk + vchunk.width_cols;
+                var col = vchunk.col_start_in_chunk;
                 var special_idx: usize = 0;
-                var byte_offset: u32 = 0;
+                var byte_offset = vchunk.byte_start_in_chunk;
+                const byte_end = vchunk.byte_start_in_chunk + vchunk.byte_len;
 
-                if (vchunk.grapheme_start > 0) {
-                    // Use UTF-8 aware position finding to skip to the grapheme_start
-                    const is_ascii_only = (vchunk.chunk.flags & tb.TextChunk.Flags.ASCII_ONLY) != 0;
-                    const pos_result = utf8.findPosByWidth(chunk_bytes, vchunk.grapheme_start, text_buffer.tabWidth(), is_ascii_only, false, text_buffer.widthMethod());
-                    byte_offset = pos_result.byte_offset;
-
-                    // Advance special_idx to match the skipped columns
-                    var init_col: u32 = 0;
-                    while (init_col < vchunk.grapheme_start and special_idx < specials.len) {
-                        const g = specials[special_idx];
-                        if (g.col_offset < vchunk.grapheme_start) {
-                            special_idx += 1;
-                            init_col = g.col_offset + g.width;
-                        } else {
-                            break;
-                        }
-                    }
+                while (special_idx < specials.len and specials[special_idx].byte_offset + specials[special_idx].byte_len <= byte_offset) {
+                    special_idx += 1;
                 }
 
-                text_buffer_loop: while (col < col_end) {
-                    const at_special = special_idx < specials.len and specials[special_idx].col_offset == col;
+                text_buffer_loop: while (byte_offset < byte_end and col < col_end) {
+                    const at_special = special_idx < specials.len and specials[special_idx].byte_offset == byte_offset;
 
                     var grapheme_bytes: []const u8 = undefined;
-                    var g_width: u8 = undefined;
+                    var g_width: u32 = undefined;
 
                     if (at_special) {
                         const g = specials[special_idx];
+                        if (g.byte_offset + g.byte_len > byte_end) break;
                         grapheme_bytes = chunk_bytes[g.byte_offset .. g.byte_offset + g.byte_len];
                         g_width = g.width;
                         byte_offset = g.byte_offset + g.byte_len;
                         special_idx += 1;
                     } else {
-                        if (byte_offset >= chunk_bytes.len) break;
+                        if (byte_offset >= byte_end or byte_offset >= chunk_bytes.len) break;
                         const cp_len = std.unicode.utf8ByteSequenceLength(chunk_bytes[byte_offset]) catch 1;
-                        const next_byte_offset = @min(byte_offset + cp_len, chunk_bytes.len);
+                        const next_byte_offset = @min(byte_offset + cp_len, byte_end);
                         grapheme_bytes = chunk_bytes[byte_offset..next_byte_offset];
                         g_width = 1;
                         byte_offset = next_byte_offset;

--- a/packages/native/src/edit-buffer.zig
+++ b/packages/native/src/edit-buffer.zig
@@ -751,7 +751,7 @@ pub const EditBuffer = struct {
                     continue;
                 };
 
-                if (utf8.isCjkAsciiTransition(previous_word_class, layout.first_word_class) and
+                if (utf8.isCjkAsciiTransition(previous_word_class, layout.word_classes.first) and
                     cols_before > cursor.col and cols_before <= line_width)
                 {
                     const offset = iter_mod.coordsToOffset(self.tb.rope(), cursor.row, cols_before) orelse cursor.offset;
@@ -799,7 +799,7 @@ pub const EditBuffer = struct {
                     // Mark that we've processed/passed the cursor position
                     passed_cursor = true;
                 }
-                previous_word_class = layout.last_word_class;
+                previous_word_class = layout.word_classes.last;
                 cols_before = next_cols;
             }
         }
@@ -837,7 +837,7 @@ pub const EditBuffer = struct {
                     continue;
                 };
 
-                if (utf8.isCjkAsciiTransition(previous_word_class, layout.first_word_class) and cols_before < cursor.col) {
+                if (utf8.isCjkAsciiTransition(previous_word_class, layout.word_classes.first) and cols_before < cursor.col) {
                     last_boundary = cols_before;
                 }
 
@@ -848,7 +848,7 @@ pub const EditBuffer = struct {
                     }
                 }
 
-                previous_word_class = layout.last_word_class;
+                previous_word_class = layout.word_classes.last;
                 cols_before = next_cols;
                 if (cursor.col <= cols_before) break;
             }

--- a/packages/native/src/edit-buffer.zig
+++ b/packages/native/src/edit-buffer.zig
@@ -672,6 +672,7 @@ pub const EditBuffer = struct {
         var current_meta_buffer: [64]u8 = undefined;
         const current_meta = try self.encodeCurrentCursorMeta(current_meta_buffer[0..]);
         const prev_meta = try self.tb.rope().undo(current_meta);
+        self.tb.refreshTabWidthMetrics();
 
         const restored = try self.restoreCursorFromMeta(prev_meta);
 
@@ -689,6 +690,7 @@ pub const EditBuffer = struct {
 
     pub fn redo(self: *EditBuffer) ![]const u8 {
         const next_meta = try self.tb.rope().redo();
+        self.tb.refreshTabWidthMetrics();
 
         const restored = try self.restoreCursorFromMeta(next_meta);
 
@@ -735,42 +737,42 @@ pub const EditBuffer = struct {
         var seg_idx = linestart.leaf_index + 1;
         var cols_before: u32 = 0;
         var passed_cursor = false;
+        var previous_word_class: utf8.WordClass = .other;
 
         while (seg_idx < self.tb.rope().count()) : (seg_idx += 1) {
             const seg = self.tb.rope().get(seg_idx) orelse break;
             if (seg.isBreak() or seg.isLineStart()) break;
             if (seg.asText()) |chunk| {
                 const next_cols = cols_before + chunk.width;
+                const layout = self.tb.getLayoutInfoFor(chunk) catch {
+                    cols_before = next_cols;
+                    passed_cursor = passed_cursor or cursor.col < next_cols;
+                    previous_word_class = .other;
+                    continue;
+                };
+
+                if (utf8.isCjkAsciiTransition(previous_word_class, layout.first_word_class) and
+                    cols_before > cursor.col and cols_before <= line_width)
+                {
+                    const offset = iter_mod.coordsToOffset(self.tb.rope(), cursor.row, cols_before) orelse cursor.offset;
+                    return .{ .row = cursor.row, .col = cols_before, .desired_col = cols_before, .offset = offset };
+                }
 
                 // Check this chunk if cursor is within it OR if we've already passed the cursor
                 if (cursor.col < next_cols or passed_cursor) {
-                    const wrap_offsets = self.tb.getWrapOffsetsFor(chunk) catch {
-                        cols_before = next_cols;
-                        passed_cursor = true;
-                        continue;
-                    };
-                    const is_ascii_only = (chunk.flags & TextChunk.Flags.ASCII_ONLY) != 0;
-                    const graphemes: []const seg_mod.GraphemeInfo = if (is_ascii_only)
-                        &[_]seg_mod.GraphemeInfo{}
-                    else
-                        chunk.getGraphemes(self.tb.getAllocator(), self.tb.memRegistry(), self.tb.tabWidth(), self.tb.widthMethod()) catch &[_]seg_mod.GraphemeInfo{};
-                    var grapheme_idx: usize = 0;
-                    var col_delta: i64 = 0;
+                    const wrap_breaks = layout.wrap_breaks;
 
                     // For chunks containing or after the cursor, find the first break after cursor position
                     const local_cursor_col = if (cursor.col > cols_before) cursor.col - cols_before else 0;
 
-                    for (wrap_offsets) |wrap_break| {
-                        const break_info = iter_mod.charOffsetToColumn(wrap_break.char_offset, graphemes, &grapheme_idx, &col_delta);
-                        const break_col = break_info.col;
+                    for (wrap_breaks) |wrap_break| {
+                        const break_col = wrap_break.col_offset;
+                        const target_col = cols_before + wrap_break.colEnd();
 
                         // If we've passed the cursor chunk, any break is valid
                         // If we're in the cursor chunk, break must be after cursor position
                         if (passed_cursor or break_col > local_cursor_col) {
-                            // break_col points at the break grapheme start.
-                            // Adding width moves the cursor to the boundary after it.
-                            const target_col = cols_before + break_col + break_info.width;
-                            if (target_col <= line_width) {
+                            if (target_col > cursor.col and target_col <= line_width) {
                                 const offset = iter_mod.coordsToOffset(self.tb.rope(), cursor.row, target_col) orelse cursor.offset;
                                 return .{ .row = cursor.row, .col = target_col, .desired_col = target_col, .offset = offset };
                             }
@@ -785,8 +787,7 @@ pub const EditBuffer = struct {
                             if (break_byte_offset < chunk_bytes.len) {
                                 const break_cp = utf8.decodeUtf8Unchecked(chunk_bytes, break_byte_offset).cp;
                                 if (utf8.isWordCodepoint(break_cp)) {
-                                    const target_col = cols_before + break_col + break_info.width;
-                                    if (target_col <= line_width) {
+                                    if (target_col > cursor.col and target_col <= line_width) {
                                         const offset = iter_mod.coordsToOffset(self.tb.rope(), cursor.row, target_col) orelse cursor.offset;
                                         return .{ .row = cursor.row, .col = target_col, .desired_col = target_col, .offset = offset };
                                     }
@@ -798,6 +799,7 @@ pub const EditBuffer = struct {
                     // Mark that we've processed/passed the cursor position
                     passed_cursor = true;
                 }
+                previous_word_class = layout.last_word_class;
                 cols_before = next_cols;
             }
         }
@@ -821,6 +823,7 @@ pub const EditBuffer = struct {
         var seg_idx = linestart.leaf_index + 1;
         var cols_before: u32 = 0;
         var last_boundary: ?u32 = null;
+        var previous_word_class: utf8.WordClass = .other;
 
         while (seg_idx < self.tb.rope().count()) : (seg_idx += 1) {
             const seg = self.tb.rope().get(seg_idx) orelse break;
@@ -828,28 +831,24 @@ pub const EditBuffer = struct {
             if (seg.asText()) |chunk| {
                 const next_cols = cols_before + chunk.width;
 
-                const wrap_offsets = self.tb.getWrapOffsetsFor(chunk) catch {
+                const layout = self.tb.getLayoutInfoFor(chunk) catch {
                     cols_before = next_cols;
+                    previous_word_class = .other;
                     continue;
                 };
-                const is_ascii_only = (chunk.flags & TextChunk.Flags.ASCII_ONLY) != 0;
-                const graphemes: []const seg_mod.GraphemeInfo = if (is_ascii_only)
-                    &[_]seg_mod.GraphemeInfo{}
-                else
-                    chunk.getGraphemes(self.tb.getAllocator(), self.tb.memRegistry(), self.tb.tabWidth(), self.tb.widthMethod()) catch &[_]seg_mod.GraphemeInfo{};
-                var grapheme_idx: usize = 0;
-                var col_delta: i64 = 0;
 
-                for (wrap_offsets) |wrap_break| {
-                    const break_info = iter_mod.charOffsetToColumn(wrap_break.char_offset, graphemes, &grapheme_idx, &col_delta);
-                    // break_info follows the same convention as getNextWordBoundary:
-                    // use break start + grapheme width to land after the break grapheme.
-                    const boundary_col = cols_before + break_info.col + break_info.width;
+                if (utf8.isCjkAsciiTransition(previous_word_class, layout.first_word_class) and cols_before < cursor.col) {
+                    last_boundary = cols_before;
+                }
+
+                for (layout.wrap_breaks) |wrap_break| {
+                    const boundary_col = cols_before + wrap_break.colEnd();
                     if (boundary_col < cursor.col) {
                         last_boundary = boundary_col;
                     }
                 }
 
+                previous_word_class = layout.last_word_class;
                 cols_before = next_cols;
                 if (cursor.col <= cols_before) break;
             }

--- a/packages/native/src/edit-buffer.zig
+++ b/packages/native/src/edit-buffer.zig
@@ -672,6 +672,7 @@ pub const EditBuffer = struct {
         var current_meta_buffer: [64]u8 = undefined;
         const current_meta = try self.encodeCurrentCursorMeta(current_meta_buffer[0..]);
         const prev_meta = try self.tb.rope().undo(current_meta);
+        // Cursor metadata is column-based, so repair stale root metrics first.
         self.tb.refreshTabWidthMetrics();
 
         const restored = try self.restoreCursorFromMeta(prev_meta);
@@ -690,6 +691,7 @@ pub const EditBuffer = struct {
 
     pub fn redo(self: *EditBuffer) ![]const u8 {
         const next_meta = try self.tb.rope().redo();
+        // Cursor metadata is column-based, so repair stale root metrics first.
         self.tb.refreshTabWidthMetrics();
 
         const restored = try self.restoreCursorFromMeta(next_meta);

--- a/packages/native/src/edit-buffer.zig
+++ b/packages/native/src/edit-buffer.zig
@@ -672,7 +672,8 @@ pub const EditBuffer = struct {
         var current_meta_buffer: [64]u8 = undefined;
         const current_meta = try self.encodeCurrentCursorMeta(current_meta_buffer[0..]);
         const prev_meta = try self.tb.rope().undo(current_meta);
-        // Cursor metadata is column-based, so repair stale root metrics first.
+        // Undo may restore widths cached before the latest tab-width change.
+        // Refresh them before restoring the column-based cursor.
         self.tb.refreshTabWidthMetrics();
 
         const restored = try self.restoreCursorFromMeta(prev_meta);
@@ -691,7 +692,8 @@ pub const EditBuffer = struct {
 
     pub fn redo(self: *EditBuffer) ![]const u8 {
         const next_meta = try self.tb.rope().redo();
-        // Cursor metadata is column-based, so repair stale root metrics first.
+        // Redo may restore widths cached before the latest tab-width change.
+        // Refresh them before restoring the column-based cursor.
         self.tb.refreshTabWidthMetrics();
 
         const restored = try self.restoreCursorFromMeta(next_meta);

--- a/packages/native/src/edit-buffer.zig
+++ b/packages/native/src/edit-buffer.zig
@@ -671,10 +671,7 @@ pub const EditBuffer = struct {
     pub fn undo(self: *EditBuffer) ![]const u8 {
         var current_meta_buffer: [64]u8 = undefined;
         const current_meta = try self.encodeCurrentCursorMeta(current_meta_buffer[0..]);
-        const prev_meta = try self.tb.rope().undo(current_meta);
-        // Undo may restore widths cached before the latest tab-width change.
-        // Refresh them before restoring the column-based cursor.
-        self.tb.refreshTabWidthMetrics();
+        const prev_meta = try self.tb.undo(current_meta);
 
         const restored = try self.restoreCursorFromMeta(prev_meta);
 
@@ -691,10 +688,7 @@ pub const EditBuffer = struct {
     }
 
     pub fn redo(self: *EditBuffer) ![]const u8 {
-        const next_meta = try self.tb.rope().redo();
-        // Redo may restore widths cached before the latest tab-width change.
-        // Refresh them before restoring the column-based cursor.
-        self.tb.refreshTabWidthMetrics();
+        const next_meta = try self.tb.redo();
 
         const restored = try self.restoreCursorFromMeta(next_meta);
 

--- a/packages/native/src/editor-view.zig
+++ b/packages/native/src/editor-view.zig
@@ -548,7 +548,12 @@ pub const EditorView = struct {
 
         const visual_col = cursor.offset - vline.col_offset;
         var visual_col_max = vline.width_cols;
-        if (self.text_buffer_view.getSelectionOccupancy() == .cell and vline.width_cols > 0 and visual_row + 1 < vlines.len) {
+        const viewport_width = if (self.text_buffer_view.getViewport()) |vp| vp.width else vline.width_cols;
+        if (self.text_buffer_view.getSelectionOccupancy() == .cell and
+            vline.width_cols > 0 and
+            vline.width_cols <= viewport_width and
+            visual_row + 1 < vlines.len)
+        {
             const next_vline = &vlines[visual_row + 1];
             if (next_vline.source_line == vline.source_line) visual_col_max -= 1;
         }
@@ -621,7 +626,7 @@ pub const EditorView = struct {
 
         // Calculate visual column within this virtual line
         const visual_col = if (clamped_col >= vline_start_col)
-            clamped_col - vline_start_col
+            @min(clamped_col - vline_start_col, vline.width_cols)
         else
             0;
 
@@ -857,11 +862,15 @@ pub const EditorView = struct {
         }
 
         const vline = &vlines[vcursor.visual_row];
+        const viewport_width = if (self.text_buffer_view.getViewport()) |vp| vp.width else vline.width_cols;
+        const oversized_visual_line = vline.width_cols > viewport_width;
         var target_visual_col = if (self.text_buffer_view.getSelectionOccupancy() == .boundary)
             vline.width_cols
+        else if (oversized_visual_line)
+            @min(vcursor.visual_col, vline.width_cols)
         else
             clampVisualColToStayOnVisualRow(vlines, vcursor.visual_row, vline.width_cols);
-        if (self.text_buffer_view.getSelectionOccupancy() == .cell) {
+        if (self.text_buffer_view.getSelectionOccupancy() == .cell and !oversized_visual_line) {
             const target_offset = vline.col_offset + target_visual_col;
             if (self.edit_buffer.tb.cursorUnitBoundsAtOffset(target_offset)) |bounds| {
                 if (bounds.start < target_offset) {

--- a/packages/native/src/editor-view.zig
+++ b/packages/native/src/editor-view.zig
@@ -549,6 +549,8 @@ pub const EditorView = struct {
         const visual_col = cursor.offset - vline.col_offset;
         var visual_col_max = vline.width_cols;
         const viewport_width = if (self.text_buffer_view.getViewport()) |vp| vp.width else vline.width_cols;
+        // An overwide visual line may be one atomic grapheme; do not reserve a
+        // viewport-edge cell as though it were an ordinary soft wrap.
         if (self.text_buffer_view.getSelectionOccupancy() == .cell and
             vline.width_cols > 0 and
             vline.width_cols <= viewport_width and
@@ -863,6 +865,7 @@ pub const EditorView = struct {
 
         const vline = &vlines[vcursor.visual_row];
         const viewport_width = if (self.text_buffer_view.getViewport()) |vp| vp.width else vline.width_cols;
+        // Keep an overwide grapheme atomic instead of targeting a synthetic wrap cell.
         const oversized_visual_line = vline.width_cols > viewport_width;
         var target_visual_col = if (self.text_buffer_view.getSelectionOccupancy() == .boundary)
             vline.width_cols

--- a/packages/native/src/lib.zig
+++ b/packages/native/src/lib.zig
@@ -3754,7 +3754,7 @@ export fn encodeUnicode(
         const at_special = special_idx < specials.len and specials[special_idx].col_offset == col;
 
         var grapheme_bytes: []const u8 = undefined;
-        var g_width: u8 = undefined;
+        var g_width: u32 = undefined;
 
         if (at_special) {
             const g = specials[special_idx];

--- a/packages/native/src/rope.zig
+++ b/packages/native/src/rope.zig
@@ -445,6 +445,7 @@ pub fn Rope(comptime T: type) type {
 
         pub const UndoNode = struct {
             root: *const Node,
+            metrics_generation: u64,
             next: ?*UndoNode = null,
             branches: ?*UndoBranch = null,
             meta: []const u8,
@@ -456,6 +457,7 @@ pub fn Rope(comptime T: type) type {
         };
 
         root: *const Node,
+        metrics_generation: u64 = 0,
         allocator: Allocator,
         empty_leaf: *const Node,
         undo_history: ?*UndoNode = null,
@@ -565,6 +567,42 @@ pub fn Rope(comptime T: type) type {
             if (result.err) |e| return e;
         }
 
+        pub fn metricsGeneration(self: *const Self) u64 {
+            return self.metrics_generation;
+        }
+
+        pub fn setMetricsGeneration(self: *Self, generation: u64) void {
+            self.metrics_generation = generation;
+            if (self.curr_history) |current| {
+                if (current.root == self.root) current.metrics_generation = generation;
+            }
+        }
+
+        /// Recompute cached branch metrics after leaf data is changed in place.
+        pub fn remeasure(self: *Self) void {
+            _ = remeasureNode(self.root);
+            self.version +%= 1;
+        }
+
+        fn remeasureNode(node: *const Node) Metrics {
+            return switch (node.*) {
+                .leaf => |*leaf| leaf.metrics(),
+                .branch => |*branch| blk: {
+                    const left_metrics = remeasureNode(branch.left);
+                    const right_metrics = remeasureNode(branch.right);
+                    var total_metrics = Metrics{};
+                    total_metrics.add(left_metrics);
+                    total_metrics.add(right_metrics);
+                    total_metrics.depth += 1;
+
+                    const mutable = @constCast(branch);
+                    mutable.left_metrics = left_metrics;
+                    mutable.total_metrics = total_metrics;
+                    break :blk total_metrics;
+                },
+            };
+        }
+
         fn walkNode(self: *const Self, node: *const Node, ctx: *anyopaque, f: Node.WalkerFn, current_index: *u32) Node.WalkerResult {
             return switch (node.*) {
                 .branch => |*b| {
@@ -657,6 +695,7 @@ pub fn Rope(comptime T: type) type {
             self.version += 1;
             return Self{
                 .root = result.right,
+                .metrics_generation = self.metrics_generation,
                 .allocator = self.allocator,
                 .empty_leaf = self.empty_leaf,
                 .undo_history = null,
@@ -820,6 +859,7 @@ pub fn Rope(comptime T: type) type {
             self.version += 1;
             return Self{
                 .root = result.right,
+                .metrics_generation = self.metrics_generation,
                 .allocator = self.allocator,
                 .empty_leaf = self.empty_leaf,
                 .undo_history = null,
@@ -1008,6 +1048,7 @@ pub fn Rope(comptime T: type) type {
             const meta = try self.allocator.dupe(u8, meta_);
             undo_node.* = UndoNode{
                 .root = root,
+                .metrics_generation = self.metrics_generation,
                 .meta = meta,
             };
             return undo_node;
@@ -1072,6 +1113,7 @@ pub fn Rope(comptime T: type) type {
             self.undo_history = h.next;
             self.curr_history = h;
             self.root = h.root;
+            self.metrics_generation = h.metrics_generation;
             self.version += 1;
             self.push_redo(r);
             if (self.undo_depth > 0) self.undo_depth -= 1;
@@ -1085,6 +1127,7 @@ pub fn Rope(comptime T: type) type {
             self.redo_history = h.next;
             self.curr_history = h;
             self.root = h.root;
+            self.metrics_generation = h.metrics_generation;
             self.version += 1;
             self.push_undo(u);
             return h.meta;

--- a/packages/native/src/rope.zig
+++ b/packages/native/src/rope.zig
@@ -573,12 +573,15 @@ pub fn Rope(comptime T: type) type {
 
         pub fn setMetricsGeneration(self: *Self, generation: u64) void {
             self.metrics_generation = generation;
+            // An undo/redo history node may alias the active root; keep its stamp
+            // current so revisiting that root does not restore a stale generation.
             if (self.curr_history) |current| {
                 if (current.root == self.root) current.metrics_generation = generation;
             }
         }
 
-        /// Recompute cached branch metrics after leaf data is changed in place.
+        /// Recompute cached branch metrics after the owner updates derived leaf data.
+        /// The persistent structure is unchanged; only aggregate caches are mutated.
         pub fn remeasure(self: *Self) void {
             _ = remeasureNode(self.root);
             self.version +%= 1;

--- a/packages/native/src/tests/edit-buffer_test.zig
+++ b/packages/native/src/tests/edit-buffer_test.zig
@@ -1637,7 +1637,7 @@ test "EditBuffer - replaceText allows undo" {
     try std.testing.expectEqualStrings("Initial", buffer[0..len]);
 }
 
-test "EditBuffer - undo redo only refreshes tab metrics for stale roots" {
+test "EditBuffer - undo redo refreshes tab metrics after tab width changes" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
     const link_pool = link.initGlobalLinkPool(std.testing.allocator);
@@ -1649,27 +1649,21 @@ test "EditBuffer - undo redo only refreshes tab metrics for stale roots" {
     try eb.setCursor(0, eb.tb.lineWidthAt(0));
     try eb.insertText("x");
 
-    const initial_refresh_count = eb.tb.getTabMetricsRefreshCount();
     _ = try eb.undo();
-    try std.testing.expectEqual(initial_refresh_count, eb.tb.getTabMetricsRefreshCount());
     try std.testing.expectEqual(@as(u32, 4), eb.tb.lineWidthAt(0));
     _ = try eb.redo();
-    try std.testing.expectEqual(initial_refresh_count, eb.tb.getTabMetricsRefreshCount());
     try std.testing.expectEqual(@as(u32, 5), eb.tb.lineWidthAt(0));
 
     eb.tb.setTabWidth(8);
-    try std.testing.expectEqual(initial_refresh_count + 1, eb.tb.getTabMetricsRefreshCount());
     try std.testing.expectEqual(@as(u32, 11), eb.tb.lineWidthAt(0));
 
     _ = try eb.undo();
-    try std.testing.expectEqual(initial_refresh_count + 2, eb.tb.getTabMetricsRefreshCount());
     try std.testing.expectEqual(@as(u32, 10), eb.tb.lineWidthAt(0));
     var view = try TextBufferView.init(std.testing.allocator, eb.tb);
     defer view.deinit();
     try std.testing.expectEqual(@as(u32, 10), view.getVirtualLines()[0].width_cols);
 
     _ = try eb.redo();
-    try std.testing.expectEqual(initial_refresh_count + 2, eb.tb.getTabMetricsRefreshCount());
     try std.testing.expectEqual(@as(u32, 11), eb.tb.lineWidthAt(0));
     try std.testing.expectEqual(@as(u32, 11), view.getVirtualLines()[0].width_cols);
 }

--- a/packages/native/src/tests/edit-buffer_test.zig
+++ b/packages/native/src/tests/edit-buffer_test.zig
@@ -4,6 +4,7 @@ const text_buffer_view = @import("../text-buffer-view.zig");
 const gp = @import("../grapheme.zig");
 const link = @import("../link.zig");
 const iter_mod = @import("../text-buffer-iterators.zig");
+const seg_mod = @import("../text-buffer-segment.zig");
 
 const EditBuffer = edit_buffer.EditBuffer;
 const TextBufferView = text_buffer_view.TextBufferView;
@@ -307,6 +308,60 @@ test "EditBuffer - word boundary mixed CJK and ASCII transition" {
     try eb.setCursor(prev_cursor.row, prev_cursor.col);
     const prev_cursor2 = eb.getPrevWordBoundary();
     try std.testing.expectEqual(@as(u32, 0), prev_cursor2.col);
+}
+
+test "EditBuffer - word boundary mixed CJK and ASCII transition across chunks" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .unicode, null);
+    defer eb.deinit();
+
+    const text = "abc日本";
+    const tb = eb.getTextBuffer();
+    const mem_id = try tb.registerMemBuffer(text, false);
+    var segments: std.ArrayListUnmanaged(seg_mod.Segment) = .empty;
+    defer segments.deinit(std.testing.allocator);
+    try segments.append(std.testing.allocator, .{ .linestart = {} });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 0, 3) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 3, @intCast(text.len)) });
+    try tb.rope().setSegments(segments.items);
+
+    try eb.setCursor(0, 0);
+    const next = eb.getNextWordBoundary();
+    try std.testing.expectEqual(@as(u32, 3), next.col);
+
+    try eb.setCursor(0, 7);
+    const prev = eb.getPrevWordBoundary();
+    try std.testing.expectEqual(@as(u32, 3), prev.col);
+}
+
+test "EditBuffer - combining mark keeps word class across chunks" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .unicode, null);
+    defer eb.deinit();
+
+    const text = "a\u{0301}日本";
+    const tb = eb.getTextBuffer();
+    const mem_id = try tb.registerMemBuffer(text, false);
+    var segments: std.ArrayListUnmanaged(seg_mod.Segment) = .empty;
+    defer segments.deinit(std.testing.allocator);
+    try segments.append(std.testing.allocator, .{ .linestart = {} });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 0, 3) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 3, @intCast(text.len)) });
+    try tb.rope().setSegments(segments.items);
+
+    try eb.setCursor(0, 0);
+    try std.testing.expectEqual(@as(u32, 1), eb.getNextWordBoundary().col);
+
+    try eb.setCursor(0, 5);
+    try std.testing.expectEqual(@as(u32, 1), eb.getPrevWordBoundary().col);
 }
 
 test "EditBuffer - word boundary keeps Hangul run grouped" {
@@ -1580,6 +1635,43 @@ test "EditBuffer - replaceText allows undo" {
     // Should be back to "Initial"
     len = eb.getText(&buffer);
     try std.testing.expectEqualStrings("Initial", buffer[0..len]);
+}
+
+test "EditBuffer - undo redo only refreshes tab metrics for stale roots" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .unicode, null);
+    defer eb.deinit();
+    try eb.setText("a\tb");
+    try eb.setCursor(0, eb.tb.lineWidthAt(0));
+    try eb.insertText("x");
+
+    const initial_refresh_count = eb.tb.getTabMetricsRefreshCount();
+    _ = try eb.undo();
+    try std.testing.expectEqual(initial_refresh_count, eb.tb.getTabMetricsRefreshCount());
+    try std.testing.expectEqual(@as(u32, 4), eb.tb.lineWidthAt(0));
+    _ = try eb.redo();
+    try std.testing.expectEqual(initial_refresh_count, eb.tb.getTabMetricsRefreshCount());
+    try std.testing.expectEqual(@as(u32, 5), eb.tb.lineWidthAt(0));
+
+    eb.tb.setTabWidth(8);
+    try std.testing.expectEqual(initial_refresh_count + 1, eb.tb.getTabMetricsRefreshCount());
+    try std.testing.expectEqual(@as(u32, 11), eb.tb.lineWidthAt(0));
+
+    _ = try eb.undo();
+    try std.testing.expectEqual(initial_refresh_count + 2, eb.tb.getTabMetricsRefreshCount());
+    try std.testing.expectEqual(@as(u32, 10), eb.tb.lineWidthAt(0));
+    var view = try TextBufferView.init(std.testing.allocator, eb.tb);
+    defer view.deinit();
+    try std.testing.expectEqual(@as(u32, 10), view.getVirtualLines()[0].width_cols);
+
+    _ = try eb.redo();
+    try std.testing.expectEqual(initial_refresh_count + 2, eb.tb.getTabMetricsRefreshCount());
+    try std.testing.expectEqual(@as(u32, 11), eb.tb.lineWidthAt(0));
+    try std.testing.expectEqual(@as(u32, 11), view.getVirtualLines()[0].width_cols);
 }
 
 test "EditBuffer - setText clears all history" {

--- a/packages/native/src/tests/editor-view_test.zig
+++ b/packages/native/src/tests/editor-view_test.zig
@@ -672,6 +672,57 @@ test "EditorView - moveDownVisual resolves wrapped boundary with canonical conve
     try std.testing.expectEqual(@as(u32, 5), cursor.visual_col);
 }
 
+test "EditorView - consumed whitespace cursor columns clamp to preceding row" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .unicode, null);
+    defer eb.deinit();
+    var ev = try EditorView.init(std.testing.allocator, eb, 5, 2);
+    defer ev.deinit();
+    ev.setWrapMode(.word);
+
+    try eb.setText("hello  world");
+    for ([_]u32{ 5, 6 }) |logical_col| {
+        const cursor = ev.logicalToVisualCursor(0, logical_col);
+        try std.testing.expectEqual(@as(u32, 0), cursor.visual_row);
+        try std.testing.expectEqual(@as(u32, 5), cursor.visual_col);
+    }
+    const spaces_boundary = ev.logicalToVisualCursor(0, 7);
+    try std.testing.expectEqual(@as(u32, 1), spaces_boundary.visual_row);
+    try std.testing.expectEqual(@as(u32, 0), spaces_boundary.visual_col);
+
+    eb.tb.setTabWidth(4);
+    try eb.setText("hello\tworld");
+    for ([_]u32{ 5, 8 }) |logical_col| {
+        const cursor = ev.logicalToVisualCursor(0, logical_col);
+        try std.testing.expectEqual(@as(u32, 0), cursor.visual_row);
+        try std.testing.expectEqual(@as(u32, 5), cursor.visual_col);
+    }
+    const tab_boundary = ev.logicalToVisualCursor(0, 9);
+    try std.testing.expectEqual(@as(u32, 1), tab_boundary.visual_row);
+    try std.testing.expectEqual(@as(u32, 0), tab_boundary.visual_col);
+
+    try eb.setCursor(0, 8);
+    try std.testing.expectEqual(@as(u32, 5), ev.getVisualCursor().visual_col);
+    ev.moveDownVisual();
+    const moved = ev.getVisualCursor();
+    try std.testing.expectEqual(@as(u32, 1), moved.visual_row);
+    try std.testing.expect(moved.visual_col <= 5);
+
+    var opt_buffer = try opt_buffer_mod.OptimizedBuffer.init(
+        std.testing.allocator,
+        5,
+        2,
+        .{ .pool = pool, .width_method = .unicode },
+    );
+    defer opt_buffer.deinit();
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawEditorView(ev, 0, 0);
+}
+
 test "EditorView - moveUpVisual at top boundary" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
@@ -3594,7 +3645,9 @@ test "occupancy - EditorView forwards occupancy and replays stored endpoints" {
     ev.setSelectionOccupancy(.boundary);
     try eb.setCursor(0, 0);
     ev.gotoVisualLineEnd();
-    try std.testing.expectEqual(@as(u32, 1), ev.getPrimaryCursor().offset);
+    // The oversized CJK grapheme remains atomic, so its visual end is after
+    // the complete width-2 cursor unit rather than inside it at the viewport edge.
+    try std.testing.expectEqual(@as(u32, 2), ev.getPrimaryCursor().offset);
 
     ev.setSelectionOccupancy(.cell);
     ev.gotoVisualLineEnd();

--- a/packages/native/src/tests/text-buffer-drawing_test.zig
+++ b/packages/native/src/tests/text-buffer-drawing_test.zig
@@ -14,6 +14,361 @@ const RGBA = text_buffer.RGBA;
 const WrapMode = text_buffer.WrapMode;
 const StyledChunk = text_buffer.StyledChunk;
 
+fn resolvedRow(allocator: std.mem.Allocator, opt_buffer: *const OptimizedBuffer, pool: *gp.GraphemePool, y: u32) ![]u8 {
+    var row: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer row.deinit(allocator);
+
+    for (0..opt_buffer.width) |x| {
+        const char = opt_buffer.get(@intCast(x), y).?.char;
+        if (gp.isContinuationChar(char)) continue;
+        if (gp.isGraphemeChar(char)) {
+            const bytes = try pool.get(gp.graphemeIdFromChar(char));
+            try row.appendSlice(allocator, bytes);
+            continue;
+        }
+        var encoded: [4]u8 = undefined;
+        const len = try std.unicode.utf8Encode(@intCast(char), &encoded);
+        try row.appendSlice(allocator, encoded[0..len]);
+    }
+    return row.toOwnedSlice(allocator);
+}
+
+fn expectRenderedRows(
+    text: []const u8,
+    wrap_mode: WrapMode,
+    width: u32,
+    expected_rows: []const []const u8,
+    expected_starts: ?[]const u32,
+) !void {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+    try tb.setText(text);
+    view.setWrapMode(wrap_mode);
+    view.setWrapWidth(width);
+    try std.testing.expectEqual(expected_rows.len, view.getVirtualLines().len);
+    if (expected_starts) |starts| {
+        try std.testing.expectEqualSlices(u32, starts, view.getCachedLineInfo().line_start_cols);
+    }
+
+    const render_width = @max(width, 16);
+    var opt_buffer = try OptimizedBuffer.init(
+        std.testing.allocator,
+        render_width,
+        @intCast(expected_rows.len),
+        .{ .pool = pool, .width_method = .wcwidth },
+    );
+    defer opt_buffer.deinit();
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
+
+    for (expected_rows, 0..) |expected, y| {
+        const row = try resolvedRow(std.testing.allocator, opt_buffer, pool, @intCast(y));
+        defer std.testing.allocator.free(row);
+        try std.testing.expect(std.unicode.utf8ValidateSlice(row));
+        try std.testing.expectEqualStrings(expected, std.mem.trim(u8, row, " "));
+    }
+}
+
+test "drawTextBuffer - exact CJK and issue 609 wrapped rows" {
+    const vectors = [_]struct {
+        text: []const u8,
+        width: u32,
+        rows: []const []const u8,
+        starts: []const u32,
+    }{
+        .{ .text = "你好世界", .width = 4, .rows = &.{ "你好", "世界" }, .starts = &.{ 0, 4 } },
+        .{ .text = "가나다", .width = 1, .rows = &.{ "가", "나", "다" }, .starts = &.{ 0, 2, 4 } },
+        .{ .text = "흐름도", .width = 4, .rows = &.{ "흐름", "도" }, .starts = &.{ 0, 4 } },
+        .{ .text = "1️⃣한글", .width = 4, .rows = &.{ "1️⃣한", "글" }, .starts = &.{ 0, 3 } },
+        .{ .text = "👋🏻👋🏿hi", .width = 4, .rows = &.{ "👋🏻", "👋🏿", "hi" }, .starts = &.{ 0, 4, 8 } },
+        .{ .text = "A👋🏻B👩‍💻C", .width = 2, .rows = &.{ "A", "👋🏻", "B", "👩‍💻", "C" }, .starts = &.{ 0, 1, 5, 6, 10 } },
+    };
+
+    for (vectors) |vector| {
+        try expectRenderedRows(vector.text, .char, vector.width, vector.rows, vector.starts);
+    }
+}
+
+test "drawTextBuffer - streaming Prepend before ASCII vector is preserved" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    const text = try std.testing.allocator.alloc(u8, 70_000);
+    defer std.testing.allocator.free(text);
+    const prefix = "\u{0600} ";
+    @memcpy(text[0..prefix.len], prefix);
+    @memset(text[prefix.len..], 'a');
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+    try tb.setText(text);
+    view.setWrapMode(.word);
+    view.setWrapWidth(8);
+
+    const lines = view.getVirtualLines();
+    try std.testing.expect(lines.len > 1);
+    try std.testing.expectEqual(@as(usize, 1), lines[0].chunks.items.len);
+    const first_chunk = lines[0].chunks.items[0];
+    const first_bytes = first_chunk.chunk.getBytes(tb.memRegistry());
+    const first_window = first_bytes[first_chunk.byte_start_in_chunk .. first_chunk.byte_start_in_chunk + first_chunk.byte_len];
+    try std.testing.expectEqualStrings(prefix, first_window);
+
+    var opt_buffer = try OptimizedBuffer.init(
+        std.testing.allocator,
+        8,
+        1,
+        .{ .pool = pool, .width_method = .unicode },
+    );
+    defer opt_buffer.deinit();
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
+    const row = try resolvedRow(std.testing.allocator, opt_buffer, pool, 0);
+    defer std.testing.allocator.free(row);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(row));
+    try std.testing.expectEqualStrings("\u{0600}", std.mem.trim(u8, row, " "));
+}
+
+test "drawTextBuffer - long grapheme byte window stays atomic for unicode and wcwidth" {
+    var text: std.ArrayListUnmanaged(u8) = .empty;
+    defer text.deinit(std.testing.allocator);
+    for (0..130) |i| {
+        if (i > 0) try text.appendSlice(std.testing.allocator, "\u{200D}");
+        try text.appendSlice(std.testing.allocator, "👩");
+    }
+
+    for ([_]struct { method: @import("../utf8.zig").WidthMethod, expected_width: u32 }{
+        .{ .method = .unicode, .expected_width = 2 },
+        .{ .method = .wcwidth, .expected_width = 260 },
+    }) |case| {
+        const pool = gp.initGlobalPool(std.testing.allocator);
+        defer gp.deinitGlobalPool();
+        const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+        defer link.deinitGlobalLinkPool();
+
+        var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, case.method);
+        defer tb.deinit();
+        var view = try TextBufferView.init(std.testing.allocator, tb);
+        defer view.deinit();
+        try tb.setText(text.items);
+        view.setWrapMode(.char);
+        view.setWrapWidth(80);
+
+        const lines = view.getVirtualLines();
+        try std.testing.expectEqual(@as(usize, 1), lines.len);
+        try std.testing.expectEqual(case.expected_width, lines[0].width_cols);
+        try std.testing.expectEqual(@as(usize, 1), lines[0].chunks.items.len);
+        const chunk = lines[0].chunks.items[0];
+        const bytes = chunk.chunk.getBytes(tb.memRegistry());
+        const window = bytes[chunk.byte_start_in_chunk .. chunk.byte_start_in_chunk + chunk.byte_len];
+        try std.testing.expectEqualStrings(text.items, window);
+
+        var opt_buffer = try OptimizedBuffer.init(
+            std.testing.allocator,
+            80,
+            1,
+            .{ .pool = pool, .width_method = case.method },
+        );
+        defer opt_buffer.deinit();
+        opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+        opt_buffer.drawTextBuffer(view, 0, 0);
+
+        const row = try resolvedRow(std.testing.allocator, opt_buffer, pool, 0);
+        defer std.testing.allocator.free(row);
+        // The grapheme pool intentionally rejects owned entries above 128 bytes.
+        // Rendering must skip the whole atomic cluster rather than slice or trap.
+        try std.testing.expectEqualStrings("", std.mem.trim(u8, row, " "));
+    }
+}
+
+test "drawTextBuffer - tab width changes refresh no-wrap and word-wrap layout" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+    try tb.setText("a\tb");
+
+    const expectRow = struct {
+        fn run(view_ptr: *TextBufferView, pool_ptr: *gp.GraphemePool, width: u32, expected: []const u8) !void {
+            var opt_buffer = try OptimizedBuffer.init(
+                std.testing.allocator,
+                width,
+                1,
+                .{ .pool = pool_ptr, .width_method = .unicode },
+            );
+            defer opt_buffer.deinit();
+            opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+            opt_buffer.drawTextBuffer(view_ptr, 0, 0);
+
+            const row = try resolvedRow(std.testing.allocator, opt_buffer, pool_ptr, 0);
+            defer std.testing.allocator.free(row);
+            try std.testing.expectEqualStrings(expected, row);
+        }
+    }.run;
+    const cases = [_]struct { tab_width: u8, row: []const u8 }{
+        .{ .tab_width = 2, .row = "a  b" },
+        .{ .tab_width = 8, .row = "a        b" },
+        .{ .tab_width = 4, .row = "a    b" },
+    };
+    for (cases) |case| {
+        tb.setTabWidth(case.tab_width);
+        const expected_width: u32 = 2 + case.tab_width;
+        try std.testing.expectEqual(expected_width, tb.lineWidthAt(0));
+
+        view.setWrapMode(.none);
+        const no_wrap = view.getVirtualLines();
+        try std.testing.expectEqual(@as(usize, 1), no_wrap.len);
+        try std.testing.expectEqual(expected_width, no_wrap[0].width_cols);
+        const no_wrap_measure = try view.measureForDimensions(80, 24);
+        try std.testing.expectEqual(expected_width, no_wrap_measure.width_cols_max);
+        try expectRow(view, pool, expected_width, case.row);
+
+        view.setWrapMode(.word);
+        view.setWrapWidth(expected_width);
+        const word_wrap = view.getVirtualLines();
+        try std.testing.expectEqual(@as(usize, 1), word_wrap.len);
+        try std.testing.expectEqual(expected_width, word_wrap[0].width_cols);
+        const word_measure = try view.measureForDimensions(expected_width, 24);
+        try std.testing.expectEqual(@as(u32, 1), word_measure.line_count);
+        try std.testing.expectEqual(expected_width, word_measure.width_cols_max);
+        try expectRow(view, pool, expected_width, case.row);
+    }
+
+    tb.setTabWidth(255);
+    try std.testing.expectEqual(@as(u8, 254), tb.getTabWidth());
+    try std.testing.expectEqual(@as(u32, 256), tb.lineWidthAt(0));
+}
+
+test "drawTextBuffer - fragmented CJK chunks render exact rows across wrap" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    const text = "你好世界";
+    const mem_id = try tb.registerMemBuffer(text, false);
+    var segments: std.ArrayListUnmanaged(@import("../text-buffer-segment.zig").Segment) = .empty;
+    defer segments.deinit(std.testing.allocator);
+    try segments.append(std.testing.allocator, .{ .linestart = {} });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 0, 3) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 3, 9) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 9, 12) });
+    try tb.rope().setSegments(segments.items);
+    view.setWrapMode(.char);
+    view.setWrapWidth(4);
+
+    var opt_buffer = try OptimizedBuffer.init(
+        std.testing.allocator,
+        4,
+        2,
+        .{ .pool = pool, .width_method = .unicode },
+    );
+    defer opt_buffer.deinit();
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
+
+    const row0 = try resolvedRow(std.testing.allocator, opt_buffer, pool, 0);
+    defer std.testing.allocator.free(row0);
+    const row1 = try resolvedRow(std.testing.allocator, opt_buffer, pool, 1);
+    defer std.testing.allocator.free(row1);
+    try std.testing.expectEqualStrings("你好", row0);
+    try std.testing.expectEqualStrings("世界", row1);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(row0));
+    try std.testing.expect(std.unicode.utf8ValidateSlice(row1));
+}
+
+test "drawTextBuffer - truncation snaps suffix past wide grapheme" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+    try tb.setText("ABCDE가FG");
+    view.setWrapMode(.none);
+    view.setTruncate(true);
+    view.setViewport(.{ .x = 0, .y = 0, .width = 8, .height = 1 });
+
+    var opt_buffer = try OptimizedBuffer.init(
+        std.testing.allocator,
+        8,
+        1,
+        .{ .pool = pool, .width_method = .unicode },
+    );
+    defer opt_buffer.deinit();
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
+
+    var out: [32]u8 = undefined;
+    const written = try opt_buffer.writeResolvedChars(&out, false);
+    try std.testing.expectEqualStrings("AB...FG ", out[0..written]);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(out[0..written]));
+}
+
+test "drawTextBuffer - wcwidth truncation never renders a modifier-only suffix" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+    try tb.setText("ABCDE👋🏻Z");
+    view.setWrapMode(.none);
+    view.setTruncate(true);
+    view.setViewport(.{ .x = 0, .y = 0, .width = 8, .height = 1 });
+
+    var opt_buffer = try OptimizedBuffer.init(
+        std.testing.allocator,
+        8,
+        1,
+        .{ .pool = pool, .width_method = .wcwidth },
+    );
+    defer opt_buffer.deinit();
+    opt_buffer.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+    opt_buffer.drawTextBuffer(view, 0, 0);
+
+    const row = try resolvedRow(std.testing.allocator, opt_buffer, pool, 0);
+    defer std.testing.allocator.free(row);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(row));
+    try std.testing.expectEqualStrings("AB...Z", std.mem.trim(u8, row, " "));
+}
+
+test "drawTextBuffer - issue 799 CJK word wrap has no duplicated glyphs" {
+    try expectRenderedRows(
+        "在aber (“但”)引入的转折从句前表示让步：虽然，的确",
+        .word,
+        15,
+        &.{ "在aber (“但”)", "引入的转折从句", "前表示让步：", "虽然，的确" },
+        null,
+    );
+}
+
 test "drawTextBuffer - simple single line text" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/tests/text-buffer-segment_test.zig
+++ b/packages/native/src/tests/text-buffer-segment_test.zig
@@ -120,10 +120,7 @@ test "walkChunkLayoutInfo stops streaming after visitor allocation failure" {
     };
     var ctx: Context = .{ .allocator = failing.allocator() };
     defer ctx.breaks.deinit(ctx.allocator);
-    _ = try utf8.walkChunkLayoutInfo(text, 2, true, .unicode, .{
-        .context = &ctx,
-        .callback = Context.visit,
-    });
+    _ = try utf8.walkChunkLayoutInfoComptime(text, 2, true, .unicode, &ctx, Context.visit);
     try testing.expect(failing.has_induced_failure);
     try testing.expect(ctx.failed);
     try testing.expectEqual(@as(usize, 1), ctx.callback_count);

--- a/packages/native/src/tests/text-buffer-segment_test.zig
+++ b/packages/native/src/tests/text-buffer-segment_test.zig
@@ -1,10 +1,187 @@
 const std = @import("std");
 const testing = std.testing;
 const seg_mod = @import("../text-buffer-segment.zig");
+const MemRegistry = @import("../mem-registry.zig").MemRegistry;
+const utf8 = @import("../utf8.zig");
 
 const Segment = seg_mod.Segment;
 const UnifiedRope = seg_mod.UnifiedRope;
 const TextChunk = seg_mod.TextChunk;
+
+test "TextChunk keeps cold cache state out of rope leaves" {
+    try testing.expect(@sizeOf(TextChunk) <= 24);
+}
+
+test "TextChunk.getLayoutInfo returns direct byte and column metadata" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var registry = MemRegistry.init(testing.allocator);
+    defer registry.deinit();
+
+    const text = "AB🌟 CD";
+    const mem_id = try registry.register(text, false);
+    var chunk: TextChunk = .{
+        .mem_id = mem_id,
+        .byte_start = 0,
+        .byte_end = @intCast(text.len),
+        .width = @intCast(utf8.calculateTextWidth(text, 2, false, .unicode)),
+    };
+
+    const layout = try chunk.getLayoutInfo(arena.allocator(), &registry, 2, .unicode);
+    try testing.expectEqual(@as(usize, 1), layout.wrap_breaks.len);
+    try testing.expectEqual(@as(u32, 6), layout.wrap_breaks[0].byte_offset);
+    try testing.expectEqual(@as(u32, 4), layout.wrap_breaks[0].col_offset);
+    try testing.expectEqual(@as(u32, 7), layout.wrap_breaks[0].byteEnd());
+    try testing.expectEqual(@as(u32, 5), layout.wrap_breaks[0].colEnd());
+
+    const cached = try chunk.getLayoutInfo(arena.allocator(), &registry, 2, .unicode);
+    try testing.expectEqual(@intFromPtr(layout.wrap_breaks.ptr), @intFromPtr(cached.wrap_breaks.ptr));
+
+    const zero_width_text = "a\u{200B}b";
+    const zero_width_mem_id = try registry.register(zero_width_text, false);
+    var zero_width_chunk: TextChunk = .{
+        .mem_id = zero_width_mem_id,
+        .byte_start = 0,
+        .byte_end = @intCast(zero_width_text.len),
+        .width = @intCast(utf8.calculateTextWidth(zero_width_text, 2, false, .unicode)),
+    };
+    const zero_width_layout = try zero_width_chunk.getLayoutInfo(arena.allocator(), &registry, 2, .unicode);
+    try testing.expectEqual(@as(usize, 1), zero_width_layout.wrap_breaks.len);
+    try testing.expectEqual(@as(u32, 1), zero_width_layout.wrap_breaks[0].byte_offset);
+    try testing.expectEqual(@as(u32, 3), zero_width_layout.wrap_breaks[0].byte_len);
+    try testing.expectEqual(@as(u32, 1), zero_width_layout.wrap_breaks[0].col_offset);
+    try testing.expectEqual(@as(u32, 0), zero_width_layout.wrap_breaks[0].width);
+}
+
+test "findChunkLayoutInfo classifies direct byte and column break metadata" {
+    const Case = struct {
+        text: []const u8,
+        tab_width: u8 = 2,
+        expected: []const utf8.LayoutWrapBreak,
+    };
+
+    const cases = [_]Case{
+        .{ .text = "AB🌟 CD", .expected = &.{.{ .byte_offset = 6, .col_offset = 4, .byte_len = 1, .width = 1, .kind = .whitespace }} },
+        .{ .text = "中A", .expected = &.{.{ .byte_offset = 0, .col_offset = 0, .byte_len = 3, .width = 2, .kind = .script_transition }} },
+        .{ .text = "A中", .expected = &.{.{ .byte_offset = 0, .col_offset = 0, .byte_len = 1, .width = 1, .kind = .script_transition }} },
+        .{ .text = "a\u{0301}中", .expected = &.{.{ .byte_offset = 0, .col_offset = 0, .byte_len = 3, .width = 1, .kind = .script_transition }} },
+        .{ .text = "0123456789abcdef中", .expected = &.{.{ .byte_offset = 15, .col_offset = 15, .byte_len = 1, .width = 1, .kind = .script_transition }} },
+        .{ .text = "a\u{200B}b", .expected = &.{.{ .byte_offset = 1, .col_offset = 1, .byte_len = 3, .width = 0, .kind = .whitespace }} },
+        .{ .text = "a\tb", .tab_width = 2, .expected = &.{.{ .byte_offset = 1, .col_offset = 1, .byte_len = 1, .width = 2, .kind = .whitespace }} },
+        .{ .text = "a\tb", .tab_width = 4, .expected = &.{.{ .byte_offset = 1, .col_offset = 1, .byte_len = 1, .width = 4, .kind = .whitespace }} },
+        .{ .text = "ab,cd", .expected = &.{.{ .byte_offset = 2, .col_offset = 2, .byte_len = 1, .width = 1, .kind = .punctuation }} },
+    };
+
+    var breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;
+    defer breaks.deinit(testing.allocator);
+
+    for (cases) |case| {
+        _ = try utf8.findChunkLayoutInfo(testing.allocator, case.text, case.tab_width, false, .unicode, &breaks);
+        try testing.expectEqualDeep(case.expected, breaks.items);
+    }
+}
+
+test "walkChunkLayoutInfo keeps Prepend joined to an ASCII vector" {
+    const text = "\u{0600} 0123456789abcdef";
+    var breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;
+    defer breaks.deinit(testing.allocator);
+
+    _ = try utf8.findChunkLayoutInfo(testing.allocator, text, 2, false, .unicode, &breaks);
+    try testing.expectEqual(@as(usize, 1), breaks.items.len);
+    try testing.expectEqual(@as(u32, 0), breaks.items[0].byte_offset);
+    try testing.expectEqual(@as(u32, 3), breaks.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 0), breaks.items[0].col_offset);
+    try testing.expectEqual(@as(u32, 1), breaks.items[0].width);
+    try testing.expectEqual(utf8.LayoutWrapBreakKind.whitespace, breaks.items[0].kind);
+}
+
+test "walkChunkLayoutInfo stops streaming after visitor allocation failure" {
+    const text = try testing.allocator.alloc(u8, 70_000);
+    defer testing.allocator.free(text);
+    @memset(text, ' ');
+
+    var failing = testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    const Context = struct {
+        allocator: std.mem.Allocator,
+        breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty,
+        callback_count: usize = 0,
+        failed: bool = false,
+
+        fn visit(ctx_ptr: *anyopaque, wrap_break: utf8.LayoutWrapBreak) !bool {
+            const ctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
+            ctx.callback_count += 1;
+            ctx.breaks.append(ctx.allocator, wrap_break) catch {
+                ctx.failed = true;
+                return false;
+            };
+            return true;
+        }
+    };
+    var ctx: Context = .{ .allocator = failing.allocator() };
+    defer ctx.breaks.deinit(ctx.allocator);
+    _ = try utf8.walkChunkLayoutInfo(text, 2, true, .unicode, .{
+        .context = &ctx,
+        .callback = Context.visit,
+    });
+    try testing.expect(failing.has_induced_failure);
+    try testing.expect(ctx.failed);
+    try testing.expectEqual(@as(usize, 1), ctx.callback_count);
+}
+
+test "TextChunk.getLayoutInfo refreshes tab-dependent metadata" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var registry = MemRegistry.init(testing.allocator);
+    defer registry.deinit();
+    const text = "a\tb";
+    const mem_id = try registry.register(text, false);
+    var chunk: TextChunk = .{
+        .mem_id = mem_id,
+        .byte_start = 0,
+        .byte_end = @intCast(text.len),
+        .width = 4,
+    };
+
+    const first = try chunk.getLayoutInfo(arena.allocator(), &registry, 2, .unicode);
+    try testing.expectEqual(@as(u32, 2), first.wrap_breaks[0].width);
+    const capacity_after_first = arena.queryCapacity();
+
+    const second = try chunk.getLayoutInfo(arena.allocator(), &registry, 8, .unicode);
+    try testing.expectEqual(@as(u32, 8), second.wrap_breaks[0].width);
+    try testing.expectEqual(@intFromPtr(first.wrap_breaks.ptr), @intFromPtr(second.wrap_breaks.ptr));
+    try testing.expectEqual(capacity_after_first, arena.queryCapacity());
+}
+
+test "TextChunk.getGraphemes reuses tab-dependent cache storage" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var registry = MemRegistry.init(testing.allocator);
+    defer registry.deinit();
+    const text = "a\tb";
+    const mem_id = try registry.register(text, false);
+    var chunk: TextChunk = .{
+        .mem_id = mem_id,
+        .byte_start = 0,
+        .byte_end = @intCast(text.len),
+        .width = 4,
+    };
+
+    const first = try chunk.getGraphemes(arena.allocator(), &registry, 2, .unicode);
+    try testing.expectEqual(@as(u32, 2), first[0].width);
+    const capacity_after_first = arena.queryCapacity();
+
+    const wider = try chunk.getGraphemes(arena.allocator(), &registry, 8, .unicode);
+    try testing.expectEqual(@as(u32, 8), wider[0].width);
+    try testing.expectEqual(@intFromPtr(first.ptr), @intFromPtr(wider.ptr));
+
+    const narrower = try chunk.getGraphemes(arena.allocator(), &registry, 4, .unicode);
+    try testing.expectEqual(@as(u32, 4), narrower[0].width);
+    try testing.expectEqual(@intFromPtr(first.ptr), @intFromPtr(narrower.ptr));
+    try testing.expectEqual(capacity_after_first, arena.queryCapacity());
+}
 
 test "Segment.measure - text chunk" {
     const chunk: TextChunk = .{

--- a/packages/native/src/tests/text-buffer-view_test.zig
+++ b/packages/native/src/tests/text-buffer-view_test.zig
@@ -198,6 +198,174 @@ test "TextBufferView word wrapping - basic word wrap at space" {
     try std.testing.expectEqual(@as(u32, 2), wrapped_count);
 }
 
+test "TextBufferView word wrapping - overflowing separator whitespace is consumed" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(5);
+    try tb.setText("hello world");
+
+    try std.testing.expectEqualSlices(u32, &.{ 5, 5 }, view.getCachedLineInfo().line_width_cols);
+    try std.testing.expectEqualSlices(u32, &.{ 0, 6 }, view.getCachedLineInfo().line_start_cols);
+
+    const measured = try view.measureForDimensions(5, 24);
+    try std.testing.expectEqual(@as(u32, 2), measured.line_count);
+    try std.testing.expectEqual(@as(u32, 5), measured.width_cols_max);
+
+    view.setWrapWidth(6);
+    try std.testing.expectEqualSlices(u32, &.{ 6, 5 }, view.getCachedLineInfo().line_width_cols);
+    try std.testing.expectEqualSlices(u32, &.{ 0, 6 }, view.getCachedLineInfo().line_start_cols);
+}
+
+test "TextBufferView word wrapping - consumed whitespace cursor positions stay on preceding visual line" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    try tb.setText("hello world again");
+    view.setWrapMode(.word);
+    view.setWrapWidth(5);
+
+    try std.testing.expectEqualSlices(u32, &.{ 0, 6, 12 }, view.getCachedLineInfo().line_start_cols);
+    try std.testing.expectEqual(@as(u32, 0), view.findVisualLineIndex(0, 5));
+    try std.testing.expectEqual(@as(u32, 1), view.findVisualLineIndex(0, 11));
+    try std.testing.expectEqual(@as(u32, 2), view.findVisualLineIndex(0, 12));
+}
+
+test "TextBufferView word wrapping - full local selection includes consumed trailing whitespace" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    try tb.setText("hello ");
+    view.setWrapMode(.word);
+    view.setWrapWidth(5);
+
+    try std.testing.expectEqual(@as(u32, 1), view.getVirtualLineCount());
+    _ = view.setLocalSelection(0, 0, 0, 1, null, null);
+    var selected: [16]u8 = undefined;
+    const selected_len = view.getSelectedTextIntoBuffer(&selected);
+    try std.testing.expectEqualStrings("hello ", selected[0..selected_len]);
+}
+
+test "TextBufferView wrapping - large single line retains its full width" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    const text = try std.testing.allocator.alloc(u8, 70_000);
+    defer std.testing.allocator.free(text);
+    @memset(text, 'a');
+    try tb.setText(text);
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(80);
+    try std.testing.expectEqual(@as(u32, 875), view.getVirtualLineCount());
+    try std.testing.expect(view.getArenaAllocatedBytes() > 0);
+
+    const measured = try view.measureForDimensions(80, 24);
+    try std.testing.expectEqual(@as(u32, 875), measured.line_count);
+    try std.testing.expectEqual(@as(u32, 80), measured.width_cols_max);
+}
+
+test "TextBufferView word wrapping - fragmented overflowing separator matches contiguous text" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    const text = "hello world";
+    const mem_id = try tb.registerMemBuffer(text, false);
+    var segments: std.ArrayListUnmanaged(seg_mod.Segment) = .empty;
+    defer segments.deinit(std.testing.allocator);
+    try segments.append(std.testing.allocator, .{ .linestart = {} });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 0, 5) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 5, 6) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 6, 11) });
+    try tb.rope().setSegments(segments.items);
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(5);
+    try std.testing.expectEqualSlices(u32, &.{ 5, 5 }, view.getCachedLineInfo().line_width_cols);
+    try std.testing.expectEqualSlices(u32, &.{ 0, 6 }, view.getCachedLineInfo().line_start_cols);
+
+    const measured = try view.measureForDimensions(5, 24);
+    try std.testing.expectEqual(@as(u32, 2), measured.line_count);
+    try std.testing.expectEqual(@as(u32, 5), measured.width_cols_max);
+}
+
+test "TextBufferView word wrapping - wide separator boundaries do not create whitespace continuations" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+    view.setWrapMode(.word);
+    view.setWrapWidth(5);
+
+    try tb.setText("hello　world");
+    try std.testing.expectEqualSlices(u32, &.{ 5, 5 }, view.getCachedLineInfo().line_width_cols);
+    try std.testing.expectEqualSlices(u32, &.{ 0, 7 }, view.getCachedLineInfo().line_start_cols);
+
+    tb.setTabWidth(4);
+    try tb.setText("hello\tworld");
+    try std.testing.expectEqualSlices(u32, &.{ 5, 5 }, view.getCachedLineInfo().line_width_cols);
+    try std.testing.expectEqualSlices(u32, &.{ 0, 9 }, view.getCachedLineInfo().line_start_cols);
+}
+
+test "TextBufferView word wrapping - logical-line leading whitespace is preserved" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    try tb.setText(" hello");
+    view.setWrapMode(.word);
+    view.setWrapWidth(5);
+    try std.testing.expectEqualSlices(u32, &.{ 1, 5 }, view.getCachedLineInfo().line_width_cols);
+    try std.testing.expectEqualSlices(u32, &.{ 0, 1 }, view.getCachedLineInfo().line_start_cols);
+}
+
 test "TextBufferView word wrapping - long word exceeds width" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
@@ -864,6 +1032,140 @@ test "TextBufferView word wrapping - fragmented rope with word boundary" {
     try std.testing.expectEqual(@as(u32, 14), vlines[0].width_cols);
 
     try std.testing.expectEqual(@as(u32, 6), vlines[1].width_cols);
+
+    var line_buf: [32]u8 = undefined;
+    const line0_len = tb.getTextRange(vlines[0].col_offset, vlines[0].col_offset + vlines[0].width_cols, &line_buf);
+    try std.testing.expectEqualStrings("hello my good ", line_buf[0..line0_len]);
+
+    const line1_len = tb.getTextRange(vlines[1].col_offset, vlines[1].col_offset + vlines[1].width_cols, &line_buf);
+    try std.testing.expectEqualStrings("friend", line_buf[0..line1_len]);
+}
+
+test "TextBufferView word wrapping - fragmented long word force-breaks by wrap width" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    const text = "abcdefghijklmnopqrst";
+    const mem_id = try tb.registerMemBuffer(text, false);
+
+    var segments: std.ArrayListUnmanaged(seg_mod.Segment) = .empty;
+    defer segments.deinit(std.testing.allocator);
+    try segments.append(std.testing.allocator, .{ .linestart = {} });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 0, 5) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 5, 13) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 13, 20) });
+    try tb.rope().setSegments(segments.items);
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(8);
+
+    const vlines = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 3), vlines.len);
+    try std.testing.expectEqualSlices(u32, &.{ 8, 8, 4 }, view.getCachedLineInfo().line_width_cols);
+}
+
+test "TextBufferView word wrapping - zero width still makes progress" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    try tb.setText("word");
+    view.setWrapMode(.word);
+    view.setWrapWidth(0);
+
+    try std.testing.expectEqual(@as(u32, 4), view.getVirtualLineCount());
+    try std.testing.expectEqualSlices(u32, &.{ 1, 1, 1, 1 }, view.getCachedLineInfo().line_width_cols);
+}
+
+test "TextBufferView word wrapping - fragmented zero width delimiter ends pending word" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    const text = "hello\u{200B}world";
+    const mem_id = try tb.registerMemBuffer(text, false);
+    var segments: std.ArrayListUnmanaged(seg_mod.Segment) = .empty;
+    defer segments.deinit(std.testing.allocator);
+    try segments.append(std.testing.allocator, .{ .linestart = {} });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 0, 5) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 5, @intCast(text.len)) });
+    try tb.rope().setSegments(segments.items);
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(6);
+
+    try std.testing.expectEqualSlices(u32, &.{ 5, 5 }, view.getCachedLineInfo().line_width_cols);
+}
+
+test "TextBufferView word wrapping - fragmented ASCII CJK transition is a boundary" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    const text = "abc日本";
+    const mem_id = try tb.registerMemBuffer(text, false);
+    var segments: std.ArrayListUnmanaged(seg_mod.Segment) = .empty;
+    defer segments.deinit(std.testing.allocator);
+    try segments.append(std.testing.allocator, .{ .linestart = {} });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 0, 3) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 3, @intCast(text.len)) });
+    try tb.rope().setSegments(segments.items);
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(5);
+
+    try std.testing.expectEqualSlices(u32, &.{ 3, 4 }, view.getCachedLineInfo().line_width_cols);
+}
+
+test "TextBufferView word wrapping - combining mark keeps base class across chunks" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    const text = "a\u{0301}日本";
+    const mem_id = try tb.registerMemBuffer(text, false);
+    var segments: std.ArrayListUnmanaged(seg_mod.Segment) = .empty;
+    defer segments.deinit(std.testing.allocator);
+    try segments.append(std.testing.allocator, .{ .linestart = {} });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 0, 3) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 3, @intCast(text.len)) });
+    try tb.rope().setSegments(segments.items);
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(4);
+    try std.testing.expectEqualSlices(u32, &.{ 1, 4 }, view.getCachedLineInfo().line_width_cols);
 }
 
 test "TextBufferView wrapping - very narrow width (1 char)" {
@@ -906,6 +1208,157 @@ test "TextBufferView wrapping - very narrow width (2 chars)" {
     const wrapped_count = view.getVirtualLineCount();
 
     try std.testing.expectEqual(@as(u32, 3), wrapped_count);
+}
+
+test "TextBufferView character wrapping - first line offset only changes initial width" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+    try tb.setText("abcdef");
+
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+    view.setWrapMode(.char);
+    view.setWrapWidth(4);
+    view.setFirstLineOffset(2);
+
+    const lines = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 2), lines.len);
+    try std.testing.expectEqual(@as(u32, 2), lines[0].width_cols);
+    try std.testing.expectEqual(@as(u32, 4), lines[1].width_cols);
+
+    const measured = try view.measureForDimensions(4, 10);
+    try std.testing.expectEqual(@as(u32, 2), measured.line_count);
+    try std.testing.expectEqual(@as(u32, 4), measured.width_cols_max);
+}
+
+test "TextBufferView character wrapping - virtual chunks grow after exact capacity one" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+    try tb.setText("abcdef");
+
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+    view.setWrapMode(.char);
+    view.setWrapWidth(10);
+
+    try std.testing.expectEqual(@as(usize, 1), view.getVirtualLines()[0].chunks.capacity);
+
+    const mem_id = try tb.registerMemBuffer("abcdef", false);
+    const segments = [_]seg_mod.Segment{
+        .{ .linestart = {} },
+        .{ .text = tb.createChunk(mem_id, 0, 2) },
+        .{ .text = tb.createChunk(mem_id, 2, 4) },
+        .{ .text = tb.createChunk(mem_id, 4, 6) },
+    };
+    try tb.rope().setSegments(&segments);
+    tb.markViewsDirty();
+
+    const chunks = view.getVirtualLines()[0].chunks;
+    try std.testing.expectEqual(@as(usize, 3), chunks.items.len);
+    try std.testing.expect(chunks.capacity >= chunks.items.len);
+}
+
+test "TextBufferView character wrapping - OOM discards partial layout without retry loop" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    try tb.setText("abcdefghij");
+
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    var view = try TextBufferView.init(failing.allocator(), tb);
+    defer view.deinit();
+    view.setWrapMode(.char);
+    view.setWrapWidth(2);
+
+    failing.fail_index = failing.alloc_index;
+    try std.testing.expectEqual(@as(u32, 0), view.getVirtualLineCount());
+    try std.testing.expect(failing.has_induced_failure);
+    try std.testing.expect(view.virtual_lines_dirty);
+    try std.testing.expectEqual(@as(usize, 0), view.virtual_lines.items.len);
+    try std.testing.expectEqual(@as(usize, 0), view.cached_line_starts.items.len);
+    try std.testing.expectEqual(@as(usize, 0), view.cached_line_widths.items.len);
+    try std.testing.expectEqual(@as(usize, 0), view.cached_line_sources.items.len);
+}
+
+test "TextBufferView word wrapping - streaming OOM discards partial layout" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    const text = try std.testing.allocator.alloc(u8, 70_000);
+    defer std.testing.allocator.free(text);
+    for (text, 0..) |*byte, i| byte.* = if (i % 2 == 0) 'a' else ' ';
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    try tb.setText(text);
+
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    var view = try TextBufferView.init(failing.allocator(), tb);
+    defer view.deinit();
+    view.setWrapMode(.word);
+    view.setWrapWidth(8);
+
+    failing.fail_index = failing.alloc_index;
+    try std.testing.expectEqual(@as(u32, 0), view.getVirtualLineCount());
+    try std.testing.expect(failing.has_induced_failure);
+    try std.testing.expect(view.virtual_lines_dirty);
+    try std.testing.expectEqual(@as(usize, 0), view.virtual_lines.items.len);
+    try std.testing.expectEqual(@as(usize, 0), view.cached_line_starts.items.len);
+    try std.testing.expectEqual(@as(usize, 0), view.cached_line_widths.items.len);
+    try std.testing.expectEqual(@as(usize, 0), view.cached_line_sources.items.len);
+}
+
+test "TextBufferView word wrapping - layout cache OOM falls back to complete streamed render" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+
+    const text = try std.testing.allocator.alloc(u8, 2048);
+    defer std.testing.allocator.free(text);
+    for (text, 0..) |*byte, i| byte.* = if (i % 2 == 0) 'a' else ',';
+    try tb.setText(text);
+
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+    view.setWrapMode(.word);
+    view.setWrapWidth(80);
+    const measured = try view.measureForDimensions(80, 24);
+    try std.testing.expectEqual(@as(u32, 26), measured.line_count);
+
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    const internal_allocator = tb.allocator;
+    tb.allocator = failing.allocator();
+    defer tb.allocator = internal_allocator;
+    const vlines = view.getVirtualLines();
+
+    try std.testing.expect(failing.has_induced_failure);
+    try std.testing.expectEqual(@as(usize, measured.line_count), vlines.len);
+    var rendered_bytes: usize = 0;
+    for (vlines) |vline| {
+        for (vline.chunks.items) |chunk| rendered_bytes += chunk.byte_len;
+    }
+    try std.testing.expectEqual(text.len, rendered_bytes);
+    try std.testing.expect(!view.virtual_lines_dirty);
 }
 
 test "TextBufferView wrapping - switch between char and word mode" {
@@ -2347,6 +2800,39 @@ test "TextBufferView measureForDimensions - word wrap" {
     try std.testing.expect(result.width_cols_max <= 10);
 }
 
+test "TextBufferView measureForDimensions - word summary OOM returns computed result" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+
+    const text = try std.testing.allocator.alloc(u8, 512);
+    defer std.testing.allocator.free(text);
+    @memset(text, 'a');
+    try tb.setText(text);
+
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+    view.setWrapMode(.word);
+
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    const internal_allocator = tb.allocator;
+    tb.allocator = failing.allocator();
+    defer tb.allocator = internal_allocator;
+    const result = try view.measureForDimensions(80, 24);
+
+    try std.testing.expect(failing.has_induced_failure);
+    try std.testing.expectEqual(@as(u32, 7), result.line_count);
+    try std.testing.expectEqual(@as(u32, 80), result.width_cols_max);
+
+    const recomputed = try view.measureForDimensions(79, 24);
+    try std.testing.expectEqual(@as(u32, 7), recomputed.line_count);
+    try std.testing.expectEqual(@as(u32, 79), recomputed.width_cols_max);
+}
+
 test "TextBufferView word wrap - first line offset reduces initial line width" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
@@ -2369,6 +2855,42 @@ test "TextBufferView word wrap - first line offset reduces initial line width" {
     try std.testing.expectEqual(@as(usize, 2), vlines.len);
     try std.testing.expectEqual(@as(u32, 1), vlines[0].width_cols);
     try std.testing.expectEqual(@as(u32, 7), vlines[1].width_cols);
+}
+
+test "TextBufferView measureForDimensions - fragmented word wrap matches render with first line offset" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    const text = "prefix fragmentedword suffix";
+    const mem_id = try tb.registerMemBuffer(text, false);
+
+    var segments: std.ArrayListUnmanaged(seg_mod.Segment) = .empty;
+    defer segments.deinit(std.testing.allocator);
+    try segments.append(std.testing.allocator, .{ .linestart = {} });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 0, 10) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 10, 18) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 18, @intCast(text.len)) });
+    try tb.rope().setSegments(segments.items);
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(12);
+    view.setFirstLineOffset(5);
+
+    const measured = try view.measureForDimensions(12, 24);
+    const vlines = view.getVirtualLines();
+    var rendered_width_max: u32 = 0;
+    for (vlines) |vline| rendered_width_max = @max(rendered_width_max, vline.width_cols);
+
+    try std.testing.expectEqual(@as(u32, @intCast(vlines.len)), measured.line_count);
+    try std.testing.expectEqual(rendered_width_max, measured.width_cols_max);
 }
 
 test "TextBufferView measureForDimensions - empty buffer" {
@@ -2415,6 +2937,43 @@ test "TextBufferView truncation - basic truncate single line" {
     try std.testing.expectEqual(@as(usize, 1), vlines.len);
     // Width should be reduced (prefix + suffix, ellipsis handled separately)
     try std.testing.expect(vlines[0].width_cols <= 10);
+}
+
+test "TextBufferView truncation - allocation failure is atomic and retryable" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    var view = try TextBufferView.init(failing.allocator(), tb);
+    defer view.deinit();
+
+    try tb.setText("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+    view.setWrapMode(.none);
+    view.setViewport(.{ .x = 0, .y = 0, .width = 10, .height = 1 });
+    view.setTruncate(true);
+    view.updateVirtualLines();
+    const original = view.virtual_lines.items[0];
+    try std.testing.expectEqual(@as(u32, 26), original.width_cols);
+    try std.testing.expectEqual(@as(usize, 1), original.chunks.items.len);
+    const original_chunk = original.chunks.items[0];
+
+    failing.fail_index = failing.alloc_index;
+    const failed = view.getVirtualLines()[0];
+    try std.testing.expect(failing.has_induced_failure);
+    try std.testing.expectEqual(@as(u32, 26), failed.width_cols);
+    try std.testing.expect(!failed.is_truncated);
+    try std.testing.expectEqual(@as(usize, 1), failed.chunks.items.len);
+    try std.testing.expectEqualDeep(original_chunk, failed.chunks.items[0]);
+
+    failing.fail_index = std.math.maxInt(usize);
+    const retried = view.getVirtualLines()[0];
+    try std.testing.expect(retried.is_truncated);
+    try std.testing.expectEqual(@as(u32, 10), retried.width_cols);
+    try std.testing.expectEqual(@as(usize, 3), retried.chunks.items.len);
 }
 
 test "TextBufferView truncation - multiline with truncate" {
@@ -2555,7 +3114,7 @@ test "TextBufferView truncation - verify ellipsis chunk injection" {
 
     // Verify the middle chunk is the ellipsis
     const ellipsis_chunk = vlines[0].chunks.items[1];
-    try std.testing.expectEqual(@as(u32, 3), ellipsis_chunk.width);
+    try std.testing.expectEqual(@as(u32, 3), ellipsis_chunk.width_cols);
 
     // Get the ellipsis text to verify it's "..."
     const ellipsis_text = ellipsis_chunk.chunk.getBytes(tb.memRegistry());
@@ -2620,6 +3179,94 @@ test "TextBufferView truncation - verify prefix and suffix content" {
 
     // Verify total width matches viewport
     try std.testing.expectEqual(@as(u32, 10), vlines[0].width_cols);
+}
+
+test "TextBufferView truncation - byte windows snap around wide graphemes" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    try tb.setText("ABCDE가FG");
+    view.setWrapMode(.none);
+    view.setTruncate(true);
+    view.setViewport(.{ .x = 0, .y = 0, .width = 8, .height = 1 });
+
+    const line = view.getVirtualLines()[0];
+    try std.testing.expectEqual(@as(u32, 7), line.width_cols);
+    try std.testing.expectEqual(@as(u32, 2), line.ellipsis_pos);
+    try std.testing.expectEqual(@as(u32, 7), line.truncation_suffix_start);
+    try std.testing.expectEqual(@as(usize, 3), line.chunks.items.len);
+
+    for (line.chunks.items) |chunk| {
+        const bytes = chunk.chunk.getBytes(tb.memRegistry());
+        const window = bytes[chunk.byte_start_in_chunk .. chunk.byte_start_in_chunk + chunk.byte_len];
+        try std.testing.expect(std.unicode.utf8ValidateSlice(window));
+    }
+    const prefix = line.chunks.items[0];
+    const suffix = line.chunks.items[2];
+    try std.testing.expectEqualStrings("AB", prefix.chunk.getBytes(tb.memRegistry())[prefix.byte_start_in_chunk .. prefix.byte_start_in_chunk + prefix.byte_len]);
+    try std.testing.expectEqualStrings("FG", suffix.chunk.getBytes(tb.memRegistry())[suffix.byte_start_in_chunk .. suffix.byte_start_in_chunk + suffix.byte_len]);
+}
+
+test "TextBufferView wcwidth wrapping keeps grapheme byte windows atomic" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    try tb.setText("A👋🏻B👩‍💻C");
+    view.setWrapMode(.char);
+    view.setWrapWidth(2);
+
+    const expected = [_][]const u8{ "A", "👋🏻", "B", "👩‍💻", "C" };
+    const lines = view.getVirtualLines();
+    try std.testing.expectEqual(expected.len, lines.len);
+    for (lines, expected) |line, expected_window| {
+        try std.testing.expectEqual(@as(usize, 1), line.chunks.items.len);
+        const chunk = line.chunks.items[0];
+        const bytes = chunk.chunk.getBytes(tb.memRegistry());
+        const window = bytes[chunk.byte_start_in_chunk .. chunk.byte_start_in_chunk + chunk.byte_len];
+        try std.testing.expect(std.unicode.utf8ValidateSlice(window));
+        try std.testing.expectEqualStrings(expected_window, window);
+    }
+    try std.testing.expectEqual(@as(u32, 4), lines[1].width_cols);
+    try std.testing.expectEqual(@as(u32, 4), lines[3].width_cols);
+}
+
+test "TextBufferView wcwidth truncation does not start suffix inside grapheme" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    try tb.setText("ABCDE👋🏻Z");
+    view.setWrapMode(.none);
+    view.setTruncate(true);
+    view.setViewport(.{ .x = 0, .y = 0, .width = 8, .height = 1 });
+
+    const line = view.getVirtualLines()[0];
+    try std.testing.expectEqual(@as(usize, 3), line.chunks.items.len);
+    const suffix = line.chunks.items[2];
+    const bytes = suffix.chunk.getBytes(tb.memRegistry());
+    const window = bytes[suffix.byte_start_in_chunk .. suffix.byte_start_in_chunk + suffix.byte_len];
+    try std.testing.expect(std.unicode.utf8ValidateSlice(window));
+    try std.testing.expectEqualStrings("Z", window);
 }
 
 test "TextBufferView measureForDimensions - multiple lines with different widths" {
@@ -3569,9 +4216,9 @@ test "TextBufferView findVisualLineIndex - finds correct line for wrapped text" 
     const idx50 = view.findVisualLineIndex(0, 50);
     try std.testing.expectEqual(@as(u32, 2), idx50);
 
-    // Column 51 should be in visual line 3 (starts at col 51)
+    // Column 51 is consumed separator whitespace and remains associated with the preceding visual line.
     const idx51 = view.findVisualLineIndex(0, 51);
-    try std.testing.expectEqual(@as(u32, 3), idx51);
+    try std.testing.expectEqual(@as(u32, 2), idx51);
 }
 
 test "TextBufferView word wrapping - chunk at exact wrap boundary" {

--- a/packages/native/src/tests/text-buffer-view_test.zig
+++ b/packages/native/src/tests/text-buffer-view_test.zig
@@ -1333,9 +1333,7 @@ test "TextBufferView word wrapping - layout cache OOM falls back to complete str
     var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
     defer tb.deinit();
 
-    const text = try std.testing.allocator.alloc(u8, 2048);
-    defer std.testing.allocator.free(text);
-    for (text, 0..) |*byte, i| byte.* = if (i % 2 == 0) 'a' else ',';
+    const text = "a," ** 1023 ++ "\xC3\xA9";
     try tb.setText(text);
 
     var view = try TextBufferView.init(std.testing.allocator, tb);

--- a/packages/native/src/tests/utf8_no_zwj_test.zig
+++ b/packages/native/src/tests/utf8_no_zwj_test.zig
@@ -103,12 +103,12 @@ test "no_zwj: findGraphemeInfo splits ZWJ sequences" {
 
     // unicode: 1 grapheme (the whole ZWJ sequence)
     try testing.expectEqual(@as(usize, 1), result_unicode.items.len);
-    try testing.expectEqual(@as(u8, 2), result_unicode.items[0].width);
+    try testing.expectEqual(@as(u32, 2), result_unicode.items[0].width);
 
     // no_zwj: 2 graphemes (woman and rocket separately)
     try testing.expectEqual(@as(usize, 2), result_no_zwj.items.len);
-    try testing.expectEqual(@as(u8, 2), result_no_zwj.items[0].width);
-    try testing.expectEqual(@as(u8, 2), result_no_zwj.items[1].width);
+    try testing.expectEqual(@as(u32, 2), result_no_zwj.items[0].width);
+    try testing.expectEqual(@as(u32, 2), result_no_zwj.items[1].width);
 }
 
 test "no_zwj: findWrapPosByWidth with ZWJ sequences" {

--- a/packages/native/src/tests/utf8_test.zig
+++ b/packages/native/src/tests/utf8_test.zig
@@ -673,16 +673,16 @@ test "tab stops: tabs across multiple SIMD chunks" {
 }
 
 // ============================================================================
-// WORD WRAP BREAK TESTS
+// CHUNK LAYOUT SCANNER TESTS
 // ============================================================================
 
-const WrapBreakTestCase = struct {
+const LayoutBreakTestCase = struct {
     name: []const u8,
     input: []const u8,
     expected: []const usize,
 };
 
-const wrap_break_golden_tests = [_]WrapBreakTestCase{
+const layout_break_golden_tests = [_]LayoutBreakTestCase{
     .{
         .name = "empty string",
         .input = "",
@@ -795,22 +795,22 @@ const wrap_break_golden_tests = [_]WrapBreakTestCase{
     },
 };
 
-fn testWrapBreaks(test_case: WrapBreakTestCase, allocator: std.mem.Allocator) !void {
-    var result = utf8.WrapBreakResult.init(allocator);
-    defer result.deinit();
+fn testLayoutBreaks(test_case: LayoutBreakTestCase, allocator: std.mem.Allocator) !void {
+    var breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;
+    defer breaks.deinit(allocator);
 
-    try utf8.findWrapBreaks(test_case.input, &result, .unicode);
+    _ = try utf8.findChunkLayoutInfo(allocator, test_case.input, 4, utf8.isAsciiOnly(test_case.input), .unicode, &breaks);
 
-    try testing.expectEqual(test_case.expected.len, result.breaks.items.len);
+    try testing.expectEqual(test_case.expected.len, breaks.items.len);
 
     for (test_case.expected, 0..) |exp, i| {
-        try testing.expectEqual(exp, result.breaks.items[i].byte_offset);
+        try testing.expectEqual(exp, breaks.items[i].byte_offset);
     }
 }
 
-test "wrap breaks: golden tests" {
-    for (wrap_break_golden_tests) |tc| {
-        try testWrapBreaks(tc, testing.allocator);
+test "chunk layout scanner: golden break offsets" {
+    for (layout_break_golden_tests) |tc| {
+        try testLayoutBreaks(tc, testing.allocator);
     }
 }
 
@@ -822,7 +822,7 @@ test "wrap breaks: space at SIMD16 edge (15)" {
 
     const expected = [_]usize{15};
 
-    try testWrapBreaks(.{
+    try testLayoutBreaks(.{
         .name = "space@15",
         .input = &buf,
         .expected = &expected,
@@ -838,7 +838,7 @@ test "wrap breaks: unicode NBSP at SIMD16 edge (15)" {
 
     const expected = [_]usize{15};
 
-    try testWrapBreaks(.{
+    try testLayoutBreaks(.{
         .name = "nbsp@15",
         .input = &buf,
         .expected = &expected,
@@ -855,7 +855,7 @@ test "wrap breaks: multiple breaks around SIMD16 boundary" {
 
     const expected = [_]usize{ 14, 15, 16, 17 };
 
-    try testWrapBreaks(.{
+    try testLayoutBreaks(.{
         .name = "multi@boundary",
         .input = &buf,
         .expected = &expected,
@@ -866,7 +866,7 @@ test "wrap breaks: multibyte adjacent to space" {
     const input = "é test"; // é is 2 bytes: 0xC3 0xA9
     const expected = [_]usize{2}; // Space at index 2
 
-    try testWrapBreaks(.{
+    try testLayoutBreaks(.{
         .name = "é space",
         .input = input,
         .expected = &expected,
@@ -877,7 +877,7 @@ test "wrap breaks: multibyte adjacent to dash" {
     const input = "漢-test"; // 漢 is 3 bytes: 0xE6 0xBC 0xA2
     const expected = [_]usize{3}; // Dash at index 3
 
-    try testWrapBreaks(.{
+    try testLayoutBreaks(.{
         .name = "漢-",
         .input = input,
         .expected = &expected,
@@ -897,377 +897,28 @@ test "wrap breaks: multibyte at SIMD boundary with script transitions" {
     // - after '界' before "Test" (byte 7)
     const expected = [_]usize{ 3, 7 };
 
-    try testWrapBreaks(.{
+    try testLayoutBreaks(.{
         .name = "unicode@boundary",
         .input = buf[0..text.len],
         .expected = &expected,
     }, testing.allocator);
 }
 
-test "wrap breaks: realistic text" {
-    const sample_text =
-        "The quick brown fox jumps over the lazy dog.\n" ++
-        "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n" ++
-        "File paths: /usr/local/bin and C:\\Windows\\System32\n" ++
-        "Punctuation test: Hello, world! How are you? I'm fine.\n" ++
-        "Brackets test: (parentheses) [square] {curly}\n" ++
-        "Dashes test: pre-dash post-dash multi-word-expression\n" ++
-        "Mixed: Hello, /path/to-file.txt [done]!\n";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-
-    try utf8.findWrapBreaks(sample_text, &result, .unicode);
-
-    // Verify we found many breaks
-    try testing.expect(result.breaks.items.len > 0);
-}
-
-test "wrap breaks: random small buffers" {
-    var prng = std.Random.DefaultPrng.init(42);
-    const random = prng.random();
-
-    const break_chars = " \t-/\\.,:;!?()[]{}";
-
-    var i: usize = 0;
-    while (i < 50) : (i += 1) {
-        const size = 16 + random.uintLessThan(usize, 1024);
-        const buf = try testing.allocator.alloc(u8, size);
-        defer testing.allocator.free(buf);
-
-        // Fill with ASCII letters and randomly insert breaks
-        for (buf) |*b| {
-            const r = random.uintLessThan(u8, 100);
-            if (r < 20) {
-                const break_idx = random.uintLessThan(usize, break_chars.len);
-                b.* = break_chars[break_idx];
-            } else {
-                b.* = 'a' + random.uintLessThan(u8, 26);
-            }
-        }
-
-        var result = utf8.WrapBreakResult.init(testing.allocator);
-        defer result.deinit();
-        try utf8.findWrapBreaks(buf, &result, .unicode);
-    }
-}
-
-test "wrap breaks: large buffer" {
-    const size = 10000;
-    const buf = try testing.allocator.alloc(u8, size);
-    defer testing.allocator.free(buf);
-
-    // Create realistic text with periodic breaks
-    for (buf, 0..) |*b, idx| {
-        if (idx % 50 == 0) {
-            b.* = ' ';
-        } else if (idx % 75 == 0) {
-            b.* = '-';
-        } else {
-            b.* = 'a' + @as(u8, @intCast(idx % 26));
-        }
-    }
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(buf, &result, .unicode);
-
-    try testing.expect(result.breaks.items.len > 0);
-}
-
-test "wrap breaks: buffer exceeding 64KB" {
+test "chunk layout scanner: break offset beyond 64KB" {
     const size = 100_000;
     const buf = try testing.allocator.alloc(u8, size);
     defer testing.allocator.free(buf);
 
     @memset(buf, 'a');
-
-    // Place a space at 70000, with u16, this will truncate to 4464 (70000 % 65536)
     const break_pos: usize = 70_000;
     buf[break_pos] = ' ';
 
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(buf, &result, .unicode);
+    var breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;
+    defer breaks.deinit(testing.allocator);
+    _ = try utf8.findChunkLayoutInfo(testing.allocator, buf, 4, true, .unicode, &breaks);
 
-    // Should find exactly one wrap break
-    try testing.expectEqual(@as(usize, 1), result.breaks.items.len);
-
-    // The byte_offset must be the actual position, not truncated
-    try testing.expectEqual(@as(u32, break_pos), result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u32, break_pos), result.breaks.items[0].char_offset);
-}
-
-// ============================================================================
-// EDGE CASES AND INTEGRATION TESTS
-// ============================================================================
-
-test "edge case: result reuse" {
-    var line_result = utf8.LineBreakResult.init(testing.allocator);
-    defer line_result.deinit();
-
-    // First use - line breaks
-    try utf8.findLineBreaks("a\nb\nc", &line_result);
-    try testing.expectEqual(@as(usize, 2), line_result.breaks.items.len);
-
-    // Second use - should reset automatically
-    try utf8.findLineBreaks("x\ny", &line_result);
-    try testing.expectEqual(@as(usize, 1), line_result.breaks.items.len);
-    try testing.expectEqual(@as(usize, 1), line_result.breaks.items[0].pos);
-
-    // Third use - wrap breaks (different result type)
-    var wrap_result = utf8.WrapBreakResult.init(testing.allocator);
-    defer wrap_result.deinit();
-    try utf8.findWrapBreaks("a b c", &wrap_result, .unicode);
-    try testing.expectEqual(@as(usize, 2), wrap_result.breaks.items.len);
-}
-
-test "edge case: empty input" {
-    var line_result = utf8.LineBreakResult.init(testing.allocator);
-    defer line_result.deinit();
-
-    try utf8.findLineBreaks("", &line_result);
-    try testing.expectEqual(@as(usize, 0), line_result.breaks.items.len);
-
-    var wrap_result = utf8.WrapBreakResult.init(testing.allocator);
-    defer wrap_result.deinit();
-    try utf8.findWrapBreaks("", &wrap_result, .unicode);
-    try testing.expectEqual(@as(usize, 0), wrap_result.breaks.items.len);
-}
-
-test "edge case: exactly 16 bytes" {
-    var line_result = utf8.LineBreakResult.init(testing.allocator);
-    defer line_result.deinit();
-
-    const input = "0123456789abcdef"; // exactly 16 bytes
-    try utf8.findLineBreaks(input, &line_result);
-    try testing.expectEqual(@as(usize, 0), line_result.breaks.items.len);
-
-    var wrap_result = utf8.WrapBreakResult.init(testing.allocator);
-    defer wrap_result.deinit();
-    try utf8.findWrapBreaks(input, &wrap_result, .unicode);
-    try testing.expectEqual(@as(usize, 0), wrap_result.breaks.items.len);
-}
-
-test "edge case: 17 bytes with break at 16" {
-    var line_result = utf8.LineBreakResult.init(testing.allocator);
-    defer line_result.deinit();
-
-    const input = "0123456789abcde\nx"; // break at position 15
-    try utf8.findLineBreaks(input, &line_result);
-    try testing.expectEqual(@as(usize, 1), line_result.breaks.items.len);
-    try testing.expectEqual(@as(usize, 15), line_result.breaks.items[0].pos);
-
-    var wrap_result = utf8.WrapBreakResult.init(testing.allocator);
-    defer wrap_result.deinit();
-    const input2 = "0123456789abcde x"; // space at position 15
-    try utf8.findWrapBreaks(input2, &wrap_result, .unicode);
-    try testing.expectEqual(@as(usize, 1), wrap_result.breaks.items.len);
-    try testing.expectEqual(@as(u16, 15), wrap_result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u16, 15), wrap_result.breaks.items[0].char_offset);
-}
-
-// ============================================================================
-// GRAPHEME CLUSTER TESTS
-// ============================================================================
-
-test "wrap breaks: emoji with ZWJ - char offset should count grapheme not codepoints" {
-    const input = "ab 👩‍🚀 cd";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(input, &result, .unicode);
-
-    try testing.expectEqual(@as(usize, 2), result.breaks.items.len);
-    try testing.expectEqual(@as(u16, 2), result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u16, 2), result.breaks.items[0].char_offset);
-    try testing.expectEqual(@as(u16, 14), result.breaks.items[1].byte_offset);
-    try testing.expectEqual(@as(u16, 4), result.breaks.items[1].char_offset); // Should be 4, not 6
-}
-
-test "wrap breaks: emoji with skin tone - char offset should count grapheme" {
-    const input = "hi 👋🏿 bye";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(input, &result, .unicode);
-
-    try testing.expectEqual(@as(usize, 2), result.breaks.items.len);
-    try testing.expectEqual(@as(u16, 2), result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u16, 2), result.breaks.items[0].char_offset);
-    try testing.expectEqual(@as(u16, 11), result.breaks.items[1].byte_offset);
-    try testing.expectEqual(@as(u16, 4), result.breaks.items[1].char_offset); // Should be 4, not 5
-}
-
-test "wrap breaks: emoji with VS16 selector - char offset should count grapheme" {
-    const input = "I ❤️ U";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(input, &result, .unicode);
-
-    try testing.expectEqual(@as(usize, 2), result.breaks.items.len);
-    try testing.expectEqual(@as(u16, 1), result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u16, 1), result.breaks.items[0].char_offset);
-    try testing.expectEqual(@as(u16, 8), result.breaks.items[1].byte_offset);
-    try testing.expectEqual(@as(u16, 3), result.breaks.items[1].char_offset); // Should be 3, not 4
-}
-
-test "wrap breaks: combining diacritic - char offset should count grapheme" {
-    const input = "cafe\u{0301} time";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(input, &result, .unicode);
-
-    try testing.expectEqual(@as(usize, 1), result.breaks.items.len);
-    try testing.expectEqual(@as(u16, 6), result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u16, 4), result.breaks.items[0].char_offset); // Should be 4, not 5
-}
-
-test "wrap breaks: flag emoji - char offset should count grapheme" {
-    const input = "USA🇺🇸 flag";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(input, &result, .unicode);
-
-    try testing.expectEqual(@as(usize, 1), result.breaks.items.len);
-    try testing.expectEqual(@as(u16, 11), result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u16, 4), result.breaks.items[0].char_offset); // 3(USA) + 1(flag) = 4
-}
-
-test "wrap breaks: mixed graphemes and ASCII" {
-    const input = "Hello 👋🏿 world 🇺🇸 test";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(input, &result, .unicode);
-
-    try testing.expectEqual(@as(usize, 4), result.breaks.items.len);
-    try testing.expectEqual(@as(u16, 5), result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u16, 5), result.breaks.items[0].char_offset);
-    try testing.expectEqual(@as(u16, 14), result.breaks.items[1].byte_offset);
-    try testing.expectEqual(@as(u16, 7), result.breaks.items[1].char_offset); // 5 + 1 + 1(grapheme) = 7
-    try testing.expectEqual(@as(u16, 20), result.breaks.items[2].byte_offset);
-    try testing.expectEqual(@as(u16, 13), result.breaks.items[2].char_offset); // 7 + 1 + 5 = 13
-    try testing.expectEqual(@as(u16, 29), result.breaks.items[3].byte_offset);
-    try testing.expectEqual(@as(u16, 15), result.breaks.items[3].char_offset); // 13 + 1(space) + 1(RI) + 1(RI) = 15 (per uucode)
-}
-
-test "wrap breaks: CJK characters keep break offsets" {
-    // Ensure multibyte graphemes don't shift wrap break offsets.
-    const input = "Hello 世界 test";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(input, &result, .unicode);
-
-    // Should find 2 wrap breaks (2 spaces)
-    try testing.expectEqual(@as(usize, 2), result.breaks.items.len);
-
-    // First break: space after "Hello"
-    try testing.expectEqual(@as(u16, 5), result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u16, 5), result.breaks.items[0].char_offset);
-
-    // Second break: space after "世界"
-    // Byte: "Hello " = 6 bytes, "世" = 3 bytes, "界" = 3 bytes, total = 12
-    try testing.expectEqual(@as(u16, 12), result.breaks.items[1].byte_offset);
-    try testing.expectEqual(@as(u16, 8), result.breaks.items[1].char_offset); // 6 graphemes(Hello space) + 2 graphemes(世界) = 8
-}
-
-test "wrap breaks: CJK to ASCII script transition" {
-    const input = "日本語abc";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(input, &result, .unicode);
-
-    try testing.expectEqual(@as(usize, 1), result.breaks.items.len);
-    try testing.expectEqual(@as(u16, 6), result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u16, 2), result.breaks.items[0].char_offset);
-}
-
-test "wrap breaks: ASCII to CJK script transition" {
-    const input = "abc日本語";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(input, &result, .unicode);
-
-    try testing.expectEqual(@as(usize, 1), result.breaks.items.len);
-    try testing.expectEqual(@as(u16, 2), result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u16, 2), result.breaks.items[0].char_offset);
-}
-
-test "wrap breaks: CJK punctuation before ASCII" {
-    const input = "日本語。abc";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(input, &result, .unicode);
-
-    try testing.expectEqual(@as(usize, 1), result.breaks.items.len);
-    try testing.expectEqual(@as(u16, 9), result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u16, 3), result.breaks.items[0].char_offset);
-}
-
-test "wrap breaks: compat ideograph to ASCII script transition" {
-    const input = "丽abc";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(input, &result, .unicode);
-
-    try testing.expectEqual(@as(usize, 1), result.breaks.items.len);
-    try testing.expectEqual(@as(u16, 0), result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u16, 0), result.breaks.items[0].char_offset);
-}
-
-test "wrap breaks: extension I ideograph to ASCII script transition" {
-    const input = "𮯰abc";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(input, &result, .unicode);
-
-    try testing.expectEqual(@as(usize, 1), result.breaks.items.len);
-    try testing.expectEqual(@as(u16, 0), result.breaks.items[0].byte_offset);
-    try testing.expectEqual(@as(u16, 0), result.breaks.items[0].char_offset);
-}
-
-test "wrap breaks: emoji and CJK mixed offsets" {
-    const input = "🌟 Unicode test: こんにちは世界 Hello World";
-
-    var result = utf8.WrapBreakResult.init(testing.allocator);
-    defer result.deinit();
-    try utf8.findWrapBreaks(input, &result, .unicode);
-
-    // Find the space before "Hello"
-    var space_before_hello: ?utf8.WrapBreak = null;
-    for (result.breaks.items) |brk| {
-        if (brk.byte_offset == 40) {
-            space_before_hello = brk;
-            break;
-        }
-    }
-
-    try testing.expect(space_before_hello != null);
-    try testing.expectEqual(@as(u16, 40), space_before_hello.?.byte_offset);
-    try testing.expectEqual(@as(u16, 23), space_before_hello.?.char_offset); // Graphemes before this space
-
-    // Find the space after "Hello"
-    var space_after_hello: ?utf8.WrapBreak = null;
-    for (result.breaks.items) |brk| {
-        if (brk.byte_offset == 46) {
-            space_after_hello = brk;
-            break;
-        }
-    }
-
-    try testing.expect(space_after_hello != null);
-    try testing.expectEqual(@as(u16, 46), space_after_hello.?.byte_offset);
-    try testing.expectEqual(@as(u16, 29), space_after_hello.?.char_offset);
+    try testing.expectEqual(@as(usize, 1), breaks.items.len);
+    try testing.expectEqual(@as(u32, break_pos), breaks.items[0].byte_offset);
 }
 
 // ============================================================================

--- a/packages/native/src/tests/utf8_test.zig
+++ b/packages/native/src/tests/utf8_test.zig
@@ -2371,8 +2371,8 @@ test "findGraphemeInfo: ASCII with tab" {
     // Should have one entry for the tab
     try testing.expectEqual(@as(usize, 1), result.items.len);
     try testing.expectEqual(@as(u32, 5), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 1), result.items[0].byte_len);
-    try testing.expectEqual(@as(u8, 4), result.items[0].width);
+    try testing.expectEqual(@as(u32, 1), result.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 4), result.items[0].width);
     try testing.expectEqual(@as(u32, 5), result.items[0].col_offset);
 }
 
@@ -2387,14 +2387,14 @@ test "findGraphemeInfo: multiple tabs" {
 
     // First tab at byte 1, col 1
     try testing.expectEqual(@as(u32, 1), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 1), result.items[0].byte_len);
-    try testing.expectEqual(@as(u8, 4), result.items[0].width);
+    try testing.expectEqual(@as(u32, 1), result.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 4), result.items[0].width);
     try testing.expectEqual(@as(u32, 1), result.items[0].col_offset);
 
     // Second tab at byte 3, col 6 (1 + 4 + 1)
     try testing.expectEqual(@as(u32, 3), result.items[1].byte_offset);
-    try testing.expectEqual(@as(u8, 1), result.items[1].byte_len);
-    try testing.expectEqual(@as(u8, 4), result.items[1].width);
+    try testing.expectEqual(@as(u32, 1), result.items[1].byte_len);
+    try testing.expectEqual(@as(u32, 4), result.items[1].width);
     try testing.expectEqual(@as(u32, 6), result.items[1].col_offset);
 }
 
@@ -2410,14 +2410,14 @@ test "findGraphemeInfo: CJK characters" {
 
     // 世 at byte 5
     try testing.expectEqual(@as(u32, 5), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 3), result.items[0].byte_len);
-    try testing.expectEqual(@as(u8, 2), result.items[0].width);
+    try testing.expectEqual(@as(u32, 3), result.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 2), result.items[0].width);
     try testing.expectEqual(@as(u32, 5), result.items[0].col_offset);
 
     // 界 at byte 8
     try testing.expectEqual(@as(u32, 8), result.items[1].byte_offset);
-    try testing.expectEqual(@as(u8, 3), result.items[1].byte_len);
-    try testing.expectEqual(@as(u8, 2), result.items[1].width);
+    try testing.expectEqual(@as(u32, 3), result.items[1].byte_len);
+    try testing.expectEqual(@as(u32, 2), result.items[1].width);
     try testing.expectEqual(@as(u32, 7), result.items[1].col_offset);
 }
 
@@ -2432,8 +2432,8 @@ test "findGraphemeInfo: emoji with skin tone" {
     try testing.expectEqual(@as(usize, 1), result.items.len);
 
     try testing.expectEqual(@as(u32, 2), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 8), result.items[0].byte_len); // 4 + 4 bytes
-    try testing.expectEqual(@as(u8, 2), result.items[0].width);
+    try testing.expectEqual(@as(u32, 8), result.items[0].byte_len); // 4 + 4 bytes
+    try testing.expectEqual(@as(u32, 2), result.items[0].width);
     try testing.expectEqual(@as(u32, 2), result.items[0].col_offset);
 }
 
@@ -2448,7 +2448,7 @@ test "findGraphemeInfo: emoji with ZWJ" {
     try testing.expectEqual(@as(usize, 1), result.items.len);
 
     try testing.expectEqual(@as(u32, 1), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 2), result.items[0].width);
+    try testing.expectEqual(@as(u32, 2), result.items[0].width);
     try testing.expectEqual(@as(u32, 1), result.items[0].col_offset);
 }
 
@@ -2463,8 +2463,8 @@ test "findGraphemeInfo: combining mark" {
     try testing.expectEqual(@as(usize, 1), result.items.len);
 
     try testing.expectEqual(@as(u32, 3), result.items[0].byte_offset); // 'e' position
-    try testing.expectEqual(@as(u8, 3), result.items[0].byte_len); // e (1 byte) + combining (2 bytes)
-    try testing.expectEqual(@as(u8, 1), result.items[0].width);
+    try testing.expectEqual(@as(u32, 3), result.items[0].byte_len); // e (1 byte) + combining (2 bytes)
+    try testing.expectEqual(@as(u32, 1), result.items[0].width);
     try testing.expectEqual(@as(u32, 3), result.items[0].col_offset);
 }
 
@@ -2479,8 +2479,8 @@ test "findGraphemeInfo: flag emoji" {
     try testing.expectEqual(@as(usize, 1), result.items.len);
 
     try testing.expectEqual(@as(u32, 2), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 8), result.items[0].byte_len); // Two 4-byte chars
-    try testing.expectEqual(@as(u8, 2), result.items[0].width);
+    try testing.expectEqual(@as(u32, 8), result.items[0].byte_len); // Two 4-byte chars
+    try testing.expectEqual(@as(u32, 2), result.items[0].width);
     try testing.expectEqual(@as(u32, 2), result.items[0].col_offset);
 }
 
@@ -2496,20 +2496,20 @@ test "findGraphemeInfo: mixed content" {
 
     // Tab at byte 2, col 2
     try testing.expectEqual(@as(u32, 2), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 1), result.items[0].byte_len);
-    try testing.expectEqual(@as(u8, 4), result.items[0].width);
+    try testing.expectEqual(@as(u32, 1), result.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 4), result.items[0].width);
     try testing.expectEqual(@as(u32, 2), result.items[0].col_offset);
 
     // 世 at byte 3, col 6
     try testing.expectEqual(@as(u32, 3), result.items[1].byte_offset);
-    try testing.expectEqual(@as(u8, 3), result.items[1].byte_len);
-    try testing.expectEqual(@as(u8, 2), result.items[1].width);
+    try testing.expectEqual(@as(u32, 3), result.items[1].byte_len);
+    try testing.expectEqual(@as(u32, 2), result.items[1].width);
     try testing.expectEqual(@as(u32, 6), result.items[1].col_offset);
 
     // 界 at byte 6, col 8
     try testing.expectEqual(@as(u32, 6), result.items[2].byte_offset);
-    try testing.expectEqual(@as(u8, 3), result.items[2].byte_len);
-    try testing.expectEqual(@as(u8, 2), result.items[2].width);
+    try testing.expectEqual(@as(u32, 3), result.items[2].byte_len);
+    try testing.expectEqual(@as(u32, 2), result.items[2].width);
     try testing.expectEqual(@as(u32, 8), result.items[2].col_offset);
 }
 
@@ -2534,7 +2534,7 @@ test "findGraphemeInfo: emoji with VS16" {
     try testing.expectEqual(@as(usize, 1), result.items.len);
 
     try testing.expectEqual(@as(u32, 2), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 2), result.items[0].width);
+    try testing.expectEqual(@as(u32, 2), result.items[0].width);
     try testing.expectEqual(@as(u32, 2), result.items[0].col_offset);
 }
 
@@ -2561,8 +2561,8 @@ test "findGraphemeInfo: hiragana" {
 
     // Check first character
     try testing.expectEqual(@as(u32, 0), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 3), result.items[0].byte_len);
-    try testing.expectEqual(@as(u8, 2), result.items[0].width);
+    try testing.expectEqual(@as(u32, 3), result.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 2), result.items[0].width);
 }
 
 test "findGraphemeInfo: at SIMD boundary" {
@@ -2582,12 +2582,37 @@ test "findGraphemeInfo: at SIMD boundary" {
     for (result.items) |g| {
         if (g.byte_offset == 14) {
             found = true;
-            try testing.expectEqual(@as(u8, 3), g.byte_len);
-            try testing.expectEqual(@as(u8, 2), g.width);
+            try testing.expectEqual(@as(u32, 3), g.byte_len);
+            try testing.expectEqual(@as(u32, 2), g.width);
             break;
         }
     }
     try testing.expect(found);
+}
+
+test "findGraphemeInfo: long grapheme metadata exceeds u8 ranges" {
+    var text: std.ArrayListUnmanaged(u8) = .empty;
+    defer text.deinit(testing.allocator);
+
+    for (0..130) |i| {
+        if (i > 0) try text.appendSlice(testing.allocator, "\u{200D}");
+        try text.appendSlice(testing.allocator, "👩");
+    }
+    try testing.expect(text.items.len > std.math.maxInt(u8));
+
+    for ([_]struct { method: utf8.WidthMethod, width: u32 }{
+        .{ .method = .unicode, .width = 2 },
+        .{ .method = .wcwidth, .width = 260 },
+    }) |case| {
+        var result: std.ArrayListUnmanaged(utf8.GraphemeInfo) = .empty;
+        defer result.deinit(testing.allocator);
+
+        try utf8.findGraphemeInfo(testing.allocator, text.items, 4, false, case.method, &result);
+        try testing.expectEqual(@as(usize, 1), result.items.len);
+        try testing.expectEqual(@as(u32, 0), result.items[0].byte_offset);
+        try testing.expectEqual(@as(u32, @intCast(text.items.len)), result.items[0].byte_len);
+        try testing.expectEqual(case.width, result.items[0].width);
+    }
 }
 
 test "calculateTextWidth: book and writing hand emojis width 2" {
@@ -4015,7 +4040,7 @@ test "Thai: grapheme info for combining marks" {
     try utf8.findGraphemeInfo(testing.allocator, text, 4, false, .unicode, &result);
 
     try testing.expectEqual(@as(usize, 1), result.items.len);
-    try testing.expectEqual(@as(u8, 1), result.items[0].width);
+    try testing.expectEqual(@as(u32, 1), result.items[0].width);
 }
 
 test "Thai: grapheme info for word with combining marks" {
@@ -4027,8 +4052,8 @@ test "Thai: grapheme info for word with combining marks" {
     try utf8.findGraphemeInfo(testing.allocator, text, 4, false, .unicode, &result);
 
     try testing.expectEqual(@as(usize, 2), result.items.len);
-    try testing.expectEqual(@as(u8, 1), result.items[0].width);
-    try testing.expectEqual(@as(u8, 1), result.items[1].width);
+    try testing.expectEqual(@as(u32, 1), result.items[0].width);
+    try testing.expectEqual(@as(u32, 1), result.items[1].width);
 }
 
 test "Thai: mixed Thai and ASCII" {
@@ -4074,5 +4099,5 @@ test "Thai: ว่ is a single grapheme cluster" {
     try utf8.findGraphemeInfo(testing.allocator, text, 4, false, .unicode, &result);
 
     try testing.expectEqual(@as(usize, 1), result.items.len);
-    try testing.expectEqual(@as(u8, 1), result.items[0].width);
+    try testing.expectEqual(@as(u32, 1), result.items[0].width);
 }

--- a/packages/native/src/tests/utf8_wcwidth_cursor_test.zig
+++ b/packages/native/src/tests/utf8_wcwidth_cursor_test.zig
@@ -209,8 +209,8 @@ test "wcwidth: findGraphemeInfo with emoji" {
     try testing.expectEqual(@as(usize, 1), result.items.len);
 
     try testing.expectEqual(@as(u32, 0), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 8), result.items[0].byte_len);
-    try testing.expectEqual(@as(u8, 4), result.items[0].width);
+    try testing.expectEqual(@as(u32, 8), result.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 4), result.items[0].width);
 }
 
 test "wcwidth: findGraphemeInfo with ZWJ sequence" {
@@ -223,8 +223,8 @@ test "wcwidth: findGraphemeInfo with ZWJ sequence" {
     try testing.expectEqual(@as(usize, 1), result.items.len);
 
     try testing.expectEqual(@as(u32, 0), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 11), result.items[0].byte_len);
-    try testing.expectEqual(@as(u8, 4), result.items[0].width);
+    try testing.expectEqual(@as(u32, 11), result.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 4), result.items[0].width);
 }
 
 test "wcwidth: findGraphemeInfo with combining marks" {
@@ -236,8 +236,8 @@ test "wcwidth: findGraphemeInfo with combining marks" {
 
     try testing.expectEqual(@as(usize, 1), result.items.len);
     try testing.expectEqual(@as(u32, 0), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 3), result.items[0].byte_len);
-    try testing.expectEqual(@as(u8, 1), result.items[0].width);
+    try testing.expectEqual(@as(u32, 3), result.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 1), result.items[0].width);
 }
 
 test "wcwidth: tab width handling" {

--- a/packages/native/src/tests/utf8_wcwidth_test.zig
+++ b/packages/native/src/tests/utf8_wcwidth_test.zig
@@ -27,8 +27,8 @@ test "findGraphemeInfo wcwidth: ASCII with tab" {
     // Should have one entry for the tab
     try testing.expectEqual(@as(usize, 1), result.items.len);
     try testing.expectEqual(@as(u32, 5), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 1), result.items[0].byte_len);
-    try testing.expectEqual(@as(u8, 4), result.items[0].width);
+    try testing.expectEqual(@as(u32, 1), result.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 4), result.items[0].width);
     try testing.expectEqual(@as(u32, 5), result.items[0].col_offset);
 }
 
@@ -44,14 +44,14 @@ test "findGraphemeInfo wcwidth: CJK characters" {
 
     // First CJK char '世' at byte 5
     try testing.expectEqual(@as(u32, 5), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 3), result.items[0].byte_len);
-    try testing.expectEqual(@as(u8, 2), result.items[0].width);
+    try testing.expectEqual(@as(u32, 3), result.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 2), result.items[0].width);
     try testing.expectEqual(@as(u32, 5), result.items[0].col_offset);
 
     // Second CJK char '界' at byte 8
     try testing.expectEqual(@as(u32, 8), result.items[1].byte_offset);
-    try testing.expectEqual(@as(u8, 3), result.items[1].byte_len);
-    try testing.expectEqual(@as(u8, 2), result.items[1].width);
+    try testing.expectEqual(@as(u32, 3), result.items[1].byte_len);
+    try testing.expectEqual(@as(u32, 2), result.items[1].width);
     try testing.expectEqual(@as(u32, 7), result.items[1].col_offset);
 }
 
@@ -65,8 +65,8 @@ test "findGraphemeInfo wcwidth: emoji with skin tone - single grapheme cluster" 
     try testing.expectEqual(@as(usize, 1), result.items.len);
 
     try testing.expectEqual(@as(u32, 0), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 8), result.items[0].byte_len);
-    try testing.expectEqual(@as(u8, 4), result.items[0].width);
+    try testing.expectEqual(@as(u32, 8), result.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 4), result.items[0].width);
 }
 
 test "findGraphemeInfo wcwidth: emoji with ZWJ - single grapheme cluster" {
@@ -78,8 +78,8 @@ test "findGraphemeInfo wcwidth: emoji with ZWJ - single grapheme cluster" {
 
     try testing.expectEqual(@as(usize, 1), result.items.len);
 
-    try testing.expectEqual(@as(u8, 11), result.items[0].byte_len);
-    try testing.expectEqual(@as(u8, 4), result.items[0].width);
+    try testing.expectEqual(@as(u32, 11), result.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 4), result.items[0].width);
 }
 
 test "findGraphemeInfo wcwidth: combining mark - part of base grapheme" {
@@ -91,8 +91,8 @@ test "findGraphemeInfo wcwidth: combining mark - part of base grapheme" {
 
     try testing.expectEqual(@as(usize, 1), result.items.len);
     try testing.expectEqual(@as(u32, 0), result.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 3), result.items[0].byte_len);
-    try testing.expectEqual(@as(u8, 1), result.items[0].width);
+    try testing.expectEqual(@as(u32, 3), result.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 1), result.items[0].width);
 }
 
 test "findGraphemeInfo wcwidth vs unicode: emoji with skin tone" {
@@ -110,13 +110,13 @@ test "findGraphemeInfo wcwidth vs unicode: emoji with skin tone" {
     try testing.expectEqual(@as(usize, 1), result_unicode.items.len);
 
     try testing.expectEqual(@as(u32, 2), result_wcwidth.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 8), result_wcwidth.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 8), result_wcwidth.items[0].byte_len);
 
     try testing.expectEqual(@as(u32, 2), result_unicode.items[0].byte_offset);
-    try testing.expectEqual(@as(u8, 8), result_unicode.items[0].byte_len);
+    try testing.expectEqual(@as(u32, 8), result_unicode.items[0].byte_len);
 
-    try testing.expectEqual(@as(u8, 4), result_wcwidth.items[0].width);
-    try testing.expectEqual(@as(u8, 2), result_unicode.items[0].width);
+    try testing.expectEqual(@as(u32, 4), result_wcwidth.items[0].width);
+    try testing.expectEqual(@as(u32, 2), result_unicode.items[0].width);
 }
 
 test "findGraphemeInfo wcwidth vs unicode: flag emoji" {
@@ -133,8 +133,8 @@ test "findGraphemeInfo wcwidth vs unicode: flag emoji" {
     try testing.expectEqual(@as(usize, 1), result_wcwidth.items.len);
     try testing.expectEqual(@as(usize, 1), result_unicode.items.len);
 
-    try testing.expectEqual(@as(u8, 2), result_wcwidth.items[0].width);
-    try testing.expectEqual(@as(u8, 2), result_unicode.items[0].width);
+    try testing.expectEqual(@as(u32, 2), result_wcwidth.items[0].width);
+    try testing.expectEqual(@as(u32, 2), result_unicode.items[0].width);
 }
 
 // ============================================================================

--- a/packages/native/src/tests/word-wrap-editing_test.zig
+++ b/packages/native/src/tests/word-wrap-editing_test.zig
@@ -419,7 +419,7 @@ test "Word wrap - word at exact wrap width" {
     vlines = view.getVirtualLines();
     try std.testing.expectEqual(@as(usize, 2), vlines.len);
     try std.testing.expectEqual(@as(u32, 20), vlines[0].width_cols);
-    try std.testing.expectEqual(@as(u32, 5), vlines[1].width_cols);
+    try std.testing.expectEqual(@as(u32, 4), vlines[1].width_cols);
 }
 
 test "Word wrap - debug virtual line contents" {

--- a/packages/native/src/text-buffer-iterators.zig
+++ b/packages/native/src/text-buffer-iterators.zig
@@ -7,7 +7,6 @@ const utf8 = @import("utf8.zig");
 const Segment = seg_mod.Segment;
 const UnifiedRope = seg_mod.UnifiedRope;
 const TextChunk = seg_mod.TextChunk;
-const GraphemeInfo = seg_mod.GraphemeInfo;
 const MemRegistry = mem_registry_mod.MemRegistry;
 
 pub const LineInfo = struct {
@@ -360,43 +359,6 @@ pub fn getPrevGraphemeWidth(rope: *UnifiedRope, mem_registry: *const MemRegistry
         }
     }
     return 0;
-}
-
-pub const CharOffsetColumnInfo = struct {
-    col: u32,
-    width: u32,
-};
-
-/// char_offset is grapheme-count based (not raw codepoint)
-/// grapheme_idx and col_delta carry incremental state across calls
-pub fn charOffsetToColumn(
-    char_offset: u32,
-    graphemes: []const GraphemeInfo,
-    grapheme_idx: *usize,
-    col_delta: *i64,
-) CharOffsetColumnInfo {
-    while (grapheme_idx.* < graphemes.len) {
-        const info = graphemes[grapheme_idx.*];
-        const info_char_offset = @as(i64, info.col_offset) - col_delta.*;
-        if (info_char_offset >= @as(i64, char_offset)) break;
-        col_delta.* += @as(i64, info.width) - 1;
-        grapheme_idx.* += 1;
-    }
-
-    var break_col_i64 = @as(i64, char_offset) + col_delta.*;
-    if (break_col_i64 < 0) break_col_i64 = 0;
-    const break_col = @as(u32, @intCast(break_col_i64));
-
-    var width: u32 = 1;
-    if (grapheme_idx.* < graphemes.len) {
-        const info = graphemes[grapheme_idx.*];
-        const info_char_offset = @as(i64, info.col_offset) - col_delta.*;
-        if (info_char_offset == @as(i64, char_offset)) {
-            width = @as(u32, info.width);
-        }
-    }
-
-    return .{ .col = break_col, .width = width };
 }
 
 /// Extract text between display-width offsets into a buffer

--- a/packages/native/src/text-buffer-segment.zig
+++ b/packages/native/src/text-buffer-segment.zig
@@ -31,16 +31,40 @@ pub const ChunkFitResult = struct {
 };
 
 pub const GraphemeInfo = utf8.GraphemeInfo;
+pub const ChunkLayoutInfo = utf8.ChunkLayoutInfo;
+
+pub const TextChunkColdState = struct {
+    graphemes: ?[]GraphemeInfo = null,
+    graphemes_capacity: usize = 0,
+    graphemes_tab_width: ?u8 = null,
+    graphemes_width_method: ?utf8.WidthMethod = null,
+    wrap_breaks: ?[]utf8.LayoutWrapBreak = null,
+    wrap_breaks_capacity: usize = 0,
+    wrap_breaks_tab_width: ?u8 = null,
+    wrap_breaks_width_method: ?utf8.WidthMethod = null,
+    first_word_class: utf8.WordClass = .other,
+    last_word_class: utf8.WordClass = .other,
+    measure_word_wrap_width: ?u32 = null,
+    measure_word_first_width: u32 = 0,
+    measure_word_tab_width: u8 = 0,
+    measure_word_width_method: utf8.WidthMethod = .unicode,
+    measure_word_line_count: u32 = 0,
+    measure_word_width_max: u32 = 0,
+};
+
+pub const WordMeasureSummary = struct {
+    line_count: u32,
+    width_max: u32,
+};
 
 /// A chunk represents a contiguous sequence of UTF-8 bytes from a specific memory buffer
 pub const TextChunk = struct {
     mem_id: u8,
     byte_start: u32,
     byte_end: u32,
-    width: u16,
+    width: u32,
     flags: u8 = 0,
-    graphemes: ?[]GraphemeInfo = null,
-    wrap_offsets: ?[]utf8.WrapBreak = null,
+    cold: ?*TextChunkColdState = null,
 
     pub const Flags = struct {
         pub const ASCII_ONLY: u8 = 0b00000001; // Printable ASCII only (32..126).
@@ -68,6 +92,66 @@ pub const TextChunk = struct {
         return mem_buf[self.byte_start..self.byte_end];
     }
 
+    fn getOrCreateCold(self: *const TextChunk, allocator: Allocator) TextBufferError!*TextChunkColdState {
+        if (self.cold) |cold| return cold;
+        const cold = allocator.create(TextChunkColdState) catch return TextBufferError.OutOfMemory;
+        cold.* = .{};
+        @constCast(self).cold = cold;
+        return cold;
+    }
+
+    pub fn resetCaches(self: *TextChunk) void {
+        self.cold = null;
+    }
+
+    pub fn getCachedLayoutInfo(
+        self: *const TextChunk,
+        tabwidth: u8,
+        width_method: utf8.WidthMethod,
+    ) ?ChunkLayoutInfo {
+        const cold = self.cold orelse return null;
+        const cached = cold.wrap_breaks orelse return null;
+        if (cold.wrap_breaks_tab_width != tabwidth or cold.wrap_breaks_width_method != width_method) return null;
+        return .{
+            .wrap_breaks = cached,
+            .first_word_class = cold.first_word_class,
+            .last_word_class = cold.last_word_class,
+        };
+    }
+
+    pub fn getWordMeasureSummary(
+        self: *const TextChunk,
+        wrap_width: u32,
+        first_width: u32,
+        tab_width: u8,
+        width_method: utf8.WidthMethod,
+    ) ?WordMeasureSummary {
+        const cold = self.cold orelse return null;
+        if (cold.measure_word_wrap_width != wrap_width or
+            cold.measure_word_first_width != first_width or
+            cold.measure_word_tab_width != tab_width or
+            cold.measure_word_width_method != width_method) return null;
+        return .{ .line_count = cold.measure_word_line_count, .width_max = cold.measure_word_width_max };
+    }
+
+    pub fn setWordMeasureSummary(
+        self: *const TextChunk,
+        allocator: Allocator,
+        wrap_width: u32,
+        first_width: u32,
+        tab_width: u8,
+        width_method: utf8.WidthMethod,
+        summary: WordMeasureSummary,
+    ) TextBufferError!void {
+        const cold = try self.getOrCreateCold(allocator);
+        cold.measure_word_wrap_width = wrap_width;
+        cold.measure_word_first_width = first_width;
+        cold.measure_word_tab_width = tab_width;
+        cold.measure_word_width_method = width_method;
+        cold.measure_word_line_count = summary.line_count;
+        cold.measure_word_width_max = summary.width_max;
+    }
+
     /// Lazily compute and cache grapheme info for this chunk
     /// Returns a slice that is valid until the buffer is reset
     /// For ASCII-only chunks, returns an empty slice (sentinel)
@@ -79,15 +163,25 @@ pub const TextChunk = struct {
         tabwidth: u8,
         width_method: utf8.WidthMethod,
     ) TextBufferError![]const GraphemeInfo {
-        const mut_self = @constCast(self);
-        if (self.graphemes) |cached| {
-            return cached;
-        }
+        if (self.isAsciiOnly()) return &[_]GraphemeInfo{};
 
-        if (self.isAsciiOnly()) {
-            const empty_slice = try allocator.alloc(GraphemeInfo, 0);
-            mut_self.graphemes = empty_slice;
-            return empty_slice;
+        const cold = try self.getOrCreateCold(allocator);
+        if (cold.graphemes) |cached| {
+            if (cold.graphemes_tab_width == tabwidth and cold.graphemes_width_method == width_method) {
+                return cached;
+            }
+
+            var reusable: std.ArrayListUnmanaged(GraphemeInfo) = .{
+                .items = cached,
+                .capacity = cold.graphemes_capacity,
+            };
+            reusable.clearRetainingCapacity();
+            try utf8.findGraphemeInfo(allocator, self.getBytes(mem_registry), tabwidth, self.isAsciiOnly(), width_method, &reusable);
+            cold.graphemes = reusable.items;
+            cold.graphemes_capacity = reusable.capacity;
+            cold.graphemes_tab_width = tabwidth;
+            cold.graphemes_width_method = width_method;
+            return reusable.items;
         }
 
         const chunk_bytes = self.getBytes(mem_registry);
@@ -97,38 +191,77 @@ pub const TextChunk = struct {
 
         try utf8.findGraphemeInfo(allocator, chunk_bytes, tabwidth, self.isAsciiOnly(), width_method, &grapheme_list);
 
-        // TODO: Calling this with an arena allocator will just double the memory usage?
-        const graphemes = try grapheme_list.toOwnedSlice(allocator);
-
-        mut_self.graphemes = graphemes;
-        return graphemes;
+        cold.graphemes = grapheme_list.items;
+        cold.graphemes_capacity = grapheme_list.capacity;
+        cold.graphemes_tab_width = tabwidth;
+        cold.graphemes_width_method = width_method;
+        return grapheme_list.items;
     }
 
-    /// Lazily compute and cache wrap offsets for this chunk
-    /// Returns a slice that is valid until the buffer is reset
-    pub fn getWrapOffsets(
+    /// Lazily compute and cache direct byte/column wrap metadata for this chunk.
+    pub fn getLayoutInfo(
         self: *const TextChunk,
         allocator: Allocator,
         mem_registry: *const MemRegistry,
+        tabwidth: u8,
         width_method: utf8.WidthMethod,
-    ) TextBufferError![]const utf8.WrapBreak {
-        const mut_self = @constCast(self);
-        if (self.wrap_offsets) |cached| {
-            return cached;
+    ) TextBufferError!ChunkLayoutInfo {
+        const cold = try self.getOrCreateCold(allocator);
+        if (cold.wrap_breaks) |cached| {
+            if (cold.wrap_breaks_tab_width == tabwidth and cold.wrap_breaks_width_method == width_method) {
+                return .{
+                    .wrap_breaks = cached,
+                    .first_word_class = cold.first_word_class,
+                    .last_word_class = cold.last_word_class,
+                };
+            }
+
+            if (cold.wrap_breaks_width_method == width_method) {
+                var reusable: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .{
+                    .items = cached,
+                    .capacity = cold.wrap_breaks_capacity,
+                };
+                reusable.clearRetainingCapacity();
+                const word_classes = try utf8.findChunkLayoutInfo(
+                    allocator,
+                    self.getBytes(mem_registry),
+                    tabwidth,
+                    self.isAsciiOnly(),
+                    width_method,
+                    &reusable,
+                );
+                cold.wrap_breaks = reusable.items;
+                cold.wrap_breaks_capacity = reusable.capacity;
+                cold.wrap_breaks_tab_width = tabwidth;
+                cold.first_word_class = word_classes.first;
+                cold.last_word_class = word_classes.last;
+                return .{
+                    .wrap_breaks = reusable.items,
+                    .first_word_class = word_classes.first,
+                    .last_word_class = word_classes.last,
+                };
+            }
         }
 
         const chunk_bytes = self.getBytes(mem_registry);
-        var wrap_result = utf8.WrapBreakResult.init(allocator);
-        errdefer wrap_result.deinit();
+        var wrap_breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;
+        errdefer wrap_breaks.deinit(allocator);
 
-        try utf8.findWrapBreaks(chunk_bytes, &wrap_result, width_method);
+        const word_classes = try utf8.findChunkLayoutInfo(allocator, chunk_bytes, tabwidth, self.isAsciiOnly(), width_method, &wrap_breaks);
 
-        // TODO: Do not cache for chunks < 64 bytes, as it does not profit from the cache
-        // Use toOwnedSlice to transfer ownership without copying
-        const wrap_offsets = try wrap_result.breaks.toOwnedSlice(allocator);
-        mut_self.wrap_offsets = wrap_offsets;
+        const cached: []utf8.LayoutWrapBreak = if (wrap_breaks.items.len > 0) wrap_breaks.items else @constCast(&[_]utf8.LayoutWrapBreak{});
+        cold.wrap_breaks = cached;
+        cold.wrap_breaks_capacity = wrap_breaks.capacity;
+        cold.wrap_breaks_tab_width = tabwidth;
+        cold.wrap_breaks_width_method = width_method;
+        cold.first_word_class = word_classes.first;
+        cold.last_word_class = word_classes.last;
 
-        return wrap_offsets;
+        return .{
+            .wrap_breaks = cached,
+            .first_word_class = word_classes.first,
+            .last_word_class = word_classes.last,
+        };
     }
 };
 
@@ -301,8 +434,6 @@ pub const Segment = union(enum) {
                 .byte_end = right_chunk.byte_end,
                 .width = left_chunk.width + right_chunk.width,
                 .flags = left_chunk.flags,
-                .graphemes = null,
-                .wrap_offsets = null,
             },
         };
     }

--- a/packages/native/src/text-buffer-segment.zig
+++ b/packages/native/src/text-buffer-segment.zig
@@ -91,6 +91,8 @@ pub const TextChunk = struct {
 
     fn getOrCreateCold(self: *const TextChunk, allocator: Allocator) TextBufferError!*TextChunkColdState {
         if (self.cold) |cold| return cold;
+        // Derived state lives behind an indirection to keep persistent rope leaves small.
+        // Attaching it does not change the chunk's rope metrics.
         const cold = allocator.create(TextChunkColdState) catch return TextBufferError.OutOfMemory;
         cold.* = .{};
         @constCast(self).cold = cold;
@@ -147,7 +149,8 @@ pub const TextChunk = struct {
     }
 
     /// Lazily compute and cache grapheme info for this chunk
-    /// Returns a slice that is valid until the buffer is reset
+    /// Returned storage is arena-owned until reset, but a lookup with different
+    /// tab-dependent settings may overwrite it.
     /// For ASCII-only chunks, returns an empty slice (sentinel)
     /// For mixed chunks, returns only multibyte (non-ASCII) graphemes and tabs with their column offsets
     pub fn getGraphemes(
@@ -240,6 +243,7 @@ pub const TextChunk = struct {
 
         const word_classes = try utf8.findChunkLayoutInfo(allocator, chunk_bytes, tabwidth, self.isAsciiOnly(), width_method, &wrap_breaks);
 
+        // The static sentinel has zero capacity, so reuse must allocate before writing.
         const cached: []utf8.LayoutWrapBreak = if (wrap_breaks.items.len > 0) wrap_breaks.items else @constCast(&[_]utf8.LayoutWrapBreak{});
         cold.wrap_breaks = cached;
         cold.wrap_breaks_capacity = wrap_breaks.capacity;

--- a/packages/native/src/text-buffer-segment.zig
+++ b/packages/native/src/text-buffer-segment.zig
@@ -25,13 +25,16 @@ pub const WrapMode = enum {
     word,
 };
 
-pub const ChunkFitResult = struct {
-    char_count: u32,
-    width: u32,
-};
-
 pub const GraphemeInfo = utf8.GraphemeInfo;
 pub const ChunkLayoutInfo = utf8.ChunkLayoutInfo;
+
+const CachedMeasure = struct {
+    wrap_width: u32,
+    first_width: u32,
+    tab_width: u8,
+    width_method: utf8.WidthMethod,
+    result: WordMeasureSummary,
+};
 
 pub const TextChunkColdState = struct {
     graphemes: ?[]GraphemeInfo = null,
@@ -42,14 +45,8 @@ pub const TextChunkColdState = struct {
     wrap_breaks_capacity: usize = 0,
     wrap_breaks_tab_width: ?u8 = null,
     wrap_breaks_width_method: ?utf8.WidthMethod = null,
-    first_word_class: utf8.WordClass = .other,
-    last_word_class: utf8.WordClass = .other,
-    measure_word_wrap_width: ?u32 = null,
-    measure_word_first_width: u32 = 0,
-    measure_word_tab_width: u8 = 0,
-    measure_word_width_method: utf8.WidthMethod = .unicode,
-    measure_word_line_count: u32 = 0,
-    measure_word_width_max: u32 = 0,
+    word_classes: utf8.WordClassEdges = .{ .first = .other, .last = .other },
+    measure_word: ?CachedMeasure = null,
 };
 
 pub const WordMeasureSummary = struct {
@@ -100,10 +97,6 @@ pub const TextChunk = struct {
         return cold;
     }
 
-    pub fn resetCaches(self: *TextChunk) void {
-        self.cold = null;
-    }
-
     pub fn getCachedLayoutInfo(
         self: *const TextChunk,
         tabwidth: u8,
@@ -114,8 +107,7 @@ pub const TextChunk = struct {
         if (cold.wrap_breaks_tab_width != tabwidth or cold.wrap_breaks_width_method != width_method) return null;
         return .{
             .wrap_breaks = cached,
-            .first_word_class = cold.first_word_class,
-            .last_word_class = cold.last_word_class,
+            .word_classes = cold.word_classes,
         };
     }
 
@@ -127,11 +119,12 @@ pub const TextChunk = struct {
         width_method: utf8.WidthMethod,
     ) ?WordMeasureSummary {
         const cold = self.cold orelse return null;
-        if (cold.measure_word_wrap_width != wrap_width or
-            cold.measure_word_first_width != first_width or
-            cold.measure_word_tab_width != tab_width or
-            cold.measure_word_width_method != width_method) return null;
-        return .{ .line_count = cold.measure_word_line_count, .width_max = cold.measure_word_width_max };
+        const cached = cold.measure_word orelse return null;
+        if (cached.wrap_width != wrap_width or
+            cached.first_width != first_width or
+            cached.tab_width != tab_width or
+            cached.width_method != width_method) return null;
+        return cached.result;
     }
 
     pub fn setWordMeasureSummary(
@@ -144,12 +137,13 @@ pub const TextChunk = struct {
         summary: WordMeasureSummary,
     ) TextBufferError!void {
         const cold = try self.getOrCreateCold(allocator);
-        cold.measure_word_wrap_width = wrap_width;
-        cold.measure_word_first_width = first_width;
-        cold.measure_word_tab_width = tab_width;
-        cold.measure_word_width_method = width_method;
-        cold.measure_word_line_count = summary.line_count;
-        cold.measure_word_width_max = summary.width_max;
+        cold.measure_word = .{
+            .wrap_width = wrap_width,
+            .first_width = first_width,
+            .tab_width = tab_width,
+            .width_method = width_method,
+            .result = summary,
+        };
     }
 
     /// Lazily compute and cache grapheme info for this chunk
@@ -211,8 +205,7 @@ pub const TextChunk = struct {
             if (cold.wrap_breaks_tab_width == tabwidth and cold.wrap_breaks_width_method == width_method) {
                 return .{
                     .wrap_breaks = cached,
-                    .first_word_class = cold.first_word_class,
-                    .last_word_class = cold.last_word_class,
+                    .word_classes = cold.word_classes,
                 };
             }
 
@@ -233,12 +226,10 @@ pub const TextChunk = struct {
                 cold.wrap_breaks = reusable.items;
                 cold.wrap_breaks_capacity = reusable.capacity;
                 cold.wrap_breaks_tab_width = tabwidth;
-                cold.first_word_class = word_classes.first;
-                cold.last_word_class = word_classes.last;
+                cold.word_classes = word_classes;
                 return .{
                     .wrap_breaks = reusable.items,
-                    .first_word_class = word_classes.first,
-                    .last_word_class = word_classes.last,
+                    .word_classes = word_classes,
                 };
             }
         }
@@ -254,13 +245,11 @@ pub const TextChunk = struct {
         cold.wrap_breaks_capacity = wrap_breaks.capacity;
         cold.wrap_breaks_tab_width = tabwidth;
         cold.wrap_breaks_width_method = width_method;
-        cold.first_word_class = word_classes.first;
-        cold.last_word_class = word_classes.last;
+        cold.word_classes = word_classes;
 
         return .{
             .wrap_breaks = cached,
-            .first_word_class = word_classes.first,
-            .last_word_class = word_classes.last,
+            .word_classes = word_classes,
         };
     }
 };

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -176,11 +176,6 @@ pub const VirtualLine = struct {
         };
     }
 
-    pub fn deinit(self: *VirtualLine, allocator: Allocator) void {
-        self.chunks.deinit(allocator);
-        self.* = undefined;
-    }
-
     fn appendChunk(self: *VirtualLine, allocator: Allocator, chunk: VirtualChunk) Allocator.Error!void {
         if (self.chunks.capacity == 0) {
             try self.chunks.ensureTotalCapacityPrecise(allocator, 1);
@@ -235,7 +230,6 @@ pub const UnifiedTextBufferView = struct {
     tab_indicator_color: ?RGBA,
     truncate: bool,
     ellipsis_chunk: TextChunk,
-    ellipsis_mem_id: u8,
 
     // Measurement cache for Yoga layout. Keyed by (buffer, epoch, width, wrap_mode).
     // Using epoch instead of dirty flag prevents stale returns when unrelated
@@ -248,8 +242,6 @@ pub const UnifiedTextBufferView = struct {
     cached_measure_buffer: ?*UnifiedTextBuffer,
 
     truncation_applied: bool,
-    truncation_epoch: u64,
-    truncation_viewport: ?Viewport,
 
     pub fn init(global_allocator: Allocator, text_buffer: *UnifiedTextBuffer) TextBufferViewError!*Self {
         const self = global_allocator.create(Self) catch return TextBufferViewError.OutOfMemory;
@@ -262,8 +254,8 @@ pub const UnifiedTextBufferView = struct {
         const view_id = text_buffer.registerView() catch return TextBufferViewError.OutOfMemory;
 
         const ellipsis_text = "...";
-        const ellipsis_mem_id = text_buffer.registerMemBuffer(ellipsis_text, false) catch return TextBufferViewError.OutOfMemory;
-        const ellipsis_chunk = text_buffer.createChunk(ellipsis_mem_id, 0, 3);
+        const mem_id = text_buffer.registerMemBuffer(ellipsis_text, false) catch return TextBufferViewError.OutOfMemory;
+        const ellipsis_chunk = text_buffer.createChunk(mem_id, 0, 3);
 
         self.* = .{
             .text_buffer = text_buffer,
@@ -292,7 +284,6 @@ pub const UnifiedTextBufferView = struct {
             .tab_indicator_color = null,
             .truncate = false,
             .ellipsis_chunk = ellipsis_chunk,
-            .ellipsis_mem_id = ellipsis_mem_id,
             .cached_measure_width = null,
             .cached_measure_wrap_mode = .none,
             .cached_measure_first_line_offset = 0,
@@ -300,8 +291,6 @@ pub const UnifiedTextBufferView = struct {
             .cached_measure_epoch = 0,
             .cached_measure_buffer = null,
             .truncation_applied = false,
-            .truncation_epoch = 0,
-            .truncation_viewport = null,
         };
 
         return self;
@@ -1206,24 +1195,13 @@ pub const UnifiedTextBufferView = struct {
     fn ensureTruncation(self: *Self) void {
         if (!self.truncate or self.viewport == null) return;
 
-        const epoch = self.text_buffer.getContentEpoch();
-        if (self.truncation_applied and self.truncation_epoch == epoch and
-            self.truncation_viewport != null and self.viewport != null and
-            self.truncation_viewport.?.x == self.viewport.?.x and
-            self.truncation_viewport.?.y == self.viewport.?.y and
-            self.truncation_viewport.?.width == self.viewport.?.width and
-            self.truncation_viewport.?.height == self.viewport.?.height)
-        {
-            return;
-        }
+        if (self.truncation_applied) return;
 
         if (!self.applyTruncation()) {
             self.truncation_applied = false;
             return;
         }
         self.truncation_applied = true;
-        self.truncation_epoch = epoch;
-        self.truncation_viewport = self.viewport;
     }
 
     fn applyTruncation(self: *Self) bool {
@@ -1262,7 +1240,7 @@ pub const UnifiedTextBufferView = struct {
 
                 const bytes = chunk.chunk.getBytes(view.text_buffer.memRegistry());
                 const window = bytes[chunk.byte_start_in_chunk .. chunk.byte_start_in_chunk + chunk.byte_len];
-                const dropped = utf8.findPosByWidthGraphemeSafe(
+                const dropped = utf8.findGraphemePosByWidth(
                     window,
                     drop_cols,
                     view.text_buffer.tabWidth(),
@@ -1743,7 +1721,7 @@ pub const UnifiedTextBufferView = struct {
 
                 if (!allow_forced_grapheme) return .{ .width = 0, .bytes_used = 0 };
 
-                const forced = utf8.findPosByWidthGraphemeSafe(
+                const forced = utf8.findGraphemePosByWidth(
                     slice_bytes,
                     max_width,
                     wctx.text_buffer.tabWidth(),
@@ -1951,7 +1929,7 @@ pub const UnifiedTextBufferView = struct {
                     break :blk null;
                 };
                 const word_classes = if (layout) |info|
-                    utf8.WordClassEdges{ .first = info.first_word_class, .last = info.last_word_class }
+                    info.word_classes
                 else
                     utf8.chunkWordClassEdges(chunk_bytes);
                 if (wctx.pending_word_width > 0 and
@@ -1968,7 +1946,7 @@ pub const UnifiedTextBufferView = struct {
                         processWordWrapBreakValue(wctx, wrap_break);
                         if (wctx.failed) return;
                     }
-                    break :blk info.last_word_class;
+                    break :blk info.word_classes.last;
                 } else blk: {
                     const streamed_layout = utf8.walkChunkLayoutInfoComptime(
                         chunk_bytes,
@@ -2016,7 +1994,7 @@ pub const UnifiedTextBufferView = struct {
                             continue;
                         }
                         const remaining_bytes = chunk_bytes[byte_offset..];
-                        const force_result = utf8.findPosByWidthGraphemeSafe(remaining_bytes, 1, tab_width, is_ascii_only, true, width_method);
+                        const force_result = utf8.findGraphemePosByWidth(remaining_bytes, 1, tab_width, is_ascii_only, true, width_method);
                         if (force_result.grapheme_count > 0) {
                             try addVirtualChunk(wctx, chunk, @intCast(byte_offset), force_result.byte_offset, char_offset, force_result.columns_used);
                             char_offset += force_result.columns_used;
@@ -2041,7 +2019,7 @@ pub const UnifiedTextBufferView = struct {
                             try commitVirtualLine(wctx);
                             continue;
                         }
-                        const force_result = utf8.findPosByWidthGraphemeSafe(remaining_bytes, 1, tab_width, is_ascii_only, true, width_method);
+                        const force_result = utf8.findGraphemePosByWidth(remaining_bytes, 1, tab_width, is_ascii_only, true, width_method);
                         if (force_result.grapheme_count > 0) {
                             try addVirtualChunk(wctx, chunk, @intCast(byte_offset), force_result.byte_offset, char_offset, force_result.columns_used);
                             char_offset += force_result.columns_used;

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -1923,14 +1923,14 @@ pub const UnifiedTextBufferView = struct {
 
             fn processWordChunk(wctx: *@This(), chunk: *const TextChunk) void {
                 const chunk_bytes = chunk.getBytes(wctx.text_buffer.memRegistry());
-                // Measurement reuses caches but does not create them. Rendering caches
-                // only medium chunks; small/large scans and cache OOM stream instead.
+                // Reuse existing caches, but retain cold layout only for medium
+                // non-ASCII chunks; vectorized ASCII and small/large chunks stream.
                 const cached_layout = chunk.getCachedLayoutInfo(wctx.text_buffer.tabWidth(), wctx.text_buffer.widthMethod());
                 const layout: ?utf8.ChunkLayoutInfo = if (cached_layout) |cached|
                     cached
                 else blk: {
                     if (comptime calculation == .render) {
-                        if (chunk_bytes.len >= 1024 and chunk_bytes.len <= 64 * 1024) {
+                        if (!chunk.isAsciiOnly() and chunk_bytes.len >= 1024 and chunk_bytes.len <= 64 * 1024) {
                             break :blk wctx.text_buffer.getLayoutInfoFor(chunk) catch |err| switch (err) {
                                 error.OutOfMemory => null,
                                 else => {

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -11,7 +11,6 @@ const TextSelection = tb.TextSelection;
 pub const WrapMode = tb.WrapMode;
 const TextChunk = seg_mod.TextChunk;
 const StyleSpan = tb.StyleSpan;
-const GraphemeInfo = seg_mod.GraphemeInfo;
 
 pub const TextBufferViewError = error{
     OutOfMemory,
@@ -134,10 +133,24 @@ pub const VirtualLineSpanInfo = struct {
 };
 
 pub const VirtualChunk = struct {
-    grapheme_start: u32,
-    width: u32,
-    // Direct reference to source chunk for rendering
     chunk: *const TextChunk,
+    byte_start_in_chunk: u32,
+    byte_len: u32,
+    col_start_in_chunk: u32,
+    width_cols: u32,
+};
+
+const PendingWordPiece = struct {
+    column_start: u32,
+    width: u32,
+    byte_start: u32,
+    byte_end: u32,
+    chunk: *const TextChunk,
+};
+
+const PendingWordPieceFit = struct {
+    width: u32,
+    bytes_used: u32,
 };
 
 pub const VirtualLine = struct {
@@ -166,6 +179,15 @@ pub const VirtualLine = struct {
     pub fn deinit(self: *VirtualLine, allocator: Allocator) void {
         self.chunks.deinit(allocator);
         self.* = undefined;
+    }
+
+    fn appendChunk(self: *VirtualLine, allocator: Allocator, chunk: VirtualChunk) Allocator.Error!void {
+        if (self.chunks.capacity == 0) {
+            try self.chunks.ensureTotalCapacityPrecise(allocator, 1);
+        } else if (self.chunks.items.len == self.chunks.capacity) {
+            try self.chunks.ensureUnusedCapacity(allocator, 1);
+        }
+        self.chunks.appendAssumeCapacity(chunk);
     }
 };
 
@@ -361,53 +383,7 @@ pub const UnifiedTextBufferView = struct {
         }
     }
 
-    fn calculateChunkFitWord(self: *const Self, chunk: *const TextChunk, char_offset_in_chunk: u32, max_width: u32) tb.ChunkFitResult {
-        if (max_width == 0) return .{ .char_count = 0, .width = 0 };
-
-        const total_width = @as(u32, chunk.width) - char_offset_in_chunk;
-        if (total_width == 0) return .{ .char_count = 0, .width = 0 };
-        if (total_width <= max_width) return .{ .char_count = total_width, .width = total_width };
-
-        const wrap_offsets = self.text_buffer.getWrapOffsetsFor(chunk) catch {
-            const fit_width = @min(max_width, total_width);
-            return .{ .char_count = fit_width, .width = fit_width };
-        };
-
-        var last_boundary: ?u32 = null;
-        var first_boundary: ?u32 = null;
-
-        for (wrap_offsets) |wrap_break| {
-            const offset = @as(u32, wrap_break.char_offset);
-            if (offset < char_offset_in_chunk) continue;
-
-            const local_offset = offset - char_offset_in_chunk;
-            if (local_offset >= total_width) break;
-
-            const width_to_boundary = local_offset + 1;
-            if (first_boundary == null) first_boundary = width_to_boundary;
-
-            if (width_to_boundary <= max_width) {
-                last_boundary = width_to_boundary;
-            } else break;
-        }
-
-        if (last_boundary) |width| return .{ .char_count = width, .width = width };
-
-        const line_width = self.wrap_width orelse max_width;
-        const needs_force_break = (first_boundary orelse total_width) > line_width;
-
-        if (needs_force_break) {
-            const fit_width = @min(max_width, total_width);
-            return .{ .char_count = fit_width, .width = fit_width };
-        }
-
-        return .{ .char_count = 0, .width = 0 };
-    }
-
-    pub fn updateVirtualLines(self: *Self) void {
-        const buffer_dirty = self.text_buffer.isViewDirty(self.view_id);
-        if (!self.virtual_lines_dirty and !buffer_dirty) return;
-
+    fn resetVirtualLineStorage(self: *Self) void {
         _ = self.virtual_lines_arena.reset(.free_all);
         self.virtual_lines = .empty;
         self.cached_line_starts = .empty;
@@ -417,6 +393,13 @@ pub const UnifiedTextBufferView = struct {
         self.cached_line_first_vline = .empty;
         self.cached_line_vline_counts = .empty;
         self.truncation_applied = false;
+    }
+
+    pub fn updateVirtualLines(self: *Self) void {
+        const buffer_dirty = self.text_buffer.isViewDirty(self.view_id);
+        if (!self.virtual_lines_dirty and !buffer_dirty) return;
+
+        self.resetVirtualLineStorage();
         const virtual_allocator = self.virtual_lines_arena.allocator();
 
         // Create output structure for the generic function
@@ -430,15 +413,18 @@ pub const UnifiedTextBufferView = struct {
             .cached_line_vline_counts = &self.cached_line_vline_counts,
         };
 
-        // Call the generic calculation function
-        calculateVirtualLinesGeneric(
-            virtual_allocator,
-            self.text_buffer,
-            self.wrap_mode,
-            self.wrap_width,
-            self.first_line_offset,
-            output,
-        );
+        const calculated = if (self.wrap_mode == .none or self.wrap_width == null)
+            calculateUnwrappedVirtualLines(virtual_allocator, self.text_buffer, output)
+        else switch (self.wrap_mode) {
+            .none => unreachable,
+            .char => calculateVirtualLinesGeneric(.render, .char, virtual_allocator, self.text_buffer, self.wrap_width.?, self.first_line_offset, output),
+            .word => calculateVirtualLinesGeneric(.render, .word, virtual_allocator, self.text_buffer, self.wrap_width.?, self.first_line_offset, output),
+        };
+        if (!calculated) {
+            self.resetVirtualLineStorage();
+            self.virtual_lines_dirty = true;
+            return;
+        }
 
         self.virtual_lines_dirty = false;
         self.text_buffer.clearViewDirty(self.view_id);
@@ -544,25 +530,11 @@ pub const UnifiedTextBufferView = struct {
 
         if (vline_count == 0) return first_vline_idx;
 
-        var i: u32 = 0;
+        var i: u32 = 1;
         while (i < vline_count) : (i += 1) {
             const vline_idx = first_vline_idx + i;
             if (vline_idx >= vlines.len) break;
-
-            const vline = &vlines[vline_idx];
-            const vline_start_col = vline.source_col_offset;
-            const vline_end_col = vline_start_col + vline.width_cols;
-
-            const is_last_vline = (i == vline_count - 1);
-
-            // For the end check: use < for all lines except the last line where we use <=
-            // This ensures that a position exactly at vline_end_col goes to the NEXT line
-            // unless this is the last line (where there is no next line)
-            const end_check = if (is_last_vline) logical_col <= vline_end_col else logical_col < vline_end_col;
-
-            if (logical_col >= vline_start_col and end_check) {
-                return vline_idx;
-            }
+            if (logical_col < vlines[vline_idx].source_col_offset) return vline_idx - 1;
         }
 
         // If not found, return last virtual line for this logical line
@@ -793,7 +765,7 @@ pub const UnifiedTextBufferView = struct {
 
         self.updateVirtualLines();
         if (self.truncate and self.viewport != null) {
-            self.applyTruncation();
+            self.ensureTruncation();
         }
 
         const focus_above = focusY < 0;
@@ -1088,7 +1060,7 @@ pub const UnifiedTextBufferView = struct {
             return last_vline.col_offset + last_vline.truncation_suffix_start + (last_vline.width_cols -| last_vline.ellipsis_pos -| 3);
         }
 
-        return last_vline.col_offset + last_vline.width_cols;
+        return self.text_buffer.rope().totalWeight();
     }
 
     /// Cell occupancy clamps wrap padding to the last cell. Boundary occupancy
@@ -1142,6 +1114,24 @@ pub const UnifiedTextBufferView = struct {
             } else if (localX_u32 >= vline.ellipsis_pos + ellipsis_width) {
                 const suffix_offset = localX_u32 - vline.ellipsis_pos - ellipsis_width;
                 localX = @intCast(vline.truncation_suffix_start + suffix_offset);
+            }
+        }
+
+        if (!vline.is_truncated and localX == @as(i32, @intCast(vline.width_cols))) {
+            const rendered_source_end = vline.source_col_offset + vline.width_cols;
+            const next_idx = vline_idx + 1;
+            const has_next_same_source = next_idx < self.virtual_lines.items.len and
+                self.virtual_lines.items[next_idx].source_line == vline.source_line;
+            if (has_next_same_source and
+                self.virtual_lines.items[next_idx].source_col_offset > rendered_source_end)
+            {
+                return self.virtual_lines.items[next_idx].col_offset;
+            }
+            if (!has_next_same_source) {
+                const logical_line_width = self.text_buffer.lineWidthAt(@intCast(vline.source_line));
+                if (logical_line_width > rendered_source_end) {
+                    return lineStart - vline.source_col_offset + logical_line_width;
+                }
             }
         }
 
@@ -1227,27 +1217,89 @@ pub const UnifiedTextBufferView = struct {
             return;
         }
 
-        self.applyTruncation();
+        if (!self.applyTruncation()) {
+            self.truncation_applied = false;
+            return;
+        }
         self.truncation_applied = true;
         self.truncation_epoch = epoch;
         self.truncation_viewport = self.viewport;
     }
 
-    fn applyTruncation(self: *Self) void {
-        const vp = self.viewport orelse return;
-        if (vp.width == 0) return;
+    fn applyTruncation(self: *Self) bool {
+        const vp = self.viewport orelse return true;
+        if (vp.width == 0) return true;
 
         const ellipsis_width: u32 = 3;
 
-        for (self.virtual_lines.items) |*vline| {
+        const keepChunkPrefix = struct {
+            fn apply(view: *Self, chunk: VirtualChunk, keep_cols: u32) ?VirtualChunk {
+                if (keep_cols == 0) return null;
+                if (keep_cols >= chunk.width_cols) return chunk;
+
+                const bytes = chunk.chunk.getBytes(view.text_buffer.memRegistry());
+                const window = bytes[chunk.byte_start_in_chunk .. chunk.byte_start_in_chunk + chunk.byte_len];
+                const fit = utf8.findWrapPosByWidthGraphemeSafe(
+                    window,
+                    keep_cols,
+                    view.text_buffer.tabWidth(),
+                    (chunk.chunk.flags & TextChunk.Flags.ASCII_ONLY) != 0,
+                    view.text_buffer.widthMethod(),
+                );
+                if (fit.byte_offset == 0 or fit.columns_used == 0) return null;
+
+                var partial = chunk;
+                partial.byte_len = fit.byte_offset;
+                partial.width_cols = fit.columns_used;
+                return partial;
+            }
+        }.apply;
+
+        const dropChunkPrefix = struct {
+            fn apply(view: *Self, chunk: VirtualChunk, drop_cols: u32) ?VirtualChunk {
+                if (drop_cols == 0) return chunk;
+                if (drop_cols >= chunk.width_cols) return null;
+
+                const bytes = chunk.chunk.getBytes(view.text_buffer.memRegistry());
+                const window = bytes[chunk.byte_start_in_chunk .. chunk.byte_start_in_chunk + chunk.byte_len];
+                const dropped = utf8.findPosByWidthGraphemeSafe(
+                    window,
+                    drop_cols,
+                    view.text_buffer.tabWidth(),
+                    (chunk.chunk.flags & TextChunk.Flags.ASCII_ONLY) != 0,
+                    true,
+                    view.text_buffer.widthMethod(),
+                );
+                if (dropped.byte_offset >= chunk.byte_len or dropped.columns_used >= chunk.width_cols) return null;
+
+                var partial = chunk;
+                partial.byte_start_in_chunk += dropped.byte_offset;
+                partial.byte_len -= dropped.byte_offset;
+                partial.col_start_in_chunk += dropped.columns_used;
+                partial.width_cols -= dropped.columns_used;
+                return partial;
+            }
+        }.apply;
+
+        const Replacement = struct {
+            active: bool = false,
+            chunks: std.ArrayListUnmanaged(VirtualChunk) = .empty,
+            width_cols: u32 = 0,
+            is_truncated: bool = false,
+            ellipsis_pos: u32 = 0,
+            truncation_suffix_start: u32 = 0,
+        };
+        const replacements = self.global_allocator.alloc(Replacement, self.virtual_lines.items.len) catch return false;
+        defer self.global_allocator.free(replacements);
+        @memset(replacements, .{});
+        const arena_allocator = self.virtual_lines_arena.allocator();
+
+        for (self.virtual_lines.items, replacements) |vline, *replacement| {
             if (vline.width_cols <= vp.width) continue;
+            replacement.active = true;
 
             if (vp.width <= ellipsis_width) {
-                vline.chunks.clearRetainingCapacity();
-                vline.width_cols = 0;
-                vline.is_truncated = true;
-                vline.ellipsis_pos = 0;
-                vline.truncation_suffix_start = vline.width_cols;
+                replacement.is_truncated = true;
                 continue;
             }
 
@@ -1255,62 +1307,76 @@ pub const UnifiedTextBufferView = struct {
             const prefix_width = available_width / 2;
             const suffix_width = available_width - prefix_width;
 
-            var new_chunks: std.ArrayListUnmanaged(VirtualChunk) = .empty;
-
             var prefix_accumulated: u32 = 0;
             for (vline.chunks.items) |chunk| {
                 if (prefix_accumulated >= prefix_width) break;
 
                 const space_left = prefix_width - prefix_accumulated;
-                if (chunk.width <= space_left) {
-                    new_chunks.append(self.virtual_lines_arena.allocator(), chunk) catch return;
-                    prefix_accumulated += chunk.width;
+                if (chunk.width_cols <= space_left) {
+                    replacement.chunks.append(arena_allocator, chunk) catch return false;
+                    prefix_accumulated += chunk.width_cols;
                 } else {
-                    var partial = chunk;
-                    partial.width = space_left;
-                    new_chunks.append(self.virtual_lines_arena.allocator(), partial) catch return;
-                    prefix_accumulated += space_left;
+                    if (keepChunkPrefix(self, chunk, space_left)) |partial| {
+                        replacement.chunks.append(arena_allocator, partial) catch return false;
+                        prefix_accumulated += partial.width_cols;
+                    }
                     break;
                 }
             }
 
-            new_chunks.append(self.virtual_lines_arena.allocator(), .{
-                .grapheme_start = 0,
-                .width = ellipsis_width,
+            replacement.chunks.append(arena_allocator, .{
                 .chunk = &self.ellipsis_chunk,
-            }) catch return;
+                .byte_start_in_chunk = 0,
+                .byte_len = self.ellipsis_chunk.byte_end - self.ellipsis_chunk.byte_start,
+                .col_start_in_chunk = 0,
+                .width_cols = ellipsis_width,
+            }) catch return false;
 
             const suffix_start_pos = vline.width_cols - suffix_width;
 
             var pos_accumulated: u32 = 0;
+            var suffix_accumulated: u32 = 0;
+            var actual_suffix_start: ?u32 = null;
             for (vline.chunks.items) |chunk| {
-                const chunk_end = pos_accumulated + chunk.width;
+                const chunk_end = pos_accumulated + chunk.width_cols;
 
                 if (chunk_end <= suffix_start_pos) {
-                    pos_accumulated += chunk.width;
+                    pos_accumulated += chunk.width_cols;
                     continue;
                 }
 
                 if (pos_accumulated >= suffix_start_pos) {
-                    new_chunks.append(self.virtual_lines_arena.allocator(), chunk) catch return;
+                    replacement.chunks.append(arena_allocator, chunk) catch return false;
+                    if (actual_suffix_start == null) actual_suffix_start = pos_accumulated;
+                    suffix_accumulated += chunk.width_cols;
                 } else {
-                    const offset_in_chunk = suffix_start_pos - pos_accumulated;
-                    var partial = chunk;
-                    partial.grapheme_start += offset_in_chunk;
-                    partial.width = chunk.width - offset_in_chunk;
-                    new_chunks.append(self.virtual_lines_arena.allocator(), partial) catch return;
+                    if (dropChunkPrefix(self, chunk, suffix_start_pos - pos_accumulated)) |partial| {
+                        replacement.chunks.append(arena_allocator, partial) catch return false;
+                        if (actual_suffix_start == null) {
+                            actual_suffix_start = pos_accumulated + partial.col_start_in_chunk - chunk.col_start_in_chunk;
+                        }
+                        suffix_accumulated += partial.width_cols;
+                    }
                 }
 
-                pos_accumulated += chunk.width;
+                pos_accumulated += chunk.width_cols;
             }
 
-            vline.chunks.clearRetainingCapacity();
-            vline.chunks.appendSlice(self.virtual_lines_arena.allocator(), new_chunks.items) catch return;
-            vline.width_cols = vp.width;
-            vline.is_truncated = true;
-            vline.ellipsis_pos = prefix_width;
-            vline.truncation_suffix_start = suffix_start_pos;
+            replacement.width_cols = prefix_accumulated + ellipsis_width + suffix_accumulated;
+            replacement.is_truncated = true;
+            replacement.ellipsis_pos = prefix_accumulated;
+            replacement.truncation_suffix_start = actual_suffix_start orelse replacement.width_cols;
         }
+
+        for (self.virtual_lines.items, replacements) |*vline, replacement| {
+            if (!replacement.active) continue;
+            vline.chunks = replacement.chunks;
+            vline.width_cols = replacement.width_cols;
+            vline.is_truncated = replacement.is_truncated;
+            vline.ellipsis_pos = replacement.ellipsis_pos;
+            vline.truncation_suffix_start = replacement.truncation_suffix_start;
+        }
+        return true;
     }
 
     /// Measure dimensions for given width/height WITHOUT modifying virtual lines cache
@@ -1360,48 +1426,13 @@ pub const UnifiedTextBufferView = struct {
         _ = self.measure_arena.reset(.retain_capacity);
         const measure_allocator = self.measure_arena.allocator();
 
-        // Create temporary output structures
-        var temp_virtual_lines: std.ArrayListUnmanaged(VirtualLine) = .empty;
-        var temp_line_starts: std.ArrayListUnmanaged(u32) = .empty;
-        var temp_line_widths: std.ArrayListUnmanaged(u32) = .empty;
-        var temp_line_sources: std.ArrayListUnmanaged(u32) = .empty;
-        var temp_line_wrap_indices: std.ArrayListUnmanaged(u32) = .empty;
-        var temp_line_first_vline: std.ArrayListUnmanaged(u32) = .empty;
-        var temp_line_vline_counts: std.ArrayListUnmanaged(u32) = .empty;
-
-        const output: VirtualLineOutput = .{
-            .virtual_lines = &temp_virtual_lines,
-            .cached_line_starts = &temp_line_starts,
-            .cached_line_widths = &temp_line_widths,
-            .cached_line_sources = &temp_line_sources,
-            .cached_line_wrap_indices = &temp_line_wrap_indices,
-            .cached_line_first_vline = &temp_line_first_vline,
-            .cached_line_vline_counts = &temp_line_vline_counts,
+        var result: MeasureResult = .{ .line_count = 0, .width_cols_max = 0 };
+        const calculated = switch (self.wrap_mode) {
+            .none => unreachable,
+            .char => calculateVirtualLinesGeneric(.measure, .char, measure_allocator, self.text_buffer, width, self.first_line_offset, &result),
+            .word => calculateVirtualLinesGeneric(.measure, .word, measure_allocator, self.text_buffer, width, self.first_line_offset, &result),
         };
-
-        // Use width for wrap calculation
-        const wrap_width_for_measure = if (self.wrap_mode != .none and width > 0) width else null;
-
-        // Call generic calculation with temporary structures
-        calculateVirtualLinesGeneric(
-            measure_allocator,
-            self.text_buffer,
-            self.wrap_mode,
-            wrap_width_for_measure,
-            self.first_line_offset,
-            output,
-        );
-
-        // Calculate max width from temp structures
-        var width_cols_max: u32 = 0;
-        for (temp_line_widths.items) |w| {
-            width_cols_max = @max(width_cols_max, w);
-        }
-
-        const result: MeasureResult = .{
-            .line_count = @intCast(temp_virtual_lines.items.len),
-            .width_cols_max = width_cols_max,
-        };
+        if (!calculated) return TextBufferViewError.OutOfMemory;
 
         self.cached_measure_width = width;
         self.cached_measure_wrap_mode = self.wrap_mode;
@@ -1413,419 +1444,772 @@ pub const UnifiedTextBufferView = struct {
         return result;
     }
 
-    /// Generic virtual line calculation that writes to provided output structures
-    fn calculateVirtualLinesGeneric(
+    const CalculationMode = enum { render, measure };
+
+    fn calculateUnwrappedVirtualLines(
         allocator: Allocator,
         text_buffer: *UnifiedTextBuffer,
-        wrap_mode: WrapMode,
-        wrap_width: ?u32,
-        first_line_offset: u32,
         output: VirtualLineOutput,
-    ) void {
-        if (wrap_mode == .none or wrap_width == null) {
-            // No wrapping - create 1:1 mapping to real lines
-            const Context = struct {
-                text_buffer: *UnifiedTextBuffer,
-                allocator: Allocator,
-                output: VirtualLineOutput,
-                current_vline: ?VirtualLine = null,
+    ) bool {
+        // No wrapping - create 1:1 mapping to real lines
+        const Context = struct {
+            text_buffer: *UnifiedTextBuffer,
+            allocator: Allocator,
+            output: VirtualLineOutput,
+            current_vline: ?VirtualLine = null,
+            failed: bool = false,
 
-                fn segment_callback(ctx_ptr: *anyopaque, line_idx: u32, chunk: *const TextChunk, _: u32) void {
-                    _ = line_idx;
-                    const ctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
+            fn segment_callback(ctx_ptr: *anyopaque, line_idx: u32, chunk: *const TextChunk, _: u32) void {
+                _ = line_idx;
+                const ctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
+                if (ctx.failed) return;
 
-                    if (ctx.current_vline) |*vline| {
-                        vline.chunks.append(ctx.allocator, .{
-                            .grapheme_start = 0,
-                            .width = chunk.width,
-                            .chunk = chunk,
-                        }) catch {};
-                    }
+                if (ctx.current_vline) |*vline| {
+                    vline.appendChunk(ctx.allocator, .{
+                        .chunk = chunk,
+                        .byte_start_in_chunk = 0,
+                        .byte_len = chunk.byte_end - chunk.byte_start,
+                        .col_start_in_chunk = 0,
+                        .width_cols = chunk.width,
+                    }) catch {
+                        ctx.failed = true;
+                    };
                 }
+            }
 
-                fn line_end_callback(ctx_ptr: *anyopaque, line_info: iter_mod.LineInfo) void {
-                    const ctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
+            fn line_end_callback(ctx_ptr: *anyopaque, line_info: iter_mod.LineInfo) void {
+                const ctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
+                if (ctx.failed) return;
 
-                    const first_vline_idx: u32 = @intCast(ctx.output.virtual_lines.items.len);
-                    ctx.output.cached_line_first_vline.append(ctx.allocator, first_vline_idx) catch {};
-                    ctx.output.cached_line_vline_counts.append(ctx.allocator, 1) catch {};
+                const first_vline_idx: u32 = @intCast(ctx.output.virtual_lines.items.len);
+                ctx.output.cached_line_first_vline.append(ctx.allocator, first_vline_idx) catch {
+                    ctx.failed = true;
+                    return;
+                };
+                ctx.output.cached_line_vline_counts.append(ctx.allocator, 1) catch {
+                    ctx.failed = true;
+                    return;
+                };
 
-                    var vline = if (ctx.current_vline) |v| v else VirtualLine.init();
-                    vline.width_cols = line_info.width_cols;
-                    vline.col_offset = line_info.col_offset;
-                    vline.source_line = line_info.line_idx;
-                    vline.source_col_offset = 0;
+                var vline = if (ctx.current_vline) |v| v else VirtualLine.init();
+                vline.width_cols = line_info.width_cols;
+                vline.col_offset = line_info.col_offset;
+                vline.source_line = line_info.line_idx;
+                vline.source_col_offset = 0;
 
-                    ctx.output.virtual_lines.append(ctx.allocator, vline) catch {};
-                    ctx.output.cached_line_starts.append(ctx.allocator, vline.col_offset) catch {};
-                    ctx.output.cached_line_widths.append(ctx.allocator, vline.width_cols) catch {};
-                    ctx.output.cached_line_sources.append(ctx.allocator, @intCast(line_info.line_idx)) catch {};
-                    ctx.output.cached_line_wrap_indices.append(ctx.allocator, 0) catch {};
+                ctx.output.virtual_lines.append(ctx.allocator, vline) catch {
+                    ctx.failed = true;
+                    return;
+                };
+                ctx.output.cached_line_starts.append(ctx.allocator, vline.col_offset) catch {
+                    ctx.failed = true;
+                    return;
+                };
+                ctx.output.cached_line_widths.append(ctx.allocator, vline.width_cols) catch {
+                    ctx.failed = true;
+                    return;
+                };
+                ctx.output.cached_line_sources.append(ctx.allocator, @intCast(line_info.line_idx)) catch {
+                    ctx.failed = true;
+                    return;
+                };
+                ctx.output.cached_line_wrap_indices.append(ctx.allocator, 0) catch {
+                    ctx.failed = true;
+                    return;
+                };
 
-                    ctx.current_vline = VirtualLine.init();
-                }
-            };
+                ctx.current_vline = VirtualLine.init();
+            }
+        };
 
-            var ctx: Context = .{
-                .text_buffer = text_buffer,
-                .allocator = allocator,
-                .output = output,
-                .current_vline = VirtualLine.init(),
-            };
+        var ctx: Context = .{
+            .text_buffer = text_buffer,
+            .allocator = allocator,
+            .output = output,
+            .current_vline = VirtualLine.init(),
+        };
 
-            text_buffer.walkLinesAndSegments(&ctx, Context.segment_callback, Context.line_end_callback);
-        } else {
-            const wrap_w = wrap_width.?;
+        text_buffer.walkLinesAndSegments(&ctx, Context.segment_callback, Context.line_end_callback);
+        return !ctx.failed;
+    }
 
-            const WrapContext = struct {
-                text_buffer: *UnifiedTextBuffer,
-                allocator: Allocator,
-                output: VirtualLineOutput,
-                wrap_mode: WrapMode,
-                wrap_w: u32,
-                first_line_offset: u32,
-                first_line_pending: bool,
-                global_char_offset: u32 = 0,
-                line_idx: u32 = 0,
-                line_col_offset: u32 = 0,
-                line_position: u32 = 0,
-                current_vline: VirtualLine = VirtualLine.init(),
-                chunk_idx_in_line: u32 = 0,
-                current_line_first_vline_idx: u32 = 0,
-                current_line_vline_count: u32 = 0,
+    /// One wrapping policy, specialized at comptime for its output and break mode.
+    fn calculateVirtualLinesGeneric(
+        comptime calculation: CalculationMode,
+        comptime wrap_mode: WrapMode,
+        allocator: Allocator,
+        text_buffer: *UnifiedTextBuffer,
+        wrap_w: u32,
+        first_line_offset: u32,
+        result: if (calculation == .render) VirtualLineOutput else *MeasureResult,
+    ) bool {
+        comptime std.debug.assert(wrap_mode != .none);
 
-                last_wrap_chunk_count: u32 = 0,
-                last_wrap_line_position: u32 = 0,
-                last_wrap_global_offset: u32 = 0,
+        const WrapContext = struct {
+            text_buffer: *UnifiedTextBuffer,
+            allocator: Allocator,
+            result: @TypeOf(result),
+            wrap_w: u32,
+            current_wrap_width: u32,
+            global_char_offset: u32 = 0,
+            line_idx: u32 = 0,
+            line_col_offset: u32 = 0,
+            line_position: u32 = 0,
+            current_vline: if (calculation == .render) VirtualLine else void = if (calculation == .render) VirtualLine.init() else {},
+            current_line_first_vline_idx: if (calculation == .render) u32 else void = if (calculation == .render) 0 else {},
+            current_line_vline_count: if (calculation == .render) u32 else void = if (calculation == .render) 0 else {},
+            pending_word_pieces: if (wrap_mode == .word) std.ArrayListUnmanaged(PendingWordPiece) else void = if (wrap_mode == .word) .empty else {},
+            pending_word_width: if (wrap_mode == .word) u32 else void = if (wrap_mode == .word) 0 else {},
+            pending_word_last_class: if (wrap_mode == .word) utf8.WordClass else void = if (wrap_mode == .word) .other else {},
+            source_line_has_non_whitespace: if (wrap_mode == .word) bool else void = if (wrap_mode == .word) false else {},
+            word_chunk: if (wrap_mode == .word) ?*const TextChunk else void = if (wrap_mode == .word) null else {},
+            word_chunk_col_start: if (wrap_mode == .word) u32 else void = if (wrap_mode == .word) 0 else {},
+            word_chunk_byte_start: if (wrap_mode == .word) u32 else void = if (wrap_mode == .word) 0 else {},
+            deferred_measure_chunk: if (wrap_mode == .word and calculation == .measure) ?*const TextChunk else void = if (wrap_mode == .word and calculation == .measure) null else {},
+            logical_measure_line_count: if (wrap_mode == .word and calculation == .measure) u32 else void = if (wrap_mode == .word and calculation == .measure) 0 else {},
+            logical_measure_width_max: if (wrap_mode == .word and calculation == .measure) u32 else void = if (wrap_mode == .word and calculation == .measure) 0 else {},
+            failed: bool = false,
 
-                fn lineWrapWidth(wctx: *@This()) u32 {
-                    if (!wctx.first_line_pending or wctx.first_line_offset == 0 or wctx.first_line_offset >= wctx.wrap_w) {
-                        return wctx.wrap_w;
-                    }
+            fn lineWrapWidth(wctx: *@This()) u32 {
+                return wctx.current_wrap_width;
+            }
 
-                    return wctx.wrap_w - wctx.first_line_offset;
-                }
+            fn wordWrapWidth(wctx: *@This()) u32 {
+                return @max(wctx.lineWrapWidth(), 1);
+            }
 
-                fn commitVirtualLine(wctx: *@This()) void {
+            fn commitVirtualLine(wctx: *@This()) Allocator.Error!void {
+                if (comptime calculation == .render) {
                     wctx.current_vline.width_cols = wctx.line_position;
                     wctx.current_vline.source_line = wctx.line_idx;
                     wctx.current_vline.source_col_offset = wctx.line_col_offset;
-                    wctx.output.virtual_lines.append(wctx.allocator, wctx.current_vline) catch {};
-                    wctx.output.cached_line_starts.append(wctx.allocator, wctx.current_vline.col_offset) catch {};
-                    wctx.output.cached_line_widths.append(wctx.allocator, wctx.current_vline.width_cols) catch {};
-                    wctx.output.cached_line_sources.append(wctx.allocator, wctx.line_idx) catch {};
-                    wctx.output.cached_line_wrap_indices.append(wctx.allocator, wctx.current_line_vline_count) catch {};
+                }
+                try wctx.recordVirtualLine();
 
-                    wctx.current_line_vline_count += 1;
+                if (comptime calculation == .render) wctx.current_line_vline_count += 1;
 
-                    wctx.line_col_offset += wctx.line_position;
+                wctx.line_col_offset += wctx.line_position;
+                if (comptime calculation == .render) {
                     wctx.current_vline = VirtualLine.init();
                     wctx.current_vline.col_offset = wctx.global_char_offset;
-                    wctx.line_position = 0;
-                    wctx.first_line_pending = false;
-
-                    wctx.last_wrap_chunk_count = 0;
-                    wctx.last_wrap_line_position = 0;
-                    wctx.last_wrap_global_offset = 0;
                 }
+                wctx.line_position = 0;
+                wctx.current_wrap_width = wctx.wrap_w;
+            }
 
-                fn addVirtualChunk(wctx: *@This(), chunk: *const TextChunk, _: u32, start: u32, width_param: u32) void {
-                    wctx.current_vline.chunks.append(wctx.allocator, .{
-                        .grapheme_start = start,
-                        .width = width_param,
-                        .chunk = chunk,
-                    }) catch {};
-                    wctx.global_char_offset += width_param;
-                    wctx.line_position += width_param;
+            fn recordVirtualLine(wctx: *@This()) Allocator.Error!void {
+                if (comptime calculation == .measure) {
+                    wctx.result.line_count += 1;
+                    wctx.result.width_cols_max = @max(wctx.result.width_cols_max, wctx.line_position);
+                    if (comptime wrap_mode == .word) {
+                        wctx.logical_measure_line_count += 1;
+                        wctx.logical_measure_width_max = @max(wctx.logical_measure_width_max, wctx.line_position);
+                    }
+                } else {
+                    const out = wctx.result;
+                    try out.virtual_lines.append(wctx.allocator, wctx.current_vline);
+                    try out.cached_line_starts.append(wctx.allocator, wctx.current_vline.col_offset);
+                    try out.cached_line_widths.append(wctx.allocator, wctx.current_vline.width_cols);
+                    try out.cached_line_sources.append(wctx.allocator, wctx.line_idx);
+                    try out.cached_line_wrap_indices.append(wctx.allocator, wctx.current_line_vline_count);
                 }
+            }
 
-                fn segment_callback(ctx_ptr: *anyopaque, _: u32, chunk: *const TextChunk, chunk_idx_in_line: u32) void {
-                    const wctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
-                    wctx.chunk_idx_in_line = chunk_idx_in_line;
+            fn addVirtualChunk(wctx: *@This(), chunk: *const TextChunk, byte_start: u32, byte_len: u32, col_start: u32, width_cols: u32) Allocator.Error!void {
+                if (byte_len == 0) return;
 
-                    if (wctx.wrap_mode == .word) {
-                        const chunk_bytes = chunk.getBytes(wctx.text_buffer.memRegistry());
-                        const wrap_offsets = wctx.text_buffer.getWrapOffsetsFor(chunk) catch &[_]utf8.WrapBreak{};
-                        const is_ascii_only = (chunk.flags & TextChunk.Flags.ASCII_ONLY) != 0;
-                        const graphemes: []const GraphemeInfo = if (is_ascii_only)
-                            &[_]GraphemeInfo{}
-                        else
-                            chunk.getGraphemes(wctx.text_buffer.getAllocator(), wctx.text_buffer.memRegistry(), wctx.text_buffer.tabWidth(), wctx.text_buffer.widthMethod()) catch &[_]GraphemeInfo{};
-                        var grapheme_idx: usize = 0;
-                        var col_delta: i64 = 0;
-
-                        // char_offset tracks COLUMN position within the chunk (not grapheme count)
-                        // chunk.width is also in columns. The loop processes the chunk column by column.
-                        var char_offset: u32 = 0; // Column offset within chunk
-                        var byte_offset: u32 = 0;
-                        var wrap_idx: usize = 0;
-
-                        while (char_offset < chunk.width) {
-                            const line_wrap_w = wctx.lineWrapWidth();
-                            const remaining_in_chunk = chunk.width - char_offset;
-                            const remaining_on_line = if (wctx.line_position < line_wrap_w) line_wrap_w - wctx.line_position else 0;
-
-                            var last_wrap_that_fits: ?u32 = null;
-                            var saved_wrap_idx = wrap_idx;
-                            while (wrap_idx < wrap_offsets.len) : (wrap_idx += 1) {
-                                const wrap_break = wrap_offsets[wrap_idx];
-
-                                const break_info = iter_mod.charOffsetToColumn(wrap_break.char_offset, graphemes, &grapheme_idx, &col_delta);
-                                const break_col = break_info.col;
-
-                                // Skip breaks that are before our current column position in the chunk
-                                if (break_col < char_offset) continue;
-
-                                // width_to_boundary: columns needed to reach and include this break
-                                // break_col is the column where the break character starts (relative to chunk)
-                                // char_offset is our current column position (relative to chunk)
-                                // To include the break character, we need: break_col - char_offset + width
-                                const width_to_boundary = break_col - char_offset + break_info.width;
-                                if (width_to_boundary > remaining_on_line or width_to_boundary > remaining_in_chunk) {
-                                    break;
-                                }
-                                last_wrap_that_fits = width_to_boundary;
-                                saved_wrap_idx = wrap_idx + 1;
-                            }
-                            wrap_idx = saved_wrap_idx;
-
-                            var to_add: u32 = 0;
-                            var has_wrap_after: bool = false;
-
-                            if (remaining_in_chunk <= remaining_on_line) {
-                                if (last_wrap_that_fits) |boundary_w| {
-                                    const would_fill_line = wctx.line_position + remaining_in_chunk >= line_wrap_w;
-                                    if (would_fill_line and boundary_w < remaining_in_chunk) {
-                                        to_add = boundary_w;
-                                        has_wrap_after = true;
-                                    } else {
-                                        to_add = remaining_in_chunk;
-                                        has_wrap_after = true;
-                                    }
-                                } else {
-                                    to_add = remaining_in_chunk;
-                                }
-                            } else if (last_wrap_that_fits) |boundary_w| {
-                                to_add = boundary_w;
-                                has_wrap_after = true;
-                            } else if (wctx.line_position == 0) {
-                                // Use tracked byte_offset instead of recalculating from scratch (avoids O(n²))
-                                const remaining_bytes = chunk_bytes[byte_offset..];
-                                const wrap_result = utf8.findWrapPosByWidth(remaining_bytes, remaining_on_line, wctx.text_buffer.tabWidth(), is_ascii_only, wctx.text_buffer.widthMethod());
-                                to_add = wrap_result.columns_used;
-                                byte_offset += wrap_result.byte_offset;
-                                if (to_add == 0) {
-                                    to_add = 1;
-                                    const single_result = utf8.findWrapPosByWidth(remaining_bytes, 1, wctx.text_buffer.tabWidth(), is_ascii_only, wctx.text_buffer.widthMethod());
-                                    byte_offset += single_result.byte_offset;
-                                }
-                            } else if (wctx.last_wrap_chunk_count > 0 and
-                                wctx.last_wrap_chunk_count <= wctx.current_vline.chunks.items.len)
-                            {
-                                var accumulated_width: u32 = 0;
-                                for (wctx.current_vline.chunks.items[0..wctx.last_wrap_chunk_count]) |vchunk| {
-                                    accumulated_width += vchunk.width;
-                                }
-
-                                const chunks_after_wrap = wctx.current_vline.chunks.items[wctx.last_wrap_chunk_count..];
-                                var chunks_to_move_count = chunks_after_wrap.len;
-                                var split_chunk: ?VirtualChunk = null;
-
-                                if (accumulated_width > wctx.last_wrap_line_position) {
-                                    const last_chunk_idx = wctx.last_wrap_chunk_count - 1;
-                                    const last_chunk = wctx.current_vline.chunks.items[last_chunk_idx];
-                                    const overhang = accumulated_width - wctx.last_wrap_line_position;
-
-                                    split_chunk = VirtualChunk{
-                                        .grapheme_start = last_chunk.grapheme_start + last_chunk.width - overhang,
-                                        .width = overhang,
-                                        .chunk = last_chunk.chunk,
-                                    };
-
-                                    wctx.current_vline.chunks.items[last_chunk_idx].width -= overhang;
-
-                                    chunks_to_move_count += 1;
-                                }
-
-                                const saved_chunks_result = wctx.allocator.alloc(VirtualChunk, chunks_to_move_count);
-                                if (saved_chunks_result) |saved_chunks| {
-                                    var saved_idx: usize = 0;
-
-                                    if (split_chunk) |sc| {
-                                        saved_chunks[saved_idx] = sc;
-                                        saved_idx += 1;
-                                    }
-
-                                    @memcpy(saved_chunks[saved_idx..], chunks_after_wrap);
-
-                                    wctx.line_position = wctx.last_wrap_line_position;
-                                    wctx.global_char_offset = wctx.last_wrap_global_offset;
-                                    wctx.current_vline.chunks.items.len = wctx.last_wrap_chunk_count;
-
-                                    commitVirtualLine(wctx);
-
-                                    for (saved_chunks) |vchunk| {
-                                        wctx.current_vline.chunks.append(wctx.allocator, vchunk) catch {};
-                                        wctx.global_char_offset += vchunk.width;
-                                        wctx.line_position += vchunk.width;
-                                    }
-                                } else |_| {
-                                    commitVirtualLine(wctx);
-                                }
-
-                                continue;
-                            } else {
-                                commitVirtualLine(wctx);
-                                if (char_offset > 0) {
-                                    const pos_result = utf8.findPosByWidth(chunk_bytes, char_offset, wctx.text_buffer.tabWidth(), is_ascii_only, false, wctx.text_buffer.widthMethod());
-                                    byte_offset = pos_result.byte_offset;
-                                }
-                                const remaining_bytes = chunk_bytes[byte_offset..];
-                                const wrap_result = utf8.findWrapPosByWidth(remaining_bytes, wctx.lineWrapWidth(), wctx.text_buffer.tabWidth(), is_ascii_only, wctx.text_buffer.widthMethod());
-                                to_add = wrap_result.columns_used;
-                                byte_offset += wrap_result.byte_offset;
-                                if (to_add == 0) {
-                                    to_add = 1;
-                                    const single_result = utf8.findWrapPosByWidth(remaining_bytes, 1, wctx.text_buffer.tabWidth(), is_ascii_only, wctx.text_buffer.widthMethod());
-                                    byte_offset += single_result.byte_offset;
-                                }
-                            }
-
-                            if (to_add > 0) {
-                                const position_before_add = wctx.line_position;
-                                const offset_before_add = wctx.global_char_offset;
-
-                                addVirtualChunk(wctx, chunk, chunk_idx_in_line, char_offset, to_add);
-                                char_offset += to_add;
-
-                                if (has_wrap_after) {
-                                    const wrap_pos_in_added = if (last_wrap_that_fits) |boundary_w|
-                                        @min(boundary_w, to_add)
-                                    else
-                                        to_add;
-
-                                    wctx.last_wrap_chunk_count = @intCast(wctx.current_vline.chunks.items.len);
-                                    wctx.last_wrap_line_position = position_before_add + wrap_pos_in_added;
-                                    wctx.last_wrap_global_offset = offset_before_add + wrap_pos_in_added;
-                                }
-
-                                if (wctx.line_position >= line_wrap_w and char_offset < chunk.width) {
-                                    if (has_wrap_after or wctx.last_wrap_chunk_count > 0) {
-                                        commitVirtualLine(wctx);
-                                    }
-                                }
-                            }
-                        }
-                    } else {
-                        const chunk_bytes = chunk.getBytes(wctx.text_buffer.memRegistry());
-                        const is_ascii_only = (chunk.flags & TextChunk.Flags.ASCII_ONLY) != 0;
-                        var byte_offset: usize = 0;
-                        var char_offset: u32 = 0;
-
-                        while (char_offset < chunk.width) {
-                            const line_wrap_w = wctx.lineWrapWidth();
-                            const remaining_width = if (wctx.line_position < line_wrap_w) line_wrap_w - wctx.line_position else 0;
-
-                            if (remaining_width == 0) {
-                                if (wctx.line_position > 0) {
-                                    commitVirtualLine(wctx);
-                                    continue;
-                                }
-                                const remaining_bytes = chunk_bytes[byte_offset..];
-                                const force_result = utf8.findWrapPosByWidth(remaining_bytes, 1, wctx.text_buffer.tabWidth(), is_ascii_only, wctx.text_buffer.widthMethod());
-                                if (force_result.grapheme_count > 0) {
-                                    addVirtualChunk(wctx, chunk, chunk_idx_in_line, char_offset, force_result.columns_used);
-                                    char_offset += force_result.columns_used;
-                                    byte_offset += force_result.byte_offset;
-                                } else {
-                                    break;
-                                }
-                                continue;
-                            }
-
-                            const remaining_bytes = chunk_bytes[byte_offset..];
-                            const wrap_result = utf8.findWrapPosByWidth(
-                                remaining_bytes,
-                                remaining_width,
-                                wctx.text_buffer.tabWidth(),
-                                is_ascii_only,
-                                wctx.text_buffer.widthMethod(),
-                            );
-
-                            if (wrap_result.grapheme_count == 0) {
-                                if (wctx.line_position > 0) {
-                                    commitVirtualLine(wctx);
-                                    continue;
-                                }
-                                const force_result = utf8.findWrapPosByWidth(remaining_bytes, 1000, wctx.text_buffer.tabWidth(), is_ascii_only, wctx.text_buffer.widthMethod());
-                                if (force_result.grapheme_count > 0) {
-                                    addVirtualChunk(wctx, chunk, chunk_idx_in_line, char_offset, force_result.columns_used);
-                                    char_offset += force_result.columns_used;
-                                    byte_offset += force_result.byte_offset;
-                                    if (char_offset < chunk.width) {
-                                        commitVirtualLine(wctx);
-                                    }
-                                }
-                                break;
-                            }
-
-                            addVirtualChunk(wctx, chunk, chunk_idx_in_line, char_offset, wrap_result.columns_used);
-                            char_offset += wrap_result.columns_used;
-                            byte_offset += wrap_result.byte_offset;
-
-                            if (wctx.line_position >= line_wrap_w and char_offset < chunk.width) {
-                                commitVirtualLine(wctx);
-                            }
+                if (comptime calculation == .render and wrap_mode == .word) {
+                    if (wctx.current_vline.chunks.items.len > 0) {
+                        const last = &wctx.current_vline.chunks.items[wctx.current_vline.chunks.items.len - 1];
+                        if (last.chunk == chunk and
+                            last.byte_start_in_chunk + last.byte_len == byte_start and
+                            last.col_start_in_chunk + last.width_cols == col_start)
+                        {
+                            last.byte_len += byte_len;
+                            last.width_cols += width_cols;
+                            wctx.global_char_offset += width_cols;
+                            wctx.line_position += width_cols;
+                            return;
                         }
                     }
                 }
 
-                fn line_end_callback(ctx_ptr: *anyopaque, line_info: iter_mod.LineInfo) void {
-                    const wctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
+                if (comptime calculation == .render) {
+                    try wctx.current_vline.appendChunk(wctx.allocator, .{
+                        .chunk = chunk,
+                        .byte_start_in_chunk = byte_start,
+                        .byte_len = byte_len,
+                        .col_start_in_chunk = col_start,
+                        .width_cols = width_cols,
+                    });
+                }
+                wctx.global_char_offset += width_cols;
+                wctx.line_position += width_cols;
+            }
 
-                    if (wctx.current_vline.chunks.items.len > 0 or line_info.width_cols == 0) {
+            fn addVirtualChunkSticky(wctx: *@This(), chunk: *const TextChunk, byte_start: u32, byte_len: u32, col_start: u32, width_cols: u32) bool {
+                addVirtualChunk(wctx, chunk, byte_start, byte_len, col_start, width_cols) catch {
+                    wctx.failed = true;
+                    return false;
+                };
+                return true;
+            }
+
+            fn commitVirtualLineSticky(wctx: *@This()) bool {
+                commitVirtualLine(wctx) catch {
+                    wctx.failed = true;
+                    return false;
+                };
+                return true;
+            }
+
+            fn consumeDroppedWhitespace(wctx: *@This(), width: u32) void {
+                wctx.global_char_offset += width;
+                wctx.line_col_offset += width;
+                if (comptime calculation == .render) wctx.current_vline.col_offset = wctx.global_char_offset;
+            }
+
+            fn queuePendingWordPiece(wctx: *@This(), chunk: *const TextChunk, start: u32, width: u32, byte_start: u32, byte_end: u32) void {
+                if (width == 0 or wctx.failed) return;
+
+                if (wctx.pending_word_pieces.items.len > 0) {
+                    const last = &wctx.pending_word_pieces.items[wctx.pending_word_pieces.items.len - 1];
+                    if (last.chunk == chunk and last.column_start + last.width == start and last.byte_end == byte_start) {
+                        last.width += width;
+                        last.byte_end = byte_end;
+                        wctx.pending_word_width += width;
+                        return;
+                    }
+                }
+
+                wctx.pending_word_pieces.append(wctx.allocator, .{
+                    .column_start = start,
+                    .width = width,
+                    .byte_start = byte_start,
+                    .byte_end = byte_end,
+                    .chunk = chunk,
+                }) catch {
+                    wctx.failed = true;
+                    return;
+                };
+                wctx.pending_word_width += width;
+            }
+
+            fn clearPendingWord(wctx: *@This()) void {
+                wctx.pending_word_pieces.clearRetainingCapacity();
+                wctx.pending_word_width = 0;
+                wctx.pending_word_last_class = .other;
+            }
+
+            fn dropPendingWordPrefix(wctx: *@This(), count: usize) void {
+                if (count == 0) return;
+                const remaining = wctx.pending_word_pieces.items.len - count;
+                if (remaining > 0) {
+                    std.mem.copyForwards(
+                        PendingWordPiece,
+                        wctx.pending_word_pieces.items[0..remaining],
+                        wctx.pending_word_pieces.items[count..],
+                    );
+                }
+                wctx.pending_word_pieces.items.len = remaining;
+            }
+
+            fn fitPendingWordPiece(wctx: *@This(), piece: PendingWordPiece, max_width: u32, allow_forced_grapheme: bool) PendingWordPieceFit {
+                if (piece.width <= max_width) {
+                    return .{ .width = piece.width, .bytes_used = piece.byte_end - piece.byte_start };
+                }
+                if (max_width == 0) return .{ .width = 0, .bytes_used = 0 };
+
+                const chunk_bytes = piece.chunk.getBytes(wctx.text_buffer.memRegistry());
+                if (piece.byte_start > piece.byte_end or piece.byte_end > chunk_bytes.len) {
+                    wctx.failed = true;
+                    return .{ .width = 0, .bytes_used = 0 };
+                }
+                const slice_bytes = chunk_bytes[piece.byte_start..piece.byte_end];
+                const is_ascii_only = (piece.chunk.flags & TextChunk.Flags.ASCII_ONLY) != 0;
+                const fit = utf8.findWrapPosByWidthGraphemeSafe(
+                    slice_bytes,
+                    max_width,
+                    wctx.text_buffer.tabWidth(),
+                    is_ascii_only,
+                    wctx.text_buffer.widthMethod(),
+                );
+                if (fit.columns_used > 0 and fit.byte_offset > 0) {
+                    return .{
+                        .width = @min(fit.columns_used, piece.width),
+                        .bytes_used = @min(fit.byte_offset, piece.byte_end - piece.byte_start),
+                    };
+                }
+
+                if (!allow_forced_grapheme) return .{ .width = 0, .bytes_used = 0 };
+
+                const forced = utf8.findPosByWidthGraphemeSafe(
+                    slice_bytes,
+                    max_width,
+                    wctx.text_buffer.tabWidth(),
+                    is_ascii_only,
+                    true,
+                    wctx.text_buffer.widthMethod(),
+                );
+                if (forced.columns_used == 0 or forced.byte_offset == 0) {
+                    wctx.failed = true;
+                    return .{ .width = 0, .bytes_used = 0 };
+                }
+                return .{
+                    .width = @min(forced.columns_used, piece.width),
+                    .bytes_used = @min(forced.byte_offset, piece.byte_end - piece.byte_start),
+                };
+            }
+
+            fn consumePendingWordPrefix(wctx: *@This(), max_width: u32) bool {
+                if (max_width == 0 or wctx.pending_word_width == 0 or wctx.failed) return false;
+
+                const line_before = wctx.line_position;
+                var remaining = max_width;
+                var consumed_count: usize = 0;
+                while (consumed_count < wctx.pending_word_pieces.items.len and remaining > 0) {
+                    const piece = wctx.pending_word_pieces.items[consumed_count];
+                    if (piece.width <= remaining) {
+                        if (!addVirtualChunkSticky(wctx, piece.chunk, piece.byte_start, piece.byte_end - piece.byte_start, piece.column_start, piece.width)) return false;
+                        remaining -= piece.width;
+                        consumed_count += 1;
+                        continue;
+                    }
+
+                    const fit = fitPendingWordPiece(wctx, piece, remaining, wctx.line_position == line_before);
+                    if (fit.width == 0) break;
+                    if (!addVirtualChunkSticky(wctx, piece.chunk, piece.byte_start, fit.bytes_used, piece.column_start, fit.width)) return false;
+                    wctx.pending_word_pieces.items[consumed_count].column_start += fit.width;
+                    wctx.pending_word_pieces.items[consumed_count].width -= fit.width;
+                    wctx.pending_word_pieces.items[consumed_count].byte_start += fit.bytes_used;
+                    if (wctx.pending_word_pieces.items[consumed_count].width == 0) consumed_count += 1;
+                    break;
+                }
+
+                dropPendingWordPrefix(wctx, consumed_count);
+                const consumed_width = wctx.line_position - line_before;
+                wctx.pending_word_width -= consumed_width;
+                return consumed_width > 0;
+            }
+
+            fn appendPendingWordToLine(wctx: *@This()) void {
+                for (wctx.pending_word_pieces.items) |piece| {
+                    if (!addVirtualChunkSticky(wctx, piece.chunk, piece.byte_start, piece.byte_end - piece.byte_start, piece.column_start, piece.width)) return;
+                }
+                clearPendingWord(wctx);
+            }
+
+            fn finalizePendingWord(wctx: *@This()) void {
+                while (wctx.pending_word_width > 0 and !wctx.failed) {
+                    const wrap_limit = wctx.wordWrapWidth();
+                    if (wctx.line_position > 0 and wctx.line_position + wctx.pending_word_width > wrap_limit) {
+                        if (!commitVirtualLineSticky(wctx)) return;
+                        continue;
+                    }
+                    if (wctx.line_position == 0 and wctx.pending_word_width > wrap_limit) {
+                        if (!consumePendingWordPrefix(wctx, wrap_limit)) return;
+                        if (wctx.pending_word_width > 0 and !commitVirtualLineSticky(wctx)) return;
+                        continue;
+                    }
+                    appendPendingWordToLine(wctx);
+                }
+            }
+
+            fn placeCompleteWordPiece(wctx: *@This(), chunk: *const TextChunk, start: u32, width: u32, byte_start: u32, byte_end: u32) void {
+                if (width == 0 or wctx.failed) return;
+
+                var piece: PendingWordPiece = .{
+                    .column_start = start,
+                    .width = width,
+                    .byte_start = byte_start,
+                    .byte_end = byte_end,
+                    .chunk = chunk,
+                };
+                while (piece.width > 0 and !wctx.failed) {
+                    const wrap_limit = wctx.wordWrapWidth();
+                    if (piece.width <= wrap_limit) {
+                        if (wctx.line_position > 0 and wctx.line_position + piece.width > wrap_limit and !commitVirtualLineSticky(wctx)) return;
+                        _ = addVirtualChunkSticky(wctx, chunk, piece.byte_start, piece.byte_end - piece.byte_start, piece.column_start, piece.width);
+                        return;
+                    }
+                    if (wctx.line_position > 0 and !commitVirtualLineSticky(wctx)) return;
+
+                    const fit = fitPendingWordPiece(wctx, piece, wctx.wordWrapWidth(), true);
+                    if (fit.width == 0) return;
+                    if (!addVirtualChunkSticky(wctx, chunk, piece.byte_start, fit.bytes_used, piece.column_start, fit.width)) return;
+                    piece.column_start += fit.width;
+                    piece.width -= fit.width;
+                    piece.byte_start += fit.bytes_used;
+                    if (piece.width > 0 and !commitVirtualLineSticky(wctx)) return;
+                }
+            }
+
+            fn flushCompleteWordPiece(wctx: *@This(), chunk: *const TextChunk, start: u32, width: u32, byte_start: u32, byte_end: u32) void {
+                if (width == 0 or wctx.failed) return;
+                if (wctx.pending_word_width > 0) {
+                    queuePendingWordPiece(wctx, chunk, start, width, byte_start, byte_end);
+                    finalizePendingWord(wctx);
+                } else {
+                    placeCompleteWordPiece(wctx, chunk, start, width, byte_start, byte_end);
+                }
+            }
+
+            fn processWhitespaceBreak(wctx: *@This(), chunk: *const TextChunk, col_start: u32, byte_start: u32, wrap_break: utf8.LayoutWrapBreak) void {
+                if (wrap_break.col_offset > col_start) {
+                    flushCompleteWordPiece(
+                        wctx,
+                        chunk,
+                        col_start,
+                        wrap_break.col_offset - col_start,
+                        byte_start,
+                        wrap_break.byte_offset,
+                    );
+                    if (wctx.failed) return;
+                    wctx.source_line_has_non_whitespace = true;
+                } else if (wctx.pending_word_width > 0) {
+                    finalizePendingWord(wctx);
+                    if (wctx.failed) return;
+                }
+
+                const preserve_leading = !wctx.source_line_has_non_whitespace;
+                const wrap_limit = wctx.wordWrapWidth();
+                if (!preserve_leading and wctx.line_position + wrap_break.width > wrap_limit) {
+                    if (wctx.line_position > 0 and !commitVirtualLineSticky(wctx)) return;
+                    consumeDroppedWhitespace(wctx, wrap_break.width);
+                    return;
+                }
+
+                if (!preserve_leading and wctx.line_position == 0) {
+                    consumeDroppedWhitespace(wctx, wrap_break.width);
+                    return;
+                }
+
+                placeCompleteWordPiece(
+                    wctx,
+                    chunk,
+                    wrap_break.col_offset,
+                    wrap_break.width,
+                    wrap_break.byte_offset,
+                    wrap_break.byteEnd(),
+                );
+            }
+
+            fn processWordWrapBreakValue(wctx: *@This(), wrap_break: utf8.LayoutWrapBreak) void {
+                const chunk = wctx.word_chunk orelse return;
+                const chunk_bytes = chunk.getBytes(wctx.text_buffer.memRegistry());
+                const col_end = @min(wrap_break.colEnd(), chunk.width);
+                const byte_end = @min(wrap_break.byteEnd(), @as(u32, @intCast(chunk_bytes.len)));
+                if (col_end < wctx.word_chunk_col_start or byte_end < wctx.word_chunk_byte_start) return;
+                if (wrap_break.kind == .whitespace) {
+                    processWhitespaceBreak(wctx, chunk, wctx.word_chunk_col_start, wctx.word_chunk_byte_start, wrap_break);
+                    if (wctx.failed) return;
+                    wctx.word_chunk_col_start = col_end;
+                    wctx.word_chunk_byte_start = byte_end;
+                    return;
+                }
+                if (col_end > wctx.word_chunk_col_start) {
+                    flushCompleteWordPiece(
+                        wctx,
+                        chunk,
+                        wctx.word_chunk_col_start,
+                        col_end - wctx.word_chunk_col_start,
+                        wctx.word_chunk_byte_start,
+                        byte_end,
+                    );
+                    if (wctx.failed) return;
+                    wctx.source_line_has_non_whitespace = true;
+                } else if (byte_end > wctx.word_chunk_byte_start and wctx.pending_word_width > 0) {
+                    finalizePendingWord(wctx);
+                    if (wctx.failed) return;
+                }
+                wctx.word_chunk_col_start = col_end;
+                wctx.word_chunk_byte_start = byte_end;
+            }
+
+            inline fn processWordWrapBreak(wctx: *@This(), wrap_break: utf8.LayoutWrapBreak) !bool {
+                processWordWrapBreakValue(wctx, wrap_break);
+                return !wctx.failed;
+            }
+
+            fn processWordChunk(wctx: *@This(), chunk: *const TextChunk) void {
+                const chunk_bytes = chunk.getBytes(wctx.text_buffer.memRegistry());
+                const cached_layout = chunk.getCachedLayoutInfo(wctx.text_buffer.tabWidth(), wctx.text_buffer.widthMethod());
+                const layout: ?utf8.ChunkLayoutInfo = if (cached_layout) |cached|
+                    cached
+                else blk: {
+                    if (comptime calculation == .render) {
+                        if (chunk_bytes.len >= 1024 and chunk_bytes.len <= 64 * 1024) {
+                            break :blk wctx.text_buffer.getLayoutInfoFor(chunk) catch |err| switch (err) {
+                                error.OutOfMemory => null,
+                                else => {
+                                    wctx.failed = true;
+                                    return;
+                                },
+                            };
+                        }
+                    }
+                    break :blk null;
+                };
+                const word_classes = if (layout) |info|
+                    utf8.WordClassEdges{ .first = info.first_word_class, .last = info.last_word_class }
+                else
+                    utf8.chunkWordClassEdges(chunk_bytes);
+                if (wctx.pending_word_width > 0 and
+                    utf8.isCjkAsciiTransition(wctx.pending_word_last_class, word_classes.first))
+                {
+                    finalizePendingWord(wctx);
+                    if (wctx.failed) return;
+                }
+                wctx.word_chunk = chunk;
+                wctx.word_chunk_col_start = 0;
+                wctx.word_chunk_byte_start = 0;
+                const last_word_class = if (layout) |info| blk: {
+                    for (info.wrap_breaks) |wrap_break| {
+                        processWordWrapBreakValue(wctx, wrap_break);
+                        if (wctx.failed) return;
+                    }
+                    break :blk info.last_word_class;
+                } else blk: {
+                    const streamed_layout = utf8.walkChunkLayoutInfoComptime(
+                        chunk_bytes,
+                        wctx.text_buffer.tabWidth(),
+                        chunk.isAsciiOnly(),
+                        wctx.text_buffer.widthMethod(),
+                        wctx,
+                        processWordWrapBreak,
+                    ) catch {
+                        wctx.failed = true;
+                        return;
+                    };
+                    break :blk streamed_layout.last;
+                };
+
+                if (wctx.word_chunk_col_start < chunk.width) {
+                    queuePendingWordPiece(
+                        wctx,
+                        chunk,
+                        wctx.word_chunk_col_start,
+                        chunk.width - wctx.word_chunk_col_start,
+                        wctx.word_chunk_byte_start,
+                        @intCast(chunk_bytes.len),
+                    );
+                    if (!wctx.failed) wctx.pending_word_last_class = last_word_class;
+                    wctx.source_line_has_non_whitespace = true;
+                }
+                wctx.word_chunk = null;
+            }
+
+            fn processCharChunk(comptime width_method: utf8.WidthMethod, wctx: *@This(), chunk: *const TextChunk) Allocator.Error!void {
+                const chunk_bytes = chunk.getBytes(wctx.text_buffer.memRegistry());
+                const is_ascii_only = (chunk.flags & TextChunk.Flags.ASCII_ONLY) != 0;
+                const tab_width = wctx.text_buffer.tabWidth();
+                var byte_offset: usize = 0;
+                var char_offset: u32 = 0;
+
+                while (char_offset < chunk.width) {
+                    const line_wrap_w = wctx.lineWrapWidth();
+                    const remaining_width = if (wctx.line_position < line_wrap_w) line_wrap_w - wctx.line_position else 0;
+
+                    if (remaining_width == 0) {
+                        if (wctx.line_position > 0) {
+                            try commitVirtualLine(wctx);
+                            continue;
+                        }
+                        const remaining_bytes = chunk_bytes[byte_offset..];
+                        const force_result = utf8.findPosByWidthGraphemeSafe(remaining_bytes, 1, tab_width, is_ascii_only, true, width_method);
+                        if (force_result.grapheme_count > 0) {
+                            try addVirtualChunk(wctx, chunk, @intCast(byte_offset), force_result.byte_offset, char_offset, force_result.columns_used);
+                            char_offset += force_result.columns_used;
+                            byte_offset += force_result.byte_offset;
+                        } else {
+                            break;
+                        }
+                        continue;
+                    }
+
+                    const remaining_bytes = chunk_bytes[byte_offset..];
+                    const wrap_result = utf8.findWrapPosByWidthGraphemeSafe(
+                        remaining_bytes,
+                        remaining_width,
+                        tab_width,
+                        is_ascii_only,
+                        width_method,
+                    );
+
+                    if (wrap_result.grapheme_count == 0) {
+                        if (wctx.line_position > 0) {
+                            try commitVirtualLine(wctx);
+                            continue;
+                        }
+                        const force_result = utf8.findPosByWidthGraphemeSafe(remaining_bytes, 1, tab_width, is_ascii_only, true, width_method);
+                        if (force_result.grapheme_count > 0) {
+                            try addVirtualChunk(wctx, chunk, @intCast(byte_offset), force_result.byte_offset, char_offset, force_result.columns_used);
+                            char_offset += force_result.columns_used;
+                            byte_offset += force_result.byte_offset;
+                            if (char_offset < chunk.width) {
+                                try commitVirtualLine(wctx);
+                                continue;
+                            }
+                        }
+                        break;
+                    }
+
+                    try addVirtualChunk(wctx, chunk, @intCast(byte_offset), wrap_result.byte_offset, char_offset, wrap_result.columns_used);
+                    char_offset += wrap_result.columns_used;
+                    byte_offset += wrap_result.byte_offset;
+
+                    if (wctx.line_position >= line_wrap_w and char_offset < chunk.width) {
+                        try commitVirtualLine(wctx);
+                    }
+                }
+            }
+
+            fn segment_callback(ctx_ptr: *anyopaque, _: u32, chunk: *const TextChunk, chunk_idx_in_line: u32) void {
+                const wctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
+                if (wctx.failed) return;
+
+                if (comptime wrap_mode == .word) {
+                    if (comptime calculation == .measure) {
+                        if (wctx.deferred_measure_chunk) |deferred| {
+                            processWordChunk(wctx, deferred);
+                            wctx.deferred_measure_chunk = null;
+                            if (wctx.failed) return;
+                        } else if (chunk_idx_in_line == 0) {
+                            wctx.deferred_measure_chunk = chunk;
+                            return;
+                        }
+                    }
+                    processWordChunk(wctx, chunk);
+                } else {
+                    const process_result = switch (wctx.text_buffer.widthMethod()) {
+                        inline else => |width_method| processCharChunk(width_method, wctx, chunk),
+                    };
+                    process_result catch {
+                        wctx.failed = true;
+                    };
+                }
+            }
+
+            fn line_end_callback(ctx_ptr: *anyopaque, line_info: iter_mod.LineInfo) void {
+                const wctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
+                if (wctx.failed) return;
+
+                var used_measure_cache = false;
+                var measure_cache_chunk: ?*const TextChunk = null;
+                var measure_cache_first_width: u32 = 0;
+                if (comptime wrap_mode == .word and calculation == .measure) {
+                    if (wctx.deferred_measure_chunk) |chunk| {
+                        wctx.deferred_measure_chunk = null;
+                        measure_cache_chunk = chunk;
+                        const first_width = wctx.lineWrapWidth();
+                        measure_cache_first_width = first_width;
+                        if (chunk.getWordMeasureSummary(
+                            wctx.wrap_w,
+                            first_width,
+                            wctx.text_buffer.tabWidth(),
+                            wctx.text_buffer.widthMethod(),
+                        )) |summary| {
+                            wctx.result.line_count += summary.line_count;
+                            wctx.result.width_cols_max = @max(wctx.result.width_cols_max, summary.width_max);
+                            wctx.global_char_offset += chunk.width;
+                            used_measure_cache = true;
+                        } else {
+                            processWordChunk(wctx, chunk);
+                            if (wctx.failed) return;
+                        }
+                    }
+                }
+
+                if (comptime wrap_mode == .word) {
+                    if (!used_measure_cache) finalizePendingWord(wctx);
+                    clearPendingWord(wctx);
+                }
+
+                const has_content = if (comptime calculation == .render)
+                    wctx.current_vline.chunks.items.len > 0
+                else
+                    wctx.line_position > 0;
+                if (!used_measure_cache and (has_content or line_info.width_cols == 0)) {
+                    if (comptime calculation == .render) {
                         wctx.current_vline.width_cols = wctx.line_position;
                         wctx.current_vline.source_line = wctx.line_idx;
                         wctx.current_vline.source_col_offset = wctx.line_col_offset;
-                        wctx.output.virtual_lines.append(wctx.allocator, wctx.current_vline) catch {};
-                        wctx.output.cached_line_starts.append(wctx.allocator, wctx.current_vline.col_offset) catch {};
-                        wctx.output.cached_line_widths.append(wctx.allocator, wctx.current_vline.width_cols) catch {};
-                        wctx.output.cached_line_sources.append(wctx.allocator, wctx.line_idx) catch {};
-                        wctx.output.cached_line_wrap_indices.append(wctx.allocator, wctx.current_line_vline_count) catch {};
-                        wctx.current_line_vline_count += 1;
                     }
+                    wctx.recordVirtualLine() catch {
+                        wctx.failed = true;
+                        return;
+                    };
+                    if (comptime calculation == .render) wctx.current_line_vline_count += 1;
+                }
 
-                    wctx.output.cached_line_first_vline.append(wctx.allocator, wctx.current_line_first_vline_idx) catch {};
-                    wctx.output.cached_line_vline_counts.append(wctx.allocator, wctx.current_line_vline_count) catch {};
+                if (comptime wrap_mode == .word and calculation == .measure) {
+                    if (!used_measure_cache) {
+                        if (measure_cache_chunk) |chunk| {
+                            chunk.setWordMeasureSummary(
+                                wctx.text_buffer.getAllocator(),
+                                wctx.wrap_w,
+                                measure_cache_first_width,
+                                wctx.text_buffer.tabWidth(),
+                                wctx.text_buffer.widthMethod(),
+                                .{
+                                    .line_count = wctx.logical_measure_line_count,
+                                    .width_max = wctx.logical_measure_width_max,
+                                },
+                            ) catch |err| switch (err) {
+                                error.OutOfMemory => {},
+                                else => {
+                                    wctx.failed = true;
+                                    return;
+                                },
+                            };
+                        }
+                    }
+                }
 
-                    wctx.global_char_offset += 1;
+                if (comptime calculation == .render) {
+                    const out = wctx.result;
+                    out.cached_line_first_vline.append(wctx.allocator, wctx.current_line_first_vline_idx) catch {
+                        wctx.failed = true;
+                        return;
+                    };
+                    out.cached_line_vline_counts.append(wctx.allocator, wctx.current_line_vline_count) catch {
+                        wctx.failed = true;
+                        return;
+                    };
+                }
 
-                    wctx.line_idx += 1;
-                    wctx.line_col_offset = 0;
-                    wctx.line_position = 0;
-                    wctx.first_line_pending = false;
+                wctx.global_char_offset += 1;
+
+                wctx.line_idx += 1;
+                wctx.line_col_offset = 0;
+                wctx.line_position = 0;
+                wctx.current_wrap_width = wctx.wrap_w;
+                if (comptime calculation == .render) {
                     wctx.current_vline = VirtualLine.init();
                     wctx.current_vline.col_offset = wctx.global_char_offset;
-                    wctx.last_wrap_chunk_count = 0;
-                    wctx.last_wrap_line_position = 0;
-                    wctx.last_wrap_global_offset = 0;
-                    wctx.chunk_idx_in_line = 0;
-                    wctx.current_line_first_vline_idx = @intCast(wctx.output.virtual_lines.items.len);
+                    wctx.current_line_first_vline_idx = @intCast(wctx.result.virtual_lines.items.len);
                     wctx.current_line_vline_count = 0;
                 }
-            };
+                if (comptime wrap_mode == .word) wctx.source_line_has_non_whitespace = false;
+                if (comptime wrap_mode == .word and calculation == .measure) {
+                    wctx.logical_measure_line_count = 0;
+                    wctx.logical_measure_width_max = 0;
+                }
+            }
+        };
 
-            var wrap_ctx: WrapContext = .{
-                .text_buffer = text_buffer,
-                .allocator = allocator,
-                .output = output,
-                .wrap_mode = wrap_mode,
-                .wrap_w = wrap_w,
-                .first_line_offset = first_line_offset,
-                .first_line_pending = first_line_offset > 0,
-            };
+        var wrap_ctx: WrapContext = .{
+            .text_buffer = text_buffer,
+            .allocator = allocator,
+            .result = result,
+            .wrap_w = wrap_w,
+            .current_wrap_width = if (first_line_offset > 0 and first_line_offset < wrap_w)
+                wrap_w - first_line_offset
+            else
+                wrap_w,
+        };
 
-            text_buffer.walkLinesAndSegments(&wrap_ctx, WrapContext.segment_callback, WrapContext.line_end_callback);
-        }
+        text_buffer.walkLinesAndSegments(&wrap_ctx, WrapContext.segment_callback, WrapContext.line_end_callback);
+        return !wrap_ctx.failed;
     }
 };

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -132,6 +132,8 @@ pub const VirtualLineSpanInfo = struct {
     col_offset: u32,
 };
 
+/// Byte and display-column windows describe the same whole-grapheme slice;
+/// columns alone cannot recover UTF-8 boundaries.
 pub const VirtualChunk = struct {
     chunk: *const TextChunk,
     byte_start_in_chunk: u32,
@@ -410,6 +412,8 @@ pub const UnifiedTextBufferView = struct {
             .word => calculateVirtualLinesGeneric(.render, .word, virtual_allocator, self.text_buffer, self.wrap_width.?, self.first_line_offset, output),
         };
         if (!calculated) {
+            // Builders append to parallel arrays; discard partial output as a unit
+            // and remain dirty so the next access can retry cleanly.
             self.resetVirtualLineStorage();
             self.virtual_lines_dirty = true;
             return;
@@ -523,6 +527,8 @@ pub const UnifiedTextBufferView = struct {
         while (i < vline_count) : (i += 1) {
             const vline_idx = first_vline_idx + i;
             if (vline_idx >= vlines.len) break;
+            // A soft-wrap boundary belongs to the following visual line. Consumed
+            // separators before its source start remain on the previous line.
             if (logical_col < vlines[vline_idx].source_col_offset) return vline_idx - 1;
         }
 
@@ -1210,6 +1216,8 @@ pub const UnifiedTextBufferView = struct {
 
         const ellipsis_width: u32 = 3;
 
+        // Truncation budgets are columns, but VirtualChunks materialize byte windows.
+        // Snap both cuts to whole graphemes so renderer bytes remain atomic.
         const keepChunkPrefix = struct {
             fn apply(view: *Self, chunk: VirtualChunk, keep_cols: u32) ?VirtualChunk {
                 if (keep_cols == 0) return null;
@@ -1267,6 +1275,7 @@ pub const UnifiedTextBufferView = struct {
             ellipsis_pos: u32 = 0,
             truncation_suffix_start: u32 = 0,
         };
+        // Stage all replacements first so OOM leaves the original layout retryable.
         const replacements = self.global_allocator.alloc(Replacement, self.virtual_lines.items.len) catch return false;
         defer self.global_allocator.free(replacements);
         @memset(replacements, .{});
@@ -1642,6 +1651,8 @@ pub const UnifiedTextBufferView = struct {
             }
 
             fn consumeDroppedWhitespace(wctx: *@This(), width: u32) void {
+                // Wrapped separators are hidden on the continuation but remain in
+                // the preceding visual line's logical source interval.
                 wctx.global_char_offset += width;
                 wctx.line_col_offset += width;
                 if (comptime calculation == .render) wctx.current_vline.col_offset = wctx.global_char_offset;
@@ -1849,6 +1860,7 @@ pub const UnifiedTextBufferView = struct {
                     if (wctx.failed) return;
                 }
 
+                // Logical-line indentation is content; only later separators may be elided.
                 const preserve_leading = !wctx.source_line_has_non_whitespace;
                 const wrap_limit = wctx.wordWrapWidth();
                 if (!preserve_leading and wctx.line_position + wrap_break.width > wrap_limit) {
@@ -1911,6 +1923,8 @@ pub const UnifiedTextBufferView = struct {
 
             fn processWordChunk(wctx: *@This(), chunk: *const TextChunk) void {
                 const chunk_bytes = chunk.getBytes(wctx.text_buffer.memRegistry());
+                // Measurement reuses caches but does not create them. Rendering caches
+                // only medium chunks; small/large scans and cache OOM stream instead.
                 const cached_layout = chunk.getCachedLayoutInfo(wctx.text_buffer.tabWidth(), wctx.text_buffer.widthMethod());
                 const layout: ?utf8.ChunkLayoutInfo = if (cached_layout) |cached|
                     cached
@@ -1984,6 +1998,8 @@ pub const UnifiedTextBufferView = struct {
                 var byte_offset: usize = 0;
                 var char_offset: u32 = 0;
 
+                // Advance bytes with columns; re-deriving each byte boundary would
+                // make repeated wraps within a long chunk quadratic.
                 while (char_offset < chunk.width) {
                     const line_wrap_w = wctx.lineWrapWidth();
                     const remaining_width = if (wctx.line_position < line_wrap_w) line_wrap_w - wctx.line_position else 0;
@@ -2048,6 +2064,8 @@ pub const UnifiedTextBufferView = struct {
 
                 if (comptime wrap_mode == .word) {
                     if (comptime calculation == .measure) {
+                        // Only an unfragmented logical line can reuse one chunk's
+                        // summary; boundaries between chunks may join words.
                         if (wctx.deferred_measure_chunk) |deferred| {
                             processWordChunk(wctx, deferred);
                             wctx.deferred_measure_chunk = null;
@@ -2123,6 +2141,7 @@ pub const UnifiedTextBufferView = struct {
                 if (comptime wrap_mode == .word and calculation == .measure) {
                     if (!used_measure_cache) {
                         if (measure_cache_chunk) |chunk| {
+                            // Summary storage is best-effort; this measurement remains valid on OOM.
                             chunk.setWordMeasureSummary(
                                 wctx.text_buffer.getAllocator(),
                                 wctx.wrap_w,
@@ -2176,6 +2195,8 @@ pub const UnifiedTextBufferView = struct {
             }
         };
 
+        // first_line_offset reduces only the initial visual-line budget;
+        // committed continuations reset to the full wrap width.
         var wrap_ctx: WrapContext = .{
             .text_buffer = text_buffer,
             .allocator = allocator,

--- a/packages/native/src/text-buffer.zig
+++ b/packages/native/src/text-buffer.zig
@@ -142,6 +142,20 @@ pub const UnifiedTextBuffer = struct {
         return &self._rope;
     }
 
+    /// Restore an undo root with metrics valid for the current tab width.
+    pub fn undo(self: *Self, meta: []const u8) ![]const u8 {
+        const previous_meta = try self._rope.undo(meta);
+        self.refreshTabWidthMetrics();
+        return previous_meta;
+    }
+
+    /// Restore a redo root with metrics valid for the current tab width.
+    pub fn redo(self: *Self) ![]const u8 {
+        const next_meta = try self._rope.redo();
+        self.refreshTabWidthMetrics();
+        return next_meta;
+    }
+
     /// Accessor: get line width at a given row.
     pub fn lineWidthAt(self: *const Self, row: u32) u32 {
         return iter_mod.lineWidthAt(@constCast(&self._rope), row);
@@ -1272,7 +1286,7 @@ pub const UnifiedTextBuffer = struct {
     /// Bring the active persistent root to the current tab-width generation.
     /// Widths and branch aggregates are derived state, so this deliberately
     /// updates shared const nodes; stale history roots are repaired when restored.
-    pub fn refreshTabWidthMetrics(self: *Self) void {
+    fn refreshTabWidthMetrics(self: *Self) void {
         if (self._rope.metricsGeneration() == self.tab_metrics_generation) return;
 
         const RefreshContext = struct {

--- a/packages/native/src/text-buffer.zig
+++ b/packages/native/src/text-buffer.zig
@@ -95,6 +95,8 @@ pub const UnifiedTextBuffer = struct {
     styled_capacity: usize,
 
     tab_width: u8,
+    tab_metrics_generation: u64,
+    tab_metrics_refresh_count: u64,
 
     pub const Defaults = struct {
         fg: ?RGBA,
@@ -196,6 +198,10 @@ pub const UnifiedTextBuffer = struct {
         return chunk.getWrapOffsets(self.allocator, &self.mem_registry, self.width_method);
     }
 
+    pub fn getLayoutInfoFor(self: *const Self, chunk: *const TextChunk) TextBufferError!seg_mod.ChunkLayoutInfo {
+        return chunk.getLayoutInfo(self.allocator, &self.mem_registry, self.tab_width, self.width_method);
+    }
+
     /// Accessor: walk all lines and segments via callbacks.
     pub fn walkLinesAndSegments(
         self: *const Self,
@@ -262,6 +268,8 @@ pub const UnifiedTextBuffer = struct {
             .styled_buffer = null,
             .styled_capacity = 0,
             .tab_width = 2,
+            .tab_metrics_generation = 1,
+            .tab_metrics_refresh_count = 0,
         };
 
         return self;
@@ -348,6 +356,7 @@ pub const UnifiedTextBuffer = struct {
     }
 
     fn markAllViewsDirty(self: *Self) void {
+        self._rope.setMetricsGeneration(self.tab_metrics_generation);
         // Increment epoch first so views see the new value when checking caches.
         // Use wrapping add for safety, though u64 won't overflow in practice.
         self.content_epoch +%= 1;
@@ -560,7 +569,7 @@ pub const UnifiedTextBuffer = struct {
             flags |= TextChunk.Flags.ASCII_ONLY;
         }
 
-        const chunk_width: u16 = @intCast(@min(65535, utf8.calculateTextWidth(chunk_bytes, self.tab_width, is_ascii, self.width_method)));
+        const chunk_width = utf8.calculateTextWidth(chunk_bytes, self.tab_width, is_ascii, self.width_method);
 
         return .{
             .mem_id = mem_id,
@@ -1251,15 +1260,51 @@ pub const UnifiedTextBuffer = struct {
         return self.tabWidth();
     }
 
-    /// Set tab width, rounding up to nearest multiple of 2 (minimum 2).
+    /// Set tab width, rounding up to an even value in the u8-safe range [2, 254].
     /// Marks all views dirty if the width actually changes, since tab width
     /// affects measured line widths and virtual line calculations.
     pub fn setTabWidth(self: *Self, width: u8) void {
-        const clamped_width = @max(2, width);
+        const clamped_width = @min(@as(u8, 254), @max(2, width));
         const new_width = if (clamped_width % 2 == 0) clamped_width else clamped_width + 1;
         if (self.tab_width == new_width) return;
         self.tab_width = new_width;
+        self.tab_metrics_generation +%= 1;
+
+        self.refreshTabWidthMetrics();
         self.markAllViewsDirty();
+    }
+
+    /// Refresh widths after switching to a persistent rope root, such as undo/redo.
+    pub fn refreshTabWidthMetrics(self: *Self) void {
+        if (self._rope.metricsGeneration() == self.tab_metrics_generation) return;
+
+        const RefreshContext = struct {
+            buffer: *Self,
+
+            fn refresh(ctx_ptr: *anyopaque, segment: *const Segment, _: u32) UnifiedRope.Node.WalkerResult {
+                const ctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
+                if (segment.asText()) |chunk| {
+                    const mutable = @constCast(chunk);
+                    const bytes = chunk.getBytes(&ctx.buffer.mem_registry);
+                    mutable.width = utf8.calculateTextWidth(
+                        bytes,
+                        ctx.buffer.tab_width,
+                        chunk.isAsciiOnly(),
+                        ctx.buffer.width_method,
+                    );
+                }
+                return .{};
+            }
+        };
+        var refresh_ctx: RefreshContext = .{ .buffer = self };
+        self._rope.walk(&refresh_ctx, RefreshContext.refresh) catch {};
+        self._rope.remeasure();
+        self._rope.setMetricsGeneration(self.tab_metrics_generation);
+        self.tab_metrics_refresh_count +%= 1;
+    }
+
+    pub fn getTabMetricsRefreshCount(self: *const Self) u64 {
+        return self.tab_metrics_refresh_count;
     }
 
     /// Debug log the rope structure using rope.toText

--- a/packages/native/src/text-buffer.zig
+++ b/packages/native/src/text-buffer.zig
@@ -97,7 +97,6 @@ pub const UnifiedTextBuffer = struct {
     // Persistent roots carry the tab-width generation used for their cached
     // chunk and branch metrics, so only stale history roots are rescanned.
     tab_metrics_generation: u64,
-    tab_metrics_refresh_count: u64,
 
     pub const Defaults = struct {
         fg: ?RGBA,
@@ -266,7 +265,6 @@ pub const UnifiedTextBuffer = struct {
             .styled_capacity = 0,
             .tab_width = 2,
             .tab_metrics_generation = 1,
-            .tab_metrics_refresh_count = 0,
         };
 
         return self;
@@ -1299,11 +1297,6 @@ pub const UnifiedTextBuffer = struct {
         self._rope.walk(&refresh_ctx, RefreshContext.refresh) catch {};
         self._rope.remeasure();
         self._rope.setMetricsGeneration(self.tab_metrics_generation);
-        self.tab_metrics_refresh_count +%= 1;
-    }
-
-    pub fn getTabMetricsRefreshCount(self: *const Self) u64 {
-        return self.tab_metrics_refresh_count;
     }
 
     /// Debug log the rope structure using rope.toText

--- a/packages/native/src/text-buffer.zig
+++ b/packages/native/src/text-buffer.zig
@@ -28,7 +28,6 @@ pub const TextBufferError = seg_mod.TextBufferError;
 pub const Highlight = seg_mod.Highlight;
 pub const StyleSpan = seg_mod.StyleSpan;
 pub const WrapMode = seg_mod.WrapMode;
-pub const ChunkFitResult = seg_mod.ChunkFitResult;
 pub const GraphemeInfo = seg_mod.GraphemeInfo;
 
 pub const SyntaxStyle = ss.SyntaxStyle;
@@ -192,10 +191,6 @@ pub const UnifiedTextBuffer = struct {
         ) orelse return null;
         const line_start = offset - coords.col;
         return .{ .start = line_start + bounds.start, .end = line_start + bounds.end };
-    }
-
-    pub fn getWrapOffsetsFor(self: *const Self, chunk: *const TextChunk) TextBufferError![]const utf8.WrapBreak {
-        return chunk.getWrapOffsets(self.allocator, &self.mem_registry, self.width_method);
     }
 
     pub fn getLayoutInfoFor(self: *const Self, chunk: *const TextChunk) TextBufferError!seg_mod.ChunkLayoutInfo {

--- a/packages/native/src/text-buffer.zig
+++ b/packages/native/src/text-buffer.zig
@@ -94,6 +94,8 @@ pub const UnifiedTextBuffer = struct {
     styled_capacity: usize,
 
     tab_width: u8,
+    // Persistent roots carry the tab-width generation used for their cached
+    // chunk and branch metrics, so only stale history roots are rescanned.
     tab_metrics_generation: u64,
     tab_metrics_refresh_count: u64,
 
@@ -1269,7 +1271,9 @@ pub const UnifiedTextBuffer = struct {
         self.markAllViewsDirty();
     }
 
-    /// Refresh widths after switching to a persistent rope root, such as undo/redo.
+    /// Bring the active persistent root to the current tab-width generation.
+    /// Widths and branch aggregates are derived state, so this deliberately
+    /// updates shared const nodes; stale history roots are repaired when restored.
     pub fn refreshTabWidthMetrics(self: *Self) void {
         if (self._rope.metricsGeneration() == self.tab_metrics_generation) return;
 

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -102,7 +102,6 @@ pub const TabStopResult = struct {
     }
 };
 
-/// Direct byte and display-column metadata for a wrap opportunity.
 pub const LayoutWrapBreakKind = enum(u8) {
     none,
     whitespace,
@@ -110,6 +109,9 @@ pub const LayoutWrapBreakKind = enum(u8) {
     script_transition,
 };
 
+/// Direct byte and display-column metadata for a wrap opportunity.
+/// The window identifies the grapheme that creates the break, not the position
+/// after it; consumers use byteEnd()/colEnd() to cross the boundary.
 pub const LayoutWrapBreak = struct {
     byte_offset: u32,
     col_offset: u32,
@@ -1436,6 +1438,7 @@ pub const ChunkLayoutInfo = struct {
     word_classes: WordClassEdges,
 };
 
+// Edge classes preserve CJK/ASCII transition boundaries across rope chunks.
 pub const WordClassEdges = struct { first: WordClass, last: WordClass };
 
 pub fn chunkWordClassEdges(text: []const u8) WordClassEdges {

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -102,16 +102,6 @@ pub const TabStopResult = struct {
     }
 };
 
-pub const WrapBreak = struct {
-    // byte_offset points at the grapheme that creates this break opportunity.
-    // For whitespace and punctuation, this is the delimiter grapheme.
-    // For CJK<->ASCII transitions, this is the last grapheme in the previous run.
-    byte_offset: u32,
-
-    // Legacy grapheme-count offset retained for findWrapBreaks callers.
-    char_offset: u32,
-};
-
 /// Direct byte and display-column metadata for a wrap opportunity.
 pub const LayoutWrapBreakKind = enum(u8) {
     none,
@@ -133,27 +123,6 @@ pub const LayoutWrapBreak = struct {
 
     pub fn byteEnd(self: LayoutWrapBreak) u32 {
         return self.byte_offset + self.byte_len;
-    }
-};
-
-pub const WrapBreakResult = struct {
-    breaks: std.ArrayListUnmanaged(WrapBreak),
-    allocator: std.mem.Allocator,
-
-    pub fn init(allocator: std.mem.Allocator) WrapBreakResult {
-        return .{
-            .breaks = .empty,
-            .allocator = allocator,
-        };
-    }
-
-    pub fn deinit(self: *WrapBreakResult) void {
-        self.breaks.deinit(self.allocator);
-        self.* = undefined;
-    }
-
-    pub fn reset(self: *WrapBreakResult) void {
-        self.breaks.clearRetainingCapacity();
     }
 };
 
@@ -203,29 +172,6 @@ pub inline fn decodeUtf8Unchecked(text: []const u8, pos: usize) struct { cp: u21
     const b3 = text[pos + 3];
     const cp4: u21 = @intCast((@as(u32, b0 & 0x07) << 18) | (@as(u32, b1 & 0x3F) << 12) | (@as(u32, b2 & 0x3F) << 6) | @as(u32, b3 & 0x3F));
     return .{ .cp = cp4, .len = 4 };
-}
-
-// Unicode wrap-break codepoints
-inline fn isUnicodeWrapBreak(cp: u21) bool {
-    return switch (cp) {
-        0x00A0, // NBSP
-        0x1680, // OGHAM SPACE MARK
-        0x2000...0x200A, // En quad..Hair space
-        0x202F, // NARROW NO-BREAK SPACE
-        0x205F, // MEDIUM MATHEMATICAL SPACE
-        0x3000, // IDEOGRAPHIC SPACE
-        0x200B, // ZERO WIDTH SPACE
-        0x00AD, // SOFT HYPHEN
-        0x2010, // HYPHEN
-        0x3001, // IDEOGRAPHIC COMMA
-        0x3002, // IDEOGRAPHIC FULL STOP
-        0xFF01, // FULLWIDTH EXCLAMATION MARK
-        0xFF0C, // FULLWIDTH COMMA
-        0xFF1A, // FULLWIDTH COLON
-        0xFF1F, // FULLWIDTH QUESTION MARK
-        => true,
-        else => false,
-    };
 }
 
 inline fn unicodeLayoutWrapBreakKind(cp: u21) LayoutWrapBreakKind {
@@ -308,255 +254,6 @@ pub inline fn isWordCodepoint(cp: u21) bool {
 pub inline fn isCjkAsciiTransition(prev_class: WordClass, curr_class: WordClass) bool {
     return (prev_class == .cjk_word and curr_class == .ascii_word) or
         (prev_class == .ascii_word and curr_class == .cjk_word);
-}
-
-// Nothing needed here - using uucode.grapheme.isBreak directly
-
-pub fn findWrapBreaks(text: []const u8, result: *WrapBreakResult, width_method: WidthMethod) !void {
-    // This function clears previous results and writes fresh break points.
-    // Callers should treat `result.breaks` as replaced after the call.
-    _ = width_method; // Currently unused, but kept for API consistency
-    result.reset();
-    const vector_len = 16;
-
-    var pos: usize = 0;
-    var char_offset: u32 = 0;
-    var prev_cp: ?u21 = null; // Track previous codepoint for grapheme detection
-    var break_state: uucode.grapheme.BreakState = .default;
-    // We keep track of the current grapheme so we can add a break at
-    // CJK<->ASCII transitions. The break is emitted at the previous grapheme,
-    // so callers that add grapheme width land exactly at the run boundary.
-    var have_current_grapheme = false;
-    var current_grapheme_byte_offset: u32 = 0;
-    var current_grapheme_char_offset: u32 = 0;
-    var current_grapheme_class: WordClass = .other;
-
-    while (pos + vector_len <= text.len) {
-        const chunk: @Vector(vector_len, u8) = text[pos..][0..vector_len].*;
-        const ascii_threshold: @Vector(vector_len, u8) = @splat(0x80);
-        const is_non_ascii = chunk >= ascii_threshold;
-
-        // Fast path: all ASCII
-        if (!@reduce(.Or, is_non_ascii)) {
-            const first_class = classifyWordClass(text[pos]);
-            if (have_current_grapheme and isCjkAsciiTransition(current_grapheme_class, first_class)) {
-                try result.breaks.append(result.allocator, .{
-                    .byte_offset = current_grapheme_byte_offset,
-                    .char_offset = current_grapheme_char_offset,
-                });
-            }
-
-            // Use SIMD to find break characters
-            var match_mask: @Vector(vector_len, bool) = @splat(false);
-
-            // Check whitespace
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat(' ')));
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat('\t')));
-
-            // Check dashes and slashes
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat('-')));
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat('/')));
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat('\\')));
-
-            // Check punctuation
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat('.')));
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat(',')));
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat(';')));
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat(':')));
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat('!')));
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat('?')));
-
-            // Check brackets
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat('(')));
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat(')')));
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat('[')));
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat(']')));
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat('{')));
-            match_mask = match_mask | (chunk == @as(@Vector(vector_len, u8), @splat('}')));
-
-            // Convert boolean mask to integer bitmask for faster iteration
-            var bitmask: u16 = 0;
-            inline for (0..vector_len) |i| {
-                if (match_mask[i]) {
-                    bitmask |= @as(u16, 1) << @intCast(i);
-                }
-            }
-
-            // Use bit manipulation to extract positions
-            while (bitmask != 0) {
-                const bit_pos = @ctz(bitmask);
-                try result.breaks.append(result.allocator, .{
-                    .byte_offset = @intCast(pos + bit_pos),
-                    .char_offset = char_offset + @as(u32, @intCast(bit_pos)),
-                });
-                bitmask &= bitmask - 1;
-            }
-
-            pos += vector_len;
-            const block_start_char_offset = char_offset;
-            char_offset += vector_len;
-            prev_cp = text[pos - 1]; // Last ASCII char
-            break_state = .default;
-            have_current_grapheme = true;
-            current_grapheme_byte_offset = @intCast(pos - 1);
-            current_grapheme_char_offset = block_start_char_offset + (vector_len - 1);
-            current_grapheme_class = classifyWordClass(text[pos - 1]);
-            continue;
-        }
-
-        // Slow path: mixed ASCII/non-ASCII - need grapheme-aware counting
-        var i: usize = 0;
-        while (i < vector_len) {
-            const b0 = text[pos + i];
-            if (b0 < 0x80) {
-                const curr_cp: u21 = b0;
-
-                // Check if this starts a new grapheme cluster
-                // Skip invalid/replacement codepoints or codepoints that might be outside the grapheme table range
-                const is_break = if (curr_cp == 0xFFFD or curr_cp > 0x10FFFF) true else if (prev_cp) |p| blk: {
-                    if (p == 0xFFFD or p > 0x10FFFF) break :blk true;
-                    break :blk uucode.grapheme.isBreak(p, curr_cp, &break_state);
-                } else true;
-
-                if (is_break) {
-                    const curr_class = classifyWordClass(curr_cp);
-                    if (have_current_grapheme and isCjkAsciiTransition(current_grapheme_class, curr_class)) {
-                        try result.breaks.append(result.allocator, .{
-                            .byte_offset = current_grapheme_byte_offset,
-                            .char_offset = current_grapheme_char_offset,
-                        });
-                    }
-                    have_current_grapheme = true;
-                    current_grapheme_byte_offset = @intCast(pos + i);
-                    current_grapheme_char_offset = char_offset;
-                    current_grapheme_class = curr_class;
-                }
-
-                if (isAsciiWrapBreak(b0)) {
-                    try result.breaks.append(result.allocator, .{
-                        .byte_offset = @intCast(pos + i),
-                        .char_offset = char_offset,
-                    });
-                }
-                i += 1;
-                if (is_break) {
-                    char_offset += 1;
-                }
-                prev_cp = curr_cp;
-            } else {
-                const dec = decodeUtf8Unchecked(text, pos + i);
-                if (pos + i + dec.len > text.len) break;
-                if (pos + i + dec.len > pos + vector_len) break;
-
-                // Check if this starts a new grapheme cluster
-                // Skip invalid/replacement codepoints or codepoints that might be outside the grapheme table range
-                const is_break = if (dec.cp == 0xFFFD or dec.cp > 0x10FFFF) true else if (prev_cp) |p| blk: {
-                    if (p == 0xFFFD or p > 0x10FFFF) break :blk true;
-                    break :blk uucode.grapheme.isBreak(p, dec.cp, &break_state);
-                } else true;
-
-                if (is_break) {
-                    const curr_class = classifyWordClass(dec.cp);
-                    if (have_current_grapheme and isCjkAsciiTransition(current_grapheme_class, curr_class)) {
-                        try result.breaks.append(result.allocator, .{
-                            .byte_offset = current_grapheme_byte_offset,
-                            .char_offset = current_grapheme_char_offset,
-                        });
-                    }
-                    have_current_grapheme = true;
-                    current_grapheme_byte_offset = @intCast(pos + i);
-                    current_grapheme_char_offset = char_offset;
-                    current_grapheme_class = curr_class;
-                }
-
-                if (isUnicodeWrapBreak(dec.cp)) {
-                    try result.breaks.append(result.allocator, .{
-                        .byte_offset = @intCast(pos + i),
-                        .char_offset = char_offset,
-                    });
-                }
-                i += dec.len;
-                if (is_break) {
-                    char_offset += 1;
-                }
-                prev_cp = dec.cp;
-            }
-        }
-        pos += i;
-    }
-
-    // Tail
-    var i: usize = pos;
-    while (i < text.len) {
-        const b0 = text[i];
-        if (b0 < 0x80) {
-            const curr_cp: u21 = b0;
-            const is_break = if (prev_cp) |p| blk: {
-                if (p == 0xFFFD or p > 0x10FFFF) break :blk true;
-                break :blk uucode.grapheme.isBreak(p, curr_cp, &break_state);
-            } else true;
-
-            if (is_break) {
-                const curr_class = classifyWordClass(curr_cp);
-                if (have_current_grapheme and isCjkAsciiTransition(current_grapheme_class, curr_class)) {
-                    try result.breaks.append(result.allocator, .{
-                        .byte_offset = current_grapheme_byte_offset,
-                        .char_offset = current_grapheme_char_offset,
-                    });
-                }
-                have_current_grapheme = true;
-                current_grapheme_byte_offset = @intCast(i);
-                current_grapheme_char_offset = char_offset;
-                current_grapheme_class = curr_class;
-            }
-
-            if (isAsciiWrapBreak(b0)) {
-                try result.breaks.append(result.allocator, .{
-                    .byte_offset = @intCast(i),
-                    .char_offset = char_offset,
-                });
-            }
-            i += 1;
-            if (is_break) {
-                char_offset += 1;
-            }
-            prev_cp = curr_cp;
-        } else {
-            const dec = decodeUtf8Unchecked(text, i);
-            if (i + dec.len > text.len) break;
-
-            const is_break = if (dec.cp == 0xFFFD or dec.cp > 0x10FFFF) true else if (prev_cp) |p| blk: {
-                if (p == 0xFFFD or p > 0x10FFFF) break :blk true;
-                break :blk uucode.grapheme.isBreak(p, dec.cp, &break_state);
-            } else true;
-
-            if (is_break) {
-                const curr_class = classifyWordClass(dec.cp);
-                if (have_current_grapheme and isCjkAsciiTransition(current_grapheme_class, curr_class)) {
-                    try result.breaks.append(result.allocator, .{
-                        .byte_offset = current_grapheme_byte_offset,
-                        .char_offset = current_grapheme_char_offset,
-                    });
-                }
-                have_current_grapheme = true;
-                current_grapheme_byte_offset = @intCast(i);
-                current_grapheme_char_offset = char_offset;
-                current_grapheme_class = curr_class;
-            }
-
-            if (isUnicodeWrapBreak(dec.cp)) {
-                try result.breaks.append(result.allocator, .{
-                    .byte_offset = @intCast(i),
-                    .char_offset = char_offset,
-                });
-            }
-            i += dec.len;
-            if (is_break) {
-                char_offset += 1;
-            }
-            prev_cp = dec.cp;
-        }
-    }
 }
 
 pub fn findTabStops(text: []const u8, result: *TabStopResult) !void {
@@ -1280,19 +977,6 @@ pub fn findGraphemePosByWidth(
     return findPosByWidthUnicode(text, max_columns, tab_width, isASCIIOnly, include_start_before, width_method);
 }
 
-/// Find a materialized byte window boundary without splitting a grapheme.
-/// Cursor-oriented callers should continue using findPosByWidth.
-pub fn findPosByWidthGraphemeSafe(
-    text: []const u8,
-    max_columns: u32,
-    tab_width: u8,
-    isASCIIOnly: bool,
-    include_start_before: bool,
-    width_method: WidthMethod,
-) PosByWidthResult {
-    return findGraphemePosByWidth(text, max_columns, tab_width, isASCIIOnly, include_start_before, width_method);
-}
-
 /// Find position by column width using Unicode grapheme cluster segmentation
 fn findPosByWidthUnicode(
     text: []const u8,
@@ -1747,43 +1431,12 @@ pub const GraphemeInfo = struct {
     col_offset: u32,
 };
 
-pub const GraphemeInfoResult = struct {
-    graphemes: std.ArrayList(GraphemeInfo),
-    allocator: std.mem.Allocator,
-
-    pub fn init(allocator: std.mem.Allocator) GraphemeInfoResult {
-        return .{
-            .graphemes = .empty,
-            .allocator = allocator,
-        };
-    }
-
-    pub fn deinit(self: *GraphemeInfoResult) void {
-        self.graphemes.deinit(self.allocator);
-        self.* = undefined;
-    }
-
-    pub fn reset(self: *GraphemeInfoResult) void {
-        self.graphemes.clearRetainingCapacity();
-    }
-};
-
 pub const ChunkLayoutInfo = struct {
     wrap_breaks: []const LayoutWrapBreak,
-    first_word_class: WordClass,
-    last_word_class: WordClass,
+    word_classes: WordClassEdges,
 };
 
 pub const WordClassEdges = struct { first: WordClass, last: WordClass };
-
-pub const LayoutWrapBreakVisitor = struct {
-    context: *anyopaque,
-    callback: *const fn (context: *anyopaque, wrap_break: LayoutWrapBreak) error{OutOfMemory}!bool,
-
-    fn emit(self: LayoutWrapBreakVisitor, wrap_break: LayoutWrapBreak) !bool {
-        return self.callback(self.context, wrap_break);
-    }
-};
 
 pub fn chunkWordClassEdges(text: []const u8) WordClassEdges {
     if (text.len == 0) return .{ .first = .other, .last = .other };
@@ -1907,17 +1560,6 @@ pub fn findChunkLayoutInfo(
     };
     var ctx: Context = .{ .allocator = allocator, .wrap_breaks = wrap_breaks };
     return walkChunkLayoutInfoComptime(text, tab_width, isASCIIOnly, width_method, &ctx, Context.append);
-}
-
-/// Stream direct wrap metadata without retaining an entry for every break.
-pub fn walkChunkLayoutInfo(
-    text: []const u8,
-    tab_width: u8,
-    isASCIIOnly: bool,
-    width_method: WidthMethod,
-    visitor: LayoutWrapBreakVisitor,
-) !WordClassEdges {
-    return walkChunkLayoutInfoGeneric(text, tab_width, isASCIIOnly, width_method, visitor);
 }
 
 pub inline fn walkChunkLayoutInfoComptime(

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -108,9 +108,32 @@ pub const WrapBreak = struct {
     // For CJK<->ASCII transitions, this is the last grapheme in the previous run.
     byte_offset: u32,
 
-    // char_offset is grapheme-count based, not a display column.
-    // Callers convert it to columns with charOffsetToColumn().
+    // Legacy grapheme-count offset retained for findWrapBreaks callers.
     char_offset: u32,
+};
+
+/// Direct byte and display-column metadata for a wrap opportunity.
+pub const LayoutWrapBreakKind = enum(u8) {
+    none,
+    whitespace,
+    punctuation,
+    script_transition,
+};
+
+pub const LayoutWrapBreak = struct {
+    byte_offset: u32,
+    col_offset: u32,
+    byte_len: u32,
+    width: u32,
+    kind: LayoutWrapBreakKind,
+
+    pub fn colEnd(self: LayoutWrapBreak) u32 {
+        return self.col_offset + self.width;
+    }
+
+    pub fn byteEnd(self: LayoutWrapBreak) u32 {
+        return self.byte_offset + self.byte_len;
+    }
 };
 
 pub const WrapBreakResult = struct {
@@ -143,6 +166,14 @@ inline fn isAsciiWrapBreak(b: u8) bool {
         '.', ',', ';', ':', '!', '?' => true, // Punctuation
         '(', ')', '[', ']', '{', '}' => true, // Brackets
         else => false,
+    };
+}
+
+inline fn asciiLayoutWrapBreakKind(b: u8) LayoutWrapBreakKind {
+    return switch (b) {
+        ' ', '\t' => .whitespace,
+        '-', '/', '\\', '.', ',', ';', ':', '!', '?', '(', ')', '[', ']', '{', '}' => .punctuation,
+        else => .none,
     };
 }
 
@@ -197,10 +228,33 @@ inline fn isUnicodeWrapBreak(cp: u21) bool {
     };
 }
 
+inline fn unicodeLayoutWrapBreakKind(cp: u21) LayoutWrapBreakKind {
+    return switch (cp) {
+        0x00A0,
+        0x1680,
+        0x2000...0x200A,
+        0x202F,
+        0x205F,
+        0x3000,
+        0x200B,
+        => .whitespace,
+        0x00AD,
+        0x2010,
+        0x3001,
+        0x3002,
+        0xFF01,
+        0xFF0C,
+        0xFF1A,
+        0xFF1F,
+        => .punctuation,
+        else => .none,
+    };
+}
+
 // WordClass keeps word-boundary behavior predictable in mixed-script text.
 // We split between ASCII word runs and CJK word runs, and we keep each
 // CJK run grouped as one unit.
-const WordClass = enum {
+pub const WordClass = enum {
     ascii_word,
     cjk_word,
     other,
@@ -251,7 +305,7 @@ pub inline fn isWordCodepoint(cp: u21) bool {
     return classifyWordClass(cp) != .other;
 }
 
-inline fn isCjkAsciiTransition(prev_class: WordClass, curr_class: WordClass) bool {
+pub inline fn isCjkAsciiTransition(prev_class: WordClass, curr_class: WordClass) bool {
     return (prev_class == .cjk_word and curr_class == .ascii_word) or
         (prev_class == .ascii_word and curr_class == .cjk_word);
 }
@@ -998,6 +1052,21 @@ pub fn findWrapPosByWidth(
     }
 }
 
+/// Find a materialized byte window boundary without splitting a grapheme.
+/// wcwidth still sums codepoint widths inside each atomic cluster.
+pub fn findWrapPosByWidthGraphemeSafe(
+    text: []const u8,
+    max_columns: u32,
+    tab_width: u8,
+    isASCIIOnly: bool,
+    width_method: WidthMethod,
+) WrapByWidthResult {
+    if (width_method == .wcwidth) {
+        return findWrapPosByWidthUnicode(text, max_columns, tab_width, isASCIIOnly, .wcwidth);
+    }
+    return findWrapPosByWidth(text, max_columns, tab_width, isASCIIOnly, width_method);
+}
+
 /// Find wrap position by width using Unicode grapheme cluster segmentation
 fn findWrapPosByWidthUnicode(
     text: []const u8,
@@ -1209,6 +1278,19 @@ pub fn findGraphemePosByWidth(
     width_method: WidthMethod,
 ) PosByWidthResult {
     return findPosByWidthUnicode(text, max_columns, tab_width, isASCIIOnly, include_start_before, width_method);
+}
+
+/// Find a materialized byte window boundary without splitting a grapheme.
+/// Cursor-oriented callers should continue using findPosByWidth.
+pub fn findPosByWidthGraphemeSafe(
+    text: []const u8,
+    max_columns: u32,
+    tab_width: u8,
+    isASCIIOnly: bool,
+    include_start_before: bool,
+    width_method: WidthMethod,
+) PosByWidthResult {
+    return findGraphemePosByWidth(text, max_columns, tab_width, isASCIIOnly, include_start_before, width_method);
 }
 
 /// Find position by column width using Unicode grapheme cluster segmentation
@@ -1660,8 +1742,8 @@ fn calculateTextWidthWCWidth(text: []const u8, tab_width: u8, isASCIIOnly: bool)
 /// Grapheme cluster information for caching
 pub const GraphemeInfo = struct {
     byte_offset: u32,
-    byte_len: u8,
-    width: u8,
+    byte_len: u32,
+    width: u32,
     col_offset: u32,
 };
 
@@ -1685,6 +1767,320 @@ pub const GraphemeInfoResult = struct {
         self.graphemes.clearRetainingCapacity();
     }
 };
+
+pub const ChunkLayoutInfo = struct {
+    wrap_breaks: []const LayoutWrapBreak,
+    first_word_class: WordClass,
+    last_word_class: WordClass,
+};
+
+pub const WordClassEdges = struct { first: WordClass, last: WordClass };
+
+pub const LayoutWrapBreakVisitor = struct {
+    context: *anyopaque,
+    callback: *const fn (context: *anyopaque, wrap_break: LayoutWrapBreak) error{OutOfMemory}!bool,
+
+    fn emit(self: LayoutWrapBreakVisitor, wrap_break: LayoutWrapBreak) !bool {
+        return self.callback(self.context, wrap_break);
+    }
+};
+
+pub fn chunkWordClassEdges(text: []const u8) WordClassEdges {
+    if (text.len == 0) return .{ .first = .other, .last = .other };
+
+    const first = decodeUtf8Unchecked(text, 0).cp;
+    var last_start = text.len - 1;
+    var continuation_count: u2 = 0;
+    while (last_start > 0 and (text[last_start] & 0xC0) == 0x80 and continuation_count < 3) {
+        last_start -= 1;
+        continuation_count += 1;
+    }
+    const last = decodeUtf8Unchecked(text, last_start).cp;
+    return .{ .first = classifyWordClass(first), .last = classifyWordClass(last) };
+}
+
+inline fn emitLayoutWrapBreak(
+    visitor: anytype,
+    byte_offset: usize,
+    byte_len: usize,
+    col_offset: u32,
+    width: u32,
+    kind: LayoutWrapBreakKind,
+) !bool {
+    return visitor.emit(.{
+        .byte_offset = @intCast(byte_offset),
+        .col_offset = col_offset,
+        .byte_len = @intCast(byte_len),
+        .width = width,
+        .kind = kind,
+    });
+}
+
+inline fn commitLayoutCluster(
+    visitor: anytype,
+    cluster_start: usize,
+    cluster_end: usize,
+    cluster_col_offset: u32,
+    cluster_width: u32,
+    cluster_break_kind: LayoutWrapBreakKind,
+    cluster_class: WordClass,
+    next_class: ?WordClass,
+) !bool {
+    const kind: LayoutWrapBreakKind = if (cluster_break_kind != .none)
+        cluster_break_kind
+    else if (next_class != null and isCjkAsciiTransition(cluster_class, next_class.?))
+        .script_transition
+    else
+        .none;
+    if (kind != .none) {
+        return emitLayoutWrapBreak(
+            visitor,
+            cluster_start,
+            cluster_end - cluster_start,
+            cluster_col_offset,
+            cluster_width,
+            kind,
+        );
+    }
+    return true;
+}
+
+inline fn findAsciiLayoutWrapBreaks(
+    text: []const u8,
+    visitor: anytype,
+) !bool {
+    const vector_len = 16;
+    const Vec = @Vector(vector_len, u8);
+    var pos: usize = 0;
+
+    while (pos + vector_len <= text.len) {
+        const chunk: Vec = text[pos..][0..vector_len].*;
+        var matches: @Vector(vector_len, bool) = @splat(false);
+        inline for ([_]u8{ ' ', '\t', '-', '/', '\\', '.', ',', ';', ':', '!', '?', '(', ')', '[', ']', '{', '}' }) |delimiter| {
+            matches = matches | (chunk == @as(Vec, @splat(delimiter)));
+        }
+
+        var bitmask: u16 = 0;
+        inline for (0..vector_len) |i| {
+            if (matches[i]) bitmask |= @as(u16, 1) << @intCast(i);
+        }
+        while (bitmask != 0) {
+            const bit_pos = @ctz(bitmask);
+            const offset = pos + bit_pos;
+            const kind: LayoutWrapBreakKind = if (text[offset] == ' ') .whitespace else asciiLayoutWrapBreakKind(text[offset]);
+            if (!try emitLayoutWrapBreak(visitor, offset, 1, @intCast(offset), 1, kind)) return false;
+            bitmask &= bitmask - 1;
+        }
+        pos += vector_len;
+    }
+
+    while (pos < text.len) : (pos += 1) {
+        const b = text[pos];
+        if (b == ' ') {
+            if (!try emitLayoutWrapBreak(visitor, pos, 1, @intCast(pos), 1, .whitespace)) return false;
+        } else if (isAsciiWrapBreak(b)) {
+            if (!try emitLayoutWrapBreak(visitor, pos, 1, @intCast(pos), 1, asciiLayoutWrapBreakKind(b))) return false;
+        }
+    }
+    return true;
+}
+
+/// Find direct wrap metadata without converting grapheme counts after the scan.
+pub fn findChunkLayoutInfo(
+    allocator: std.mem.Allocator,
+    text: []const u8,
+    tab_width: u8,
+    isASCIIOnly: bool,
+    width_method: WidthMethod,
+    wrap_breaks: *std.ArrayListUnmanaged(LayoutWrapBreak),
+) !WordClassEdges {
+    wrap_breaks.clearRetainingCapacity();
+    const Context = struct {
+        allocator: std.mem.Allocator,
+        wrap_breaks: *std.ArrayListUnmanaged(LayoutWrapBreak),
+
+        fn append(ctx_ptr: *anyopaque, wrap_break: LayoutWrapBreak) !bool {
+            const ctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
+            try ctx.wrap_breaks.append(ctx.allocator, wrap_break);
+            return true;
+        }
+    };
+    var ctx: Context = .{ .allocator = allocator, .wrap_breaks = wrap_breaks };
+    return walkChunkLayoutInfoComptime(text, tab_width, isASCIIOnly, width_method, &ctx, Context.append);
+}
+
+/// Stream direct wrap metadata without retaining an entry for every break.
+pub fn walkChunkLayoutInfo(
+    text: []const u8,
+    tab_width: u8,
+    isASCIIOnly: bool,
+    width_method: WidthMethod,
+    visitor: LayoutWrapBreakVisitor,
+) !WordClassEdges {
+    return walkChunkLayoutInfoGeneric(text, tab_width, isASCIIOnly, width_method, visitor);
+}
+
+pub inline fn walkChunkLayoutInfoComptime(
+    text: []const u8,
+    tab_width: u8,
+    isASCIIOnly: bool,
+    width_method: WidthMethod,
+    context: anytype,
+    comptime callback: anytype,
+) !WordClassEdges {
+    const Visitor = struct {
+        context: @TypeOf(context),
+
+        inline fn emit(self: @This(), wrap_break: LayoutWrapBreak) !bool {
+            return callback(self.context, wrap_break);
+        }
+    };
+    return walkChunkLayoutInfoGeneric(text, tab_width, isASCIIOnly, width_method, Visitor{ .context = context });
+}
+
+fn walkChunkLayoutInfoGeneric(
+    text: []const u8,
+    tab_width: u8,
+    isASCIIOnly: bool,
+    width_method: WidthMethod,
+    visitor: anytype,
+) !WordClassEdges {
+    if (text.len == 0) return .{ .first = .other, .last = .other };
+
+    if (isASCIIOnly) {
+        _ = try findAsciiLayoutWrapBreaks(text, visitor);
+        return chunkWordClassEdges(text);
+    }
+
+    const first_word_class = classifyWordClass(decodeUtf8Unchecked(text, 0).cp);
+
+    const vector_len = 16;
+    var pos: usize = 0;
+    var col: u32 = 0;
+    var prev_cp: ?u21 = null;
+    var break_state: uucode.grapheme.BreakState = .default;
+    var cluster_started = false;
+    var cluster_start: usize = 0;
+    var cluster_col_offset: u32 = 0;
+    var cluster_width_state: GraphemeWidthState = undefined;
+    var cluster_break_kind: LayoutWrapBreakKind = .none;
+    var cluster_class: WordClass = .other;
+
+    while (pos < text.len) {
+        if (pos + vector_len <= text.len) {
+            const chunk: @Vector(vector_len, u8) = text[pos..][0..vector_len].*;
+            const is_non_ascii = chunk >= @as(@Vector(vector_len, u8), @splat(0x80));
+            if (!@reduce(.Or, is_non_ascii)) {
+                var can_use_ascii_fast_path = true;
+                if (cluster_started) {
+                    var probe_state = break_state;
+                    can_use_ascii_fast_path = isGraphemeBreak(prev_cp, text[pos], &probe_state, width_method);
+                }
+                if (!can_use_ascii_fast_path) {
+                    // The active cluster joins the first ASCII byte (for example GB9b Prepend).
+                    // Process it below so the cluster's byte window remains intact.
+                } else {
+                    const first_class = classifyWordClass(text[pos]);
+                    if (cluster_started) {
+                        if (!try commitLayoutCluster(
+                            visitor,
+                            cluster_start,
+                            pos,
+                            cluster_col_offset,
+                            cluster_width_state.width,
+                            cluster_break_kind,
+                            cluster_class,
+                            first_class,
+                        )) return chunkWordClassEdges(text);
+                        col += cluster_width_state.width;
+                        cluster_started = false;
+                    }
+
+                    var i: usize = 0;
+                    while (i + 1 < vector_len) : (i += 1) {
+                        const b = text[pos + i];
+                        const width = asciiCharWidth(b, tab_width);
+                        if (isAsciiWrapBreak(b)) {
+                            if (!try emitLayoutWrapBreak(visitor, pos + i, 1, col, width, asciiLayoutWrapBreakKind(b))) return chunkWordClassEdges(text);
+                        }
+                        col += width;
+                    }
+
+                    const last_b = text[pos + vector_len - 1];
+                    const last_cp: u21 = last_b;
+                    cluster_started = true;
+                    cluster_start = pos + vector_len - 1;
+                    cluster_col_offset = col;
+                    cluster_width_state = GraphemeWidthState.init(last_cp, asciiCharWidth(last_b, tab_width), width_method);
+                    cluster_break_kind = asciiLayoutWrapBreakKind(last_b);
+                    cluster_class = classifyWordClass(last_cp);
+                    prev_cp = last_cp;
+                    break_state = .default;
+                    pos += vector_len;
+                    continue;
+                }
+            }
+        }
+
+        const b0 = text[pos];
+        const Decoded = struct { cp: u21, len: usize };
+        const decoded: Decoded = if (b0 < 0x80)
+            .{ .cp = @as(u21, b0), .len = @as(usize, 1) }
+        else blk: {
+            const value = decodeUtf8Unchecked(text, pos);
+            const len: usize = value.len;
+            break :blk .{ .cp = value.cp, .len = if (pos + len <= text.len) len else 1 };
+        };
+        const curr_class = classifyWordClass(decoded.cp);
+        const is_break = isGraphemeBreak(prev_cp, decoded.cp, &break_state, width_method);
+        const cp_width = charWidth(b0, decoded.cp, tab_width);
+
+        if (is_break) {
+            if (cluster_started) {
+                if (!try commitLayoutCluster(
+                    visitor,
+                    cluster_start,
+                    pos,
+                    cluster_col_offset,
+                    cluster_width_state.width,
+                    cluster_break_kind,
+                    cluster_class,
+                    curr_class,
+                )) return chunkWordClassEdges(text);
+                col += cluster_width_state.width;
+            }
+
+            cluster_started = true;
+            cluster_start = pos;
+            cluster_col_offset = col;
+            cluster_width_state = GraphemeWidthState.init(decoded.cp, cp_width, width_method);
+            cluster_break_kind = if (b0 < 0x80) asciiLayoutWrapBreakKind(b0) else unicodeLayoutWrapBreakKind(decoded.cp);
+            cluster_class = curr_class;
+        } else {
+            cluster_width_state.addCodepoint(decoded.cp, cp_width);
+            const next_break_kind = if (b0 < 0x80) asciiLayoutWrapBreakKind(b0) else unicodeLayoutWrapBreakKind(decoded.cp);
+            if (next_break_kind == .whitespace or cluster_break_kind == .none) cluster_break_kind = next_break_kind;
+        }
+
+        prev_cp = decoded.cp;
+        pos += decoded.len;
+    }
+
+    if (cluster_started) {
+        _ = try commitLayoutCluster(
+            visitor,
+            cluster_start,
+            text.len,
+            cluster_col_offset,
+            cluster_width_state.width,
+            cluster_break_kind,
+            cluster_class,
+            null,
+        );
+    }
+
+    return .{ .first = first_word_class, .last = if (cluster_started) cluster_class else .other };
+}
 
 /// Find all grapheme clusters in text and return info for multi-byte graphemes and tabs
 /// This is a proxy function that dispatches to the appropriate implementation based on width_method
@@ -1754,7 +2150,7 @@ fn findGraphemeInfoUnicode(
                             try result.append(allocator, .{
                                 .byte_offset = @intCast(cluster_start),
                                 .byte_len = @intCast(cluster_byte_len),
-                                .width = @intCast(cluster_width_state.width),
+                                .width = cluster_width_state.width,
                                 .col_offset = cluster_start_col,
                             });
                         }
@@ -1800,7 +2196,7 @@ fn findGraphemeInfoUnicode(
                         try result.append(allocator, .{
                             .byte_offset = @intCast(cluster_start),
                             .byte_len = @intCast(cluster_byte_len),
-                            .width = @intCast(cluster_width_state.width),
+                            .width = cluster_width_state.width,
                             .col_offset = cluster_start_col,
                         });
                     }
@@ -1845,7 +2241,7 @@ fn findGraphemeInfoUnicode(
                     try result.append(allocator, .{
                         .byte_offset = @intCast(cluster_start),
                         .byte_len = @intCast(cluster_byte_len),
-                        .width = @intCast(cluster_width_state.width),
+                        .width = cluster_width_state.width,
                         .col_offset = cluster_start_col,
                     });
                 }
@@ -1877,7 +2273,7 @@ fn findGraphemeInfoUnicode(
             try result.append(allocator, .{
                 .byte_offset = @intCast(cluster_start),
                 .byte_len = @intCast(cluster_byte_len),
-                .width = @intCast(cluster_width_state.width),
+                .width = cluster_width_state.width,
                 .col_offset = cluster_start_col,
             });
         }
@@ -1937,7 +2333,7 @@ fn findGraphemeInfoWCWidth(
                 try result.append(allocator, .{
                     .byte_offset = @intCast(cluster_start),
                     .byte_len = @intCast(pos - cluster_start),
-                    .width = @intCast(cluster_width_state.width),
+                    .width = cluster_width_state.width,
                     .col_offset = cluster_start_col,
                 });
                 col += cluster_width_state.width;
@@ -1971,7 +2367,7 @@ fn findGraphemeInfoWCWidth(
             try result.append(allocator, .{
                 .byte_offset = @intCast(cluster_start),
                 .byte_len = @intCast(text.len - cluster_start),
-                .width = @intCast(cluster_width_state.width),
+                .width = cluster_width_state.width,
                 .col_offset = cluster_start_col,
             });
             col += cluster_width_state.width;

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -176,24 +176,25 @@ pub inline fn decodeUtf8Unchecked(text: []const u8, pos: usize) struct { cp: u21
     return .{ .cp = cp4, .len = 4 };
 }
 
+// Unicode wrap-break codepoints.
 inline fn unicodeLayoutWrapBreakKind(cp: u21) LayoutWrapBreakKind {
     return switch (cp) {
-        0x00A0,
-        0x1680,
-        0x2000...0x200A,
-        0x202F,
-        0x205F,
-        0x3000,
-        0x200B,
+        0x00A0, // NBSP
+        0x1680, // OGHAM SPACE MARK
+        0x2000...0x200A, // En quad..Hair space
+        0x202F, // NARROW NO-BREAK SPACE
+        0x205F, // MEDIUM MATHEMATICAL SPACE
+        0x3000, // IDEOGRAPHIC SPACE
+        0x200B, // ZERO WIDTH SPACE
         => .whitespace,
-        0x00AD,
-        0x2010,
-        0x3001,
-        0x3002,
-        0xFF01,
-        0xFF0C,
-        0xFF1A,
-        0xFF1F,
+        0x00AD, // SOFT HYPHEN
+        0x2010, // HYPHEN
+        0x3001, // IDEOGRAPHIC COMMA
+        0x3002, // IDEOGRAPHIC FULL STOP
+        0xFF01, // FULLWIDTH EXCLAMATION MARK
+        0xFF0C, // FULLWIDTH COMMA
+        0xFF1A, // FULLWIDTH COLON
+        0xFF1F, // FULLWIDTH QUESTION MARK
         => .punctuation,
         else => .none,
     };

--- a/packages/solid/tests/__snapshots__/textarea.test.tsx.snap
+++ b/packages/solid/tests/__snapshots__/textarea.test.tsx.snap
@@ -125,86 +125,6 @@ exports[`Textarea Layout Tests Prompt-like Layout should render textarea in shel
 "
 `;
 
-exports[`Textarea Layout Tests Reactive Textarea Updates should update textarea content reactively 1`] = `
-"┌────────────────────────────────────────────────┐
-│                                                │
-│ > Initial text                                 │
-│                                                │
-└────────────────────────────────────────────────┘
-                                                  
-                                                  
-                                                  
-                                                  
-                                                  
-                                                  
-                                                  
-"
-`;
-
-exports[`Textarea Layout Tests Reactive Textarea Updates should update textarea content reactively 2`] = `
-"┌────────────────────────────────────────────────┐
-│                                                │
-│   Updated text that is much longer and should  │
-│ > wrap to multiple lines if word wrapping is   │
-│   enabled                                      │
-│                                                │
-└────────────────────────────────────────────────┘
-                                                  
-                                                  
-                                                  
-                                                  
-                                                  
-"
-`;
-
-exports[`Textarea Layout Tests Reactive Textarea Updates should handle textarea growth with word wrapping 1`] = `
-"┌──────────────────────────────────────┐
-│>                                     │
-│   Short                              │
-│                                      │
-│Status line below textarea            │
-└──────────────────────────────────────┘
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-"
-`;
-
-exports[`Textarea Layout Tests Reactive Textarea Updates should handle textarea growth with word wrapping 2`] = `
-"┌──────────────────────────────────────┐
-│>                                     │
-│   This is a very long text that will │
-│   definitely wrap to multiple lines  │
-│   and cause the textarea to grow in  │
-│   height. It should push down the    │
-│   status line below it.              │
-│                                      │
-│Status line below textarea            │
-└──────────────────────────────────────┘
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-                                        
-"
-`;
-
 exports[`Textarea Layout Tests Complex Layouts with Multiple Textareas should render multiple textareas in a column layout 1`] = `
 "┌─Chat─────────────────────────────────────────────────────┐
 │┌────────────────────────────────────────────────────────┐│
@@ -212,8 +132,8 @@ exports[`Textarea Layout Tests Complex Layouts with Multiple Textareas should re
 │└────────────────────────────────────────────────────────┘│
 │                                                          │
 │┌────────────────────────────────────────────────────────┐│
-││AI    I don't have access to real-time weather data,    ││
-││      but I can help you find that information through  ││
+││AI    I don't have access to real-time weather data, but││
+││      I can help you find that information through      ││
 ││      various weather services.                         ││
 │└────────────────────────────────────────────────────────┘│
 └──────────────────────────────────────────────────────────┘
@@ -287,7 +207,7 @@ exports[`Textarea Layout Tests Text Component Comparison should render text with
 │                                                │
 │   This is a very long prompt that will wrap    │
 │ > across multiple lines in the text component. │
-│    It should maintain proper layout with the   │
+│   It should maintain proper layout with the    │
 │   indicator on the left.                       │
 │                                                │
 │openai gpt-4                                    │
@@ -544,8 +464,8 @@ exports[`Textarea Layout Tests Measure Cache Edge Cases should correctly measure
 exports[`Textarea Layout Tests Measure Cache Edge Cases should correctly measure text after content change 2`] = `
 "┌──────────────────────────────────────┐          
 │This is a much longer text that will  │          
-│definitely wrap to multiple lines     │          
-│when rendered                         │          
+│definitely wrap to multiple lines when│          
+│rendered                              │          
 └──────────────────────────────────────┘          
                                                   
                                                   


### PR DESCRIPTION
- Makes wrapped layout byte/column authoritative; fixes CJK/emoji splits and leading wrap whitespace.
- Removes legacy wrap paths and specializes render/measure hot paths.
- Uses `u32` chunk widths, streamed large-chunk layout, and lazy cold caches.
- Fixes a pre-existing `setTabWidth` bug by refreshing cached rope metrics, including undo/redo roots.

| ReleaseFast benchmark | `main` median | PR median | Median paired result |
|---|---:|---:|---:|
| **Validated equivalent output:** char wrap, 62.5 KiB, width 40 | 0.264 ms | 0.191 ms | **27.8% less time** |
| **Validated equivalent output:** char wrap, 62.5 KiB, width 80 | 0.150 ms | 0.111 ms | **26.2% less time** |
| **Validated equivalent output:** char wrap, 62.5 KiB, width 120 | 0.103 ms | 0.075 ms | **26.9% less time** |
| **Validated equivalent output:** word wrap, 62.5 KiB, width 80 | 0.298 ms | 0.287 ms | **3.7% less time** |
| Word wrap, 1 MiB multiline, width 40 | 14.816 ms | 12.123 ms | **18.4% less time** |
| Word wrap, 1 MiB multiline, width 80 | 12.508 ms | 10.845 ms | **12.7% less time** |
| Word wrap, 1 MiB multiline, width 120 | 11.816 ms | 10.100 ms | **14.5% less time** |
| Incremental appends + wrapped measurement | 276.111 ms | 50.699 ms | **5.42× faster** |
| Incremental appends + intrinsic measurement | 63.090 ms | 62.931 ms | **neutral** |
| Repeated cached wrapped measurement | 12.584 ms | 7.851 ms | **38.1% less time** |
| First char wrap + render, 500 lines | 0.382 ms | 0.337 ms | **10.4% less time** |

- Alternating CPU-pinned pairs against current `main` `8046c846`; absolute columns are marginal medians, comparisons use median paired `main / PR` ratios. Current head is `6c02af05`; product implementation is `98709be8`, followed only by comments/benchmark corrections.
- The validated cases use one exact 64,000-column chunk and assert complete output outside timing. The old ~2 MiB rows were removed because `main` clipped layout at 65,535 columns while the PR processed all 1.86M columns.
- Uncached ASCII render chunks stream instead of retaining rich break metadata; existing caches and medium non-ASCII caching remain.
- Multiline and measurement cases use the same requests and inputs but intentionally corrected wrapping output, so they are end-to-end comparisons rather than isolated scanner claims.
- The direct scanner benchmark records 0.105 ms per 62.5 KiB scan on the PR; `main` has no equivalent API, so no direct scanner speedup is claimed.
- The three-line `setText` microbenchmark is neutral over 20 paired processes: 0.04% difference, paired CI −3.2% to +2.9%.
- Internal unit-name cleanup is split into stacked PR #1429.
