### PR TITLE
fix(core): limit embedded terminal selection highlights to text

### DIFF
--- a/packages/core/src/renderables/EmbeddedTerminal.test.ts
+++ b/packages/core/src/renderables/EmbeddedTerminal.test.ts
@@ -87,6 +87,88 @@ describe("EmbeddedTerminalRenderable", () => {
     expect(terminal.getSelectedText()).toBe("")
   })
 
+  test("waits for a drag to leave its starting cell before selecting", async () => {
+    const terminal = new EmbeddedTerminalRenderable(setup.renderer, { width: 20, height: 4 })
+    setup.renderer.root.add(terminal)
+    terminal.write("hello")
+    await setup.renderOnce()
+    const original = setup.captureSpans().lines
+
+    await setup.mockMouse.pressDown(1, 0)
+    await setup.renderOnce()
+    expect(terminal.hasSelection()).toBe(false)
+    expect(setup.captureSpans().lines).toEqual(original)
+
+    await setup.mockMouse.moveTo(1, 0)
+    await setup.renderOnce()
+    expect(terminal.hasSelection()).toBe(false)
+    expect(setup.captureSpans().lines).toEqual(original)
+    await setup.mockMouse.release(1, 0)
+    await setup.renderOnce()
+    expect(terminal.hasSelection()).toBe(false)
+    expect(terminal.getSelectedText()).toBe("")
+    expect(setup.renderer.getSelection()?.getSelectedText()).toBe("")
+    expect(setup.captureSpans().lines).toEqual(original)
+
+    setup.renderer.clearSelection()
+    await setup.mockMouse.pressDown(1, 0)
+    await setup.mockMouse.moveTo(2, 0)
+    await setup.renderOnce()
+    expect(terminal.hasSelection()).toBe(true)
+    expect(terminal.getSelectedText()).toBe("el")
+    expect(setup.captureSpans().lines).not.toEqual(original)
+
+    // Crossing the threshold once enables normal selection, even back at the anchor.
+    await setup.mockMouse.moveTo(1, 0)
+    await setup.mockMouse.release(1, 0)
+    await setup.renderOnce()
+    expect(terminal.getSelectedText()).toBe("e")
+    expect(setup.captureSpans().lines).not.toEqual(original)
+
+    await setup.mockMouse.pressDown(4, 0)
+    await setup.renderOnce()
+    expect(terminal.hasSelection()).toBe(false)
+    expect(terminal.getSelectedText()).toBe("")
+    expect(setup.captureSpans().lines).toEqual(original)
+    await setup.mockMouse.release(4, 0)
+  })
+
+  test("starts selection on horizontal or vertical movement even when only one text cell is selected", async () => {
+    const terminal = new EmbeddedTerminalRenderable(setup.renderer, { width: 20, height: 4 })
+    setup.renderer.root.add(terminal)
+    terminal.write("hello")
+    await setup.renderOnce()
+    const original = setup.captureSpans().lines
+
+    for (const point of [
+      { x: 5, y: 0 },
+      { x: 4, y: 1 },
+    ]) {
+      setup.renderer.clearSelection()
+      await setup.mockMouse.pressDown(4, 0)
+      expect(terminal.hasSelection()).toBe(false)
+      await setup.mockMouse.moveTo(point.x, point.y)
+      await setup.renderOnce()
+      expect(terminal.hasSelection()).toBe(true)
+      expect(terminal.getSelectedText()).toBe("o")
+      expect(setup.captureSpans().lines).not.toEqual(original)
+      await setup.mockMouse.release(point.x, point.y)
+    }
+  })
+
+  test("does not delay word or line selection gestures", async () => {
+    const terminal = new EmbeddedTerminalRenderable(setup.renderer, { width: 20, height: 4 })
+    setup.renderer.root.add(terminal)
+    terminal.write("hello")
+    await setup.renderOnce()
+
+    for (const behavior of ["word", "line"] as const) {
+      setup.renderer.startSelection(terminal, 0, 0, behavior)
+      expect(terminal.hasSelection()).toBe(true)
+      expect(terminal.getSelectedText()).toBe("h")
+    }
+  })
+
   test("encodes keys and bracketed paste", () => {
     const terminal = new EmbeddedTerminalRenderable(setup.renderer, { width: 20, height: 4 })
     setup.renderer.root.add(terminal)

--- a/packages/core/src/renderables/EmbeddedTerminal.ts
+++ b/packages/core/src/renderables/EmbeddedTerminal.ts
@@ -175,6 +175,15 @@ export class EmbeddedTerminalRenderable extends Renderable {
       return false
     }
 
+    // Only gate the start of a cell drag; returning to the anchor after dragging is a valid selection.
+    if (
+      !this.selection &&
+      local.behavior === "cell" &&
+      local.anchorX === local.focusX &&
+      local.anchorY === local.focusY
+    )
+      return false
+
     const point = (x: number, y: number) => {
       if (y < 0) return { x: 0, y: 0 }
       if (y >= this.height) return { x: this.width - 1, y: this.height - 1 }

--- a/packages/native/src/embedded-terminal/compositor.zig
+++ b/packages/native/src/embedded-terminal/compositor.zig
@@ -70,6 +70,17 @@ fn composeRow(
     const raw_items = cells.items(.raw);
     const graphemes = cells.items(.grapheme);
     const styles = cells.items(.style);
+    const text_end = if (selection != null) end: {
+        var x = raw_items.len;
+        while (x > 0) {
+            x -= 1;
+            const raw = raw_items[x];
+            if (raw.wide == .spacer_tail or raw.wide == .spacer_head) continue;
+            // Keep explicit spaces and gaps within text, but not unused row tails.
+            if (raw.codepoint() != 0) break :end x + raw.gridWidth();
+        }
+        break :end 0;
+    } else 0;
 
     cell_loop: for (raw_items, 0..) |raw, x| {
         const dest_x = origin_x + @as(i32, @intCast(x));
@@ -82,7 +93,7 @@ fn composeRow(
         var bg = style.bg(&raw, &colors.palette) orelse colors.background;
         if (style.flags.inverse) std.mem.swap(@TypeOf(fg), &fg, &bg);
         if (selection) |range| {
-            if (x >= range[0] and x <= range[1]) std.mem.swap(@TypeOf(fg), &fg, &bg);
+            if (x < text_end and x + raw.gridWidth() > range[0] and x <= range[1]) std.mem.swap(@TypeOf(fg), &fg, &bg);
         }
 
         var stack: [128]u8 = undefined;

--- a/packages/native/src/embedded-terminal/tests.zig
+++ b/packages/native/src/embedded-terminal/tests.zig
@@ -124,6 +124,119 @@ test "embedded terminal selects rendered cells and extracts text" {
     try std.testing.expect(ansi.red(cleared.fg) > ansi.red(cleared.bg));
 }
 
+test "embedded terminal selection highlights text without unused cells" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var target = try buffer.OptimizedBuffer.init(std.testing.allocator, 8, 3, .{ .pool = pool });
+    defer target.deinit();
+
+    const cases = [_]struct {
+        output: []const u8,
+        start: ghostty.Coordinate = .{ .x = 0, .y = 0 },
+        end: ghostty.Coordinate = .{ .x = 7, .y = 2 },
+        text: []const u8,
+        highlight: [3][]const u8,
+    }{
+        .{
+            .output = "hello\r\nabc",
+            .start = .{ .x = 1, .y = 0 },
+            .text = "ello\nabc",
+            .highlight = .{ ".####...", "###.....", "........" },
+        },
+        .{
+            .output = "hello",
+            .start = .{ .x = 7, .y = 0 },
+            .end = .{ .x = 7, .y = 0 },
+            .text = "",
+            .highlight = .{ "........", "........", "........" },
+        },
+        .{
+            .output = "",
+            .text = "",
+            .highlight = .{ "........", "........", "........" },
+        },
+        .{
+            .output = "  a\x1b[3Cb",
+            .text = "  a   b",
+            .highlight = .{ "#######.", "........", "........" },
+        },
+        .{
+            // Written spaces remain text even though clipboard extraction trims them.
+            .output = "a  ",
+            .text = "a",
+            .highlight = .{ "###.....", "........", "........" },
+        },
+        .{
+            .output = "\x1b[44m\x1b[2J\x1b[0mhi",
+            .text = "hi",
+            .highlight = .{ "##......", "........", "........" },
+        },
+        .{
+            .output = "abcdefghi",
+            .text = "abcdefghi",
+            .highlight = .{ "########", "#.......", "........" },
+        },
+        .{
+            .output = "\xe7\x95\x8c",
+            .start = .{ .x = 1, .y = 0 },
+            .end = .{ .x = 1, .y = 0 },
+            .text = "\xe7\x95\x8c",
+            .highlight = .{ "##......", "........", "........" },
+        },
+        .{
+            .output = "e\xcc\x81 \xf0\x9f\x98\x80",
+            .text = "e\xcc\x81 \xf0\x9f\x98\x80",
+            .highlight = .{ "####....", "........", "........" },
+        },
+        .{
+            .output = "abcdefg\xe7\x95\x8c",
+            .text = "abcdefg\xe7\x95\x8c",
+            .highlight = .{ "#######.", "##......", "........" },
+        },
+    };
+
+    for (cases) |case| {
+        const terminal = try EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 8, .rows = 3 });
+        defer terminal.deinit();
+        try terminal.write(case.output);
+        try terminal.compose(target, 0, 0);
+        var original: [3][8]buffer.Cell = undefined;
+        for (&original, 0..) |*row, y| {
+            for (row, 0..) |*cell, x| cell.* = target.get(@intCast(x), @intCast(y)).?;
+        }
+
+        for ([_]bool{ false, true }) |reverse| {
+            try terminal.setSelection(if (reverse) case.end else case.start, if (reverse) case.start else case.end);
+            const selected = try terminal.selectedText();
+            defer terminal.freeSelectedText(selected);
+            try std.testing.expectEqualStrings(case.text, selected);
+            try terminal.compose(target, 0, 0);
+
+            for (case.highlight, 0..) |row, y| {
+                for (row, 0..) |highlight, x| {
+                    const cell = target.get(@intCast(x), @intCast(y)).?;
+                    const before = original[y][x];
+                    try std.testing.expectEqualDeep(if (highlight == '#') before.bg else before.fg, cell.fg);
+                    try std.testing.expectEqualDeep(if (highlight == '#') before.fg else before.bg, cell.bg);
+                }
+            }
+
+            // Moving into an unused row must repaint the previous highlight too.
+            try terminal.setSelection(.{ .x = 0, .y = 2 }, .{ .x = 7, .y = 2 });
+            try terminal.compose(target, 0, 0);
+            for (original, 0..) |row, y| {
+                for (row, 0..) |before, x| {
+                    const cell = target.get(@intCast(x), @intCast(y)).?;
+                    try std.testing.expectEqualDeep(before.fg, cell.fg);
+                    try std.testing.expectEqualDeep(before.bg, cell.bg);
+                }
+            }
+            terminal.clearSelection();
+            try terminal.compose(target, 0, 0);
+        }
+    }
+}
+
 test "embedded terminal preserves parser state and provides mode-aware input" {
     const terminal = try EmbeddedTerminal.init(std.testing.io, std.testing.allocator, .{ .cols = 20, .rows = 4 });
     defer terminal.deinit();


### PR DESCRIPTION
## Summary

- Clip embedded-terminal selection painting to each row's occupied text extent instead of highlighting unused trailing cells and empty rows.
- Preserve written spaces and interior cursor-created gaps; highlight both display cells of wide characters when either cell is selected.
- Delay cell-drag selection in EmbeddedTerminalRenderable until the pointer leaves its starting cell. Once activated, keep normal behavior for the rest of the drag, including returning to the anchor or selecting just one text cell.
- Leave shared renderer selection policy, word/line gesture handling, mouse-up clearing, and clipboard extraction unchanged. A click that never crosses the threshold exposes no selected terminal text. Written trailing spaces remain highlightable even though copying trims them.
- Add native coverage for text-only painting and mouse-event regression tests for same-cell presses/movement, release without dragging, horizontal/vertical activation, returning to the anchor, and resetting on a new gesture.

## Verification

- Reproduced both regressions with failing tests before their respective fixes.
- Full native suite: 2,067 passed, 8 skipped.
- Latest core JavaScript suite after rebuilding: 5,464 passed, 23 skipped.
- Focused embedded-terminal and shared-renderer selection tests: 28 passed.
- Full OpenTUI build for the native change, core library/declaration rebuild for the gesture change, formatting checks, lint, and Zig formatting passed. Native verification used Zig 0.16.0.
- Checked wide/narrow text-only painting and press/drag/return-to-anchor rendering with the production embedded-terminal component on Linux.
- Linked the local build into a fresh OpenCode v2 worktree and smoke-tested the TUI. Source-link typechecking reports existing errors in unchanged OpenTUI TypeScript files; configured external plugins also report failures. macOS was not tested.
