### PR TITLE
fix(react): wrap test renderer teardown in act

### DIFF
--- a/packages/react/src/test-utils.ts
+++ b/packages/react/src/test-utils.ts
@@ -1,3 +1,4 @@
+import { CliRenderEvents } from "@opentui/core"
 import { createTestRenderer, type TestRendererOptions } from "@opentui/core/testing"
 import { act, type ReactNode } from "react"
 import { createRoot, type Root } from "./reconciler/renderer.js"
@@ -8,29 +9,25 @@ function setIsReactActEnvironment(isReactActEnvironment: boolean) {
 }
 
 export async function testRender(node: ReactNode, testRendererOptions: TestRendererOptions) {
-  let root: Root | null = null
   setIsReactActEnvironment(true)
 
   const testSetup = await createTestRenderer({
     ...testRendererOptions,
     onDestroy() {
-      act(() => {
-        if (root) {
-          root.unmount()
-          root = null
-        }
-      })
       testRendererOptions.onDestroy?.()
       setIsReactActEnvironment(false)
     },
   })
 
-  root = createRoot(testSetup.renderer)
-  act(() => {
-    if (root) {
-      root.render(node)
-    }
+  let root: Root
+  // Register before createRoot so this listener unmounts inside act() before
+  // createRoot's own DESTROY listener tries to unmount the same container.
+  testSetup.renderer.once(CliRenderEvents.DESTROY, () => {
+    act(() => root.unmount())
   })
+
+  root = createRoot(testSetup.renderer)
+  act(() => root.render(node))
 
   return testSetup
 }

--- a/packages/react/tests/test-utils.test.tsx
+++ b/packages/react/tests/test-utils.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it, spyOn } from "bun:test"
+import { testRender } from "../src/test-utils.js"
+
+describe("React test utilities", () => {
+  it("renders a static component without an act warning", async () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {})
+    const setup = await testRender(<text>hello</text>, { width: 80, height: 24 })
+
+    try {
+      await setup.renderOnce()
+      expect(setup.captureCharFrame()).toContain("hello")
+      setup.renderer.destroy()
+      await Promise.resolve()
+      expect(consoleError.mock.calls.flat().join("\n")).not.toContain("was not wrapped in act")
+    } finally {
+      setup.renderer.destroy()
+      consoleError.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- unmount the React test root inside `act()` when the CLI renderer emits `DESTROY`
- register the test cleanup before `createRoot` so its automatic cleanup becomes a no-op
- add a regression test for static `testRender` usage

## Root cause

`CliRenderer` emits `DESTROY` before invoking its configured `onDestroy` callback. `createRoot` therefore unmounted the React container outside `act()` before `testRender` reached its wrapped cleanup, producing the warning.

## Verification

- `cd packages/react && bun test tests/test-utils.test.tsx`
- `cd packages/react && bun test`
- `cd packages/react && bun run build --ci`
- formatting and lint checks

Closes #1315