### PR TITLE
docs: document shared Zig cache for worktrees

### DIFF
--- a/packages/web/src/content/docs/test-and-debug/troubleshooting.mdx
+++ b/packages/web/src/content/docs/test-and-debug/troubleshooting.mdx
@@ -60,6 +60,19 @@ Start with the visible symptom. Run the diagnostic in its row, then open the lin
 | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | `Timed out waiting for visual idle after ... frames` | Read the attached `frameId`, `nativeFrameCount`, `cellsUpdated`, and scheduler fields. Stop unintended live rendering or release the live request. Increase `maxFrames` only when the expected work needs more frames. | [Waiting for observable output](/docs/core-concepts/testing#waiting-for-observable-output) |
 
+## Native builds across worktrees
+
+Zig already shares its global cache. For repeated native builds across many worktrees, opt in to sharing the project
+cache too:
+
+```sh
+export ZIG_LOCAL_CACHE_DIR="$HOME/.cache/opentui/zig-local-0.16.0"
+bun run build:native
+```
+
+Use a persistent local path and a separate directory for each Zig version. Do not prune it while Zig is running. Delete
+the complete cache only when builds are idle. `bun run clean` does not remove an external cache.
+
 ## Next
 
 - [Environment variables](/docs/reference/env-vars) lists diagnostics and overrides.

--- a/packages/web/src/content/docs/test-and-debug/troubleshooting.mdx
+++ b/packages/web/src/content/docs/test-and-debug/troubleshooting.mdx
@@ -62,16 +62,16 @@ Start with the visible symptom. Run the diagnostic in its row, then open the lin
 
 ## Native builds across worktrees
 
-Zig already shares its global cache. For repeated native builds across many worktrees, opt in to sharing the project
-cache too:
+Zig shares its global cache by default. For repeated native builds across many worktrees, you can also share the project
+cache:
 
 ```sh
 export ZIG_LOCAL_CACHE_DIR="$HOME/.cache/opentui/zig-local-0.16.0"
 bun run build:native
 ```
 
-Use a persistent local path and a separate directory for each Zig version. Do not prune it while Zig is running. Delete
-the complete cache only when builds are idle. `bun run clean` does not remove an external cache.
+Use a persistent local directory. Use a separate directory for each Zig version. `bun run clean` does not remove an
+external cache.
 
 ## Next
 


### PR DESCRIPTION
Document the opt-in shared Zig local cache workflow for repeated native builds across worktrees.