### PR TITLE
fix(core): release the stdin handle on destroy

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -997,6 +997,14 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   // or duck-typed capability checks (e.g. `stdin.setRawMode?.()`).
   private readonly _usesProcessStdout: boolean
 
+  // Whether this renderer is what put process.stdin's handle on the event loop.
+  // Captured before any listener is attached: touching process.stdin lazily
+  // instantiates the TTY read stream and registers its handle, and `pause()` on
+  // destroy stops the read without releasing that registration (#1405). If the
+  // host app was already consuming stdin the handle is theirs, and destroy()
+  // must leave it exactly as it found it.
+  private readonly _ownsStdinHandle: boolean
+
   // Feed wiring. Non-null when the given stdout is not process.stdout and native
   // output is not explicitly redirected to a buffered memory destination.
   private _feed: NativeSpanFeed | null = null
@@ -1045,6 +1053,8 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this.stdin = stdin
     this.stdout = stdout
+    this._ownsStdinHandle =
+      stdin === process.stdin && stdin.listenerCount("data") === 0 && stdin.listenerCount("readable") === 0
     this._usesProcessStdout = stdout === process.stdout
     this.realStdoutWrite = stdout.write
 
@@ -1318,6 +1328,36 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   private startTerminalKeepAlive(): void {
     if (this.stdin !== process.stdin || this.terminalKeepAliveTimer !== null) return
     this.terminalKeepAliveTimer = setInterval(() => {}, 60_000)
+  }
+
+  /**
+   * Put stdin's event-loop registration back the way this renderer found it.
+   *
+   * `pause()` stops the read but leaves the libuv handle registered, so after
+   * `destroy()` the loop still holds it. On the legacy Windows console host that
+   * wedges conhost once any read has completed and then takes the window with it
+   * (#1405); `suspend()` deliberately does not do this, because `resume()`
+   * follows it.
+   *
+   * Three conditions, all required:
+   *   - we are what registered the handle (`_ownsStdinHandle`) — a caller-supplied
+   *     `config.stdin`, or a stdin the host app was already consuming, is not ours
+   *     to unref;
+   *   - nothing else is consuming it now, so a listener attached during our
+   *     lifetime and kept afterwards still keeps the process alive;
+   *   - the stream actually implements `unref` — a redirected, file-backed stdin
+   *     is a plain ReadStream and does not.
+   */
+  private releaseStdinHandle(): void {
+    if (!this._ownsStdinHandle) return
+    if (this.stdin.listenerCount("data") > 0 || this.stdin.listenerCount("readable") > 0) return
+    const unref = (this.stdin as Partial<{ unref: () => void }>).unref
+    if (typeof unref !== "function") return
+    try {
+      unref.call(this.stdin)
+    } catch (e) {
+      console.error("Error releasing stdin during destroy:", e)
+    }
   }
 
   private stopTerminalKeepAlive(): void {
@@ -4353,6 +4393,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     } catch (e) {
       console.error("Error pausing stdin during destroy:", e)
     }
+    this.releaseStdinHandle()
 
     if (this._feed !== null && this._splitHeight > 0 && !this._terminalIsSetup) {
       this.flushPendingSplitOutputBeforeTransition(false, { allowSuspended: true, allowUnsetup: true })

--- a/packages/core/src/tests/renderer.stdin-handle.test.ts
+++ b/packages/core/src/tests/renderer.stdin-handle.test.ts
@@ -1,0 +1,128 @@
+import { test, expect, afterEach } from "bun:test"
+import { Readable } from "stream"
+import { createCliRenderer, type CliRenderer } from "../renderer.js"
+import { createTestStdout } from "../testing/test-streams.js"
+
+// #1405: createCliRenderer touches process.stdin, which lazily instantiates the
+// TTY read stream and registers its handle on the event loop. destroy() removed
+// the listener, cleared raw mode and paused — but pause() stops the read without
+// releasing the registration, so the loop kept holding it. On the legacy Windows
+// console host that wedges conhost shortly after destroy() and takes the window
+// with it. These cover the release and, just as importantly, every case where
+// releasing would be wrong.
+
+class FakeStdin extends Readable {
+  public unrefCalls = 0
+  public rawMode: boolean | null = null
+  constructor() {
+    super({ read() {} })
+  }
+  unref(): void {
+    this.unrefCalls += 1
+  }
+  setRawMode(mode: boolean): this {
+    this.rawMode = mode
+    return this
+  }
+}
+
+/** A stdin with no `unref` at all — what a redirected, file-backed stdin looks like. */
+class UnrefLessStdin extends Readable {
+  constructor() {
+    super({ read() {} })
+  }
+  setRawMode(mode: boolean): this {
+    return this
+  }
+}
+
+const destroyFns: Array<() => void> = []
+let restoreStdin: (() => void) | null = null
+
+afterEach(() => {
+  while (destroyFns.length) destroyFns.pop()!()
+  restoreStdin?.()
+  restoreStdin = null
+})
+
+/** Install `stream` as process.stdin so the renderer's default path picks it up. */
+function useAsProcessStdin(stream: Readable): void {
+  const original = Object.getOwnPropertyDescriptor(process, "stdin")!
+  Object.defineProperty(process, "stdin", { value: stream, configurable: true })
+  restoreStdin = () => Object.defineProperty(process, "stdin", original)
+}
+
+async function makeRenderer(config: Record<string, unknown> = {}): Promise<CliRenderer> {
+  const renderer = await createCliRenderer({ stdout: createTestStdout(), ...config })
+  destroyFns.push(() => {
+    if (!renderer.isDestroyed) renderer.destroy()
+  })
+  return renderer
+}
+
+test("destroy releases the stdin handle the renderer itself registered", async () => {
+  const stdin = new FakeStdin()
+  useAsProcessStdin(stdin)
+
+  const renderer = await makeRenderer()
+  expect(stdin.unrefCalls).toBe(0)
+
+  renderer.destroy()
+  expect(stdin.unrefCalls).toBe(1)
+})
+
+test("destroy leaves a caller-supplied stdin alone", async () => {
+  const processStdin = new FakeStdin()
+  useAsProcessStdin(processStdin)
+  const supplied = new FakeStdin()
+
+  const renderer = await makeRenderer({ stdin: supplied })
+  renderer.destroy()
+
+  expect(supplied.unrefCalls).toBe(0)
+  expect(processStdin.unrefCalls).toBe(0)
+})
+
+test("destroy leaves a stdin the host app was already consuming", async () => {
+  const stdin = new FakeStdin()
+  stdin.on("data", () => {}) // the app is reading stdin before the renderer exists
+  useAsProcessStdin(stdin)
+
+  const renderer = await makeRenderer()
+  renderer.destroy()
+
+  expect(stdin.unrefCalls).toBe(0)
+})
+
+test("destroy leaves stdin alone when a listener attached during the session survives", async () => {
+  const stdin = new FakeStdin()
+  useAsProcessStdin(stdin)
+
+  const renderer = await makeRenderer()
+  const appListener = () => {}
+  stdin.on("data", appListener) // host app starts reading while the renderer runs
+
+  renderer.destroy()
+  expect(stdin.unrefCalls).toBe(0)
+})
+
+test("destroy does not throw when stdin has no unref", async () => {
+  const stdin = new UnrefLessStdin()
+  useAsProcessStdin(stdin)
+
+  const renderer = await makeRenderer()
+  expect(() => renderer.destroy()).not.toThrow()
+})
+
+test("suspend does not release the handle, because resume follows it", async () => {
+  const stdin = new FakeStdin()
+  useAsProcessStdin(stdin)
+
+  const renderer = await makeRenderer()
+  renderer.suspend()
+  expect(stdin.unrefCalls).toBe(0)
+
+  renderer.resume()
+  renderer.destroy()
+  expect(stdin.unrefCalls).toBe(1)
+})


### PR DESCRIPTION
Fixes #1405.

## Summary

`createCliRenderer()` touches `process.stdin`, which lazily instantiates the TTY read stream and registers its handle on the event loop. `cleanupBeforeDestroy()` removes the data listener, clears raw mode and calls `pause()` — but `pause()` stops the read without releasing that registration, so the loop keeps holding it after `destroy()`. As the report puts it: pause() stops the read; it does not remove the handle from the loop.

`stdin.unref()` / `stdin.destroy()` appear nowhere in `packages/core/src` on current main.

## Measured

Node 26.7.0, Windows 11 (build 26200.9168), a real `conhost.exe` window, same script both times — create renderer, wait for a keypress, `destroy()`, let the loop turn 3s. `process.stdin` checked against `process._getActiveHandles()` immediately after `destroy()`:

| | stdin still on the event loop | outcome |
|---|---|---|
| main | `true` | survived |
| this branch | `false` | survived |

So the leaked registration is real and this removes it.

**What I did not reproduce:** the console wedge itself. Both runs survived the 3s window on this Windows build, so the conhost crash remains the reporter's observation rather than mine — what is fixed here is the leaked registration their report identifies as the cause. If someone can still reproduce the wedge, a run against this branch would be worth having.

One gotcha for anyone re-measuring: `process._getActiveHandles()` is a stub under Bun — it reports zero handles even with an active stdin listener — so this can only be measured on Node.

## Changes

`releaseStdinHandle()`, called from `cleanupBeforeDestroy()` right after `pause()`. Deliberately not called from `suspend()`, since `resume()` follows that.

Three conditions, all required, each for a case where releasing would be wrong:

- **`_ownsStdinHandle`** — captured in the constructor before anything touches stdin, true only when the stream is `process.stdin` *and* nothing was already consuming it. A caller-supplied `config.stdin`, or a stdin the host app was already reading, is not ours to unref. This follows the existing `this.stdin === process.stdin` pattern already used by `startTerminalKeepAlive`, `disableMouse` and `destroyRenderer`.
- **no listeners at destroy time** — so a listener the host attached during our lifetime and kept afterwards still holds the loop open.
- **`typeof unref === "function"`** — a redirected, file-backed stdin is a plain `ReadStream` with no `unref`; calling it there throws `TypeError`.

Worth stating explicitly: `unref()` persists. A consumer that attaches to stdin *after* `destroy()` will not be kept alive by it, because `resume()` does not re-ref. That is the state stdin was in before the renderer ran, which is why the ownership guard is scoped the way it is.

## Tests

Six in `packages/core/src/tests/renderer.stdin-handle.test.ts`. The two positive ones fail on main and pass here; the other four are guards that pass either way and exist so the release can never be widened by accident:

- releases the handle the renderer itself registered
- leaves a caller-supplied `config.stdin` alone
- leaves a stdin the host app was already consuming
- leaves stdin alone when a listener attached during the session survives
- does not throw when stdin has no `unref`
- `suspend()` does not release, because `resume()` follows it

`bun test` in `packages/core`: 5469 pass. The 37 failures are all pre-existing on a clean checkout of the same commit — 36 are "Unhandled error between tests" in the vendored Yoga suites under `src/zig/zig-pkg/`, and `getNodeAssets` fails on a missing `parser.worker.js` build artifact. I verified both by stashing this change and re-running them.

`bun run lint` clean; `tsc --noEmit` reports no errors in `renderer.ts`.