### PR TITLE
perf(native): reduce word rewrap work without expanding caches

### DIFF
--- a/packages/native/src/tests/text-buffer-segment_test.zig
+++ b/packages/native/src/tests/text-buffer-segment_test.zig
@@ -96,6 +96,23 @@ test "walkChunkLayoutInfo keeps Prepend joined to an ASCII vector" {
     try testing.expectEqual(utf8.LayoutWrapBreakKind.preserved_whitespace, breaks.items[0].kind);
 }
 
+test "walkChunkLayoutInfo ASCII prefixes keep their final grapheme intact" {
+    var breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;
+    defer breaks.deinit(testing.allocator);
+    for (0..32) |prefix_len| {
+        const text = try std.fmt.allocPrint(testing.allocator, "{s} \u{301} \u{754c}abc", .{("a" ** 32)[0..prefix_len]});
+        defer testing.allocator.free(text);
+        _ = try utf8.findChunkLayoutInfo(testing.allocator, text, 2, false, .unicode, &breaks);
+        try testing.expectEqual(@as(usize, 3), breaks.items.len);
+        try testing.expectEqual(@as(u32, @intCast(prefix_len)), breaks.items[0].byte_start);
+        try testing.expectEqual(@as(u32, 3), breaks.items[0].byte_len);
+        try testing.expectEqual(@as(u32, 1), breaks.items[0].width_cols);
+        try testing.expectEqual(utf8.LayoutWrapBreakKind.preserved_whitespace, breaks.items[0].kind);
+        try testing.expectEqual(utf8.LayoutWrapBreakKind.whitespace, breaks.items[1].kind);
+        try testing.expectEqual(utf8.LayoutWrapBreakKind.script_transition, breaks.items[2].kind);
+    }
+}
+
 test "walkChunkLayoutInfo preserves mixed-content whitespace graphemes" {
     const cases = [_][]const u8{
         "\u{0D4E} ", // U+0D4E MALAYALAM LETTER DOT REPH

--- a/packages/native/src/tests/text-buffer-view_test.zig
+++ b/packages/native/src/tests/text-buffer-view_test.zig
@@ -11,6 +11,95 @@ const TextBuffer = text_buffer.UnifiedTextBuffer;
 const TextBufferView = text_buffer_view.UnifiedTextBufferView;
 const RGBA = text_buffer.RGBA;
 
+test "TextBufferView rewrap reuses virtual line allocation without retaining cleared layout" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    var tracking = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    const tb = try TextBuffer.init(tracking.allocator(), pool, link_pool, .unicode);
+    defer tb.deinit();
+    const view = try TextBufferView.init(tracking.allocator(), tb);
+    defer view.deinit();
+    try tb.setText("OpenTUI text metrics: \u{754c} e\u{301} abcdefghijklmnop " ** 100);
+    view.setWrapMode(.word);
+    view.setWrapWidth(80);
+    _ = view.getVirtualLines();
+    view.setWrapWidth(79);
+    _ = view.getVirtualLines();
+    view.setWrapWidth(80);
+    _ = view.getVirtualLines();
+    const allocated = tracking.allocated_bytes;
+    const capacity = view.virtual_lines_arena.queryCapacity();
+    for (0..20) |i| {
+        view.setWrapWidth(@intCast(79 + i % 2));
+        _ = view.getVirtualLines();
+    }
+    try std.testing.expectEqual(allocated, tracking.allocated_bytes);
+    tb.clear();
+    try std.testing.expectEqual(@as(u32, 1), view.getVirtualLineCount());
+    try std.testing.expect(view.virtual_lines_arena.queryCapacity() < capacity);
+}
+
+test "TextBufferView rewrap matches fresh layout after text and tab changes" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const texts = [_][]const u8{
+        "",                                                             "one",                                                              "one two three\n\nshort\n",
+        "\talpha \u{754c}abc e\u{301} \u{1f469}\u{200d}\u{1f4bb}\tend", "abcdefg \u{301} hi\n\u{0600} 0123456789abcdef\nword\u{200b}word ", "\u{754c} " ** 600,
+        "\u{754c}abc " ** 10000,
+    };
+    inline for (std.meta.tags(@import("../utf8.zig").WidthMethod)) |method| {
+        const tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, method);
+        defer tb.deinit();
+        const view = try TextBufferView.init(std.testing.allocator, tb);
+        defer view.deinit();
+        view.setWrapMode(.word);
+        const mem_id = try tb.registerMemBuffer("", false);
+        for (texts) |text| {
+            try tb.replaceMemBuffer(mem_id, text, false);
+            try tb.setTextFromMemId(mem_id);
+            for ([_]u8{ 2, 4 }) |tab_width| {
+                tb.setTabWidth(tab_width);
+                for ([_]u32{ 7, 16, 79, 16 }) |width| {
+                    const fresh_tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, method);
+                    defer fresh_tb.deinit();
+                    fresh_tb.setTabWidth(tab_width);
+                    try fresh_tb.setText(text);
+                    const fresh = try TextBufferView.init(std.testing.allocator, fresh_tb);
+                    defer fresh.deinit();
+                    fresh.setWrapMode(.word);
+                    fresh.setWrapWidth(width);
+                    view.setWrapWidth(width);
+                    const measured = try view.measureForDimensions(width, 24);
+                    const expected = fresh.getVirtualLines();
+                    const actual = view.getVirtualLines();
+                    try std.testing.expectEqual(expected.len, actual.len);
+                    try std.testing.expectEqual(measured.line_count, actual.len);
+                    for (expected, actual) |want, got| {
+                        try std.testing.expectEqual(want.width_cols, got.width_cols);
+                        try std.testing.expectEqual(want.source_line, got.source_line);
+                        try std.testing.expectEqual(want.source_col_start, got.source_col_start);
+                        try std.testing.expectEqual(want.document_cell_offset, got.document_cell_offset);
+                        try std.testing.expectEqual(want.chunks.items.len, got.chunks.items.len);
+                        for (want.chunks.items, got.chunks.items) |wc, gc| {
+                            try std.testing.expectEqual(wc.byte_start_in_chunk, gc.byte_start_in_chunk);
+                            try std.testing.expectEqual(wc.byte_len, gc.byte_len);
+                            try std.testing.expectEqual(wc.col_start_in_chunk, gc.col_start_in_chunk);
+                            try std.testing.expectEqual(wc.width_cols, gc.width_cols);
+                            try std.testing.expectEqualStrings(wc.chunk.getBytes(fresh_tb.memRegistry()), gc.chunk.getBytes(tb.memRegistry()));
+                        }
+                    }
+                }
+            }
+        }
+        tb.clear();
+        try std.testing.expectEqual(@as(u32, 1), view.getVirtualLineCount());
+    }
+}
+
 test "TextBufferView wrapping - no wrap returns same line count" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -374,8 +374,8 @@ pub const UnifiedTextBufferView = struct {
         }
     }
 
-    fn resetVirtualLineStorage(self: *Self) void {
-        _ = self.virtual_lines_arena.reset(.free_all);
+    fn resetVirtualLineStorage(self: *Self, mode: std.heap.ArenaAllocator.ResetMode) void {
+        _ = self.virtual_lines_arena.reset(mode);
         self.virtual_lines = .empty;
         self.cached_line_starts = .empty;
         self.cached_line_widths = .empty;
@@ -390,7 +390,7 @@ pub const UnifiedTextBufferView = struct {
         const buffer_dirty = self.text_buffer.isViewDirty(self.view_id);
         if (!self.virtual_lines_dirty and !buffer_dirty) return;
 
-        self.resetVirtualLineStorage();
+        self.resetVirtualLineStorage(if (!buffer_dirty and self.wrap_mode == .word) .retain_capacity else .free_all);
         const virtual_allocator = self.virtual_lines_arena.allocator();
 
         // Create output structure for the generic function
@@ -414,7 +414,7 @@ pub const UnifiedTextBufferView = struct {
         if (!calculated) {
             // Builders append to parallel arrays; discard partial output as a unit
             // and remain dirty so the next access can retry cleanly.
-            self.resetVirtualLineStorage();
+            self.resetVirtualLineStorage(.free_all);
             self.virtual_lines_dirty = true;
             return;
         }
@@ -1613,7 +1613,7 @@ pub const UnifiedTextBufferView = struct {
                 }
             }
 
-            fn addVirtualChunk(wctx: *@This(), chunk: *const TextChunk, byte_start: u32, byte_len: u32, col_start: u32, width_cols: u32) Allocator.Error!void {
+            inline fn addVirtualChunk(wctx: *@This(), chunk: *const TextChunk, byte_start: u32, byte_len: u32, col_start: u32, width_cols: u32) Allocator.Error!void {
                 if (byte_len == 0) return;
 
                 if (comptime calculation == .render and wrap_mode == .word) {
@@ -1645,7 +1645,7 @@ pub const UnifiedTextBufferView = struct {
                 wctx.current_vline_width_cols += width_cols;
             }
 
-            fn addVirtualChunkSticky(wctx: *@This(), chunk: *const TextChunk, byte_start: u32, byte_len: u32, col_start: u32, width_cols: u32) bool {
+            inline fn addVirtualChunkSticky(wctx: *@This(), chunk: *const TextChunk, byte_start: u32, byte_len: u32, col_start: u32, width_cols: u32) bool {
                 addVirtualChunk(wctx, chunk, byte_start, byte_len, col_start, width_cols) catch {
                     wctx.failed = true;
                     return false;
@@ -1815,7 +1815,7 @@ pub const UnifiedTextBufferView = struct {
                 }
             }
 
-            fn placeCompleteWordPiece(wctx: *@This(), chunk: *const TextChunk, col_start_in_chunk: u32, width_cols: u32, byte_start: u32, byte_end: u32) void {
+            inline fn placeCompleteWordPiece(wctx: *@This(), chunk: *const TextChunk, col_start_in_chunk: u32, width_cols: u32, byte_start: u32, byte_end: u32) void {
                 if (width_cols == 0 or wctx.failed) return;
 
                 var piece: PendingWordPiece = .{
@@ -1855,6 +1855,14 @@ pub const UnifiedTextBufferView = struct {
             }
 
             fn processWhitespaceBreak(wctx: *@This(), chunk: *const TextChunk, col_start: u32, byte_start: u32, wrap_break: utf8.LayoutWrapBreak) void {
+                // A fitting word and separator already coalesce into one chunk.
+                if (wctx.pending_word_width_cols == 0 and wrap_break.width_cols > 0 and wrap_break.col_start > col_start and
+                    wctx.current_vline_width_cols + (wrap_break.colEnd() - col_start) <= wctx.wordWrapWidth())
+                {
+                    _ = addVirtualChunkSticky(wctx, chunk, byte_start, wrap_break.byteEnd() - byte_start, col_start, wrap_break.colEnd() - col_start);
+                    wctx.source_line_has_non_whitespace = true;
+                    return;
+                }
                 if (wrap_break.col_start > col_start) {
                     flushCompleteWordPiece(
                         wctx,
@@ -1895,7 +1903,7 @@ pub const UnifiedTextBufferView = struct {
                 );
             }
 
-            fn processWordWrapBreakValue(wctx: *@This(), wrap_break: utf8.LayoutWrapBreak) void {
+            inline fn processWordWrapBreakValue(wctx: *@This(), wrap_break: utf8.LayoutWrapBreak) void {
                 const chunk = wctx.word_chunk orelse return;
                 const chunk_bytes = chunk.getBytes(wctx.text_buffer.memRegistry());
                 const col_end = @min(wrap_break.colEnd(), chunk.width_cols);

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -1615,10 +1615,16 @@ fn walkChunkLayoutInfoGeneric(
     var cluster_class: WordClass = .other;
 
     while (pos < text.len) {
-        if (pos + vector_len <= text.len) {
-            const chunk: @Vector(vector_len, u8) = text[pos..][0..vector_len].*;
-            const is_non_ascii = chunk >= @as(@Vector(vector_len, u8), @splat(0x80));
-            if (!@reduce(.Or, is_non_ascii)) {
+        {
+            var ascii_len: usize = 0;
+            if (pos + vector_len <= text.len) {
+                const chunk: @Vector(vector_len, u8) = text[pos..][0..vector_len].*;
+                const is_non_ascii = chunk >= @as(@Vector(vector_len, u8), @splat(0x80));
+                ascii_len = if (std.simd.firstTrue(is_non_ascii)) |index| index else vector_len;
+            } else {
+                while (pos + ascii_len < text.len and text[pos + ascii_len] < 0x80) : (ascii_len += 1) {}
+            }
+            if (ascii_len > 1) {
                 var can_use_ascii_fast_path = true;
                 if (cluster_started) {
                     var probe_state = break_state;
@@ -1645,7 +1651,7 @@ fn walkChunkLayoutInfoGeneric(
                     }
 
                     var i: usize = 0;
-                    while (i + 1 < vector_len) : (i += 1) {
+                    while (i + 1 < ascii_len) : (i += 1) {
                         const b = text[pos + i];
                         const width = asciiCharWidth(b, tab_width);
                         if (isAsciiWrapBreak(b)) {
@@ -1654,17 +1660,17 @@ fn walkChunkLayoutInfoGeneric(
                         col += width;
                     }
 
-                    const last_b = text[pos + vector_len - 1];
+                    const last_b = text[pos + ascii_len - 1];
                     const last_cp: u21 = last_b;
                     cluster_started = true;
-                    cluster_start = pos + vector_len - 1;
+                    cluster_start = pos + ascii_len - 1;
                     cluster_col_offset = col;
                     cluster_width_state = GraphemeWidthState.init(last_cp, asciiCharWidth(last_b, tab_width), width_method);
                     cluster_break_kind = asciiLayoutWrapBreakKind(last_b);
                     cluster_class = classifyWordClass(last_cp);
                     prev_cp = last_cp;
                     break_state = .default;
-                    pos += vector_len;
+                    pos += ascii_len;
                     continue;
                 }
             }


### PR DESCRIPTION
Short Unicode chunks rescan on resize, and word layout also freed/rebuilt its arena each time. Reuse word-layout capacity while text is unchanged, process ASCII prefixes/tails in the existing scanner, and append fitting words/separators together; break-cache policy and output stay unchanged.

| 945 KB Unicode word-wrap | v0.5.8 | Main | Branch |
|---|---:|---:|---:|
| First layout | 11.63 ms | 7.55 ms | 5.29 ms |
| First measurement | 11.11 ms | 5.51 ms | 3.69 ms |
| Width 79/80 rewrap | 2.62 ms | 7.38 ms | 4.18 ms |
| Native retained | 22.77 MiB | 14.52 MiB | 14.52 MiB |

Six balanced fresh-process triples, CPU-pinned Zig 0.16 ReleaseFast/page allocator, identical input and verified layout/rendered output. Retained bytes include TextBuffer/View arena capacity; 40 resizes reduce allocation traffic from 376 to 24 MiB, with zero after destruction. Rewrap is 44.5% faster than main but still 1.6x slower than v0.5.8; expanding metadata caching was rejected because it increased retained/edit-history memory.
