### PR TITLE
fix(native): expose Yoga C API to Zig consumers

### DIFF
--- a/packages/native/examples/hello/src/acceptance_test.zig
+++ b/packages/native/examples/hello/src/acceptance_test.zig
@@ -1,6 +1,19 @@
 const std = @import("std");
 const opentui = @import("opentui");
 
+test "Yoga layout is available through the public Zig module" {
+    const yoga = opentui.yoga_c;
+    const node = yoga.YGNodeNew();
+    defer yoga.YGNodeFree(node);
+
+    yoga.YGNodeStyleSetWidth(node, 12);
+    yoga.YGNodeStyleSetHeight(node, 3);
+    yoga.YGNodeCalculateLayout(node, 80, 24, yoga.YGDirectionLTR);
+
+    try std.testing.expectEqual(@as(f32, 12), yoga.YGNodeLayoutGetWidth(node));
+    try std.testing.expectEqual(@as(f32, 3), yoga.YGNodeLayoutGetHeight(node));
+}
+
 const MemorySink = struct {
     const capacity = 16 * 1024;
 

--- a/packages/native/src/opentui.zig
+++ b/packages/native/src/opentui.zig
@@ -4,6 +4,7 @@ pub const buffer = @import("buffer.zig");
 pub const renderer = @import("renderer.zig");
 pub const text_buffer = @import("text-buffer.zig");
 pub const text_buffer_view = @import("text-buffer-view.zig");
+pub const yoga_c = @import("yoga");
 
 pub const BufferedOutput = renderer.BufferedOutput;
 pub const CliRenderer = renderer.CliRenderer;

--- a/packages/native/src/opentui.zig
+++ b/packages/native/src/opentui.zig
@@ -4,6 +4,8 @@ pub const buffer = @import("buffer.zig");
 pub const renderer = @import("renderer.zig");
 pub const text_buffer = @import("text-buffer.zig");
 pub const text_buffer_view = @import("text-buffer-view.zig");
+/// Preliminary, unstable API. May change or be removed at any time without compatibility guarantees.
+/// Temporary access for native integration until OpenTUI has a native render tree.
 pub const yoga_c = @import("yoga");
 
 pub const BufferedOutput = renderer.BufferedOutput;


### PR DESCRIPTION
Export the existing Yoga C API as `opentui.yoga_c` for native Zig consumers. Preliminary and unstable; may change or be removed at any time without compatibility guarantees. Consumer acceptance and formatting checks pass.