### PR TITLE
perf(core): skip tab refresh for tab-free roots

### DIFF
--- a/packages/native/src/bench.zig
+++ b/packages/native/src/bench.zig
@@ -52,6 +52,7 @@ const edit_buffer_bench = @import("bench/edit-buffer_bench.zig");
 const rope_bench = @import("bench/rope_bench.zig");
 const rope_markers_bench = @import("bench/rope-markers_bench.zig");
 const text_buffer_coords_bench = @import("bench/text-buffer-coords_bench.zig");
+const text_buffer_tab_width_bench = @import("bench/text-buffer-tab-width_bench.zig");
 const styled_text_bench = @import("bench/styled-text_bench.zig");
 const buffer_draw_text_buffer_bench = @import("bench/buffer-draw-text-buffer_bench.zig");
 const buffer_color_blending_bench = @import("bench/buffer-color-blending_bench.zig");
@@ -111,6 +112,7 @@ pub fn main(init: std.process.Init) !void {
         .{ .name = rope_bench.benchName, .run = rope_bench.run },
         .{ .name = rope_markers_bench.benchName, .run = rope_markers_bench.run },
         .{ .name = text_buffer_coords_bench.benchName, .run = text_buffer_coords_bench.run },
+        .{ .name = text_buffer_tab_width_bench.benchName, .run = text_buffer_tab_width_bench.run },
         .{ .name = styled_text_bench.benchName, .run = styled_text_bench.run },
         .{ .name = buffer_draw_text_buffer_bench.benchName, .run = buffer_draw_text_buffer_bench.run },
         .{ .name = buffer_color_blending_bench.benchName, .run = buffer_color_blending_bench.run },

--- a/packages/native/src/bench/text-buffer-tab-width_bench.zig
+++ b/packages/native/src/bench/text-buffer-tab-width_bench.zig
@@ -1,0 +1,138 @@
+const std = @import("std");
+const bench_utils = @import("../bench-utils.zig");
+const gp = @import("../grapheme.zig");
+const link = @import("../link.zig");
+const text_buffer = @import("../text-buffer.zig");
+
+const BenchResult = bench_utils.BenchResult;
+const BenchStats = bench_utils.BenchStats;
+const TextBuffer = text_buffer.UnifiedTextBuffer;
+
+pub const benchName = "TextBuffer Tab Width";
+
+const change_count = 40;
+const sample_count = 8;
+const unit = "OpenTUI text metrics: 世界🙂 ";
+const repeat_count = 32768;
+
+fn makeInput(allocator: std.mem.Allocator) ![]u8 {
+    const input = try allocator.alloc(u8, unit.len * repeat_count);
+    for (0..repeat_count) |i| {
+        @memcpy(input[i * unit.len ..][0..unit.len], unit);
+    }
+    return input;
+}
+
+fn changeTabWidth(tb: *TextBuffer) void {
+    for (0..change_count) |i| {
+        tb.setTabWidth(if (i % 2 == 0) 4 else 2);
+    }
+}
+
+pub fn run(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    _: bool,
+    bench_filter: ?[]const u8,
+) ![]BenchResult {
+    const pool = gp.initGlobalPool(allocator);
+    const link_pool = link.initGlobalLinkPool(allocator);
+    var results: std.ArrayList(BenchResult) = .empty;
+    errdefer results.deinit(allocator);
+
+    const tab_free = try makeInput(allocator);
+    const one_tab = try allocator.dupe(u8, tab_free);
+    one_tab[std.mem.indexOfScalar(u8, one_tab, 'x').?] = '\t';
+
+    const tab_free_name = "40 tab-width changes: 1 MiB Unicode, no tabs";
+    if (bench_utils.matchesBenchFilter(tab_free_name, bench_filter)) {
+        var stats: BenchStats = .{};
+        for (0..sample_count) |_| {
+            var tb = try TextBuffer.init(allocator, pool, link_pool, .unicode);
+            defer tb.deinit();
+            try tb.setText(tab_free);
+            const expected_width = tb.lineWidthAt(0);
+
+            const timer = bench_utils.BenchTimer.start(io);
+            changeTabWidth(tb);
+            stats.record(timer.read());
+
+            if (tb.lineWidthAt(0) != expected_width) return error.UnexpectedWidth;
+            std.mem.doNotOptimizeAway(tb.lineWidthAt(0));
+        }
+        try results.append(allocator, .{
+            .name = tab_free_name,
+            .min_ns = stats.min_ns,
+            .avg_ns = stats.avg(),
+            .max_ns = stats.max_ns,
+            .total_ns = stats.total_ns,
+            .iterations = sample_count,
+            .stddev_ns = stats.standardDeviation(),
+            .rme_95 = stats.relativeMarginOfError95(),
+            .mem_stats = null,
+        });
+    }
+
+    const one_tab_name = "40 tab-width changes: 1 MiB Unicode, one tab";
+    if (bench_utils.matchesBenchFilter(one_tab_name, bench_filter)) {
+        var stats: BenchStats = .{};
+        for (0..sample_count) |_| {
+            var tb = try TextBuffer.init(allocator, pool, link_pool, .unicode);
+            defer tb.deinit();
+            try tb.setText(one_tab);
+            const expected_width = tb.lineWidthAt(0);
+            const tab_free_width = tb.measureText(tab_free);
+            if (expected_width != tab_free_width + 1) return error.UnexpectedWidth;
+            tb.setTabWidth(4);
+            if (tb.lineWidthAt(0) != tab_free_width + 3) return error.UnexpectedWidth;
+            tb.setTabWidth(2);
+
+            const timer = bench_utils.BenchTimer.start(io);
+            changeTabWidth(tb);
+            stats.record(timer.read());
+
+            if (tb.lineWidthAt(0) != expected_width) return error.UnexpectedWidth;
+            std.mem.doNotOptimizeAway(tb.lineWidthAt(0));
+        }
+        try results.append(allocator, .{
+            .name = one_tab_name,
+            .min_ns = stats.min_ns,
+            .avg_ns = stats.avg(),
+            .max_ns = stats.max_ns,
+            .total_ns = stats.total_ns,
+            .iterations = sample_count,
+            .stddev_ns = stats.standardDeviation(),
+            .rme_95 = stats.relativeMarginOfError95(),
+            .mem_stats = null,
+        });
+    }
+
+    const set_text_name = "setText: 1 MiB Unicode, no tabs";
+    if (bench_utils.matchesBenchFilter(set_text_name, bench_filter)) {
+        var stats: BenchStats = .{};
+        for (0..sample_count) |_| {
+            var tb = try TextBuffer.init(allocator, pool, link_pool, .unicode);
+            defer tb.deinit();
+
+            const timer = bench_utils.BenchTimer.start(io);
+            try tb.setText(tab_free);
+            stats.record(timer.read());
+
+            if (tb.lineWidthAt(0) == 0) return error.UnexpectedWidth;
+            std.mem.doNotOptimizeAway(tb.lineWidthAt(0));
+        }
+        try results.append(allocator, .{
+            .name = set_text_name,
+            .min_ns = stats.min_ns,
+            .avg_ns = stats.avg(),
+            .max_ns = stats.max_ns,
+            .total_ns = stats.total_ns,
+            .iterations = sample_count,
+            .stddev_ns = stats.standardDeviation(),
+            .rme_95 = stats.relativeMarginOfError95(),
+            .mem_stats = null,
+        });
+    }
+
+    return results.toOwnedSlice(allocator);
+}

--- a/packages/native/src/tests/edit-buffer_test.zig
+++ b/packages/native/src/tests/edit-buffer_test.zig
@@ -1668,6 +1668,32 @@ test "EditBuffer - undo redo refreshes tab metrics after tab width changes" {
     try std.testing.expectEqual(@as(u32, 11), view.getVirtualLines()[0].width_cols);
 }
 
+test "EditBuffer - stale tab-free undo redo roots preserve Unicode widths" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .unicode, null);
+    defer eb.deinit();
+    try eb.setText("界🙂alpha");
+    const initial_width = eb.tb.lineWidthAt(0);
+    try eb.setCursor(0, initial_width);
+    try eb.insertText("x");
+    const edited_width = eb.tb.lineWidthAt(0);
+
+    _ = try eb.undo();
+    try std.testing.expectEqual(initial_width, eb.tb.lineWidthAt(0));
+
+    eb.tb.setTabWidth(8);
+    _ = try eb.redo();
+    try std.testing.expectEqual(edited_width, eb.tb.lineWidthAt(0));
+
+    eb.tb.setTabWidth(4);
+    _ = try eb.undo();
+    try std.testing.expectEqual(initial_width, eb.tb.lineWidthAt(0));
+}
+
 test "EditBuffer - setText clears all history" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/tests/edit-buffer_test.zig
+++ b/packages/native/src/tests/edit-buffer_test.zig
@@ -1668,6 +1668,53 @@ test "EditBuffer - undo redo refreshes tab metrics after tab width changes" {
     try std.testing.expectEqual(@as(u32, 11), view.getVirtualLines()[0].width_cols);
 }
 
+test "EditBuffer - contiguous inserts coalesce across tab presence" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const Flags = seg_mod.TextChunk.Flags;
+    const cases = [_]struct { text: []const u8, split_byte: usize, flags: []const u8 }{
+        .{ .text = "\u{754c}\t", .split_byte = 3, .flags = &.{Flags.HAS_TAB} },
+        .{ .text = "\t\u{754c}", .split_byte = 1, .flags = &.{Flags.HAS_TAB} },
+        .{ .text = "\u{754c}\u{754c}", .split_byte = 3, .flags = &.{0} },
+        .{ .text = "abcd", .split_byte = 2, .flags = &.{Flags.ASCII_ONLY} },
+        .{ .text = "ab\t", .split_byte = 2, .flags = &.{ Flags.ASCII_ONLY, Flags.HAS_TAB } },
+        .{ .text = "\tab", .split_byte = 1, .flags = &.{ Flags.HAS_TAB, Flags.ASCII_ONLY } },
+        .{ .text = "ab\u{754c}", .split_byte = 2, .flags = &.{ Flags.ASCII_ONLY, 0 } },
+        .{ .text = "\u{754c}ab", .split_byte = 3, .flags = &.{ 0, Flags.ASCII_ONLY } },
+    };
+
+    for (cases) |case| {
+        const eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .unicode, null);
+        defer eb.deinit();
+        try eb.insertText(case.text[0..case.split_byte]);
+        try eb.insertText(case.text[case.split_byte..]);
+
+        for (0..2) |stage| {
+            if (stage == 1) {
+                try eb.setCursor(0, 2);
+                try eb.insertText("\n");
+                try std.testing.expectEqual(@as(u32, 2), eb.tb.lineCount());
+                try eb.backspace();
+            }
+            var out: [16]u8 = undefined;
+            try std.testing.expectEqualStrings(case.text, out[0..eb.getText(&out)]);
+            try std.testing.expectEqual(@as(u32, 4), eb.tb.lineWidthAt(0));
+            try std.testing.expectEqual(case.flags.len + 1, eb.tb.rope().count());
+            for (case.flags, 0..) |flags, i| {
+                const chunk = eb.tb.rope().get(@intCast(i + 1)).?.asText().?;
+                try std.testing.expectEqual(flags, chunk.flags);
+            }
+        }
+
+        const has_tab = std.mem.indexOfScalar(u8, case.text, '\t') != null;
+        try std.testing.expectEqual(has_tab, eb.tb.rope().root.metrics().custom.has_tabs);
+        eb.tb.setTabWidth(8);
+        try std.testing.expectEqual(@as(u32, if (has_tab) 10 else 4), eb.tb.lineWidthAt(0));
+    }
+}
+
 test "EditBuffer - tab presence survives splitting merging and history" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/tests/edit-buffer_test.zig
+++ b/packages/native/src/tests/edit-buffer_test.zig
@@ -1668,6 +1668,52 @@ test "EditBuffer - undo redo refreshes tab metrics after tab width changes" {
     try std.testing.expectEqual(@as(u32, 11), view.getVirtualLines()[0].width_cols);
 }
 
+test "EditBuffer - tab presence survives splitting merging and history" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .unicode, null);
+    defer eb.deinit();
+    var out: [64]u8 = undefined;
+
+    for ([_][]const u8{ "abc\tdef", "\u{754c}x\tdef" }) |text| {
+        eb.tb.setTabWidth(2);
+        try eb.setText(text);
+        try eb.setCursor(0, 3);
+        for (0..5) |stage| {
+            switch (stage) {
+                0 => try eb.insertText("\n"),
+                1 => try eb.backspace(),
+                2 => try eb.deleteRange(.{ .row = 0, .col = 3 }, .{ .row = 0, .col = 5 }),
+                3 => {
+                    eb.tb.setTabWidth(8);
+                    _ = try eb.undo();
+                    try std.testing.expectEqual(@as(u32, 14), eb.tb.lineWidthAt(0));
+                },
+                4 => {
+                    _ = try eb.redo();
+                    try std.testing.expectEqual(@as(u32, 6), eb.tb.lineWidthAt(0));
+                },
+                else => unreachable,
+            }
+            const bytes = out[0..eb.getText(&out)];
+            const has_tab = std.mem.indexOfScalar(u8, bytes, '\t') != null;
+            try std.testing.expectEqual(stage != 2 and stage != 4, has_tab);
+            try std.testing.expectEqual(has_tab, eb.tb.rope().root.metrics().custom.has_tabs);
+            for (0..eb.tb.rope().count()) |i| {
+                const segment = eb.tb.rope().get(@intCast(i)).?;
+                if (segment.asText()) |chunk| {
+                    const chunk_bytes = chunk.getBytes(eb.tb.memRegistry());
+                    try std.testing.expectEqual(std.mem.indexOfScalar(u8, chunk_bytes, '\t') != null, chunk.hasTab());
+                    if (chunk.isAsciiOnly()) try std.testing.expect(!chunk.hasTab());
+                }
+            }
+            if (stage == 1 or stage == 3) try std.testing.expectEqualStrings(text, bytes);
+        }
+    }
+}
+
 test "EditBuffer - stale tab-free undo redo roots preserve Unicode widths" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/tests/text-buffer-segment_test.zig
+++ b/packages/native/src/tests/text-buffer-segment_test.zig
@@ -217,6 +217,28 @@ test "Segment.measure - text chunk" {
     try testing.expect(metrics.ascii_only);
 }
 
+test "Segment.measure - propagates tab presence" {
+    const without_tab = Segment{ .text = .{
+        .mem_id = 0,
+        .byte_start = 0,
+        .byte_end = 1,
+        .width_cols = 1,
+        .flags = TextChunk.Flags.ASCII_ONLY,
+    } };
+    const with_tab = Segment{ .text = .{
+        .mem_id = 0,
+        .byte_start = 1,
+        .byte_end = 2,
+        .width_cols = 2,
+        .flags = TextChunk.Flags.HAS_TAB,
+    } };
+
+    var metrics = without_tab.measure();
+    try std.testing.expect(!metrics.has_tabs);
+    metrics.add(with_tab.measure());
+    try std.testing.expect(metrics.has_tabs);
+}
+
 test "Segment.measure - break" {
     const seg: Segment = .{ .brk = {} };
     const metrics = seg.measure();

--- a/packages/native/src/tests/text-buffer_test.zig
+++ b/packages/native/src/tests/text-buffer_test.zig
@@ -61,6 +61,42 @@ test "TextBuffer line info - simple text without newlines" {
     try std.testing.expectEqualStrings(text, out_buffer[0..written]);
 }
 
+test "TextBuffer tab width changes preserve large tab-free Unicode and update one-tab control" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+
+    const unit = "OpenTUI text: 世界🙂 ";
+    const repeat_count = 4096;
+    const tab_free = try std.testing.allocator.alloc(u8, unit.len * repeat_count);
+    defer std.testing.allocator.free(tab_free);
+    for (0..repeat_count) |i| {
+        @memcpy(tab_free[i * unit.len ..][0..unit.len], unit);
+    }
+
+    try tb.setText(tab_free);
+    try std.testing.expect(!tb.rope().root.metrics().custom.has_tabs);
+    const tab_free_width = tb.lineWidthAt(0);
+    for (0..40) |i| {
+        tb.setTabWidth(if (i % 2 == 0) 4 else 2);
+        try std.testing.expectEqual(tab_free_width, tb.lineWidthAt(0));
+    }
+
+    const one_tab = try std.testing.allocator.dupe(u8, tab_free);
+    defer std.testing.allocator.free(one_tab);
+    one_tab[std.mem.indexOfScalar(u8, one_tab, 'x').?] = '\t';
+    try tb.setText(one_tab);
+    try std.testing.expect(tb.rope().root.metrics().custom.has_tabs);
+    for (0..40) |i| {
+        tb.setTabWidth(if (i % 2 == 0) 4 else 2);
+        try std.testing.expectEqual(tb.measureText(one_tab), tb.lineWidthAt(0));
+    }
+}
+
 test "TextBuffer line info - single newline" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/text-buffer-segment.zig
+++ b/packages/native/src/text-buffer-segment.zig
@@ -414,7 +414,7 @@ pub const Segment = union(enum) {
 
         if (left_chunk.mem_id != right_chunk.mem_id) return false;
         if (left_chunk.byte_end != right_chunk.byte_start) return false;
-        if (left_chunk.flags != right_chunk.flags) return false;
+        if ((left_chunk.flags & ~TextChunk.Flags.HAS_TAB) != (right_chunk.flags & ~TextChunk.Flags.HAS_TAB)) return false;
 
         return true;
     }
@@ -434,7 +434,7 @@ pub const Segment = union(enum) {
                 .byte_start = left_chunk.byte_start,
                 .byte_end = right_chunk.byte_end,
                 .width_cols = left_chunk.width_cols + right_chunk.width_cols,
-                .flags = left_chunk.flags,
+                .flags = left_chunk.flags | right_chunk.flags,
             },
         };
     }

--- a/packages/native/src/text-buffer-segment.zig
+++ b/packages/native/src/text-buffer-segment.zig
@@ -65,10 +65,15 @@ pub const TextChunk = struct {
 
     pub const Flags = struct {
         pub const ASCII_ONLY: u8 = 0b00000001; // Printable ASCII only (32..126).
+        pub const HAS_TAB: u8 = 0b00000010;
     };
 
     pub fn isAsciiOnly(self: *const TextChunk) bool {
         return (self.flags & Flags.ASCII_ONLY) != 0;
+    }
+
+    pub fn hasTab(self: *const TextChunk) bool {
+        return (self.flags & Flags.HAS_TAB) != 0;
     }
 
     pub fn empty() TextChunk {
@@ -295,6 +300,7 @@ pub const Segment = union(enum) {
         max_line_width_cols: u32 = 0,
         /// Whether all text segments in subtree are ASCII-only (for fast wrapping paths)
         ascii_only: bool = true,
+        has_tabs: bool = false,
 
         pub fn add(self: *Metrics, other: Metrics) void {
             self.total_width_cols += other.total_width_cols;
@@ -305,6 +311,7 @@ pub const Segment = union(enum) {
             self.max_line_width_cols = @max(self.max_line_width_cols, other.max_line_width_cols);
 
             self.ascii_only = self.ascii_only and other.ascii_only;
+            self.has_tabs = self.has_tabs or other.has_tabs;
         }
 
         /// Get the balancing weight for the rope
@@ -328,6 +335,7 @@ pub const Segment = union(enum) {
                     .newline_count = 0,
                     .max_line_width_cols = chunk.width_cols,
                     .ascii_only = is_ascii,
+                    .has_tabs = chunk.hasTab(),
                 };
             },
             .brk => Metrics{

--- a/packages/native/src/text-buffer.zig
+++ b/packages/native/src/text-buffer.zig
@@ -577,7 +577,7 @@ pub const UnifiedTextBuffer = struct {
         if (chunk_bytes.len > 0 and is_ascii) {
             flags |= TextChunk.Flags.ASCII_ONLY;
         }
-        if (std.mem.indexOfScalar(u8, chunk_bytes, '\t') != null) {
+        if (!is_ascii and std.mem.indexOfScalar(u8, chunk_bytes, '\t') != null) {
             flags |= TextChunk.Flags.HAS_TAB;
         }
 

--- a/packages/native/src/text-buffer.zig
+++ b/packages/native/src/text-buffer.zig
@@ -577,6 +577,9 @@ pub const UnifiedTextBuffer = struct {
         if (chunk_bytes.len > 0 and is_ascii) {
             flags |= TextChunk.Flags.ASCII_ONLY;
         }
+        if (std.mem.indexOfScalar(u8, chunk_bytes, '\t') != null) {
+            flags |= TextChunk.Flags.HAS_TAB;
+        }
 
         const chunk_width = utf8.calculateTextWidth(chunk_bytes, self.tab_width, is_ascii, self.width_method);
 
@@ -1289,12 +1292,20 @@ pub const UnifiedTextBuffer = struct {
     fn refreshTabWidthMetrics(self: *Self) void {
         if (self._rope.metricsGeneration() == self.tab_metrics_generation) return;
 
+        // Tab presence is content-derived, so even a stale persistent root can
+        // use this aggregate to prove that its widths remain valid.
+        if (!self._rope.root.metrics().custom.has_tabs) {
+            self._rope.setMetricsGeneration(self.tab_metrics_generation);
+            return;
+        }
+
         const RefreshContext = struct {
             buffer: *Self,
 
             fn refresh(ctx_ptr: *anyopaque, segment: *const Segment, _: u32) UnifiedRope.Node.WalkerResult {
                 const ctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
                 if (segment.asText()) |chunk| {
+                    if (!chunk.hasTab()) return .{};
                     const mutable = @constCast(chunk);
                     const bytes = chunk.getBytes(&ctx.buffer.mem_registry);
                     mutable.width_cols = utf8.calculateTextWidth(


### PR DESCRIPTION
- Track tab presence in chunk/root metrics. Tab-free roots advance their generation in O(1); otherwise refresh only tab-containing chunks.
- Skip the tab scan for already-known printable ASCII. No tab counts or new ownership layer; product change: +19 lines.

| Workload | Base → PR |
|---|---:|
| 1 MiB Unicode, 40 tab-width changes, no tabs | 211.4 ms → <1 µs |
| Same-sized one-tab control | 211.4 → 210.8 ms |
| Tab-free `setText` | 5.39 → 5.36 ms |

ReleaseFast/Linux, 12 CPU-pinned alternating pairs against `7a0dca8d`; correctness checked outside timing. One-tab/`setText` controls show no established slowdown. ASCII split/rejoin results remain variable and inconclusive.

Tab-presence, split/merge, deletion and stale-history regressions pass. Native 2,100; affected Core 320 passed. Build, format/lint and all 29 CI checks pass.
