### PR TITLE
fix(native): preserve mixed whitespace graphemes

### DIFF
--- a/packages/core/src/renderables/Text.test.ts
+++ b/packages/core/src/renderables/Text.test.ts
@@ -2345,6 +2345,33 @@ describe("TextRenderable Selection", () => {
       expect(lines).toEqual(expectedLines)
     })
 
+    it("should preserve mixed-content graphemes at word-wrap boundaries", async () => {
+      for (const prefix of [
+        "\u0D4E", // U+0D4E MALAYALAM LETTER DOT REPH
+        "\u0600", // U+0600 ARABIC NUMBER SIGN
+      ]) {
+        for (const { width, expected } of [
+          { width: 5, expected: ["hello", prefix, "world"] },
+          { width: 7, expected: [`hello ${prefix}`, "world"] },
+        ]) {
+          const { text } = await createTextRenderable(currentRenderer, {
+            content: `hello ${prefix} world`,
+            wrapMode: "word",
+            width,
+          })
+
+          const lines = captureFrame()
+            .split("\n")
+            .map((line) => line.trimEnd())
+            .filter((line) => line.length > 0)
+          expect(lines).toEqual(expected)
+
+          currentRenderer.root.remove(text)
+          await renderOnce()
+        }
+      }
+    })
+
     it("should dynamically change wrap mode", async () => {
       const { text } = await createTextRenderable(currentRenderer, {
         content: "The quick brown fox jumps",

--- a/packages/core/src/renderables/Text.test.ts
+++ b/packages/core/src/renderables/Text.test.ts
@@ -64,6 +64,7 @@ describe("TextRenderable Selection", () => {
     } = await createTestRenderer({
       width: 20,
       height: 5,
+      forwardEnvKeys: [],
     }))
   })
 

--- a/packages/native/src/tests/text-buffer-segment_test.zig
+++ b/packages/native/src/tests/text-buffer-segment_test.zig
@@ -93,7 +93,26 @@ test "walkChunkLayoutInfo keeps Prepend joined to an ASCII vector" {
     try testing.expectEqual(@as(u32, 3), breaks.items[0].byte_len);
     try testing.expectEqual(@as(u32, 0), breaks.items[0].col_start);
     try testing.expectEqual(@as(u32, 1), breaks.items[0].width_cols);
-    try testing.expectEqual(utf8.LayoutWrapBreakKind.whitespace, breaks.items[0].kind);
+    try testing.expectEqual(utf8.LayoutWrapBreakKind.preserved_whitespace, breaks.items[0].kind);
+}
+
+test "walkChunkLayoutInfo preserves mixed-content whitespace graphemes" {
+    const cases = [_][]const u8{
+        "\u{0D4E} ", // U+0D4E MALAYALAM LETTER DOT REPH
+        "\u{0600} ", // U+0600 ARABIC NUMBER SIGN
+    };
+    var breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;
+    defer breaks.deinit(testing.allocator);
+
+    for (cases) |text| {
+        _ = try utf8.findChunkLayoutInfo(testing.allocator, text, 2, false, .unicode, &breaks);
+        try testing.expectEqual(@as(usize, 1), breaks.items.len);
+        try testing.expectEqual(@as(u32, 0), breaks.items[0].byte_start);
+        try testing.expectEqual(@as(u32, @intCast(text.len)), breaks.items[0].byte_len);
+        try testing.expectEqual(@as(u32, 0), breaks.items[0].col_start);
+        try testing.expectEqual(@as(u32, 1), breaks.items[0].width_cols);
+        try testing.expectEqual(utf8.LayoutWrapBreakKind.preserved_whitespace, breaks.items[0].kind);
+    }
 }
 
 test "walkChunkLayoutInfo stops streaming after visitor allocation failure" {

--- a/packages/native/src/tests/text-buffer-segment_test.zig
+++ b/packages/native/src/tests/text-buffer-segment_test.zig
@@ -100,6 +100,8 @@ test "walkChunkLayoutInfo preserves mixed-content whitespace graphemes" {
     const cases = [_][]const u8{
         "\u{0D4E} ", // U+0D4E MALAYALAM LETTER DOT REPH
         "\u{0600} ", // U+0600 ARABIC NUMBER SIGN
+        " \u{301}", // Non-whitespace after whitespace in the same grapheme
+        "\u{0600} \u{301}", // Mixed content on both sides of whitespace
     };
     var breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;
     defer breaks.deinit(testing.allocator);

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -105,6 +105,7 @@ pub const TabStopResult = struct {
 pub const LayoutWrapBreakKind = enum(u8) {
     none,
     whitespace,
+    preserved_whitespace,
     punctuation,
     script_transition,
 };
@@ -1481,10 +1482,13 @@ inline fn commitLayoutCluster(
     cluster_col_offset: u32,
     cluster_width: u32,
     cluster_break_kind: LayoutWrapBreakKind,
+    cluster_has_non_whitespace: bool,
     cluster_class: WordClass,
     next_class: ?WordClass,
 ) !bool {
-    const kind: LayoutWrapBreakKind = if (cluster_break_kind != .none)
+    const kind: LayoutWrapBreakKind = if (cluster_break_kind == .whitespace and cluster_has_non_whitespace)
+        .preserved_whitespace
+    else if (cluster_break_kind != .none)
         cluster_break_kind
     else if (next_class != null and isCjkAsciiTransition(cluster_class, next_class.?))
         .script_transition
@@ -1611,6 +1615,7 @@ fn walkChunkLayoutInfoGeneric(
     var cluster_col_offset: u32 = 0;
     var cluster_width_state: GraphemeWidthState = undefined;
     var cluster_break_kind: LayoutWrapBreakKind = .none;
+    var cluster_has_non_whitespace = false;
     var cluster_class: WordClass = .other;
 
     while (pos < text.len) {
@@ -1636,6 +1641,7 @@ fn walkChunkLayoutInfoGeneric(
                             cluster_col_offset,
                             cluster_width_state.width,
                             cluster_break_kind,
+                            cluster_has_non_whitespace,
                             cluster_class,
                             first_class,
                         )) return chunkWordClassEdges(text);
@@ -1660,6 +1666,7 @@ fn walkChunkLayoutInfoGeneric(
                     cluster_col_offset = col;
                     cluster_width_state = GraphemeWidthState.init(last_cp, asciiCharWidth(last_b, tab_width), width_method);
                     cluster_break_kind = asciiLayoutWrapBreakKind(last_b);
+                    cluster_has_non_whitespace = cluster_break_kind != .whitespace;
                     cluster_class = classifyWordClass(last_cp);
                     prev_cp = last_cp;
                     break_state = .default;
@@ -1691,6 +1698,7 @@ fn walkChunkLayoutInfoGeneric(
                     cluster_col_offset,
                     cluster_width_state.width,
                     cluster_break_kind,
+                    cluster_has_non_whitespace,
                     cluster_class,
                     curr_class,
                 )) return chunkWordClassEdges(text);
@@ -1702,11 +1710,13 @@ fn walkChunkLayoutInfoGeneric(
             cluster_col_offset = col;
             cluster_width_state = GraphemeWidthState.init(decoded.cp, cp_width, width_method);
             cluster_break_kind = if (b0 < 0x80) asciiLayoutWrapBreakKind(b0) else unicodeLayoutWrapBreakKind(decoded.cp);
+            cluster_has_non_whitespace = cluster_break_kind != .whitespace;
             cluster_class = curr_class;
         } else {
             cluster_width_state.addCodepoint(decoded.cp, cp_width);
             const next_break_kind = if (b0 < 0x80) asciiLayoutWrapBreakKind(b0) else unicodeLayoutWrapBreakKind(decoded.cp);
             if (next_break_kind == .whitespace or cluster_break_kind == .none) cluster_break_kind = next_break_kind;
+            cluster_has_non_whitespace = cluster_has_non_whitespace or next_break_kind != .whitespace;
         }
 
         prev_cp = decoded.cp;
@@ -1721,6 +1731,7 @@ fn walkChunkLayoutInfoGeneric(
             cluster_col_offset,
             cluster_width_state.width,
             cluster_break_kind,
+            cluster_has_non_whitespace,
             cluster_class,
             null,
         );

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -1482,13 +1482,10 @@ inline fn commitLayoutCluster(
     cluster_col_offset: u32,
     cluster_width: u32,
     cluster_break_kind: LayoutWrapBreakKind,
-    cluster_has_non_whitespace: bool,
     cluster_class: WordClass,
     next_class: ?WordClass,
 ) !bool {
-    const kind: LayoutWrapBreakKind = if (cluster_break_kind == .whitespace and cluster_has_non_whitespace)
-        .preserved_whitespace
-    else if (cluster_break_kind != .none)
+    const kind: LayoutWrapBreakKind = if (cluster_break_kind != .none)
         cluster_break_kind
     else if (next_class != null and isCjkAsciiTransition(cluster_class, next_class.?))
         .script_transition
@@ -1615,7 +1612,6 @@ fn walkChunkLayoutInfoGeneric(
     var cluster_col_offset: u32 = 0;
     var cluster_width_state: GraphemeWidthState = undefined;
     var cluster_break_kind: LayoutWrapBreakKind = .none;
-    var cluster_has_non_whitespace = false;
     var cluster_class: WordClass = .other;
 
     while (pos < text.len) {
@@ -1641,7 +1637,6 @@ fn walkChunkLayoutInfoGeneric(
                             cluster_col_offset,
                             cluster_width_state.width,
                             cluster_break_kind,
-                            cluster_has_non_whitespace,
                             cluster_class,
                             first_class,
                         )) return chunkWordClassEdges(text);
@@ -1666,7 +1661,6 @@ fn walkChunkLayoutInfoGeneric(
                     cluster_col_offset = col;
                     cluster_width_state = GraphemeWidthState.init(last_cp, asciiCharWidth(last_b, tab_width), width_method);
                     cluster_break_kind = asciiLayoutWrapBreakKind(last_b);
-                    cluster_has_non_whitespace = cluster_break_kind != .whitespace;
                     cluster_class = classifyWordClass(last_cp);
                     prev_cp = last_cp;
                     break_state = .default;
@@ -1698,7 +1692,6 @@ fn walkChunkLayoutInfoGeneric(
                     cluster_col_offset,
                     cluster_width_state.width,
                     cluster_break_kind,
-                    cluster_has_non_whitespace,
                     cluster_class,
                     curr_class,
                 )) return chunkWordClassEdges(text);
@@ -1710,13 +1703,17 @@ fn walkChunkLayoutInfoGeneric(
             cluster_col_offset = col;
             cluster_width_state = GraphemeWidthState.init(decoded.cp, cp_width, width_method);
             cluster_break_kind = if (b0 < 0x80) asciiLayoutWrapBreakKind(b0) else unicodeLayoutWrapBreakKind(decoded.cp);
-            cluster_has_non_whitespace = cluster_break_kind != .whitespace;
             cluster_class = curr_class;
         } else {
             cluster_width_state.addCodepoint(decoded.cp, cp_width);
             const next_break_kind = if (b0 < 0x80) asciiLayoutWrapBreakKind(b0) else unicodeLayoutWrapBreakKind(decoded.cp);
-            if (next_break_kind == .whitespace or cluster_break_kind == .none) cluster_break_kind = next_break_kind;
-            cluster_has_non_whitespace = cluster_has_non_whitespace or next_break_kind != .whitespace;
+            // Only all-whitespace graphemes may be elided by wrapping.
+            if (cluster_break_kind == .whitespace or next_break_kind == .whitespace) {
+                cluster_break_kind = if (cluster_break_kind == .whitespace and next_break_kind == .whitespace)
+                    .whitespace
+                else
+                    .preserved_whitespace;
+            } else if (cluster_break_kind == .none) cluster_break_kind = next_break_kind;
         }
 
         prev_cp = decoded.cp;
@@ -1731,7 +1728,6 @@ fn walkChunkLayoutInfoGeneric(
             cluster_col_offset,
             cluster_width_state.width,
             cluster_break_kind,
-            cluster_has_non_whitespace,
             cluster_class,
             null,
         );


### PR DESCRIPTION
- Preserve whole graphemes containing non-whitespace content instead of dropping visible characters at wrap boundaries. ASCII whitespace behavior is unchanged.
- Repros cover U+0D4E/U+0600 + space at widths 5/7 and combining marks. Product change: +8/-1 lines, no extra state.

| Mixed Unicode workload | Base → PR |
|---|---:|
| Word wrap | 10.205 → 10.181 ms |
| Scanner, confirmation | 6.805 → 7.038 ms (+3.4%) |

ReleaseFast/Linux, 12 CPU-pinned alternating pairs per run against `7a0dca8d`; output checked outside timing. A later unchanged-head scanner run measured +0.7% with a CI spanning parity. Small scanner overhead remains possible; no further tuning or added complexity.

Native 2,091 passed; Core Text/View 151 passed. Build, format/lint and all 29 CI checks pass.
