### PR TITLE
fix(core): preserve edit cursors across tab widths

### DIFF
--- a/packages/core/src/edit-buffer.test.ts
+++ b/packages/core/src/edit-buffer.test.ts
@@ -120,12 +120,20 @@ describe("EditBuffer", () => {
     it("routes borrowed text buffer tab changes through its editor", () => {
       buffer.setText("a\tb")
       buffer.setCursor(0, 4)
+      buffer.insertText("x")
 
       const lib = (buffer as any).lib
       const textBuffer = lib.editBufferGetTextBuffer(buffer.ptr)
       lib.textBufferSetTabWidth(textBuffer, 8)
 
+      expect(buffer.getCursorPosition()).toEqual({ row: 0, col: 11, offset: 11 })
+      expect(buffer.undo()).toBe("cursor:0:4:4")
       expect(buffer.getCursorPosition()).toEqual({ row: 0, col: 10, offset: 10 })
+      expect(buffer.redo()).toBe("cursor:0:11:11")
+      lib.textBufferSetTabWidth(textBuffer, 3)
+      expect(buffer.getCursorPosition()).toEqual({ row: 0, col: 7, offset: 7 })
+      buffer.insertText("y")
+      expect(buffer.getText()).toBe("a\tbxy")
     })
   })
 

--- a/packages/core/src/edit-buffer.test.ts
+++ b/packages/core/src/edit-buffer.test.ts
@@ -100,6 +100,33 @@ describe("EditBuffer", () => {
       cursor = buffer.getCursorPosition()
       expect(cursor.row).toBe(2)
     })
+
+    it("preserves cursor text boundaries across tab width changes and history", () => {
+      buffer.setText("a\tb")
+      buffer.setCursor(0, 4)
+      buffer.insertText("x")
+
+      buffer.setTabWidth(8)
+      expect(buffer.getTabWidth()).toBe(8)
+      expect(buffer.getCursorPosition()).toEqual({ row: 0, col: 11, offset: 11 })
+
+      expect(buffer.undo()).toBe("cursor:0:4:4")
+      expect(buffer.getCursorPosition()).toEqual({ row: 0, col: 10, offset: 10 })
+
+      buffer.insertText("y")
+      expect(buffer.getText()).toBe("a\tby")
+    })
+
+    it("routes borrowed text buffer tab changes through its editor", () => {
+      buffer.setText("a\tb")
+      buffer.setCursor(0, 4)
+
+      const lib = (buffer as any).lib
+      const textBuffer = lib.editBufferGetTextBuffer(buffer.ptr)
+      lib.textBufferSetTabWidth(textBuffer, 8)
+
+      expect(buffer.getCursorPosition()).toEqual({ row: 0, col: 10, offset: 10 })
+    })
   })
 
   describe("cursor movement", () => {

--- a/packages/core/src/edit-buffer.ts
+++ b/packages/core/src/edit-buffer.ts
@@ -131,6 +131,16 @@ export class EditBuffer extends EventEmitter {
     return this.lib.textBufferGetLineCount(this.textBufferPtr)
   }
 
+  public setTabWidth(width: number): void {
+    this.guard()
+    this.lib.editBufferSetTabWidth(this.bufferPtr, width)
+  }
+
+  public getTabWidth(): number {
+    this.guard()
+    return this.lib.textBufferGetTabWidth(this.textBufferPtr)
+  }
+
   public getText(): string {
     this.guard()
     // TODO: Use byte size of text buffer to get the actual size of the text

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -1370,6 +1370,10 @@ function getOpenTUILib(libPath?: string) {
       args: ["u32"],
       returns: "u32",
     },
+    editBufferSetTabWidth: {
+      args: ["u32", "u8"],
+      returns: "void",
+    },
     editBufferDebugLogRope: {
       args: ["u32"],
       returns: "void",
@@ -2923,6 +2927,7 @@ export interface RenderLib extends AudioEngineLib {
   editBufferGetCursorPosition: (buffer: EditBufferHandle) => LogicalCursor
   editBufferGetId: (buffer: EditBufferHandle) => number
   editBufferGetTextBuffer: (buffer: EditBufferHandle) => TextBufferHandle
+  editBufferSetTabWidth: (buffer: EditBufferHandle, width: number) => void
   editBufferDebugLogRope: (buffer: EditBufferHandle) => void
   editBufferUndo: (buffer: EditBufferHandle, maxLength: number) => Uint8Array | null
   editBufferRedo: (buffer: EditBufferHandle, maxLength: number) => Uint8Array | null
@@ -5652,6 +5657,10 @@ class FFIRenderLib implements RenderLib {
       throw new Error("Failed to get TextBuffer from EditBuffer")
     }
     return result
+  }
+
+  public editBufferSetTabWidth(buffer: Pointer, width: number): void {
+    this.opentui.symbols.editBufferSetTabWidth(buffer, width)
   }
 
   public editBufferDebugLogRope(buffer: Pointer): void {

--- a/packages/native/src/edit-buffer.zig
+++ b/packages/native/src/edit-buffer.zig
@@ -40,16 +40,21 @@ const CursorMeta = struct {
     row: u32,
     col: u32,
     desired_col: u32,
+    byte_col: ?u32 = null,
 
-    fn fromCursor(cursor: Cursor) CursorMeta {
+    fn fromCursor(cursor: Cursor, byte_col: ?u32) CursorMeta {
         return .{
             .row = cursor.row,
             .col = cursor.col,
             .desired_col = cursor.desired_col,
+            .byte_col = byte_col,
         };
     }
 
     fn encode(self: CursorMeta, out_buffer: []u8) ![]const u8 {
+        if (self.byte_col) |byte_col| {
+            return std.fmt.bufPrint(out_buffer, "cursor:{d}:{d}:{d}:{d}", .{ self.row, self.col, self.desired_col, byte_col });
+        }
         return std.fmt.bufPrint(out_buffer, "cursor:{d}:{d}:{d}", .{ self.row, self.col, self.desired_col });
     }
 
@@ -64,6 +69,10 @@ const CursorMeta = struct {
         const row = std.fmt.parseInt(u32, parts.next() orelse return null, 10) catch return null;
         const col = std.fmt.parseInt(u32, parts.next() orelse return null, 10) catch return null;
         const desired_col = std.fmt.parseInt(u32, parts.next() orelse return null, 10) catch return null;
+        const byte_col = if (parts.next()) |part|
+            std.fmt.parseInt(u32, part, 10) catch return null
+        else
+            null;
 
         if (parts.next() != null) {
             return null;
@@ -73,7 +82,15 @@ const CursorMeta = struct {
             .row = row,
             .col = col,
             .desired_col = desired_col,
+            .byte_col = byte_col,
         };
+    }
+
+    fn publicBytes(bytes: []const u8) []const u8 {
+        const decoded = decode(bytes) orelse return bytes;
+        if (decoded.byte_col == null) return bytes;
+        const last_separator = std.mem.lastIndexOfScalar(u8, bytes, ':') orelse return bytes;
+        return bytes[0..last_separator];
     }
 };
 
@@ -232,6 +249,89 @@ pub const EditBuffer = struct {
     pub fn setCursorByOffset(self: *EditBuffer, offset: u32) !void {
         const coords = iter_mod.offsetToCoords(self.tb.rope(), offset) orelse iter_mod.Coords{ .row = 0, .col = 0 };
         try self.setCursor(coords.row, coords.col);
+    }
+
+    fn cursorByteCol(self: *EditBuffer, cursor: Cursor) ?u32 {
+        const linestart = self.tb.rope().getMarker(.linestart, cursor.row) orelse return null;
+        var seg_idx = linestart.leaf_index + 1;
+        var col: u32 = 0;
+        var byte_col: u32 = 0;
+
+        while (seg_idx < self.tb.rope().count()) : (seg_idx += 1) {
+            const seg = self.tb.rope().get(seg_idx) orelse break;
+            if (seg.isBreak() or seg.isLineStart()) break;
+            const chunk = seg.asText() orelse continue;
+            const bytes = chunk.getBytes(self.tb.memRegistry());
+            const next_col = col +| chunk.width_cols;
+            if (cursor.col <= next_col) {
+                const pos = utf8.findPosByWidth(
+                    bytes,
+                    cursor.col -| col,
+                    self.tb.tabWidth(),
+                    chunk.isAsciiOnly(),
+                    false,
+                    self.tb.widthMethod(),
+                );
+                return byte_col +| pos.byte_offset;
+            }
+            col = next_col;
+            byte_col +|= @intCast(bytes.len);
+        }
+
+        return if (cursor.col == col) byte_col else null;
+    }
+
+    fn colForByteCol(self: *EditBuffer, row: u32, target_byte_col: u32) ?u32 {
+        const linestart = self.tb.rope().getMarker(.linestart, row) orelse return null;
+        var seg_idx = linestart.leaf_index + 1;
+        var col: u32 = 0;
+        var byte_col: u32 = 0;
+
+        while (seg_idx < self.tb.rope().count()) : (seg_idx += 1) {
+            const seg = self.tb.rope().get(seg_idx) orelse break;
+            if (seg.isBreak() or seg.isLineStart()) break;
+            const chunk = seg.asText() orelse continue;
+            const bytes = chunk.getBytes(self.tb.memRegistry());
+            const next_byte_col = byte_col +| @as(u32, @intCast(bytes.len));
+            if (target_byte_col <= next_byte_col) {
+                const local_byte_col: usize = @intCast(target_byte_col -| byte_col);
+                return col +| utf8.calculateTextWidth(
+                    bytes[0..local_byte_col],
+                    self.tb.tabWidth(),
+                    chunk.isAsciiOnly(),
+                    self.tb.widthMethod(),
+                );
+            }
+            col +|= chunk.width_cols;
+            byte_col = next_byte_col;
+        }
+
+        return if (target_byte_col == byte_col) col else null;
+    }
+
+    pub fn setTabWidth(self: *EditBuffer, width: u8) void {
+        const old_width = self.tb.tabWidth();
+        for (self.cursors.items) |*cursor| {
+            cursor.offset = self.cursorByteCol(cursor.*) orelse std.math.maxInt(u32);
+        }
+
+        self.tb.setTabWidth(width);
+
+        for (self.cursors.items) |*cursor| {
+            const byte_col = cursor.offset;
+            const new_col = if (byte_col == std.math.maxInt(u32))
+                @min(cursor.col, iter_mod.lineWidthAt(self.tb.rope(), cursor.row))
+            else
+                self.colForByteCol(cursor.row, byte_col) orelse @min(cursor.col, iter_mod.lineWidthAt(self.tb.rope(), cursor.row));
+            if (cursor.desired_col == cursor.col) cursor.desired_col = new_col;
+            cursor.col = new_col;
+            cursor.offset = iter_mod.coordsToOffset(self.tb.rope(), cursor.row, new_col) orelse 0;
+        }
+
+        if (old_width != self.tb.tabWidth()) {
+            self.events.emit(.cursorChanged);
+            self.emitNativeEvent("cursor-changed");
+        }
     }
 
     fn ensureAddCapacity(self: *EditBuffer, need: usize) !void {
@@ -646,17 +746,25 @@ pub const EditBuffer = struct {
         self.tb.debugLogRope();
     }
 
-    fn encodeCurrentCursorMeta(self: *const EditBuffer, out_buffer: []u8) ![]const u8 {
-        return CursorMeta.fromCursor(self.getPrimaryCursor()).encode(out_buffer);
+    fn encodeCurrentCursorMeta(self: *EditBuffer, out_buffer: []u8) ![]const u8 {
+        const cursor = self.getPrimaryCursor();
+        return CursorMeta.fromCursor(cursor, self.cursorByteCol(cursor)).encode(out_buffer);
     }
 
     fn restoreCursorFromMeta(self: *EditBuffer, meta: []const u8) !bool {
         const decodedMeta = CursorMeta.decode(meta) orelse return false;
 
-        try self.setCursor(decodedMeta.row, decodedMeta.col);
+        const col = if (decodedMeta.byte_col) |byte_col|
+            self.colForByteCol(decodedMeta.row, byte_col) orelse decodedMeta.col
+        else
+            decodedMeta.col;
+        try self.setCursor(decodedMeta.row, col);
 
         if (self.cursors.items.len > 0) {
-            self.cursors.items[0].desired_col = decodedMeta.desired_col;
+            self.cursors.items[0].desired_col = if (decodedMeta.byte_col != null and decodedMeta.desired_col == decodedMeta.col)
+                col
+            else
+                decodedMeta.desired_col;
         }
 
         return true;
@@ -684,7 +792,7 @@ pub const EditBuffer = struct {
         self.events.emit(.cursorChanged);
         self.emitNativeEvent("cursorChanged");
 
-        return prev_meta;
+        return CursorMeta.publicBytes(prev_meta);
     }
 
     pub fn redo(self: *EditBuffer) ![]const u8 {
@@ -701,7 +809,7 @@ pub const EditBuffer = struct {
         self.events.emit(.cursorChanged);
         self.emitNativeEvent("cursorChanged");
 
-        return next_meta;
+        return CursorMeta.publicBytes(next_meta);
     }
 
     pub fn canUndo(self: *const EditBuffer) bool {

--- a/packages/native/src/edit-buffer.zig
+++ b/packages/native/src/edit-buffer.zig
@@ -40,20 +40,20 @@ const CursorMeta = struct {
     row: u32,
     col: u32,
     desired_col: u32,
-    byte_col: ?u32 = null,
+    tab_width: ?u8 = null,
 
-    fn fromCursor(cursor: Cursor, byte_col: ?u32) CursorMeta {
+    fn fromCursor(cursor: Cursor, tab_width: u8) CursorMeta {
         return .{
             .row = cursor.row,
             .col = cursor.col,
             .desired_col = cursor.desired_col,
-            .byte_col = byte_col,
+            .tab_width = tab_width,
         };
     }
 
     fn encode(self: CursorMeta, out_buffer: []u8) ![]const u8 {
-        if (self.byte_col) |byte_col| {
-            return std.fmt.bufPrint(out_buffer, "cursor:{d}:{d}:{d}:{d}", .{ self.row, self.col, self.desired_col, byte_col });
+        if (self.tab_width) |tab_width| {
+            return std.fmt.bufPrint(out_buffer, "cursor:{d}:{d}:{d}:{d}", .{ self.row, self.col, self.desired_col, tab_width });
         }
         return std.fmt.bufPrint(out_buffer, "cursor:{d}:{d}:{d}", .{ self.row, self.col, self.desired_col });
     }
@@ -69,8 +69,8 @@ const CursorMeta = struct {
         const row = std.fmt.parseInt(u32, parts.next() orelse return null, 10) catch return null;
         const col = std.fmt.parseInt(u32, parts.next() orelse return null, 10) catch return null;
         const desired_col = std.fmt.parseInt(u32, parts.next() orelse return null, 10) catch return null;
-        const byte_col = if (parts.next()) |part|
-            std.fmt.parseInt(u32, part, 10) catch return null
+        const tab_width = if (parts.next()) |part|
+            std.fmt.parseInt(u8, part, 10) catch return null
         else
             null;
 
@@ -82,13 +82,13 @@ const CursorMeta = struct {
             .row = row,
             .col = col,
             .desired_col = desired_col,
-            .byte_col = byte_col,
+            .tab_width = tab_width,
         };
     }
 
     fn publicBytes(bytes: []const u8) []const u8 {
         const decoded = decode(bytes) orelse return bytes;
-        if (decoded.byte_col == null) return bytes;
+        if (decoded.tab_width == null) return bytes;
         const last_separator = std.mem.lastIndexOfScalar(u8, bytes, ':') orelse return bytes;
         return bytes[0..last_separator];
     }
@@ -251,87 +251,57 @@ pub const EditBuffer = struct {
         try self.setCursor(coords.row, coords.col);
     }
 
-    fn cursorByteCol(self: *EditBuffer, cursor: Cursor) ?u32 {
-        const linestart = self.tb.rope().getMarker(.linestart, cursor.row) orelse return null;
+    fn remapCol(self: *EditBuffer, row: u32, target_col: u32, old_tab_width: u8) ?u32 {
+        const linestart = self.tb.rope().getMarker(.linestart, row) orelse return null;
         var seg_idx = linestart.leaf_index + 1;
-        var col: u32 = 0;
-        var byte_col: u32 = 0;
+        var old_col: u32 = 0;
+        var new_col: u32 = 0;
 
         while (seg_idx < self.tb.rope().count()) : (seg_idx += 1) {
             const seg = self.tb.rope().get(seg_idx) orelse break;
             if (seg.isBreak() or seg.isLineStart()) break;
             const chunk = seg.asText() orelse continue;
             const bytes = chunk.getBytes(self.tb.memRegistry());
-            const next_col = col +| chunk.width_cols;
-            if (cursor.col <= next_col) {
+            // The restored root's cached widths use the current policy, not the checkpoint's.
+            const next_col = old_col +| utf8.calculateTextWidth(bytes, old_tab_width, chunk.isAsciiOnly(), self.tb.widthMethod());
+            if (target_col <= next_col) {
                 const pos = utf8.findPosByWidth(
                     bytes,
-                    cursor.col -| col,
-                    self.tb.tabWidth(),
+                    target_col -| old_col,
+                    old_tab_width,
                     chunk.isAsciiOnly(),
                     false,
                     self.tb.widthMethod(),
                 );
-                return byte_col +| pos.byte_offset;
-            }
-            col = next_col;
-            byte_col +|= @intCast(bytes.len);
-        }
-
-        return if (cursor.col == col) byte_col else null;
-    }
-
-    fn colForByteCol(self: *EditBuffer, row: u32, target_byte_col: u32) ?u32 {
-        const linestart = self.tb.rope().getMarker(.linestart, row) orelse return null;
-        var seg_idx = linestart.leaf_index + 1;
-        var col: u32 = 0;
-        var byte_col: u32 = 0;
-
-        while (seg_idx < self.tb.rope().count()) : (seg_idx += 1) {
-            const seg = self.tb.rope().get(seg_idx) orelse break;
-            if (seg.isBreak() or seg.isLineStart()) break;
-            const chunk = seg.asText() orelse continue;
-            const bytes = chunk.getBytes(self.tb.memRegistry());
-            const next_byte_col = byte_col +| @as(u32, @intCast(bytes.len));
-            if (target_byte_col <= next_byte_col) {
-                const local_byte_col: usize = @intCast(target_byte_col -| byte_col);
-                return col +| utf8.calculateTextWidth(
-                    bytes[0..local_byte_col],
+                return new_col +| utf8.calculateTextWidth(
+                    bytes[0..pos.byte_offset],
                     self.tb.tabWidth(),
                     chunk.isAsciiOnly(),
                     self.tb.widthMethod(),
                 );
             }
-            col +|= chunk.width_cols;
-            byte_col = next_byte_col;
+            old_col = next_col;
+            new_col +|= chunk.width_cols;
         }
 
-        return if (target_byte_col == byte_col) col else null;
+        return if (target_col == old_col) new_col else null;
     }
 
     pub fn setTabWidth(self: *EditBuffer, width: u8) void {
         const old_width = self.tb.tabWidth();
-        for (self.cursors.items) |*cursor| {
-            cursor.offset = self.cursorByteCol(cursor.*) orelse std.math.maxInt(u32);
-        }
-
         self.tb.setTabWidth(width);
+        if (old_width == self.tb.tabWidth()) return;
 
         for (self.cursors.items) |*cursor| {
-            const byte_col = cursor.offset;
-            const new_col = if (byte_col == std.math.maxInt(u32))
-                @min(cursor.col, iter_mod.lineWidthAt(self.tb.rope(), cursor.row))
-            else
-                self.colForByteCol(cursor.row, byte_col) orelse @min(cursor.col, iter_mod.lineWidthAt(self.tb.rope(), cursor.row));
+            const new_col = self.remapCol(cursor.row, cursor.col, old_width) orelse
+                @min(cursor.col, iter_mod.lineWidthAt(self.tb.rope(), cursor.row));
             if (cursor.desired_col == cursor.col) cursor.desired_col = new_col;
             cursor.col = new_col;
             cursor.offset = iter_mod.coordsToOffset(self.tb.rope(), cursor.row, new_col) orelse 0;
         }
 
-        if (old_width != self.tb.tabWidth()) {
-            self.events.emit(.cursorChanged);
-            self.emitNativeEvent("cursor-changed");
-        }
+        self.events.emit(.cursorChanged);
+        self.emitNativeEvent("cursor-changed");
     }
 
     fn ensureAddCapacity(self: *EditBuffer, need: usize) !void {
@@ -748,20 +718,21 @@ pub const EditBuffer = struct {
 
     fn encodeCurrentCursorMeta(self: *EditBuffer, out_buffer: []u8) ![]const u8 {
         const cursor = self.getPrimaryCursor();
-        return CursorMeta.fromCursor(cursor, self.cursorByteCol(cursor)).encode(out_buffer);
+        return CursorMeta.fromCursor(cursor, self.tb.tabWidth()).encode(out_buffer);
     }
 
     fn restoreCursorFromMeta(self: *EditBuffer, meta: []const u8) !bool {
         const decodedMeta = CursorMeta.decode(meta) orelse return false;
 
-        const col = if (decodedMeta.byte_col) |byte_col|
-            self.colForByteCol(decodedMeta.row, byte_col) orelse decodedMeta.col
+        const width_changed = if (decodedMeta.tab_width) |width| width != self.tb.tabWidth() else false;
+        const col = if (width_changed)
+            self.remapCol(decodedMeta.row, decodedMeta.col, decodedMeta.tab_width.?) orelse decodedMeta.col
         else
             decodedMeta.col;
         try self.setCursor(decodedMeta.row, col);
 
         if (self.cursors.items.len > 0) {
-            self.cursors.items[0].desired_col = if (decodedMeta.byte_col != null and decodedMeta.desired_col == decodedMeta.col)
+            self.cursors.items[0].desired_col = if (width_changed and decodedMeta.desired_col == decodedMeta.col)
                 col
             else
                 decodedMeta.desired_col;

--- a/packages/native/src/handles.zig
+++ b/packages/native/src/handles.zig
@@ -222,6 +222,12 @@ pub fn isOwned(handle: Handle, expected_kind: ObjectKind) bool {
     return slots[index].owned;
 }
 
+pub fn getOwner(handle: Handle, expected_kind: ObjectKind) ?Handle {
+    const index = validateSlot(handle, expected_kind) orelse return null;
+    const owner = slots[index].owner;
+    return if (owner == 0) null else owner;
+}
+
 pub fn invalidate(handle: Handle, expected_kind: ObjectKind) void {
     const index = validateSlot(handle, expected_kind) orelse return;
     slots[index].state = .destroying;

--- a/packages/native/src/lib.zig
+++ b/packages/native/src/lib.zig
@@ -2249,6 +2249,12 @@ export fn textBufferGetTabWidth(tb_handle: NativeHandle) u8 {
 }
 
 export fn textBufferSetTabWidth(tb_handle: NativeHandle, width: u8) void {
+    if (handles.getOwner(tb_handle, .text_buffer)) |owner| {
+        if (acquireEditBuffer(owner)) |edit_buffer| {
+            edit_buffer.setTabWidth(width);
+            return;
+        }
+    }
     const object_ptr = acquireTextBuffer(tb_handle) orelse return;
     object_ptr.setTabWidth(width);
 }
@@ -2570,6 +2576,11 @@ export fn destroyEditBuffer(edit_handle: NativeHandle) void {
 export fn editBufferGetTextBuffer(edit_handle: NativeHandle) NativeHandle {
     const object_ptr = acquireEditBuffer(edit_handle) orelse return INVALID_HANDLE;
     return handles.getOrInsertBorrowed(.text_buffer, erasePtr(object_ptr.getTextBuffer()), edit_handle) catch INVALID_HANDLE;
+}
+
+export fn editBufferSetTabWidth(edit_handle: NativeHandle, width: u8) void {
+    const object_ptr = acquireEditBuffer(edit_handle) orelse return;
+    object_ptr.setTabWidth(width);
 }
 
 export fn editBufferInsertText(edit_handle: NativeHandle, textPtr: ?[*]const u8, textLen: u32) void {

--- a/packages/native/src/tests/edit-buffer-history_test.zig
+++ b/packages/native/src/tests/edit-buffer-history_test.zig
@@ -60,6 +60,69 @@ test "EditBuffer - undo and redo restore cursor for mid-line edits" {
     try std.testing.expectEqual(@as(u32, 9), cursor.col);
 }
 
+test "EditBuffer - unchanged normalized tab width preserves cursor" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .unicode, null);
+    defer eb.deinit();
+
+    try eb.setText("a\tb");
+    try eb.setCursor(0, 2);
+    const cursor = eb.getPrimaryCursor();
+    eb.setTabWidth(0);
+    try std.testing.expectEqualDeep(cursor, eb.getPrimaryCursor());
+}
+
+test "EditBuffer - tab width remaps multi-chunk history under each checkpoint policy" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .unicode, null);
+    defer eb.deinit();
+
+    try eb.setText("head\n\u{754c}\tb");
+    try eb.setCursor(1, 2);
+    eb.setTabWidth(8);
+    try std.testing.expectEqualDeep(edit_buffer.Cursor{ .row = 1, .col = 2, .desired_col = 2, .offset = 7 }, eb.getPrimaryCursor());
+    eb.setTabWidth(2);
+    try eb.setCursor(1, 4);
+    try eb.insertText("e\u{301}\t");
+    eb.setTabWidth(8);
+    try std.testing.expectEqualDeep(edit_buffer.Cursor{ .row = 1, .col = 19, .desired_col = 19, .offset = 24 }, eb.getPrimaryCursor());
+    try std.testing.expectEqualStrings("cursor:1:4:4", try eb.undo());
+    try std.testing.expectEqualDeep(edit_buffer.Cursor{ .row = 1, .col = 10, .desired_col = 10, .offset = 15 }, eb.getPrimaryCursor());
+    try std.testing.expectEqualStrings("cursor:1:19:19", try eb.redo());
+    try std.testing.expectEqual(@as(u32, 19), eb.getPrimaryCursor().col);
+    eb.setTabWidth(4);
+    try std.testing.expectEqualStrings("cursor:1:4:4", try eb.undo());
+    try std.testing.expectEqual(@as(u32, 6), eb.getPrimaryCursor().col);
+    try std.testing.expectEqualStrings("cursor:1:19:19", try eb.redo());
+    try std.testing.expectEqual(@as(u32, 11), eb.getPrimaryCursor().col);
+    try eb.insertText("y");
+    var out: [64]u8 = undefined;
+    try std.testing.expectEqualStrings("head\n\u{754c}\te\u{301}\tyb", out[0..eb.getText(&out)]);
+
+    try eb.setText("abcdefghijklmnop\na\tb");
+    try eb.setCursor(0, 16);
+    eb.moveDown();
+    eb.setTabWidth(8);
+    try std.testing.expectEqual(@as(u32, 10), eb.getPrimaryCursor().col);
+    try std.testing.expectEqual(@as(u32, 16), eb.getPrimaryCursor().desired_col);
+    try eb.insertText("x");
+    eb.setTabWidth(2);
+    _ = try eb.undo();
+    try std.testing.expectEqual(@as(u32, 4), eb.getPrimaryCursor().col);
+    try std.testing.expectEqual(@as(u32, 16), eb.getPrimaryCursor().desired_col);
+
+    eb.clearHistory();
+    try eb.getTextBuffer().rope().store_undo("cursor:1:1:9");
+    try std.testing.expectEqualStrings("cursor:1:1:9", try eb.undo());
+    try std.testing.expectEqualDeep(edit_buffer.Cursor{ .row = 1, .col = 1, .desired_col = 9, .offset = 18 }, eb.getPrimaryCursor());
+}
+
 test "EditBuffer - tab width changes preserve live and undo cursor text boundaries" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/tests/edit-buffer-history_test.zig
+++ b/packages/native/src/tests/edit-buffer-history_test.zig
@@ -22,12 +22,12 @@ test "EditBuffer - basic undo/redo with insertText" {
     try std.testing.expectEqualStrings("Hello World", out_buffer[0..written]);
 
     const meta = try eb.undo();
-    try std.testing.expect(std.mem.startsWith(u8, meta, "cursor:"));
+    try std.testing.expectEqualStrings("cursor:0:5:5", meta);
     written = eb.getText(&out_buffer);
     try std.testing.expectEqualStrings("Hello", out_buffer[0..written]);
 
     const meta2 = try eb.redo();
-    try std.testing.expect(std.mem.startsWith(u8, meta2, "cursor:"));
+    try std.testing.expectEqualStrings("cursor:0:11:11", meta2);
     written = eb.getText(&out_buffer);
     try std.testing.expectEqualStrings("Hello World", out_buffer[0..written]);
 }
@@ -58,6 +58,32 @@ test "EditBuffer - undo and redo restore cursor for mid-line edits" {
     cursor = eb.getPrimaryCursor();
     try std.testing.expectEqual(@as(u32, 0), cursor.row);
     try std.testing.expectEqual(@as(u32, 9), cursor.col);
+}
+
+test "EditBuffer - tab width changes preserve live and undo cursor text boundaries" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .unicode, null);
+    defer eb.deinit();
+
+    try eb.setText("a\tb");
+    try eb.setCursor(0, 4);
+    try eb.insertText("x");
+
+    eb.setTabWidth(8);
+    try std.testing.expectEqual(@as(u32, 11), eb.getPrimaryCursor().col);
+
+    _ = try eb.undo();
+
+    try std.testing.expectEqual(@as(u32, 10), eb.getPrimaryCursor().col);
+    try eb.insertText("y");
+
+    var out_buffer: [16]u8 = undefined;
+    const written = eb.getText(&out_buffer);
+    try std.testing.expectEqualStrings("a\tby", out_buffer[0..written]);
 }
 
 test "EditBuffer - canUndo/canRedo" {

--- a/packages/native/src/tests/edit-buffer_test.zig
+++ b/packages/native/src/tests/edit-buffer_test.zig
@@ -1654,7 +1654,7 @@ test "EditBuffer - undo redo refreshes tab metrics after tab width changes" {
     _ = try eb.redo();
     try std.testing.expectEqual(@as(u32, 5), eb.tb.lineWidthAt(0));
 
-    eb.tb.setTabWidth(8);
+    eb.setTabWidth(8);
     try std.testing.expectEqual(@as(u32, 11), eb.tb.lineWidthAt(0));
 
     _ = try eb.undo();

--- a/packages/native/src/tests/editor-view_test.zig
+++ b/packages/native/src/tests/editor-view_test.zig
@@ -694,7 +694,7 @@ test "EditorView - consumed whitespace cursor columns clamp to preceding row" {
     try std.testing.expectEqual(@as(u32, 1), spaces_boundary.visual_row);
     try std.testing.expectEqual(@as(u32, 0), spaces_boundary.visual_col);
 
-    eb.tb.setTabWidth(4);
+    eb.setTabWidth(4);
     try eb.setText("hello\tworld");
     for ([_]u32{ 5, 8 }) |logical_col| {
         const cursor = ev.logicalToVisualCursor(0, logical_col);
@@ -3081,7 +3081,7 @@ test "EditorView - tab indicator renders in buffer" {
     var ev = try EditorView.init(std.testing.allocator, eb, 80, 24);
     defer ev.deinit();
 
-    eb.tb.setTabWidth(4);
+    eb.setTabWidth(4);
     try eb.insertText("A\tB");
 
     ev.setTabIndicator('→');


### PR DESCRIPTION
- Route editor tab-width changes through `EditBuffer`, including borrowed FFI handles. Preserve live/undo/redo cursor boundaries and public metadata compatibility.
- Store checkpoint tab width, remapping only when it changes—not byte-scanning every edit. No callbacks or history rewrite. Direct internal `edit_buffer.tb` mutation still bypasses this route.

| 14 KiB Unicode line, unchanged tab width | Base → PR |
|---|---:|
| Insert, confirmation | 8.14 → 7.50 µs |
| Undo + redo, confirmation | 10.85 → 11.18 µs |
| Same-width setter | 7.2 → 5.9 ns |

ReleaseFast/Linux, 12 CPU-pinned alternating pairs per cohort against `7a0dca8d`; text/cursors checked outside timing. Insert/history confidence intervals span parity. The earlier 8× history regression is removed; no exact-parity claim.

Live/history, multi-chunk, desired-column and borrowed-handle repros pass. Native 2,103; full Core 5,483 passed. Build, format/lint and all 29 CI checks pass.
