### PR TITLE
feat(native): export audio module to Zig consumers

### DIFF
--- a/packages/native/examples/hello/src/main.zig
+++ b/packages/native/examples/hello/src/main.zig
@@ -35,6 +35,9 @@ pub fn main() !void {
     defer std.debug.assert(debug_allocator.deinit() == .ok);
     const allocator = debug_allocator.allocator();
 
+    const audio_engine = opentui.audio.create(allocator, null) orelse return error.AudioEngineCreationFailed;
+    defer opentui.audio.destroy(audio_engine);
+
     var graphemes = opentui.GraphemePool.init(allocator);
     defer graphemes.deinit();
     var links = opentui.LinkPool.init(allocator);

--- a/packages/native/src/opentui.zig
+++ b/packages/native/src/opentui.zig
@@ -1,4 +1,5 @@
 pub const ansi = @import("ansi.zig");
+pub const audio = @import("audio.zig");
 pub const buffer = @import("buffer.zig");
 pub const renderer = @import("renderer.zig");
 pub const text_buffer = @import("text-buffer.zig");


### PR DESCRIPTION
## Summary

- export the existing native audio module from the public `opentui` Zig package
- exercise the exact consumer import path in the standalone native Zig example by creating and destroying an audio engine

No documentation, façade, FFI, or build-system changes are included.

## Verification

- `zig build run -Doptimize=ReleaseSmall` in `packages/native/examples/hello`
- `PATH=/tmp/opencode/zig-0.16.0/bin:$PATH bun run test:native` in `packages/core`: 2,067 passed, 8 skipped

The root `bun run build` was attempted but this clean worktree resolved `typescript@7.0.2`, whose CommonJS export lacks `transpileModule`; `bun install --frozen-lockfile` also reports that the current lockfile would change under Bun 1.3.14. The affected native suite is green.
