### PR TITLE
perf(native): reduce word layout work with eager view metadata

### DIFF
--- a/packages/native/src/tests/text-buffer-segment_test.zig
+++ b/packages/native/src/tests/text-buffer-segment_test.zig
@@ -96,6 +96,23 @@ test "walkChunkLayoutInfo keeps Prepend joined to an ASCII vector" {
     try testing.expectEqual(utf8.LayoutWrapBreakKind.preserved_whitespace, breaks.items[0].kind);
 }
 
+test "walkChunkLayoutInfo ASCII prefixes keep their final grapheme intact" {
+    var breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;
+    defer breaks.deinit(testing.allocator);
+    for (0..32) |prefix_len| {
+        const text = try std.fmt.allocPrint(testing.allocator, "{s} \u{301} \u{754c}abc", .{("a" ** 32)[0..prefix_len]});
+        defer testing.allocator.free(text);
+        _ = try utf8.findChunkLayoutInfo(testing.allocator, text, 2, false, .unicode, &breaks);
+        try testing.expectEqual(@as(usize, 3), breaks.items.len);
+        try testing.expectEqual(@as(u32, @intCast(prefix_len)), breaks.items[0].byte_start);
+        try testing.expectEqual(@as(u32, 3), breaks.items[0].byte_len);
+        try testing.expectEqual(@as(u32, 1), breaks.items[0].width_cols);
+        try testing.expectEqual(utf8.LayoutWrapBreakKind.preserved_whitespace, breaks.items[0].kind);
+        try testing.expectEqual(utf8.LayoutWrapBreakKind.whitespace, breaks.items[1].kind);
+        try testing.expectEqual(utf8.LayoutWrapBreakKind.script_transition, breaks.items[2].kind);
+    }
+}
+
 test "walkChunkLayoutInfo preserves mixed-content whitespace graphemes" {
     const cases = [_][]const u8{
         "\u{0D4E} ", // U+0D4E MALAYALAM LETTER DOT REPH

--- a/packages/native/src/tests/text-buffer-view_test.zig
+++ b/packages/native/src/tests/text-buffer-view_test.zig
@@ -11,6 +11,70 @@ const TextBuffer = text_buffer.UnifiedTextBuffer;
 const TextBufferView = text_buffer_view.UnifiedTextBufferView;
 const RGBA = text_buffer.RGBA;
 
+test "TextBufferView first layout retains reusable word metadata" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const links = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const tb = try TextBuffer.init(std.testing.allocator, pool, links, .unicode);
+    defer tb.deinit();
+    const view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+    try tb.setText("alpha \u{754c}abc e\u{301} words\n" ** 100);
+    view.setWrapMode(.word);
+    view.setWrapWidth(80);
+    _ = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 100), view.word_layout.layouts.items.len);
+    const ptr = view.word_layout.layouts.items.ptr;
+    const capacity = view.word_layout.arena.queryCapacity();
+    view.setWrapWidth(79);
+    _ = view.getVirtualLines();
+    try std.testing.expectEqual(ptr, view.word_layout.layouts.items.ptr);
+    try std.testing.expectEqual(capacity, view.word_layout.arena.queryCapacity());
+}
+
+test "TextBufferView optional metadata failure preserves every streamed piece" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const links = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const tb = try TextBuffer.init(std.testing.allocator, pool, links, .unicode);
+    defer tb.deinit();
+    try tb.setText(("a\u{754c}e\u{301} \u{0600} xy\tend-" ** 5000) ++ "\n" ++ ("\u{754c}abc e\u{301}\n" ** 100));
+    const expected = try TextBufferView.init(std.testing.allocator, tb);
+    defer expected.deinit();
+    expected.setWrapMode(.word);
+    expected.setWrapWidth(79);
+    const want = expected.getVirtualLines();
+    for (0..14) |failure| {
+        var tracking = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+        const actual = try TextBufferView.init(std.testing.allocator, tb);
+        defer actual.deinit();
+        actual.word_layout.arena.child_allocator = tracking.allocator();
+        actual.setWrapMode(.word);
+        tracking.fail_index = failure;
+        actual.setWrapWidth(79);
+        const got = actual.getVirtualLines();
+        try std.testing.expect(!actual.virtual_lines_dirty);
+        try std.testing.expectEqual(want.len, got.len);
+        for (want, got) |wl, gl| {
+            try std.testing.expectEqual(wl.width_cols, gl.width_cols);
+            try std.testing.expectEqual(wl.source_line, gl.source_line);
+            try std.testing.expectEqual(wl.source_col_start, gl.source_col_start);
+            try std.testing.expectEqual(wl.document_cell_offset, gl.document_cell_offset);
+            try std.testing.expectEqualDeep(wl.chunks.items, gl.chunks.items);
+        }
+        if (tracking.has_induced_failure) try std.testing.expectEqual(@as(usize, 0), actual.word_layout.layouts.items.len);
+        tracking.fail_index = std.math.maxInt(usize);
+        actual.setWrapWidth(80);
+        _ = actual.getVirtualLines();
+        actual.setWrapWidth(79);
+        try std.testing.expectEqual(want.len, actual.getVirtualLines().len);
+        const measured = try actual.measureForDimensions(79, 24);
+        try std.testing.expectEqual(want.len, measured.line_count);
+    }
+}
+
 test "TextBufferView width reuse does not leave metadata in old buffer roots" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
@@ -65,7 +129,7 @@ test "TextBufferView live word metadata follows views history and buffer switche
     second.setWrapWidth(32);
     _ = view.getVirtualLines();
     _ = second.getVirtualLines();
-    try std.testing.expectEqual(@as(usize, 0), view.word_layout.layouts.items.len);
+    try std.testing.expect(view.word_layout.layouts.items.len > 0);
     view.setWrapWidth(17);
     second.setWrapWidth(33);
     _ = view.getVirtualLines();
@@ -85,7 +149,7 @@ test "TextBufferView live word metadata follows views history and buffer switche
         edit.tb.setTabWidth(@intCast(2 + step * 2));
         for ([_]*TextBufferView{ view, second }) |current| {
             _ = current.getVirtualLines();
-            try std.testing.expectEqual(@as(usize, 0), current.word_layout.layouts.items.len);
+            try std.testing.expect(current.word_layout.layouts.items.len > 0);
             current.setWrapWidth(19);
             _ = current.getVirtualLines();
             current.setWrapWidth(23);
@@ -146,14 +210,12 @@ test "TextBufferView live word metadata discards partial allocation on failure" 
         try tb.setText("alpha \u{754c} e\u{301} word word word word\n" ** 100);
         view.setWrapMode(.word);
         view.setWrapWidth(16);
-        _ = view.getVirtualLines();
         tracking.fail_index = tracking.alloc_index + failure;
         view.setWrapWidth(17);
         _ = view.getVirtualLines();
         if (tracking.has_induced_failure) {
             try std.testing.expectEqual(@as(usize, 0), view.word_layout.layouts.items.len);
             if (view.virtual_lines_dirty) try std.testing.expectEqual(@as(usize, 0), view.virtual_lines.items.len);
-            if (failure == 1) try std.testing.expect(!view.virtual_lines_dirty);
         }
         tracking.fail_index = std.math.maxInt(usize);
         const measured = try view.measureForDimensions(17, 24);

--- a/packages/native/src/tests/text-buffer-view_test.zig
+++ b/packages/native/src/tests/text-buffer-view_test.zig
@@ -11,6 +11,156 @@ const TextBuffer = text_buffer.UnifiedTextBuffer;
 const TextBufferView = text_buffer_view.UnifiedTextBufferView;
 const RGBA = text_buffer.RGBA;
 
+test "TextBufferView width reuse does not leave metadata in old buffer roots" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    var retained: [2]usize = undefined;
+    for (0..2) |side| {
+        var tracking = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+        const tb = try TextBuffer.init(tracking.allocator(), pool, link_pool, .unicode);
+        defer tb.deinit();
+        const view = try TextBufferView.init(tracking.allocator(), tb);
+        view.setWrapMode(.word);
+        view.setWrapWidth(80);
+        const mem_id = try tb.registerMemBuffer("", false);
+        for (0..20) |edit| {
+            const text = if (edit % 2 == 0)
+                "OpenTUI text metrics: \u{754c} e\u{301} abcdefghijklmnop \n" ** 100
+            else
+                "Changed text metrics: \u{754c} e\u{301} abcdefghijklmnop \n" ** 100;
+            try tb.replaceMemBuffer(mem_id, text, false);
+            try tb.setTextFromMemId(mem_id);
+            _ = view.getVirtualLines();
+            if (side == 1) for ([_]u32{ 79, 80, 43, 96, 80 }) |width| {
+                view.setWrapWidth(width);
+                _ = view.getVirtualLines();
+            };
+        }
+        view.deinit();
+        retained[side] = tracking.allocated_bytes - tracking.freed_bytes;
+    }
+    try std.testing.expectEqual(retained[0], retained[1]);
+}
+
+test "TextBufferView live word metadata follows views history and buffer switches" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const edit = try @import("../edit-buffer.zig").EditBuffer.init(std.testing.allocator, pool, link_pool, .unicode, null);
+    defer edit.deinit();
+    const view = try TextBufferView.init(std.testing.allocator, edit.tb);
+    defer view.deinit();
+    const second = try TextBufferView.init(std.testing.allocator, edit.tb);
+    defer second.deinit();
+    const other = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer other.deinit();
+    try other.setText("unrelated\t\u{754c} text");
+    try edit.setText("alpha \u{754c} e\u{301} abcdefghijklmnopqrstuvwxyz\n" ** 10);
+    view.setWrapMode(.word);
+    second.setWrapMode(.word);
+    view.setWrapWidth(16);
+    second.setWrapWidth(32);
+    _ = view.getVirtualLines();
+    _ = second.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 0), view.word_layout.layouts.items.len);
+    view.setWrapWidth(17);
+    second.setWrapWidth(33);
+    _ = view.getVirtualLines();
+    _ = second.getVirtualLines();
+    const ptr = view.word_layout.layouts.items.ptr;
+    const capacity = view.word_layout.arena.queryCapacity();
+    for ([_]u32{ 43, 7, 16, 96, 32 }) |width| {
+        view.setWrapWidth(width);
+        _ = view.getVirtualLines();
+        try std.testing.expectEqual(ptr, view.word_layout.layouts.items.ptr);
+        try std.testing.expectEqual(capacity, view.word_layout.arena.queryCapacity());
+    }
+    try edit.replaceText("changed\ttext \u{0600} \u{301} \u{754c} words\n" ** 10);
+    for (0..3) |step| {
+        if (step == 1) _ = try edit.undo();
+        if (step == 2) _ = try edit.redo();
+        edit.tb.setTabWidth(@intCast(2 + step * 2));
+        for ([_]*TextBufferView{ view, second }) |current| {
+            _ = current.getVirtualLines();
+            try std.testing.expectEqual(@as(usize, 0), current.word_layout.layouts.items.len);
+            current.setWrapWidth(19);
+            _ = current.getVirtualLines();
+            current.setWrapWidth(23);
+            const measured = try current.measureForDimensions(23, 24);
+            try std.testing.expectEqual(measured.line_count, current.getVirtualLineCount());
+            try std.testing.expect(current.word_layout.layouts.items.len > 0);
+            var bytes: [4096]u8 = undefined;
+            const len = edit.tb.getPlainTextIntoBuffer(&bytes);
+            const fresh_tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+            defer fresh_tb.deinit();
+            fresh_tb.setTabWidth(edit.tb.tabWidth());
+            try fresh_tb.setText(bytes[0..len]);
+            const fresh = try TextBufferView.init(std.testing.allocator, fresh_tb);
+            defer fresh.deinit();
+            fresh.setWrapMode(.word);
+            fresh.setWrapWidth(23);
+            const expected = fresh.getVirtualLines();
+            const actual = current.getVirtualLines();
+            try std.testing.expectEqual(expected.len, actual.len);
+            for (expected, actual) |want, got| {
+                try std.testing.expectEqual(want.width_cols, got.width_cols);
+                try std.testing.expectEqual(want.source_line, got.source_line);
+                try std.testing.expectEqual(want.source_col_start, got.source_col_start);
+                try std.testing.expectEqual(want.document_cell_offset, got.document_cell_offset);
+                try std.testing.expectEqual(want.chunks.items.len, got.chunks.items.len);
+                for (want.chunks.items, got.chunks.items) |wc, gc| {
+                    try std.testing.expectEqual(wc.byte_start_in_chunk, gc.byte_start_in_chunk);
+                    try std.testing.expectEqual(wc.byte_len, gc.byte_len);
+                    try std.testing.expectEqual(wc.col_start_in_chunk, gc.col_start_in_chunk);
+                    try std.testing.expectEqual(wc.width_cols, gc.width_cols);
+                    try std.testing.expectEqualStrings(wc.chunk.getBytes(fresh_tb.memRegistry()), gc.chunk.getBytes(edit.tb.memRegistry()));
+                }
+            }
+        }
+    }
+    view.switchToBuffer(other);
+    try std.testing.expectEqual(@as(usize, 0), view.word_layout.layouts.items.len);
+    _ = view.getVirtualLines();
+    view.switchToOriginalBuffer();
+    try std.testing.expectEqual(@as(usize, 0), view.word_layout.layouts.items.len);
+    _ = view.getVirtualLines();
+    view.setWrapMode(.char);
+    _ = view.getVirtualLines();
+    try std.testing.expectEqual(@as(usize, 0), view.word_layout.arena.queryCapacity());
+}
+
+test "TextBufferView live word metadata discards partial allocation on failure" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    for (0..10) |failure| {
+        var tracking = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+        const tb = try TextBuffer.init(tracking.allocator(), pool, link_pool, .unicode);
+        defer tb.deinit();
+        const view = try TextBufferView.init(tracking.allocator(), tb);
+        defer view.deinit();
+        try tb.setText("alpha \u{754c} e\u{301} word word word word\n" ** 100);
+        view.setWrapMode(.word);
+        view.setWrapWidth(16);
+        _ = view.getVirtualLines();
+        tracking.fail_index = tracking.alloc_index + failure;
+        view.setWrapWidth(17);
+        _ = view.getVirtualLines();
+        if (tracking.has_induced_failure) {
+            try std.testing.expectEqual(@as(usize, 0), view.word_layout.layouts.items.len);
+            if (view.virtual_lines_dirty) try std.testing.expectEqual(@as(usize, 0), view.virtual_lines.items.len);
+            if (failure == 1) try std.testing.expect(!view.virtual_lines_dirty);
+        }
+        tracking.fail_index = std.math.maxInt(usize);
+        const measured = try view.measureForDimensions(17, 24);
+        try std.testing.expectEqual(measured.line_count, view.getVirtualLineCount());
+    }
+}
+
 test "TextBufferView rewrap reuses virtual line allocation without retaining cleared layout" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/tests/text-buffer-view_test.zig
+++ b/packages/native/src/tests/text-buffer-view_test.zig
@@ -11,6 +11,95 @@ const TextBuffer = text_buffer.UnifiedTextBuffer;
 const TextBufferView = text_buffer_view.UnifiedTextBufferView;
 const RGBA = text_buffer.RGBA;
 
+test "TextBufferView rewrap reuses virtual line allocation without retaining cleared layout" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    var tracking = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    const tb = try TextBuffer.init(tracking.allocator(), pool, link_pool, .unicode);
+    defer tb.deinit();
+    const view = try TextBufferView.init(tracking.allocator(), tb);
+    defer view.deinit();
+    try tb.setText("OpenTUI text metrics: \u{754c} e\u{301} abcdefghijklmnop " ** 100);
+    view.setWrapMode(.word);
+    view.setWrapWidth(80);
+    _ = view.getVirtualLines();
+    view.setWrapWidth(79);
+    _ = view.getVirtualLines();
+    view.setWrapWidth(80);
+    _ = view.getVirtualLines();
+    const allocated = tracking.allocated_bytes;
+    const capacity = view.virtual_lines_arena.queryCapacity();
+    for (0..20) |i| {
+        view.setWrapWidth(@intCast(79 + i % 2));
+        _ = view.getVirtualLines();
+    }
+    try std.testing.expectEqual(allocated, tracking.allocated_bytes);
+    tb.clear();
+    try std.testing.expectEqual(@as(u32, 1), view.getVirtualLineCount());
+    try std.testing.expect(view.virtual_lines_arena.queryCapacity() < capacity);
+}
+
+test "TextBufferView rewrap matches fresh layout after text and tab changes" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const texts = [_][]const u8{
+        "",                                                             "one",                                                              "one two three\n\nshort\n",
+        "\talpha \u{754c}abc e\u{301} \u{1f469}\u{200d}\u{1f4bb}\tend", "abcdefg \u{301} hi\n\u{0600} 0123456789abcdef\nword\u{200b}word ", "\u{754c} " ** 600,
+        "\u{754c}abc " ** 10000,
+    };
+    inline for (std.meta.tags(@import("../utf8.zig").WidthMethod)) |method| {
+        const tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, method);
+        defer tb.deinit();
+        const view = try TextBufferView.init(std.testing.allocator, tb);
+        defer view.deinit();
+        view.setWrapMode(.word);
+        const mem_id = try tb.registerMemBuffer("", false);
+        for (texts) |text| {
+            try tb.replaceMemBuffer(mem_id, text, false);
+            try tb.setTextFromMemId(mem_id);
+            for ([_]u8{ 2, 4 }) |tab_width| {
+                tb.setTabWidth(tab_width);
+                for ([_]u32{ 7, 16, 79, 16 }) |width| {
+                    const fresh_tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, method);
+                    defer fresh_tb.deinit();
+                    fresh_tb.setTabWidth(tab_width);
+                    try fresh_tb.setText(text);
+                    const fresh = try TextBufferView.init(std.testing.allocator, fresh_tb);
+                    defer fresh.deinit();
+                    fresh.setWrapMode(.word);
+                    fresh.setWrapWidth(width);
+                    view.setWrapWidth(width);
+                    const measured = try view.measureForDimensions(width, 24);
+                    const expected = fresh.getVirtualLines();
+                    const actual = view.getVirtualLines();
+                    try std.testing.expectEqual(expected.len, actual.len);
+                    try std.testing.expectEqual(measured.line_count, actual.len);
+                    for (expected, actual) |want, got| {
+                        try std.testing.expectEqual(want.width_cols, got.width_cols);
+                        try std.testing.expectEqual(want.source_line, got.source_line);
+                        try std.testing.expectEqual(want.source_col_start, got.source_col_start);
+                        try std.testing.expectEqual(want.document_cell_offset, got.document_cell_offset);
+                        try std.testing.expectEqual(want.chunks.items.len, got.chunks.items.len);
+                        for (want.chunks.items, got.chunks.items) |wc, gc| {
+                            try std.testing.expectEqual(wc.byte_start_in_chunk, gc.byte_start_in_chunk);
+                            try std.testing.expectEqual(wc.byte_len, gc.byte_len);
+                            try std.testing.expectEqual(wc.col_start_in_chunk, gc.col_start_in_chunk);
+                            try std.testing.expectEqual(wc.width_cols, gc.width_cols);
+                            try std.testing.expectEqualStrings(wc.chunk.getBytes(fresh_tb.memRegistry()), gc.chunk.getBytes(tb.memRegistry()));
+                        }
+                    }
+                }
+            }
+        }
+        tb.clear();
+        try std.testing.expectEqual(@as(u32, 1), view.getVirtualLineCount());
+    }
+}
+
 test "TextBufferView wrapping - no wrap returns same line count" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -198,6 +198,18 @@ pub const LocalSelection = struct {
 
 pub const TextBufferView = UnifiedTextBufferView;
 
+// Width-independent metadata for the current view layout, in rope traversal
+// order. Nothing is attached to chunks or retained by their undo roots.
+const WordLayoutStorage = struct {
+    arena: std.heap.ArenaAllocator,
+    layouts: std.ArrayListUnmanaged(utf8.ChunkLayoutInfo) = .empty,
+
+    fn reset(self: *WordLayoutStorage) void {
+        _ = self.arena.reset(.free_all);
+        self.layouts = .empty;
+    }
+};
+
 pub const UnifiedTextBufferView = struct {
     const Self = UnifiedTextBufferView;
 
@@ -224,6 +236,7 @@ pub const UnifiedTextBufferView = struct {
     cached_line_vline_counts: std.ArrayListUnmanaged(u32),
     global_allocator: Allocator,
     virtual_lines_arena: *std.heap.ArenaAllocator,
+    word_layout: WordLayoutStorage,
 
     /// Persistent arena for measureForDimensions. Each call resets it with
     /// retain_capacity to avoid mmap/munmap churn during streaming.
@@ -281,6 +294,7 @@ pub const UnifiedTextBufferView = struct {
             .cached_line_vline_counts = .empty,
             .global_allocator = global_allocator,
             .virtual_lines_arena = virtual_lines_internal_arena,
+            .word_layout = .{ .arena = std.heap.ArenaAllocator.init(global_allocator) },
             .measure_arena = std.heap.ArenaAllocator.init(global_allocator),
             .tab_indicator = null,
             .tab_indicator_color = null,
@@ -309,6 +323,7 @@ pub const UnifiedTextBufferView = struct {
         self.virtual_lines_arena.deinit();
         global_allocator.destroy(self.virtual_lines_arena);
         self.measure_arena.deinit();
+        self.word_layout.arena.deinit();
         self.* = undefined;
     }
 
@@ -390,6 +405,8 @@ pub const UnifiedTextBufferView = struct {
         const buffer_dirty = self.text_buffer.isViewDirty(self.view_id);
         if (!self.virtual_lines_dirty and !buffer_dirty) return;
 
+        if (buffer_dirty or self.wrap_mode != .word or self.wrap_width == null) self.word_layout.reset();
+        const reuse_words = !buffer_dirty and self.virtual_lines.items.len > 0;
         self.resetVirtualLineStorage(if (!buffer_dirty and self.wrap_mode == .word) .retain_capacity else .free_all);
         const virtual_allocator = self.virtual_lines_arena.allocator();
 
@@ -408,13 +425,14 @@ pub const UnifiedTextBufferView = struct {
             calculateUnwrappedVirtualLines(virtual_allocator, self.text_buffer, output)
         else switch (self.wrap_mode) {
             .none => unreachable,
-            .char => calculateVirtualLinesGeneric(.render, .char, virtual_allocator, self.text_buffer, self.wrap_width.?, self.first_line_offset, output),
-            .word => calculateVirtualLinesGeneric(.render, .word, virtual_allocator, self.text_buffer, self.wrap_width.?, self.first_line_offset, output),
+            .char => calculateVirtualLinesGeneric(.render, .char, virtual_allocator, self.text_buffer, self.wrap_width.?, self.first_line_offset, output, null),
+            .word => calculateVirtualLinesGeneric(.render, .word, virtual_allocator, self.text_buffer, self.wrap_width.?, self.first_line_offset, output, if (reuse_words) &self.word_layout else null),
         };
         if (!calculated) {
             // Builders append to parallel arrays; discard partial output as a unit
             // and remain dirty so the next access can retry cleanly.
             self.resetVirtualLineStorage(.free_all);
+            self.word_layout.reset();
             self.virtual_lines_dirty = true;
             return;
         }
@@ -658,12 +676,14 @@ pub const UnifiedTextBufferView = struct {
     }
 
     pub fn switchToBuffer(self: *Self, buffer: *UnifiedTextBuffer) void {
+        self.word_layout.reset();
         self.text_buffer = buffer;
         self.virtual_lines_dirty = true;
     }
 
     pub fn switchToOriginalBuffer(self: *Self) void {
         if (self.text_buffer != self.original_text_buffer) {
+            self.word_layout.reset();
             self.text_buffer = self.original_text_buffer;
             self.virtual_lines_dirty = true;
         }
@@ -1427,8 +1447,8 @@ pub const UnifiedTextBufferView = struct {
         var result: MeasureResult = .{ .line_count = 0, .width_cols_max = 0 };
         const calculated = switch (self.wrap_mode) {
             .none => unreachable,
-            .char => calculateVirtualLinesGeneric(.measure, .char, measure_allocator, self.text_buffer, width, self.first_line_offset, &result),
-            .word => calculateVirtualLinesGeneric(.measure, .word, measure_allocator, self.text_buffer, width, self.first_line_offset, &result),
+            .char => calculateVirtualLinesGeneric(.measure, .char, measure_allocator, self.text_buffer, width, self.first_line_offset, &result, null),
+            .word => calculateVirtualLinesGeneric(.measure, .word, measure_allocator, self.text_buffer, width, self.first_line_offset, &result, null),
         };
         if (!calculated) return TextBufferViewError.OutOfMemory;
 
@@ -1540,6 +1560,7 @@ pub const UnifiedTextBufferView = struct {
         wrap_w: u32,
         first_line_offset: u32,
         result: if (calculation == .render) VirtualLineOutput else *MeasureResult,
+        word_layout: ?*WordLayoutStorage,
     ) bool {
         comptime std.debug.assert(wrap_mode != .none);
 
@@ -1547,6 +1568,8 @@ pub const UnifiedTextBufferView = struct {
             text_buffer: *UnifiedTextBuffer,
             allocator: Allocator,
             result: @TypeOf(result),
+            word_layout: ?*WordLayoutStorage,
+            word_layout_index: usize = 0,
             wrap_w: u32,
             current_wrap_width: u32,
             document_cell_offset: u32 = 0,
@@ -1945,7 +1968,7 @@ pub const UnifiedTextBufferView = struct {
                 // Reuse existing caches, but retain cold layout only for medium
                 // non-ASCII chunks; vectorized ASCII and small/large chunks stream.
                 const cached_layout = chunk.getCachedLayoutInfo(wctx.text_buffer.tabWidth(), wctx.text_buffer.widthMethod());
-                const layout: ?utf8.ChunkLayoutInfo = if (cached_layout) |cached|
+                var layout: ?utf8.ChunkLayoutInfo = if (cached_layout) |cached|
                     cached
                 else blk: {
                     if (comptime calculation == .render) {
@@ -1961,6 +1984,30 @@ pub const UnifiedTextBufferView = struct {
                     }
                     break :blk null;
                 };
+                if (wctx.word_layout) |storage| {
+                    const index = wctx.word_layout_index;
+                    wctx.word_layout_index += 1;
+                    if (index < storage.layouts.items.len) {
+                        layout = storage.layouts.items[index];
+                    } else {
+                        const saved = save: {
+                            const layout_allocator = storage.arena.allocator();
+                            if (layout == null) {
+                                var breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;
+                                const classes = utf8.findChunkLayoutInfo(layout_allocator, chunk_bytes, wctx.text_buffer.tabWidth(), chunk.isAsciiOnly(), wctx.text_buffer.widthMethod(), &breaks) catch break :save false;
+                                layout = .{ .wrap_breaks = breaks.toOwnedSlice(layout_allocator) catch break :save false, .word_classes = classes };
+                            }
+                            storage.layouts.append(layout_allocator, layout.?) catch break :save false;
+                            break :save true;
+                        };
+                        if (!saved) {
+                            // Optional reuse must not prevent a streaming layout on OOM.
+                            storage.reset();
+                            wctx.word_layout = null;
+                            layout = null;
+                        }
+                    }
+                }
                 const word_classes = if (layout) |info|
                     info.word_classes
                 else
@@ -2220,6 +2267,7 @@ pub const UnifiedTextBufferView = struct {
             .text_buffer = text_buffer,
             .allocator = allocator,
             .result = result,
+            .word_layout = word_layout,
             .wrap_w = wrap_w,
             .current_wrap_width = if (first_line_offset > 0 and first_line_offset < wrap_w)
                 wrap_w - first_line_offset

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -406,7 +406,6 @@ pub const UnifiedTextBufferView = struct {
         if (!self.virtual_lines_dirty and !buffer_dirty) return;
 
         if (buffer_dirty or self.wrap_mode != .word or self.wrap_width == null) self.word_layout.reset();
-        const reuse_words = !buffer_dirty and self.virtual_lines.items.len > 0;
         self.resetVirtualLineStorage(if (!buffer_dirty and self.wrap_mode == .word) .retain_capacity else .free_all);
         const virtual_allocator = self.virtual_lines_arena.allocator();
 
@@ -426,7 +425,7 @@ pub const UnifiedTextBufferView = struct {
         else switch (self.wrap_mode) {
             .none => unreachable,
             .char => calculateVirtualLinesGeneric(.render, .char, virtual_allocator, self.text_buffer, self.wrap_width.?, self.first_line_offset, output, null),
-            .word => calculateVirtualLinesGeneric(.render, .word, virtual_allocator, self.text_buffer, self.wrap_width.?, self.first_line_offset, output, if (reuse_words) &self.word_layout else null),
+            .word => calculateVirtualLinesGeneric(.render, .word, virtual_allocator, self.text_buffer, self.wrap_width.?, self.first_line_offset, output, &self.word_layout),
         };
         if (!calculated) {
             // Builders append to parallel arrays; discard partial output as a unit

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -374,8 +374,8 @@ pub const UnifiedTextBufferView = struct {
         }
     }
 
-    fn resetVirtualLineStorage(self: *Self) void {
-        _ = self.virtual_lines_arena.reset(.free_all);
+    fn resetVirtualLineStorage(self: *Self, mode: std.heap.ArenaAllocator.ResetMode) void {
+        _ = self.virtual_lines_arena.reset(mode);
         self.virtual_lines = .empty;
         self.cached_line_starts = .empty;
         self.cached_line_widths = .empty;
@@ -390,7 +390,7 @@ pub const UnifiedTextBufferView = struct {
         const buffer_dirty = self.text_buffer.isViewDirty(self.view_id);
         if (!self.virtual_lines_dirty and !buffer_dirty) return;
 
-        self.resetVirtualLineStorage();
+        self.resetVirtualLineStorage(if (!buffer_dirty and self.wrap_mode == .word) .retain_capacity else .free_all);
         const virtual_allocator = self.virtual_lines_arena.allocator();
 
         // Create output structure for the generic function
@@ -414,7 +414,7 @@ pub const UnifiedTextBufferView = struct {
         if (!calculated) {
             // Builders append to parallel arrays; discard partial output as a unit
             // and remain dirty so the next access can retry cleanly.
-            self.resetVirtualLineStorage();
+            self.resetVirtualLineStorage(.free_all);
             self.virtual_lines_dirty = true;
             return;
         }
@@ -1613,7 +1613,7 @@ pub const UnifiedTextBufferView = struct {
                 }
             }
 
-            fn addVirtualChunk(wctx: *@This(), chunk: *const TextChunk, byte_start: u32, byte_len: u32, col_start: u32, width_cols: u32) Allocator.Error!void {
+            inline fn addVirtualChunk(wctx: *@This(), chunk: *const TextChunk, byte_start: u32, byte_len: u32, col_start: u32, width_cols: u32) Allocator.Error!void {
                 if (byte_len == 0) return;
 
                 if (comptime calculation == .render and wrap_mode == .word) {
@@ -1645,7 +1645,7 @@ pub const UnifiedTextBufferView = struct {
                 wctx.current_vline_width_cols += width_cols;
             }
 
-            fn addVirtualChunkSticky(wctx: *@This(), chunk: *const TextChunk, byte_start: u32, byte_len: u32, col_start: u32, width_cols: u32) bool {
+            inline fn addVirtualChunkSticky(wctx: *@This(), chunk: *const TextChunk, byte_start: u32, byte_len: u32, col_start: u32, width_cols: u32) bool {
                 addVirtualChunk(wctx, chunk, byte_start, byte_len, col_start, width_cols) catch {
                     wctx.failed = true;
                     return false;
@@ -1815,7 +1815,7 @@ pub const UnifiedTextBufferView = struct {
                 }
             }
 
-            fn placeCompleteWordPiece(wctx: *@This(), chunk: *const TextChunk, col_start_in_chunk: u32, width_cols: u32, byte_start: u32, byte_end: u32) void {
+            inline fn placeCompleteWordPiece(wctx: *@This(), chunk: *const TextChunk, col_start_in_chunk: u32, width_cols: u32, byte_start: u32, byte_end: u32) void {
                 if (width_cols == 0 or wctx.failed) return;
 
                 var piece: PendingWordPiece = .{
@@ -1855,6 +1855,14 @@ pub const UnifiedTextBufferView = struct {
             }
 
             fn processWhitespaceBreak(wctx: *@This(), chunk: *const TextChunk, col_start: u32, byte_start: u32, wrap_break: utf8.LayoutWrapBreak) void {
+                // A fitting word and separator already coalesce into one chunk.
+                if (wctx.pending_word_width_cols == 0 and wrap_break.width_cols > 0 and wrap_break.col_start > col_start and
+                    wctx.current_vline_width_cols + (wrap_break.colEnd() - col_start) <= wctx.wordWrapWidth())
+                {
+                    _ = addVirtualChunkSticky(wctx, chunk, byte_start, wrap_break.byteEnd() - byte_start, col_start, wrap_break.colEnd() - col_start);
+                    wctx.source_line_has_non_whitespace = true;
+                    return;
+                }
                 if (wrap_break.col_start > col_start) {
                     flushCompleteWordPiece(
                         wctx,
@@ -1895,7 +1903,7 @@ pub const UnifiedTextBufferView = struct {
                 );
             }
 
-            fn processWordWrapBreakValue(wctx: *@This(), wrap_break: utf8.LayoutWrapBreak) void {
+            inline fn processWordWrapBreakValue(wctx: *@This(), wrap_break: utf8.LayoutWrapBreak) void {
                 const chunk = wctx.word_chunk orelse return;
                 const chunk_bytes = chunk.getBytes(wctx.text_buffer.memRegistry());
                 const col_end = @min(wrap_break.colEnd(), chunk.width_cols);

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -1615,10 +1615,16 @@ fn walkChunkLayoutInfoGeneric(
     var cluster_class: WordClass = .other;
 
     while (pos < text.len) {
-        if (pos + vector_len <= text.len) {
-            const chunk: @Vector(vector_len, u8) = text[pos..][0..vector_len].*;
-            const is_non_ascii = chunk >= @as(@Vector(vector_len, u8), @splat(0x80));
-            if (!@reduce(.Or, is_non_ascii)) {
+        {
+            var ascii_len: usize = 0;
+            if (pos + vector_len <= text.len) {
+                const chunk: @Vector(vector_len, u8) = text[pos..][0..vector_len].*;
+                const is_non_ascii = chunk >= @as(@Vector(vector_len, u8), @splat(0x80));
+                ascii_len = if (std.simd.firstTrue(is_non_ascii)) |index| index else vector_len;
+            } else {
+                while (pos + ascii_len < text.len and text[pos + ascii_len] < 0x80) : (ascii_len += 1) {}
+            }
+            if (ascii_len > 1) {
                 var can_use_ascii_fast_path = true;
                 if (cluster_started) {
                     var probe_state = break_state;
@@ -1645,7 +1651,7 @@ fn walkChunkLayoutInfoGeneric(
                     }
 
                     var i: usize = 0;
-                    while (i + 1 < vector_len) : (i += 1) {
+                    while (i + 1 < ascii_len) : (i += 1) {
                         const b = text[pos + i];
                         const width = asciiCharWidth(b, tab_width);
                         if (isAsciiWrapBreak(b)) {
@@ -1654,17 +1660,17 @@ fn walkChunkLayoutInfoGeneric(
                         col += width;
                     }
 
-                    const last_b = text[pos + vector_len - 1];
+                    const last_b = text[pos + ascii_len - 1];
                     const last_cp: u21 = last_b;
                     cluster_started = true;
-                    cluster_start = pos + vector_len - 1;
+                    cluster_start = pos + ascii_len - 1;
                     cluster_col_offset = col;
                     cluster_width_state = GraphemeWidthState.init(last_cp, asciiCharWidth(last_b, tab_width), width_method);
                     cluster_break_kind = asciiLayoutWrapBreakKind(last_b);
                     cluster_class = classifyWordClass(last_cp);
                     prev_cp = last_cp;
                     break_state = .default;
-                    pos += vector_len;
+                    pos += ascii_len;
                     continue;
                 }
             }


### PR DESCRIPTION
Reduce word-layout scanner, placement and arena-allocation work, and build reusable word-break metadata during the first wrapped layout. Metadata belongs to the current view, not chunks or undo history; optional allocation failure falls back to streaming. Combines and supersedes #1455.

945 KB Unicode fixture; matched latency medians (lower is better):

| Operation | v0.5.8 | This PR |
| --- | ---: | ---: |
| Initial layout | 11.283 ms | 6.525 ms |
| Initial layout + first resize | 13.654 ms | 9.399 ms |
| First resize alone | 2.842 ms | 2.968 ms |
| Steady rewrap | 2.517 ms | 2.005 ms |

Warm native requested allocation: 22.774 MiB in v0.5.8 versus 19.114 MiB here (TextBuffer/View arena capacity, not process RSS).

**Tradeoff:** metadata is now built upfront even for views that are never resized. Compared with the previous lazy version of this PR, this fixture adds 4.60 MiB at initial layout and roughly 20% initial-layout cost, in exchange for about 21% lower initial-layout-plus-first-resize time. Metadata is discarded on invalidation and does not accumulate in undo history. These fixture results are not a universal speedup; first resize alone remains slightly slower than v0.5.8.

Timing methodology: six balanced CPU-pinned fresh-process rounds, eight warmups and all 32 measured observations retained per process, with matching layout/render output. Initial layout starts at width 80; first resize uses 79; steady rewrap alternates 79/80. The combined row uses one timer, not a sum of stage medians. Text/view creation and teardown are outside the timers.
