### PR TITLE
core: gate capability mutation on an outstanding probe, not response shape

### DIFF
--- a/packages/core/src/lib/outstanding-capability-probes.ts
+++ b/packages/core/src/lib/outstanding-capability-probes.ts
@@ -1,0 +1,67 @@
+import { isCapabilityResponse } from "./terminal-capability-detection.js"
+
+/**
+ * A terminal-capability mutation request minted by
+ * OutstandingCapabilityProbes.consume() — the only producer. The renderer
+ * applies capability changes exclusively through this value, so a mutation
+ * without an outstanding probe is unrepresentable at the API level.
+ */
+export interface CapabilityUpdate {
+  readonly sequence: string
+  readonly hasCursorReport: boolean
+  readonly hasStandardCapabilitySignature: boolean
+}
+
+/**
+ * Provenance gate for terminal capability mutations.
+ *
+ * The renderer issues its startup capability probes when it arms the
+ * capability window in setupTerminal(); the window expires with the probe
+ * timeout (or renderer teardown). While no probe is outstanding, consume()
+ * returns null for every byte sequence — including bytes that merely SHARE
+ * THE SHAPE of a capability response, such as modified F-key chords
+ * (`CSI 1;<mod>R`, byte-identical to a row-1 cursor position report, e.g.
+ * Ctrl+F3 = `ESC [ 1;5R`). Shape-matching without provenance let such a
+ * chord latch explicit_width/scaled_text in the native layer (set-only,
+ * never cleared), corrupting rendering until restart.
+ *
+ * Residual, documented: bytes arriving while a probe window IS open still
+ * pass — within the window a colliding chord is indistinguishable from a
+ * genuine probe reply at this layer. That is a much smaller surface than a
+ * lifetime-open listener and is not solvable here.
+ */
+export class OutstandingCapabilityProbes {
+  private windowOpen = false
+
+  /** True while startup capability queries are outstanding. */
+  public get isOpen(): boolean {
+    return this.windowOpen
+  }
+
+  /** Mark probes as issued; called where the renderer arms the probe window. */
+  public begin(): void {
+    this.windowOpen = true
+  }
+
+  /** Expire every outstanding probe (probe-window timeout or renderer teardown). */
+  public expire(): void {
+    this.windowOpen = false
+  }
+
+  /**
+   * The only CapabilityUpdate producer. Returns null unless the probe window
+   * is open AND the sequence is a recognizable capability response or a
+   * cursor report (cursor reports carry no self-identifying signature, so
+   * the open window is their only provenance).
+   */
+  public consume(sequence: string, hasCursorReport: boolean): CapabilityUpdate | null {
+    if (!this.windowOpen) {
+      return null
+    }
+    const hasStandardCapabilitySignature = isCapabilityResponse(sequence)
+    if (!hasStandardCapabilitySignature && !hasCursorReport) {
+      return null
+    }
+    return { sequence, hasCursorReport, hasStandardCapabilitySignature }
+  }
+}

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -51,6 +51,7 @@ import {
   isPixelResolutionResponse,
   parsePixelResolution,
 } from "./lib/terminal-capability-detection.js"
+import { OutstandingCapabilityProbes, type CapabilityUpdate } from "./lib/outstanding-capability-probes.js"
 import { type Clock, type TimerHandle, SystemClock } from "./lib/clock.js"
 import { StdinParser, type StdinEvent, type StdinParserProtocolContext } from "./lib/stdin-parser.js"
 import { matchesKeyBinding } from "./lib/keybinding.internal.js"
@@ -849,6 +850,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private resizeTimeoutId: TimerHandle | null = null
   private capabilityTimeoutId: TimerHandle | null = null
+  private readonly outstandingCapabilityProbes = new OutstandingCapabilityProbes()
   private terminalKeepAliveTimer: ReturnType<typeof setInterval> | null = null
   private xtVersionWaiters = new Set<() => void>()
   private splitStartupSeedTimeoutId: TimerHandle | null = null
@@ -3211,8 +3213,10 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       }
     }
 
+    this.outstandingCapabilityProbes.begin()
     this.capabilityTimeoutId = this.clock.setTimeout(() => {
       this.capabilityTimeoutId = null
+      this.outstandingCapabilityProbes.expire()
       this.clearSplitStartupCursorSeed()
 
       if (this._screenMode === "split-footer" && this._externalOutputMode === "capture-stdout") {
@@ -3315,29 +3319,22 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private processCapabilitySequence(sequence: string, hasCursorReport: boolean): boolean {
     const hasStandardCapabilitySignature = isCapabilityResponse(sequence)
-    const shouldProcessAsCapability =
-      hasStandardCapabilitySignature || (hasCursorReport && this.capabilityTimeoutId !== null)
+    const update = this.outstandingCapabilityProbes.consume(sequence, hasCursorReport)
 
-    if (!shouldProcessAsCapability) {
-      return false
+    if (!update) {
+      // No probe outstanding: capability-shaped bytes are still recognized and
+      // swallowed (never forwarded as application input), but they must not
+      // mutate state. Provenance, not shape, gates mutation.
+      return hasStandardCapabilitySignature
     }
 
-    this.lib.processCapabilityResponse(this.rendererPtr, sequence)
-    this._capabilities = this.lib.getTerminalCapabilities(this.rendererPtr)
-    if (this._capabilities?.terminal?.from_xtversion) {
-      this.resolveXtVersionWaiters()
-    }
-    if (hasStandardCapabilitySignature) {
-      this.forceFullRepaintRequested = true
-      this.requestRender()
-    }
-    this.emit(CliRenderEvents.CAPABILITIES, this._capabilities)
+    this.applyCapabilities(update)
 
     const hadPendingSplitStartupCursorSeed = this.pendingSplitStartupCursorSeed
 
     if (
       hadPendingSplitStartupCursorSeed &&
-      hasCursorReport &&
+      update.hasCursorReport &&
       this._screenMode === "split-footer" &&
       this._externalOutputMode === "capture-stdout"
     ) {
@@ -3353,9 +3350,26 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
 
     const consumeStartupCursorReport =
-      hadPendingSplitStartupCursorSeed && hasCursorReport && this.splitStartupSeedTimeoutId !== null
+      hadPendingSplitStartupCursorSeed && update.hasCursorReport && this.splitStartupSeedTimeoutId !== null
 
-    return hasStandardCapabilitySignature || consumeStartupCursorReport
+    return update.hasStandardCapabilitySignature || consumeStartupCursorReport
+  }
+
+  /**
+   * The single mutation sink for terminal capabilities. Reachable only with a
+   * CapabilityUpdate minted by OutstandingCapabilityProbes.consume().
+   */
+  private applyCapabilities(update: CapabilityUpdate): void {
+    this.lib.processCapabilityResponse(this.rendererPtr, update.sequence)
+    this._capabilities = this.lib.getTerminalCapabilities(this.rendererPtr)
+    if (this._capabilities?.terminal?.from_xtversion) {
+      this.resolveXtVersionWaiters()
+    }
+    if (update.hasStandardCapabilitySignature) {
+      this.forceFullRepaintRequested = true
+      this.requestRender()
+    }
+    this.emit(CliRenderEvents.CAPABILITIES, this._capabilities)
   }
 
   private capabilityHandler: (sequence: string) => boolean = ((sequence: string) => {
@@ -4308,6 +4322,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this.clock.clearTimeout(this.capabilityTimeoutId)
       this.capabilityTimeoutId = null
     }
+    this.outstandingCapabilityProbes.expire()
 
     this.clearSplitStartupCursorSeed()
 
@@ -5041,7 +5056,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   }
 
   private waitForXtVersion(): Promise<void> {
-    if (this.capabilityTimeoutId === null || this._capabilities?.terminal?.from_xtversion) {
+    if (!this.outstandingCapabilityProbes.isOpen || this._capabilities?.terminal?.from_xtversion) {
       return Promise.resolve()
     }
 

--- a/packages/core/src/tests/renderer.capability-provenance.test.ts
+++ b/packages/core/src/tests/renderer.capability-provenance.test.ts
@@ -1,0 +1,128 @@
+import { test, expect, describe } from "bun:test"
+import { createTestRenderer } from "../testing/test-renderer.js"
+import { ManualClock } from "../testing/manual-clock.js"
+import { createTerminalCapabilities } from "../testing/terminal-capabilities.js"
+
+// Capability mutation must require a probe this process actually issued.
+//
+// xterm encodes modified F1–F4 as `CSI 1;<mod> P/Q/R/S`; the R slot (e.g.
+// Ctrl+F3 = `ESC [ 1;5R`) is byte-identical to a row-1 cursor position
+// report. When such a chord is classified as a capability response by shape
+// alone, the native layer reads col >= 2 as proof of the explicit-width /
+// scaled-text protocol and latches both capabilities (set-only, never
+// cleared) — rendering is corrupted until restart.
+//
+// The renderer arms a capability probe window in setupTerminal()
+// (capabilityTimeoutId, 5000ms). These tests pin the invariant: outside an
+// outstanding probe window no capability-shaped byte sequence mutates
+// capabilities; inside it, genuine probe replies still apply.
+
+interface CapabilityWriteSpy {
+  processCalls: string[]
+  events: unknown[]
+  restore: () => void
+}
+
+function spyOnCapabilityWrites(renderer: unknown): CapabilityWriteSpy {
+  const lib = (renderer as { lib: any }).lib
+  const originalProcess = lib.processCapabilityResponse
+  const originalGet = lib.getTerminalCapabilities
+
+  let explicitWidthLatched = false
+  const processCalls: string[] = []
+  lib.processCapabilityResponse = (_ptr: unknown, sequence: string) => {
+    processCalls.push(sequence)
+    explicitWidthLatched = true
+  }
+  lib.getTerminalCapabilities = () => createTerminalCapabilities({ explicit_width: explicitWidthLatched })
+
+  const events: unknown[] = []
+  ;(renderer as { on: (ev: string, cb: (caps: unknown) => void) => void }).on("capabilities", (caps) => {
+    events.push(caps)
+  })
+
+  return {
+    processCalls,
+    events,
+    restore: () => {
+      lib.processCapabilityResponse = originalProcess
+      lib.getTerminalCapabilities = originalGet
+    },
+  }
+}
+
+describe("capability probe provenance", () => {
+  test("a capability-shaped chord with no probe outstanding does not mutate capabilities", async () => {
+    const clock = new ManualClock()
+    const { renderer } = await createTestRenderer({ clock })
+    const spy = spyOnCapabilityWrites(renderer)
+
+    // Ctrl+F3 under modifyOtherKeys — byte-identical to a row-1/col-5 CPR.
+    // @ts-expect-error - private method under test
+    const handled = renderer.processCapabilitySequence("\x1b[1;5R", true)
+
+    expect(handled).toBe(true) // swallowed, never forwarded as input
+    expect(spy.processCalls).toHaveLength(0)
+    expect(spy.events).toHaveLength(0)
+    // @ts-expect-error - private state under test
+    expect(renderer.forceFullRepaintRequested).toBe(false)
+    expect(renderer.capabilities?.explicit_width ?? false).toBe(false)
+
+    spy.restore()
+    renderer.destroy()
+  })
+
+  test("a DA1-shaped response with no probe outstanding does not mutate capabilities", async () => {
+    const clock = new ManualClock()
+    const { renderer } = await createTestRenderer({ clock })
+    const spy = spyOnCapabilityWrites(renderer)
+
+    // @ts-expect-error - private method under test
+    const handled = renderer.processCapabilitySequence("\x1b[?62;22c", false)
+
+    expect(handled).toBe(true) // swallowed, never forwarded as input
+    expect(spy.processCalls).toHaveLength(0)
+    expect(spy.events).toHaveLength(0)
+
+    spy.restore()
+    renderer.destroy()
+  })
+
+  test("a width-probe reply inside the outstanding window still mutates capabilities", async () => {
+    const clock = new ManualClock()
+    const { renderer } = await createTestRenderer({ clock })
+    const spy = spyOnCapabilityWrites(renderer)
+
+    await renderer.setupTerminal()
+
+    // @ts-expect-error - private method under test
+    const handled = renderer.processCapabilitySequence("\x1b[1;2R", true)
+
+    expect(handled).toBe(true)
+    expect(spy.processCalls).toEqual(["\x1b[1;2R"])
+    expect(spy.events).toHaveLength(1)
+    expect(renderer.capabilities?.explicit_width).toBe(true)
+
+    spy.restore()
+    renderer.destroy()
+  })
+
+  test("after the probe window expires, capability-shaped bytes are inert", async () => {
+    const clock = new ManualClock()
+    const { renderer } = await createTestRenderer({ clock })
+    const spy = spyOnCapabilityWrites(renderer)
+
+    await renderer.setupTerminal()
+    clock.advance(5000)
+
+    // @ts-expect-error - private method under test
+    const handled = renderer.processCapabilitySequence("\x1b[?62;22c", false)
+
+    expect(handled).toBe(true) // swallowed, never forwarded as input
+    expect(spy.processCalls).toHaveLength(0)
+    expect(spy.events).toHaveLength(0)
+
+    spy.restore()
+    renderer.destroy()
+  })
+})

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -1930,6 +1930,7 @@ test("CliRenderer reseeds split startup offset from non-home CPR capability resp
   const originalGetCursorState = lib.getCursorState.bind(lib)
   ;(renderer as any).pendingSplitStartupCursorSeed = true
   ;(renderer as any).capabilityTimeoutId = setTimeout(() => {}, 10)
+  ;(renderer as any).outstandingCapabilityProbes.begin()
   ;(renderer as any).setPendingSplitFooterTransition({
     mode: "clear-stale-rows",
     sourceTopLine: 2,
@@ -1969,6 +1970,7 @@ test("CliRenderer does not consume standalone CPR replies during capability wind
   renderer = result.renderer
   ;(renderer as any).pendingSplitStartupCursorSeed = false
   ;(renderer as any).capabilityTimeoutId = setTimeout(() => {}, 10)
+  ;(renderer as any).outstandingCapabilityProbes.begin()
 
   const handled = (renderer as any).processCapabilitySequence("\x1b[7;11R", true)
   expect(handled).toBe(false)

--- a/packages/core/src/tests/renderer.palette.test.ts
+++ b/packages/core/src/tests/renderer.palette.test.ts
@@ -164,8 +164,10 @@ async function createSilentFollowUpPaletteRenderer(clock = new ManualClock()) {
 
 function startCapabilityDetectionWindow(renderer: any, clock: ManualClock): void {
   renderer._terminalIsSetup = true
+  renderer.outstandingCapabilityProbes.begin()
   renderer.capabilityTimeoutId = clock.setTimeout(() => {
     renderer.capabilityTimeoutId = null
+    renderer.outstandingCapabilityProbes.expire()
     renderer.resolveXtVersionWaiters()
   }, 5000)
 }
@@ -716,6 +718,8 @@ describe("Capability repaint handling", () => {
 
     // @ts-expect-error - testing private renderer state
     expect(renderer.forceFullRepaintRequested).toBe(false)
+
+    startCapabilityDetectionWindow(renderer, clock)
 
     // @ts-expect-error - testing private renderer method
     renderer.capabilityHandler("\x1bP>|wezterm\x1b\\")


### PR DESCRIPTION
## Problem

`CliRenderer.processCapabilitySequence()` accepted any stdin sequence matching the capability-response *shape* at *any* time — an unconditional, lifetime-open listener.

xterm encodes modified F1–F4 as `CSI 1;<mod> P/Q/R/S`. The `R` slot (e.g. **Ctrl+F3** = `ESC [ 1 ; 5 R`) is byte-identical to a **row-1 cursor position report**. The native layer reads `col >= 2` as proof of the explicit-width/scaled-text protocol and latches both capabilities — **set-only, never cleared**. One modified-F-key chord arriving at the wrong moment permanently corrupts rendering until restart.

Shape is not provenance: bytes that merely *look like* a capability response must never be able to latch capabilities.

## Fix

Introduce `OutstandingCapabilityProbes` (`lib/outstanding-capability-probes.ts`): the startup probe window armed in `setupTerminal()` is now the sole provenance of capability mutations.

- `consume()` is the **only producer** of `CapabilityUpdate`; `CliRenderer.applyCapabilities()` is the **only mutation sink**. With no probe outstanding, mutation is unrepresentable at the API level.
- The renderer's `capabilityTimeoutId` remains the window timer; all window-state reads (the capability gate, `waitForXtVersion`, `destroy` teardown) now go through the registry.
- **Recognition stays shape-based**: with no probe outstanding, capability-shaped bytes (including malformed XTGETTCAP replies) are still swallowed rather than forwarded as application input — they simply cannot latch state. In-window behavior for genuine probe replies is unchanged.

Residual, documented in the module header: bytes arriving *while* a probe window is open still pass — within the window a colliding chord is indistinguishable from a genuine reply at this layer. That is a far smaller surface than a lifetime-open listener and is not solvable here.

## Tests

- New `renderer.capability-provenance.test.ts` (**written red-first** per AGENTS.md — fails on the pre-fix gate, passes after):
  - a modified-F3-shaped chord with no probe outstanding mutates nothing
  - a DA1-shaped response with no probe outstanding mutates nothing
  - a width-probe reply *inside* the window still applies
  - window expiry closes provenance
- Existing tests that drive capability responses without `setupTerminal()` (palette, console-startup) now arm the registry explicitly via `startCapabilityDetectionWindow`.

## Verification

- `bun test` in `packages/core`: **5467 pass / 23 skip** (1 failure in `node-assets.test.ts` reproduces identically on clean `main` in this environment — host artifact, unrelated)
- `bun run fmt:check` and `bun run lint` clean; `bun run build:lib` clean