### PR TITLE
ffi: preserve viewport lookup success result

### DIFF
--- a/packages/core/src/tests/ffi-borrowed-pointer-callsites.test.ts
+++ b/packages/core/src/tests/ffi-borrowed-pointer-callsites.test.ts
@@ -77,6 +77,16 @@ function readPackedColor(packed: ArrayBuffer, offset: number): number[] {
 }
 
 describe("borrowed pointer call sites", () => {
+  test("preserves the native viewport lookup success result", () => {
+    const x = new Uint32Array([1])
+    const y = new Uint32Array([1])
+    const width = new Uint32Array([1])
+    const height = new Uint32Array([1])
+
+    expect([false, 0]).toContain(symbols.editorViewGetViewport(0, x, y, width, height))
+    expect([x[0], y[0], width[0], height[0]]).toEqual([0, 0, 0, 0])
+  })
+
   test("stabilizes retained text memory before resolving its pointer", () => {
     withStubbedSymbols(
       {

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -1238,7 +1238,7 @@ function getOpenTUILib(libPath?: string) {
     },
     editorViewGetViewport: {
       args: ["u32", "buffer", "buffer", "buffer", "buffer"],
-      returns: "void",
+      returns: "bool",
     },
     editorViewSetScrollMargin: {
       args: ["u32", "f32"],


### PR DESCRIPTION
The native viewport lookup reports whether a view exists, but the FFI
binding discarded that result. Preserve the boolean so callers can
distinguish missing views from successful lookups.
