### PR TITLE
feat: FreeBSD support for the native library

### DIFF
--- a/packages/core/src/node-asset-target.ts
+++ b/packages/core/src/node-asset-target.ts
@@ -1,5 +1,5 @@
 export type NodeAssetTarget = {
-  readonly platform: "darwin" | "linux" | "win32"
+  readonly platform: "darwin" | "linux" | "win32" | "freebsd"
   readonly arch: "arm64" | "x64"
   readonly libc?: "glibc" | "musl"
 }
@@ -14,6 +14,7 @@ const NATIVE_FILE_NAMES = {
   darwin: "libopentui.dylib",
   linux: "libopentui.so",
   win32: "opentui.dll",
+  freebsd: "libopentui.so",
 } as const
 
 export function getNativeAssetDescriptor(target: NodeAssetTarget): NativeAssetDescriptor {

--- a/packages/core/src/platform/runtime-assets.bun.ts
+++ b/packages/core/src/platform/runtime-assets.bun.ts
@@ -68,6 +68,14 @@ export async function resolveNativeLibraryPath(): Promise<string> {
     }
   }
 
+  if (process.platform === "freebsd") {
+    if (process.arch === "x64") {
+      return (await import("@opentui/core-freebsd-x64")).default
+    }
+    if (process.arch === "arm64") {
+      return (await import("@opentui/core-freebsd-arm64")).default
+    }
+  }
   if (process.platform === "win32") {
     if (process.arch === "x64") {
       return ((await import("@opentui/core-win32-x64" as string)) as NativePackageModule).default

--- a/packages/core/src/platform/runtime-assets.bun.ts
+++ b/packages/core/src/platform/runtime-assets.bun.ts
@@ -69,13 +69,15 @@ export async function resolveNativeLibraryPath(): Promise<string> {
   }
 
   if (process.platform === "freebsd") {
-    if (process.arch === "x64") {
-      return (await import("@opentui/core-freebsd-x64")).default
-    }
-    if (process.arch === "arm64") {
-      return (await import("@opentui/core-freebsd-arm64")).default
-    }
+    // Built at runtime rather than written as a literal: no @opentui/core-freebsd-*
+    // package is published yet, and a literal specifier would make the bundler try to
+    // resolve it at build time, failing `bun run build:lib` on every platform. The node
+    // resolver already imports asset.packageName the same way. Set OTUI_ASSET_ROOT to
+    // point at a locally built libopentui.so instead (handled above).
+    const specifier: string = `@opentui/core-freebsd-${process.arch}`
+    return ((await import(specifier)) as NativePackageModule).default
   }
+
   if (process.platform === "win32") {
     if (process.arch === "x64") {
       return ((await import("@opentui/core-win32-x64" as string)) as NativePackageModule).default

--- a/packages/native/build.zig
+++ b/packages/native/build.zig
@@ -25,6 +25,8 @@ const SUPPORTED_TARGETS = [_]SupportedTarget{
     .{ .zig_target = "aarch64-linux-musl", .output_name = "aarch64-linux-musl", .description = "Linux aarch64 (musl)" },
     .{ .zig_target = "x86_64-macos.13.0", .output_name = "x86_64-macos", .description = "macOS x86_64 (Intel)" },
     .{ .zig_target = "aarch64-macos.13.0", .output_name = "aarch64-macos", .description = "macOS aarch64 (Apple Silicon)" },
+    .{ .zig_target = "x86_64-freebsd", .output_name = "x86_64-freebsd", .description = "FreeBSD x86_64" },
+    .{ .zig_target = "aarch64-freebsd", .output_name = "aarch64-freebsd", .description = "FreeBSD aarch64" },
     .{ .zig_target = "x86_64-windows-gnu", .output_name = "x86_64-windows", .description = "Windows x86_64" },
     .{ .zig_target = "aarch64-windows-gnu", .output_name = "aarch64-windows", .description = "Windows aarch64" },
 };
@@ -367,6 +369,10 @@ fn addNativeAudioDependencies(
         .macos => addMacOSSystemLibraries(b, module, macos_sdk_path.?),
         .linux => {
             module.linkSystemLibrary("dl", .{});
+            module.linkSystemLibrary("pthread", .{});
+            module.linkSystemLibrary("m", .{});
+        },
+        .freebsd => {
             module.linkSystemLibrary("pthread", .{});
             module.linkSystemLibrary("m", .{});
         },


### PR DESCRIPTION
## What this does

Makes `@opentui/core` build and load its native library on FreeBSD. Four small changes, none of them in the Zig or C/C++ sources — the renderer itself already compiles cleanly for this target.

## Why it does not work today

`zig build` refuses to build for the host at all:

```
No matching supported target for native platform (x86_64-freebsd)
error: UnsupportedNativeTarget
```

`buildNativeTarget()` matches the host against `SUPPORTED_TARGETS` and errors out when nothing matches. Even with a library in hand, `getNativeAssetDescriptor()` then throws `Unsupported OpenTUI Node asset target: freebsd-x64` before any lookup happens — including before `OTUI_ASSET_ROOT` is consulted, so there is no escape hatch for a locally built `.so` either.

## The changes

1. **`packages/native/build.zig`** — FreeBSD entries in `SUPPORTED_TARGETS`, plus a `.freebsd` arm in `linkSystemLibraries()`. It deliberately omits the `dl` that the Linux arm links: FreeBSD keeps `dlopen(3)` and friends in libc and has no separate `libdl` to link against. `m` and `pthread` are linked as on Linux.

2. **`packages/core/src/node-asset-target.ts`** — `freebsd: "libopentui.so"` in `NATIVE_FILE_NAMES`, and `"freebsd"` in the `NodeAssetTarget["platform"]` union.

3. **`packages/core/src/platform/runtime-assets.bun.ts`** — a `freebsd` arm in `resolveNativeLibraryPath()`. The **node** resolver needs no change: it imports `asset.packageName` dynamically, so it works as soon as the descriptor resolves. Only the bun path hardcodes one branch per platform.

`ghosttyVtAvailable()` is intentionally untouched — FreeBSD falls through its `else` arm, so ghostty-vt is compiled out. I did not investigate what, if anything, that costs at runtime; the TUI I tested rendered correctly without it.

## Verification

FreeBSD 15.1-RC2, amd64, zig 0.16.0:

- `sh scripts/prepare-zig-deps.sh` then `zig build -Doptimize=ReleaseFast` exits 0 and produces `lib/x86_64-freebsd/libopentui.so` (20 MB, 1829 exported text symbols).
- Importing `@opentui/core` resolves to that library through the new arm.
- End-to-end rendering was verified against the **0.4.5** tree rather than main, because that is what the application I was porting pins. The same two `build.zig` edits apply there (the sources live at `packages/core/src/zig`, and that tree needs zig 0.15.2 — 0.16 fails on a vendored uucode `build.zig` with `std.Build` API errors). With that library in place a full-screen TUI renders correctly under a real tty: logo, input box, status bar, the lot.

`aarch64-freebsd` is listed in the table but was **not** built or tested — I included it so an arm64 FreeBSD user does not need a second patch, but treat it as unverified and drop that line if you would rather not carry an untested target.

## What this PR does not do

Publishing `@opentui/core-freebsd-x64` to npm and adding a FreeBSD job to `build-native.yml` are yours to decide — I have not touched the workflows. Without a published platform package, FreeBSD users can still point `OTUI_ASSET_ROOT` at a locally built library, which now works because change 2 stops the descriptor from throwing first.