### PR TITLE
fix(native): preserve truncated copy ranges

### DIFF
--- a/packages/core/src/renderables/Text.test.ts
+++ b/packages/core/src/renderables/Text.test.ts
@@ -1277,6 +1277,25 @@ describe("TextRenderable Selection", () => {
   })
 
   describe("Text Selection with Truncation", () => {
+    it("copies the full source through an ellipsis-only line", async () => {
+      const { text } = await createTextRenderable(currentRenderer, {
+        content: "ABCDE好",
+        width: 4,
+        height: 1,
+        selectable: true,
+        truncate: true,
+        wrapMode: "none",
+      })
+
+      expect(captureFrame().split("\n")[0]?.slice(0, 4)).toBe("... ")
+
+      await currentMouse.drag(text.x, text.y, text.x + 3, text.y)
+      expect(text.getSelectedText()).toBe("ABCDE好")
+
+      await currentMouse.drag(text.x + 3, text.y, text.x, text.y)
+      expect(text.getSelectedText()).toBe("ABCDE好")
+    })
+
     it("should not extend selection across ellipsis in single line", async () => {
       const buffer = currentRenderer.currentRenderBuffer
       const { text } = await createTextRenderable(currentRenderer, {

--- a/packages/native/src/tests/text-buffer-selection_test.zig
+++ b/packages/native/src/tests/text-buffer-selection_test.zig
@@ -1343,9 +1343,9 @@ test "occupancy - replay clamps tiny truncated views" {
     try tb.setText("abcde");
 
     view.setSelectionOccupancy(.boundary);
-    try std.testing.expectEqual(@as(u64, 0xFFFFFFFF_FFFFFFFF), view.packSelectionInfo());
-
-    view.setSelection(0, 5, null, null);
+    const range = occupancyPacked(view);
+    try std.testing.expectEqual(@as(u32, 0), range.start);
+    try std.testing.expectEqual(@as(u32, 5), range.end);
     var out: [100]u8 = undefined;
     try std.testing.expectEqualStrings("abcde", occupancySelected(view, &out));
 }

--- a/packages/native/src/tests/text-buffer-view_test.zig
+++ b/packages/native/src/tests/text-buffer-view_test.zig
@@ -2974,6 +2974,73 @@ test "TextBufferView truncation - allocation failure is atomic and retryable" {
     try std.testing.expectEqual(@as(usize, 3), retried.chunks.items.len);
 }
 
+test "TextBufferView truncation - fitting prebuilt lines do not allocate" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    var view = try TextBufferView.init(failing.allocator(), tb);
+    defer view.deinit();
+
+    var text: std.ArrayListUnmanaged(u8) = .empty;
+    defer text.deinit(std.testing.allocator);
+    for (0..4096) |_| try text.appendSlice(std.testing.allocator, "fit\n");
+    try tb.setText(text.items);
+    view.setWrapMode(.none);
+    view.setViewport(.{ .x = 0, .y = 0, .width = 10, .height = 4096 });
+    view.setTruncate(true);
+    view.updateVirtualLines();
+
+    const allocation_index = failing.alloc_index;
+    failing.fail_index = allocation_index;
+    _ = view.getVirtualLines();
+
+    try std.testing.expect(!failing.has_induced_failure);
+    try std.testing.expectEqual(allocation_index, failing.alloc_index);
+}
+
+test "TextBufferView truncation - replacement staging is proportional to overflow" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+    var tracking = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    var view = try TextBufferView.init(tracking.allocator(), tb);
+    defer view.deinit();
+
+    var text: std.ArrayListUnmanaged(u8) = .empty;
+    defer text.deinit(std.testing.allocator);
+    try text.appendSlice(std.testing.allocator, "first line overflows\n");
+    for (0..4096) |_| try text.appendSlice(std.testing.allocator, "fit\n");
+    try text.appendSlice(std.testing.allocator, "last line overflows");
+    try tb.setText(text.items);
+    view.setWrapMode(.none);
+    view.setViewport(.{ .x = 0, .y = 0, .width = 10, .height = 4098 });
+    view.setTruncate(true);
+    view.updateVirtualLines();
+
+    const Replacement = struct {
+        chunks: std.ArrayListUnmanaged(text_buffer_view.VirtualChunk) = .empty,
+        width_cols: u32 = 0,
+        is_truncated: bool = false,
+        ellipsis_col: u32 = 0,
+        truncation_suffix_col_start: u32 = 0,
+    };
+    const allocated_bytes = tracking.allocated_bytes;
+    const lines = view.getVirtualLines();
+
+    try std.testing.expect(lines[0].is_truncated);
+    try std.testing.expect(lines[lines.len - 1].is_truncated);
+    try std.testing.expectEqual(2 * @sizeOf(Replacement), tracking.allocated_bytes - allocated_bytes);
+}
+
 test "TextBufferView truncation - multiline with truncate" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
@@ -3082,6 +3149,29 @@ test "TextBufferView truncation - very small viewport" {
 
     // With width=3, only room for "..." - should clear the line
     try std.testing.expectEqual(@as(u32, 0), vlines[0].width_cols);
+}
+
+test "TextBufferView truncation - empty suffix retains the source end" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    try tb.setText("ABCDE好");
+    view.setWrapMode(.none);
+    view.setTruncate(true);
+
+    for (2..5) |width| {
+        view.setViewport(.{ .x = 0, .y = 0, .width = @intCast(width), .height = 1 });
+        const line = view.getVirtualLines()[0];
+        try std.testing.expect(line.is_truncated);
+        try std.testing.expectEqual(@as(u32, 7), line.truncation_suffix_col_start);
+    }
 }
 
 test "TextBufferView truncation - verify ellipsis chunk injection" {

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -1268,22 +1268,30 @@ pub const UnifiedTextBufferView = struct {
         }.apply;
 
         const Replacement = struct {
-            active: bool = false,
             chunks: std.ArrayListUnmanaged(VirtualChunk) = .empty,
             width_cols: u32 = 0,
             is_truncated: bool = false,
             ellipsis_col: u32 = 0,
             truncation_suffix_col_start: u32 = 0,
         };
+        var overflow_count: usize = 0;
+        for (self.virtual_lines.items) |vline| {
+            if (vline.width_cols > vp.width) overflow_count += 1;
+        }
+        if (overflow_count == 0) return true;
+
         // Stage all replacements first so OOM leaves the original layout retryable.
-        const replacements = self.global_allocator.alloc(Replacement, self.virtual_lines.items.len) catch return false;
+        const replacements = self.global_allocator.alloc(Replacement, overflow_count) catch return false;
         defer self.global_allocator.free(replacements);
         @memset(replacements, .{});
         const arena_allocator = self.virtual_lines_arena.allocator();
 
-        for (self.virtual_lines.items, replacements) |vline, *replacement| {
+        var replacement_index: usize = 0;
+        for (self.virtual_lines.items) |vline| {
             if (vline.width_cols <= vp.width) continue;
-            replacement.active = true;
+            const replacement = &replacements[replacement_index];
+            replacement_index += 1;
+            replacement.truncation_suffix_col_start = vline.width_cols;
 
             if (vp.width <= ellipsis_width) {
                 replacement.is_truncated = true;
@@ -1352,11 +1360,14 @@ pub const UnifiedTextBufferView = struct {
             replacement.width_cols = prefix_accumulated + ellipsis_width + suffix_accumulated;
             replacement.is_truncated = true;
             replacement.ellipsis_col = prefix_accumulated;
-            replacement.truncation_suffix_col_start = actual_suffix_start orelse replacement.width_cols;
+            replacement.truncation_suffix_col_start = actual_suffix_start orelse vline.width_cols;
         }
 
-        for (self.virtual_lines.items, replacements) |*vline, replacement| {
-            if (!replacement.active) continue;
+        replacement_index = 0;
+        for (self.virtual_lines.items) |*vline| {
+            if (vline.width_cols <= vp.width) continue;
+            const replacement = replacements[replacement_index];
+            replacement_index += 1;
             vline.chunks = replacement.chunks;
             vline.width_cols = replacement.width_cols;
             vline.is_truncated = replacement.is_truncated;


### PR DESCRIPTION
- Fix ellipsis-only copy: `ABCDE好` at width 4 now copies the full source, not `ABC`.
- Stage replacements only for overflowing lines; preserve atomic OOM handling. Product change: +18/-7 lines.

| Truncation workload | Base → PR |
|---|---:|
| 100,000 fitting lines, staging allocation | 4,000,000 → 0 bytes |
| 4,096 lines, two overflowing | 37.4 → 12.4 µs |
| 4,096 lines, all overflowing | 256.0 → 256.0 µs |

ReleaseFast/Linux, 12 CPU-pinned alternating pairs against `7a0dca8d`; prebuilt layouts, validation outside timing. No established slowdown in dense/small controls.

Forward/backward copy, widths 2–4 and allocation/OOM regressions covered. Native 2,093 passed; Core Text/View 151 passed. Build, format/lint and all 29 CI checks pass.
